### PR TITLE
feat(block-pipeline): validate canonical restart replay persistence

### DIFF
--- a/crates/kamn-core/src/block_pipeline.rs
+++ b/crates/kamn-core/src/block_pipeline.rs
@@ -12,6 +12,9 @@ use crate::transaction::BaselineTransaction;
 use std::collections::{BTreeMap, BTreeSet};
 use std::error::Error;
 use std::fmt::{Display, Formatter};
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::PathBuf;
 
 /// Input contract for one consensus-validation and block-commit round.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -68,6 +71,13 @@ pub enum BlockPipelineError {
         /// Deterministic reason code supplied by fork-choice hook.
         reason_code: String,
     },
+    /// Restart/replay lineage drift detected for canonical commit persistence.
+    ReplayDrift {
+        /// Deterministic replay drift reason code.
+        reason_code: String,
+        /// Human-readable drift details.
+        detail: String,
+    },
 }
 
 impl From<ListenerQuorumError> for BlockPipelineError {
@@ -113,6 +123,12 @@ impl Display for BlockPipelineError {
                     f,
                     "block pipeline fork-choice rejected candidate: {reason_code}"
                 )
+            }
+            Self::ReplayDrift {
+                reason_code,
+                detail,
+            } => {
+                write!(f, "block pipeline replay drift: {detail} ({reason_code})")
             }
         }
     }
@@ -455,6 +471,23 @@ impl CanonicalCommitRecord {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+/// Restart/replay evidence bundle for canonical commit lineage continuity.
+pub struct CanonicalReplayEvidenceBundle {
+    /// Versioned schema marker for policy and contract-lane checks.
+    pub schema_version: String,
+    /// Canonical head block height at restart boundary.
+    pub restart_boundary_block_height: u64,
+    /// Canonical head block height after replay checkpoint validation.
+    pub replay_checkpoint_block_height: u64,
+    /// Canonical commit count captured before restart.
+    pub pre_restart_commit_count: usize,
+    /// Canonical commit count observed after restart/replay.
+    pub post_restart_commit_count: usize,
+    /// Deterministic continuity status marker (`verified` on success).
+    pub continuity_status: String,
+}
+
 /// Deterministic decision outcome for one transport candidate reconciliation.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CanonicalCandidateDecision {
@@ -676,6 +709,88 @@ impl CanonicalCommitStore for InMemoryCanonicalCommitStore {
 
     fn list_canonical_commits(&self) -> Result<Vec<CanonicalCommitRecord>, BlockPipelineError> {
         Ok(self.records.clone())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+/// File-backed canonical commit store for restart/replay persistence checks.
+pub struct FileCanonicalCommitStore {
+    path: PathBuf,
+}
+
+impl FileCanonicalCommitStore {
+    /// Creates file-backed canonical commit store from path.
+    pub fn new(path: PathBuf) -> Result<Self, BlockPipelineError> {
+        if path.as_os_str().is_empty() {
+            return Err(BlockPipelineError::CommitStore(
+                "canonical commit store path is empty (canonical_commit_store_path_invalid)"
+                    .to_owned(),
+            ));
+        }
+        Ok(Self { path })
+    }
+}
+
+impl CanonicalCommitStore for FileCanonicalCommitStore {
+    fn persist_canonical_commit(
+        &mut self,
+        record: CanonicalCommitRecord,
+    ) -> Result<(), BlockPipelineError> {
+        let existing = self.list_canonical_commits()?;
+        if let Some(last) = existing.last() {
+            if record.block_height <= last.block_height {
+                return Err(BlockPipelineError::CommitStore(format!(
+                    "canonical commit block height regression: previous {}, found {} (canonical_commit_store_block_height_regression)",
+                    last.block_height, record.block_height
+                )));
+            }
+        }
+
+        let serialized = serialize_canonical_commit_record(&record)?;
+        let mut file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.path)
+            .map_err(|error| {
+                BlockPipelineError::CommitStore(format!(
+                    "canonical commit store append failed: {error} (canonical_commit_store_io)"
+                ))
+            })?;
+        file.write_all(serialized.as_bytes()).map_err(|error| {
+            BlockPipelineError::CommitStore(format!(
+                "canonical commit store write failed: {error} (canonical_commit_store_io)"
+            ))
+        })
+    }
+
+    fn list_canonical_commits(&self) -> Result<Vec<CanonicalCommitRecord>, BlockPipelineError> {
+        if !self.path.exists() {
+            return Ok(Vec::new());
+        }
+
+        let payload = fs::read_to_string(&self.path).map_err(|error| {
+            BlockPipelineError::CommitStore(format!(
+                "canonical commit store read failed: {error} (canonical_commit_store_io)"
+            ))
+        })?;
+        let mut records: Vec<CanonicalCommitRecord> = Vec::new();
+        for raw_line in payload.lines() {
+            let line = raw_line.trim();
+            if line.is_empty() {
+                continue;
+            }
+            let record = parse_canonical_commit_record(line)?;
+            if let Some(previous) = records.last() {
+                if record.block_height <= previous.block_height {
+                    return Err(BlockPipelineError::CommitStore(format!(
+                        "canonical commit block height regression in persisted lineage: previous {}, found {} (canonical_commit_store_block_height_regression)",
+                        previous.block_height, record.block_height
+                    )));
+                }
+            }
+            records.push(record);
+        }
+        Ok(records)
     }
 }
 
@@ -910,6 +1025,226 @@ fn sort_canonical_candidates_for_reconciliation(candidates: &mut [CanonicalCommi
             })
             .then_with(|| left.transaction_ids.cmp(&right.transaction_ids))
     });
+}
+
+const CANONICAL_REPLAY_EVIDENCE_SCHEMA_VERSION: &str = "kamn.runtime.canonical-replay-evidence.v1";
+
+/// Validates canonical lineage continuity across restart/replay checkpoints.
+pub fn build_canonical_replay_evidence_bundle(
+    pre_restart: &[CanonicalCommitRecord],
+    post_restart: &[CanonicalCommitRecord],
+) -> Result<CanonicalReplayEvidenceBundle, BlockPipelineError> {
+    let Some(restart_boundary) = pre_restart.last() else {
+        return Err(BlockPipelineError::ReplayDrift {
+            reason_code: "canonical_replay_pre_restart_lineage_empty".to_owned(),
+            detail: "pre-restart canonical lineage cannot be empty".to_owned(),
+        });
+    };
+
+    for (index, expected) in pre_restart.iter().enumerate() {
+        let Some(found) = post_restart.get(index) else {
+            return Err(BlockPipelineError::ReplayDrift {
+                reason_code: "canonical_replay_checkpoint_missing".to_owned(),
+                detail: format!(
+                    "post-restart lineage missing checkpoint at index {index} (expected height {})",
+                    expected.block_height
+                ),
+            });
+        };
+
+        if found.block_height != expected.block_height {
+            return Err(BlockPipelineError::ReplayDrift {
+                reason_code: "canonical_replay_block_height_mismatch".to_owned(),
+                detail: format!(
+                    "canonical replay block height mismatch at index {index}: expected {}, found {}",
+                    expected.block_height, found.block_height
+                ),
+            });
+        }
+        if found.producer_role != expected.producer_role {
+            return Err(BlockPipelineError::ReplayDrift {
+                reason_code: "canonical_replay_producer_role_mismatch".to_owned(),
+                detail: format!(
+                    "canonical replay producer role mismatch at index {index}: expected {}, found {}",
+                    expected.producer_role.as_str(),
+                    found.producer_role.as_str()
+                ),
+            });
+        }
+        if found.payload_digest != expected.payload_digest {
+            return Err(BlockPipelineError::ReplayDrift {
+                reason_code: "canonical_replay_payload_digest_mismatch".to_owned(),
+                detail: format!(
+                    "canonical replay payload digest mismatch at index {index}: expected {}, found {}",
+                    expected.payload_digest, found.payload_digest
+                ),
+            });
+        }
+        if found.transaction_ids != expected.transaction_ids {
+            return Err(BlockPipelineError::ReplayDrift {
+                reason_code: "canonical_replay_transaction_ids_mismatch".to_owned(),
+                detail: format!(
+                    "canonical replay transaction ids mismatch at index {index}: expected {:?}, found {:?}",
+                    expected.transaction_ids, found.transaction_ids
+                ),
+            });
+        }
+    }
+
+    let replay_checkpoint = post_restart
+        .get(pre_restart.len().saturating_sub(1))
+        .ok_or_else(|| BlockPipelineError::ReplayDrift {
+            reason_code: "canonical_replay_checkpoint_missing".to_owned(),
+            detail: "post-restart lineage missing replay checkpoint".to_owned(),
+        })?;
+
+    Ok(CanonicalReplayEvidenceBundle {
+        schema_version: CANONICAL_REPLAY_EVIDENCE_SCHEMA_VERSION.to_owned(),
+        restart_boundary_block_height: restart_boundary.block_height,
+        replay_checkpoint_block_height: replay_checkpoint.block_height,
+        pre_restart_commit_count: pre_restart.len(),
+        post_restart_commit_count: post_restart.len(),
+        continuity_status: "verified".to_owned(),
+    })
+}
+
+fn serialize_canonical_commit_record(
+    record: &CanonicalCommitRecord,
+) -> Result<String, BlockPipelineError> {
+    if record.block_height == 0 {
+        return Err(BlockPipelineError::CommitStore(
+            "canonical commit block height must be positive (canonical_commit_store_block_height_invalid)"
+                .to_owned(),
+        ));
+    }
+    if record.transaction_ids.is_empty() {
+        return Err(BlockPipelineError::CommitStore(
+            "canonical commit transaction ids cannot be empty (canonical_commit_store_transaction_ids_invalid)"
+                .to_owned(),
+        ));
+    }
+    validate_canonical_commit_store_field("payload_digest", record.payload_digest.as_str())?;
+    let mut encoded_ids = Vec::with_capacity(record.transaction_ids.len());
+    for tx_id in &record.transaction_ids {
+        validate_canonical_commit_store_field("transaction_id", tx_id.as_str())?;
+        if tx_id.contains(',') {
+            return Err(BlockPipelineError::CommitStore(
+                "canonical commit transaction id cannot contain ',' (canonical_commit_store_transaction_ids_invalid)"
+                    .to_owned(),
+            ));
+        }
+        encoded_ids.push(tx_id.as_str());
+    }
+
+    Ok(format!(
+        "{}|{}|{}|{}\n",
+        record.block_height,
+        record.producer_role.as_str(),
+        record.payload_digest,
+        encoded_ids.join(",")
+    ))
+}
+
+fn parse_canonical_commit_record(line: &str) -> Result<CanonicalCommitRecord, BlockPipelineError> {
+    let mut segments = line.split('|');
+    let block_height_raw = segments.next().ok_or_else(|| {
+        BlockPipelineError::CommitStore(format!(
+            "canonical commit record malformed: {line} (canonical_commit_store_record_malformed)"
+        ))
+    })?;
+    let producer_role_raw = segments.next().ok_or_else(|| {
+        BlockPipelineError::CommitStore(format!(
+            "canonical commit record malformed: {line} (canonical_commit_store_record_malformed)"
+        ))
+    })?;
+    let payload_digest = segments.next().ok_or_else(|| {
+        BlockPipelineError::CommitStore(format!(
+            "canonical commit record malformed: {line} (canonical_commit_store_record_malformed)"
+        ))
+    })?;
+    let transaction_ids_raw = segments.next().ok_or_else(|| {
+        BlockPipelineError::CommitStore(format!(
+            "canonical commit record malformed: {line} (canonical_commit_store_record_malformed)"
+        ))
+    })?;
+    if segments.next().is_some() {
+        return Err(BlockPipelineError::CommitStore(format!(
+            "canonical commit record malformed: {line} (canonical_commit_store_record_malformed)"
+        )));
+    }
+
+    let block_height = block_height_raw.parse::<u64>().map_err(|_| {
+        BlockPipelineError::CommitStore(format!(
+            "canonical commit block height is invalid: {block_height_raw} (canonical_commit_store_block_height_invalid)"
+        ))
+    })?;
+    if block_height == 0 {
+        return Err(BlockPipelineError::CommitStore(
+            "canonical commit block height must be positive (canonical_commit_store_block_height_invalid)"
+                .to_owned(),
+        ));
+    }
+    let producer_role = match producer_role_raw {
+        "processor" => NodeRole::Processor,
+        "listener" => NodeRole::Listener,
+        "approver" => NodeRole::Approver,
+        other => {
+            return Err(BlockPipelineError::CommitStore(format!(
+                "canonical commit producer role is invalid: {other} (canonical_commit_store_producer_role_invalid)"
+            )));
+        }
+    };
+    validate_canonical_commit_store_field("payload_digest", payload_digest)?;
+
+    let mut seen_ids = BTreeSet::new();
+    let mut transaction_ids = Vec::new();
+    for tx_id in transaction_ids_raw.split(',').map(|value| value.trim()) {
+        if tx_id.is_empty() {
+            continue;
+        }
+        validate_canonical_commit_store_field("transaction_id", tx_id)?;
+        if !seen_ids.insert(tx_id.to_owned()) {
+            return Err(BlockPipelineError::CommitStore(format!(
+                "canonical commit transaction id is duplicated: {tx_id} (canonical_commit_store_transaction_ids_invalid)"
+            )));
+        }
+        transaction_ids.push(tx_id.to_owned());
+    }
+    if transaction_ids.is_empty() {
+        return Err(BlockPipelineError::CommitStore(
+            "canonical commit transaction ids cannot be empty (canonical_commit_store_transaction_ids_invalid)"
+                .to_owned(),
+        ));
+    }
+
+    Ok(CanonicalCommitRecord {
+        block_height,
+        producer_role,
+        payload_digest: payload_digest.to_owned(),
+        transaction_ids,
+    })
+}
+
+fn validate_canonical_commit_store_field(
+    field: &str,
+    value: &str,
+) -> Result<(), BlockPipelineError> {
+    if value.trim().is_empty() {
+        return Err(BlockPipelineError::CommitStore(format!(
+            "canonical commit field is empty: {field} (canonical_commit_store_field_empty)"
+        )));
+    }
+    if value.contains('|') {
+        return Err(BlockPipelineError::CommitStore(format!(
+            "canonical commit field contains reserved separator '|': {field} (canonical_commit_store_field_separator_invalid)"
+        )));
+    }
+    if value.contains('\n') || value.contains('\r') {
+        return Err(BlockPipelineError::CommitStore(format!(
+            "canonical commit field contains line break: {field} (canonical_commit_store_field_line_break)"
+        )));
+    }
+    Ok(())
 }
 
 fn classify_gossip_topic(topic: &str) -> Result<GossipIngressTopicKind, GossipIngressError> {

--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -152,16 +152,17 @@ pub use audit_exports::{
     AuditExportFilter, AuditExportFormat, AuditExportManifest, AuditExportRequest,
 };
 pub use block_pipeline::{
-    decode_transport_candidate_payload, decode_transport_canonical_candidate_payload,
-    encode_transport_candidate_payload, encode_transport_canonical_candidate_payload,
-    encode_transport_commit_report_payload, AcceptAllForkChoiceHook, BlockConsensusRoundInput,
-    BlockPipelineCommitReport, BlockPipelineError, CanonicalCandidateDecision,
-    CanonicalCandidateOutcome, CanonicalCommitRecord, CanonicalCommitStore,
-    DeterministicCompetingBranchForkChoiceHook, ForkChoiceDecision, ForkChoiceHook,
-    GossipFrameTransportMempoolFeed, GossipIngressAdapter, GossipIngressBatch, GossipIngressError,
-    GossipIngressRecord, InMemoryCanonicalCommitStore, InMemoryTransportMempoolFeed,
-    MempoolBlockPipeline, TransportCanonicalCandidateFeed, TransportEventMempoolFeed,
-    TransportFedBlockPipeline, TransportMempoolFeed,
+    build_canonical_replay_evidence_bundle, decode_transport_candidate_payload,
+    decode_transport_canonical_candidate_payload, encode_transport_candidate_payload,
+    encode_transport_canonical_candidate_payload, encode_transport_commit_report_payload,
+    AcceptAllForkChoiceHook, BlockConsensusRoundInput, BlockPipelineCommitReport,
+    BlockPipelineError, CanonicalCandidateDecision, CanonicalCandidateOutcome,
+    CanonicalCommitRecord, CanonicalCommitStore, CanonicalReplayEvidenceBundle,
+    DeterministicCompetingBranchForkChoiceHook, FileCanonicalCommitStore, ForkChoiceDecision,
+    ForkChoiceHook, GossipFrameTransportMempoolFeed, GossipIngressAdapter, GossipIngressBatch,
+    GossipIngressError, GossipIngressRecord, InMemoryCanonicalCommitStore,
+    InMemoryTransportMempoolFeed, MempoolBlockPipeline, TransportCanonicalCandidateFeed,
+    TransportEventMempoolFeed, TransportFedBlockPipeline, TransportMempoolFeed,
 };
 pub use bootstrap::{bootstrap, bootstrap_from_state_version, BootstrapPlan};
 pub use bridge_adapter::{

--- a/crates/kamn-core/tests/block_pipeline_transport_fed.rs
+++ b/crates/kamn-core/tests/block_pipeline_transport_fed.rs
@@ -1,14 +1,18 @@
 use kamn_core::{
-    decode_transport_canonical_candidate_payload, encode_transport_candidate_payload,
-    encode_transport_canonical_candidate_payload, encode_transport_commit_report_payload,
-    BaselineTransaction, BlockConsensusRoundInput, BlockPipelineError, CanonicalCommitRecord,
-    DeterministicCompetingBranchForkChoiceHook, ForkChoiceDecision, ForkChoiceHook,
-    InMemoryCanonicalCommitStore, InMemoryPeerLifecycleTransport, InMemoryTransportMempoolFeed,
-    MempoolBlockPipeline, NodeRole, PeerDiscoveryRecord, PeerGossipFrame, PeerLifecycleTransport,
-    TransportCanonicalCandidateFeed, TransportEventMempoolFeed, TransportFedBlockPipeline,
-    TransportMempoolFeed,
+    build_canonical_replay_evidence_bundle, decode_transport_canonical_candidate_payload,
+    encode_transport_candidate_payload, encode_transport_canonical_candidate_payload,
+    encode_transport_commit_report_payload, BaselineTransaction, BlockConsensusRoundInput,
+    BlockPipelineError, CanonicalCommitRecord, CanonicalCommitStore, CanonicalReplayEvidenceBundle,
+    DeterministicCompetingBranchForkChoiceHook, FileCanonicalCommitStore, ForkChoiceDecision,
+    ForkChoiceHook, InMemoryCanonicalCommitStore, InMemoryPeerLifecycleTransport,
+    InMemoryTransportMempoolFeed, MempoolBlockPipeline, NodeRole, PeerDiscoveryRecord,
+    PeerGossipFrame, PeerLifecycleTransport, TransportCanonicalCandidateFeed,
+    TransportEventMempoolFeed, TransportFedBlockPipeline, TransportMempoolFeed,
 };
+use std::fs;
+use std::path::PathBuf;
 use std::time::{Duration, Instant};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 #[derive(Debug, Default)]
 struct RejectAllForkChoiceHook;
@@ -48,6 +52,23 @@ fn build_valid_chain_transactions() -> Vec<BaselineTransaction> {
     let state_hash_two = planner.expected_state_hash().to_owned();
     let tx_two = BaselineTransaction::signed("tx-2", "agent-a", 2, "payload-2", &state_hash_two);
     vec![tx_two, tx_one]
+}
+
+fn sample_canonical_record(height: u64, digest: &str, tx_id: &str) -> CanonicalCommitRecord {
+    CanonicalCommitRecord {
+        block_height: height,
+        producer_role: NodeRole::Processor,
+        payload_digest: digest.to_owned(),
+        transaction_ids: vec![tx_id.to_owned()],
+    }
+}
+
+fn temp_canonical_commit_store_path(tag: &str) -> PathBuf {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock should be monotonic")
+        .as_nanos();
+    std::env::temp_dir().join(format!("kamn-canonical-commit-{tag}-{nonce}.log"))
 }
 
 #[test]
@@ -411,4 +432,210 @@ fn functional_transport_event_feed_drains_canonical_candidates_from_block_topic_
         .drain_canonical_candidates()
         .expect("candidate drain should decode block frame");
     assert_eq!(candidates, vec![record]);
+}
+
+#[test]
+fn unit_canonical_replay_checkpoint_validator_accepts_matching_lineage() {
+    let pre_restart = vec![
+        sample_canonical_record(7, "digest-7", "tx-7"),
+        sample_canonical_record(8, "digest-8", "tx-8"),
+    ];
+    let post_restart = pre_restart.clone();
+    let evidence = build_canonical_replay_evidence_bundle(&pre_restart, &post_restart)
+        .expect("matching lineage should validate");
+
+    assert_eq!(
+        evidence.schema_version,
+        "kamn.runtime.canonical-replay-evidence.v1"
+    );
+    assert_eq!(evidence.restart_boundary_block_height, 8);
+    assert_eq!(evidence.replay_checkpoint_block_height, 8);
+    assert_eq!(evidence.continuity_status, "verified");
+}
+
+#[test]
+fn unit_canonical_replay_checkpoint_validator_rejects_payload_digest_drift_reason_code() {
+    let pre_restart = vec![sample_canonical_record(9, "digest-9", "tx-9")];
+    let post_restart = vec![sample_canonical_record(9, "digest-9-tampered", "tx-9")];
+
+    let error = build_canonical_replay_evidence_bundle(&pre_restart, &post_restart)
+        .expect_err("payload drift must fail closed");
+    assert!(
+        matches!(error, BlockPipelineError::ReplayDrift { reason_code, .. }
+            if reason_code == "canonical_replay_payload_digest_mismatch"),
+        "payload drift should emit deterministic reason-code marker"
+    );
+}
+
+#[test]
+fn functional_transport_fed_restart_replay_harness_reports_boundary_and_checkpoint_markers() {
+    let path = temp_canonical_commit_store_path("restart-replay-functional");
+    let _ = fs::remove_file(&path);
+
+    let mut store = FileCanonicalCommitStore::new(path.clone()).expect("store should build");
+    store
+        .persist_canonical_commit(sample_canonical_record(11, "digest-11", "tx-11"))
+        .expect("first record should persist");
+    store
+        .persist_canonical_commit(sample_canonical_record(12, "digest-12", "tx-12"))
+        .expect("second record should persist");
+    let pre_restart = store
+        .list_canonical_commits()
+        .expect("pre-restart list should load");
+
+    let restarted_store = FileCanonicalCommitStore::new(path.clone()).expect("store should build");
+    let post_restart = restarted_store
+        .list_canonical_commits()
+        .expect("post-restart list should load");
+    let evidence: CanonicalReplayEvidenceBundle =
+        build_canonical_replay_evidence_bundle(&pre_restart, &post_restart)
+            .expect("restart replay evidence should validate");
+    assert_eq!(evidence.restart_boundary_block_height, 12);
+    assert_eq!(evidence.replay_checkpoint_block_height, 12);
+    assert_eq!(evidence.pre_restart_commit_count, 2);
+    assert_eq!(evidence.post_restart_commit_count, 2);
+
+    let _ = fs::remove_file(path);
+}
+
+#[test]
+fn integration_transport_fed_restart_replay_preserves_canonical_lineage_across_restart() {
+    let path = temp_canonical_commit_store_path("restart-replay-integration");
+    let _ = fs::remove_file(&path);
+    let topic = "kamn/blocks/v1";
+    let sender = "peer-replay-sender";
+    let recipient = "peer-replay-recipient";
+    let baseline_record = sample_canonical_record(21, "digest-21", "tx-21");
+
+    let mut first_store = FileCanonicalCommitStore::new(path.clone()).expect("store should build");
+    first_store
+        .persist_canonical_commit(baseline_record.clone())
+        .expect("baseline record should persist");
+    let pre_restart = first_store
+        .list_canonical_commits()
+        .expect("pre-restart list should load");
+
+    let transport = InMemoryPeerLifecycleTransport::default();
+    transport
+        .advertise(
+            PeerDiscoveryRecord::new(sender, NodeRole::Approver, vec![topic.to_owned()])
+                .expect("sender discovery record should build"),
+        )
+        .expect("sender should advertise");
+    transport
+        .advertise(
+            PeerDiscoveryRecord::new(recipient, NodeRole::Processor, vec![topic.to_owned()])
+                .expect("recipient discovery record should build"),
+        )
+        .expect("recipient should advertise");
+
+    let payload = encode_transport_canonical_candidate_payload(&baseline_record)
+        .expect("canonical candidate payload should encode");
+    transport
+        .send(
+            PeerGossipFrame::new(topic, sender, recipient, payload.as_str())
+                .expect("gossip frame should build"),
+        )
+        .expect("gossip frame should send");
+
+    let feed = TransportEventMempoolFeed::new(transport, recipient, Some(vec![topic.to_owned()]))
+        .expect("feed should build");
+    let restarted_store = FileCanonicalCommitStore::new(path.clone()).expect("store should build");
+    let hook = DeterministicCompetingBranchForkChoiceHook::with_canonical_head(
+        pre_restart
+            .last()
+            .cloned()
+            .expect("baseline canonical head should exist"),
+    );
+    let mut pipeline = TransportFedBlockPipeline::new(true, 1, 1, feed, restarted_store, hook)
+        .expect("transport-fed pipeline should build");
+
+    let outcomes = pipeline
+        .reconcile_transport_candidates()
+        .expect("reconciliation should succeed");
+    assert_eq!(outcomes.len(), 1);
+    assert_eq!(
+        outcomes[0].decision,
+        kamn_core::CanonicalCandidateDecision::Rejected {
+            reason_code: "fork_choice_duplicate_candidate".to_owned(),
+        }
+    );
+
+    let post_restart = pipeline
+        .list_canonical_commits()
+        .expect("post-restart list should load");
+    let evidence = build_canonical_replay_evidence_bundle(&pre_restart, &post_restart)
+        .expect("replay evidence should validate after duplicate reconciliation");
+    assert_eq!(evidence.continuity_status, "verified");
+    assert_eq!(evidence.post_restart_commit_count, 1);
+
+    let _ = fs::remove_file(path);
+}
+
+#[test]
+fn regression_transport_fed_restart_replay_tamper_matrix_emits_deterministic_reason_codes() {
+    let baseline = sample_canonical_record(31, "digest-31", "tx-31");
+    let pre_restart = vec![baseline.clone()];
+    let tamper_cases = vec![
+        (
+            vec![],
+            "canonical_replay_checkpoint_missing".to_owned(),
+            "missing checkpoint",
+        ),
+        (
+            vec![sample_canonical_record(99, "digest-31", "tx-31")],
+            "canonical_replay_block_height_mismatch".to_owned(),
+            "height drift",
+        ),
+        (
+            vec![sample_canonical_record(31, "digest-31-tampered", "tx-31")],
+            "canonical_replay_payload_digest_mismatch".to_owned(),
+            "payload digest drift",
+        ),
+        (
+            vec![CanonicalCommitRecord {
+                transaction_ids: vec!["tx-31-tampered".to_owned()],
+                ..baseline.clone()
+            }],
+            "canonical_replay_transaction_ids_mismatch".to_owned(),
+            "transaction id drift",
+        ),
+    ];
+
+    for (tampered_post_restart, expected_reason_code, case_name) in tamper_cases {
+        let error = build_canonical_replay_evidence_bundle(&pre_restart, &tampered_post_restart)
+            .expect_err("tampered replay lineage must fail closed");
+        assert!(
+            matches!(error, BlockPipelineError::ReplayDrift { reason_code, .. }
+                if reason_code == expected_reason_code),
+            "unexpected reason code for tamper case: {case_name}"
+        );
+    }
+}
+
+#[test]
+fn performance_canonical_replay_checkpoint_validator_stays_within_local_budget() {
+    let mut pre_restart = Vec::new();
+    let mut post_restart = Vec::new();
+    for index in 1..=256 {
+        pre_restart.push(sample_canonical_record(
+            index,
+            format!("digest-{index}").as_str(),
+            format!("tx-{index}").as_str(),
+        ));
+        post_restart.push(sample_canonical_record(
+            index,
+            format!("digest-{index}").as_str(),
+            format!("tx-{index}").as_str(),
+        ));
+    }
+
+    let start = Instant::now();
+    let evidence = build_canonical_replay_evidence_bundle(&pre_restart, &post_restart)
+        .expect("large replay lineage should validate");
+    assert_eq!(evidence.pre_restart_commit_count, 256);
+    assert!(
+        start.elapsed() <= Duration::from_secs(1),
+        "canonical replay validator exceeded runtime budget"
+    );
 }

--- a/docs/architecture/block-pipeline.md
+++ b/docs/architecture/block-pipeline.md
@@ -25,6 +25,11 @@ production and consensus validation (Task #2926, Subtask #2927).
 - `TransportFedBlockPipeline::reconcile_transport_candidates(...)`
   - applies deterministic fork-choice over transport-provided canonical
     candidates and persists accepted records before transaction consensus.
+- `FileCanonicalCommitStore`
+  - persists canonical commit lineage across process restart boundaries.
+- `build_canonical_replay_evidence_bundle(...)`
+  - validates restart/replay lineage continuity and emits deterministic
+    checkpoint evidence (`kamn.runtime.canonical-replay-evidence.v1`).
 - `BlockConsensusRoundInput`
   - listener and approver attestation input envelope for a round.
 - `BlockPipelineCommitReport`
@@ -68,6 +73,18 @@ Processor role runtime wiring now includes:
 - Reconciled canonical candidates surface deterministic reject reasons:
   `fork_choice_stale_block_height`, `fork_choice_duplicate_candidate`,
   `fork_choice_tie_break_loser`.
+- Restart/replay lineage validation fails closed with deterministic reason codes:
+  `canonical_replay_pre_restart_lineage_empty`,
+  `canonical_replay_checkpoint_missing`,
+  `canonical_replay_block_height_mismatch`,
+  `canonical_replay_producer_role_mismatch`,
+  `canonical_replay_payload_digest_mismatch`,
+  `canonical_replay_transaction_ids_mismatch`.
+- File-backed canonical persistence rejects malformed or regressive records with
+  deterministic reason markers such as:
+  `canonical_commit_store_record_malformed`,
+  `canonical_commit_store_block_height_regression`,
+  `canonical_commit_store_transaction_ids_invalid`.
 
 Regression marker:
 - `Regression: #2927` keeps digest mismatch fail-closed before commit.
@@ -81,6 +98,7 @@ Regression marker:
 cargo test -p kamn-core --test block_pipeline
 cargo test -p kamn-core --test block_pipeline_gossip_ingest
 cargo test -p kamn-core --test block_pipeline_canonical_reconciliation
+cargo test -p kamn-core --test block_pipeline_transport_fed
 cargo test -p kamn-core block_pipeline
 cargo clippy -p kamn-core -- -D warnings
 cargo fmt --check

--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -173,6 +173,22 @@ Versioned thresholds are defined in `.ci/ci-budget.env`.
   - `full_supervisor_invariant_violation:full_supervisor_bootstrap_component_order_mismatch`
   - `full_supervisor_invariant_violation:full_supervisor_stop_unknown_completion_reason`
 
+## Transport-Fed Restart/Replay Canonical Persistence Fast Lane
+- For transport-fed block pipeline canonical persistence/restart drift changes, keep PR checks bounded to:
+  - `cargo test -p kamn-core --test block_pipeline_transport_fed unit_canonical_replay_checkpoint_validator_accepts_matching_lineage -- --exact`
+  - `cargo test -p kamn-core --test block_pipeline_transport_fed unit_canonical_replay_checkpoint_validator_rejects_payload_digest_drift_reason_code -- --exact`
+  - `cargo test -p kamn-core --test block_pipeline_transport_fed integration_transport_fed_restart_replay_preserves_canonical_lineage_across_restart -- --exact`
+  - `cargo test -p kamn-core --test block_pipeline_transport_fed regression_transport_fed_restart_replay_tamper_matrix_emits_deterministic_reason_codes -- --exact`
+- This lane remains cost-effective:
+  - all checks run in-process with deterministic in-memory transport and local temp-file persistence.
+  - no external node/process bootstrap is required.
+  - replay validator performance guard is bounded to sub-second local budget.
+- Deterministic fail-closed restart/replay reason markers:
+  - `canonical_replay_checkpoint_missing`
+  - `canonical_replay_block_height_mismatch`
+  - `canonical_replay_payload_digest_mismatch`
+  - `canonical_replay_transaction_ids_mismatch`
+
 ## Runtime Local Full-Mode Live Validation Contract Lane
 - Entry commands:
   - `bash scripts/runtime/validate_local_full_runtime_live.sh --mode dry-run --output-json /tmp/local-full-runtime-live-summary.json`


### PR DESCRIPTION
Closes #3446

## Summary
Add restart/replay canonical persistence invariants for the transport-fed block pipeline so canonical lineage can be validated deterministically across process restart boundaries.

## Changes
- `crates/kamn-core/src/block_pipeline.rs`: added `FileCanonicalCommitStore`, replay evidence bundle contracts, and `build_canonical_replay_evidence_bundle(...)`; introduced deterministic `BlockPipelineError::ReplayDrift` reason-code outcomes.
- `crates/kamn-core/tests/block_pipeline_transport_fed.rs`: added unit, functional, integration, regression, and performance tests for restart/replay persistence and tamper drift reason codes.
- `docs/architecture/block-pipeline.md`: documented restart/replay canonical persistence contracts, fail-closed reason markers, and validation command updates.
- `docs/ci/strategy.md`: added bounded fast-lane command guidance for transport-fed restart/replay canonical persistence checks.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
`cargo test -p kamn-core --test block_pipeline_transport_fed`

Failing output excerpt:
- unresolved import: `build_canonical_replay_evidence_bundle`
- unresolved import: `CanonicalReplayEvidenceBundle`
- unresolved import: `FileCanonicalCommitStore`
- missing variant: `BlockPipelineError::ReplayDrift`

### 🟢 Green Phase
Command:
`cargo test -p kamn-core --test block_pipeline_transport_fed`

Passing output summary:
- `18 passed; 0 failed`

### 🔁 Regression
Commands:
- `cargo test -p kamn-core --test block_pipeline_transport_fed`
- `cargo test -p kamn-core block_pipeline`
- `cargo clippy -p kamn-core --tests -- -D warnings`
- `cargo fmt --all --check`

Result summary:
- all commands passed

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified                                                                 | Justification if N/A |
|--------------|--------|---------------------------------------------------------------------------------------|----------------------|
| Unit         | ✅     | replay checkpoint validator success/failure reason-code tests                        |                      |
| Functional   | ✅     | restart harness boundary/checkpoint evidence test                                    |                      |
| Integration  | ✅     | transport-fed restart reconciliation preserves canonical lineage across restart       |                      |
| Regression   | ✅     | tamper matrix verifies deterministic replay drift reason codes                        |                      |
| Performance  | ✅     | replay checkpoint validator bounded runtime budget test                               |                      |

## Risks & Rollback
- Breaking changes: None.
- Rollback plan: revert commit `e73ef6b` if downstream behavior changes unexpectedly.

## Documentation Updates
- `docs/architecture/block-pipeline.md`
- `docs/ci/strategy.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (relevant scope)
- [x] Docs updated (or justified why not)
