### PR TITLE
feat(runtime): gate go-no-go on transport-fed evidence artifacts

### DIFF
--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -2676,6 +2676,8 @@ The runtime go/no-go gate lane enforces a versioned release evidence manifest:
   - `rollback_readiness`
   - `dr_readiness`
   - `local_full_stack_integration`
+  - `local_full_runtime_convergence`
+  - `transport_fault_matrix`
 - contract lane command:
   - CI-safe dry-run policy path:
     - `bash scripts/runtime/run_go_no_go_gate_lane.sh --mode dry-run --max-seconds 120 --output-json /tmp/go-no-go-gate-report.json`

--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -37,8 +37,12 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
 - Deterministic tamper reason:
   - `local_full_stack_integration_policy_runtime_commit_finality_status_mismatch`
 - Release go/no-go linkage:
-  - `scripts/runtime/release_evidence_manifest.json` includes required artifact id `local_full_stack_integration`.
+  - `scripts/runtime/release_evidence_manifest.json` includes required artifact ids:
+    `local_full_stack_integration`,
+    `local_full_runtime_convergence`,
+    `transport_fault_matrix`.
   - release gate runner consumes `validate_local_full_stack_integration_live_contract_lane.sh` and fails closed on missing/tampered evidence linkage.
+  - release gate runner consumes `validate_local_full_runtime_live_contract_lane.sh` and `validate_block_reconciliation_partition_rejoin_live_contract_lane.sh` and fails closed on missing/tampered transport-fed convergence + fault-matrix evidence linkage.
 - Architecture boundary reference:
   - `docs/architecture/kolme-live-integration.md`
 
@@ -1123,7 +1127,8 @@ Operator checkpoints:
   2. `python3 scripts/kolme/check_local_kolme_live_deployment_preflight_policy.py --report-file /tmp/kolme-local-live-deployment-preflight-summary.json --expected-final-decision GO --ci-fast-gate PASS --require-reason-code dry_run_no_commands_executed --output-json /tmp/kolme-local-live-deployment-preflight-policy.json`
   3. `bash scripts/kolme/run_local_live_node_validation_bundle_lane.sh --mode dry-run --output-json /tmp/kolme-local-live-node-validation-bundle-summary.json`
   4. `python3 scripts/kolme/check_local_live_node_validation_bundle_policy.py --report-file /tmp/kolme-local-live-node-validation-bundle-summary.json --expected-final-decision GO --ci-fast-gate PASS --require-reason-code dry_run_no_commands_executed --output-json /tmp/kolme-local-live-node-validation-bundle-policy.json`
-  5. `bash scripts/runtime/run_go_no_go_gate_lane.sh --max-seconds 120 --output-json /tmp/go-no-go-gate-report.json`
+  5. `bash scripts/runtime/run_go_no_go_gate_lane.sh --mode dry-run --max-seconds 120 --output-json /tmp/go-no-go-gate-report.json`
+  6. `KAMN_GONOGO_GATE_LOCAL_OPT_IN=1 bash scripts/runtime/run_go_no_go_gate_lane.sh --mode run --max-seconds 120 --output-json /tmp/go-no-go-gate-run-report.json`
 - Generate deterministic milestone aggregate review bundle:
   - `bash scripts/deploy/generate_gonogo_evidence_bundle.sh --output-file /tmp/gonogo-milestone.json --release-candidate v1.0.0-rc.5 --schema-target-version 1.0.0 --runtime-image-digest sha256:abc123 --ci-fast-gate PASS --ci-deep-lane PASS --rollback-precheck PASS --rollback-trigger-status CLEAR --required-approvals 2 --received-approvals 2 --deployment-preflight-summary-file /tmp/kolme-local-live-deployment-preflight-summary.json --deployment-preflight-policy-file /tmp/kolme-local-live-deployment-preflight-policy.json --live-node-validation-summary-file /tmp/kolme-local-live-node-validation-bundle-summary.json --live-node-validation-policy-file /tmp/kolme-local-live-node-validation-bundle-policy.json --go-no-go-gate-report-file /tmp/go-no-go-gate-report.json`
 - Validate aggregate lineage policy:

--- a/docs/plans/2026-02-14-production-service-next-steps.md
+++ b/docs/plans/2026-02-14-production-service-next-steps.md
@@ -62,11 +62,15 @@ This refreshed version separates:
   - local-heavy live lane validation with CI fast-gate exclusion.
 
 ### Item 4 follow-on: Transport-fed consensus convergence
-- Open chain: `#3228 -> #3413 -> #3414 -> (#3415, #3416, #3417, #3418)`.
+- Open chain: `#3228 -> #3413 -> #3414 -> (#3443, #3444, #3446, #3447, #3448)`.
 - Current focus:
   - block pipeline consumption from real transport adapters,
-  - canonical fork-choice/reconciliation under partition-rejoin and convergence drills,
-  - deterministic policy/taxonomy reason-code contracts.
+  - canonical fork-choice/reconciliation under partition-rejoin/publish-drop/churn convergence drills,
+  - deterministic policy/taxonomy reason-code contracts,
+  - release go/no-go artifact gating on transport-fed convergence + fault-matrix evidence.
+- Status progression note:
+  - delivered in this chain: `#3443`, `#3444`, `#3446`, `#3447`
+  - remaining in this chain: `#3448`
 
 ### Composed full-stack E2E against `kolme_fork`
 - Open chain: `#3333 -> #3419 -> #3420 -> (#3432, #3433, #3434)`.

--- a/scripts/runtime/go_no_go_gate_lane_contract.py
+++ b/scripts/runtime/go_no_go_gate_lane_contract.py
@@ -37,6 +37,8 @@ REQUIRED_ARTIFACT_IDS = (
     "rollback_readiness",
     "dr_readiness",
     "local_full_stack_integration",
+    "local_full_runtime_convergence",
+    "transport_fault_matrix",
 )
 ARTIFACT_LANE_REGISTRY: dict[str, dict[str, object]] = {
     "go_no_go_evidence": {
@@ -70,6 +72,31 @@ ARTIFACT_LANE_REGISTRY: dict[str, dict[str, object]] = {
         ],
         "success_marker": "local_full_stack_integration_policy_status=verified",
         "failure_label": "local full-stack integration lane failed unexpectedly",
+    },
+    "local_full_runtime_convergence": {
+        "expected_lane": "runtime.validate_local_full_runtime_live_contract_lane",
+        "command": [
+            "bash",
+            str(ROOT_DIR / "scripts/runtime/validate_local_full_runtime_live_contract_lane.sh"),
+            "--mode",
+            "dry-run",
+        ],
+        "success_marker": "local_full_runtime_policy_status=verified",
+        "failure_label": "local full-runtime convergence lane failed unexpectedly",
+    },
+    "transport_fault_matrix": {
+        "expected_lane": "runtime.validate_block_reconciliation_partition_rejoin_live_contract_lane",
+        "command": [
+            "bash",
+            str(
+                ROOT_DIR
+                / "scripts/runtime/validate_block_reconciliation_partition_rejoin_live_contract_lane.sh"
+            ),
+            "--mode",
+            "dry-run",
+        ],
+        "success_marker": "block_reconciliation_partition_rejoin_policy_status=verified",
+        "failure_label": "transport fault-matrix lane failed unexpectedly",
     },
 }
 
@@ -464,6 +491,12 @@ def run_go_no_go_gate_lane(args: argparse.Namespace) -> int:
         "local_full_stack_integration_status": "verified"
         if lane_mode == "run"
         else "dry_run_pending",
+        "local_full_runtime_convergence_status": "verified"
+        if lane_mode == "run"
+        else "dry_run_pending",
+        "transport_fault_matrix_status": "verified"
+        if lane_mode == "run"
+        else "dry_run_pending",
         "policy_evaluator_status": "verified",
         "manifest_schema_version": manifest_payload["schema_version"],
         "manifest_registry_status": "verified",
@@ -503,11 +536,15 @@ def run_go_no_go_gate_lane(args: argparse.Namespace) -> int:
         print("rollback_readiness_status=verified")
         print("dr_readiness_status=verified")
         print("local_full_stack_integration_status=verified")
+        print("local_full_runtime_convergence_status=verified")
+        print("transport_fault_matrix_status=verified")
     else:
         print("go_no_go_evidence_status=dry_run_pending")
         print("rollback_readiness_status=dry_run_pending")
         print("dr_readiness_status=dry_run_pending")
         print("local_full_stack_integration_status=dry_run_pending")
+        print("local_full_runtime_convergence_status=dry_run_pending")
+        print("transport_fault_matrix_status=dry_run_pending")
     print("policy_evaluator_status=verified")
     print(f"manifest_schema_version={manifest_payload['schema_version']}")
     print(f"reason_taxonomy_version={GO_NO_GO_REASON_TAXONOMY_VERSION}")

--- a/scripts/runtime/release_evidence_manifest.json
+++ b/scripts/runtime/release_evidence_manifest.json
@@ -21,6 +21,16 @@
       "artifact_id": "local_full_stack_integration",
       "expected_lane": "runtime.validate_local_full_stack_integration_live_contract_lane",
       "expected_success_marker": "local_full_stack_integration_policy_status=verified"
+    },
+    {
+      "artifact_id": "local_full_runtime_convergence",
+      "expected_lane": "runtime.validate_local_full_runtime_live_contract_lane",
+      "expected_success_marker": "local_full_runtime_policy_status=verified"
+    },
+    {
+      "artifact_id": "transport_fault_matrix",
+      "expected_lane": "runtime.validate_block_reconciliation_partition_rejoin_live_contract_lane",
+      "expected_success_marker": "block_reconciliation_partition_rejoin_policy_status=verified"
     }
   ]
 }

--- a/scripts/runtime/test_run_go_no_go_gate_lane.sh
+++ b/scripts/runtime/test_run_go_no_go_gate_lane.sh
@@ -90,6 +90,14 @@ if ! printf '%s\n' "$lane_output" | grep -q '^local_full_stack_integration_statu
   echo "expected go/no-go gate lane dry-run local full-stack integration status marker" >&2
   exit 1
 fi
+if ! printf '%s\n' "$lane_output" | grep -q '^local_full_runtime_convergence_status=dry_run_pending$'; then
+  echo "expected go/no-go gate lane dry-run local full-runtime convergence status marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$lane_output" | grep -q '^transport_fault_matrix_status=dry_run_pending$'; then
+  echo "expected go/no-go gate lane dry-run transport fault-matrix status marker" >&2
+  exit 1
+fi
 if ! printf '%s\n' "$lane_output" | grep -q '^policy_evaluator_status=verified$'; then
   echo "expected go/no-go gate lane policy evaluator status marker" >&2
   exit 1
@@ -161,6 +169,10 @@ if payload.get("dr_readiness_status") != "dry_run_pending":
     raise SystemExit("expected dr_readiness_status=dry_run_pending")
 if payload.get("local_full_stack_integration_status") != "dry_run_pending":
     raise SystemExit("expected local_full_stack_integration_status=dry_run_pending")
+if payload.get("local_full_runtime_convergence_status") != "dry_run_pending":
+    raise SystemExit("expected local_full_runtime_convergence_status=dry_run_pending")
+if payload.get("transport_fault_matrix_status") != "dry_run_pending":
+    raise SystemExit("expected transport_fault_matrix_status=dry_run_pending")
 if payload.get("policy_evaluator_status") != "verified":
     raise SystemExit("expected policy_evaluator_status=verified")
 if payload.get("manifest_schema_version") != "kamn.runtime.release-evidence-manifest.v1":
@@ -168,13 +180,22 @@ if payload.get("manifest_schema_version") != "kamn.runtime.release-evidence-mani
 if payload.get("manifest_registry_status") != "verified":
     raise SystemExit("expected manifest_registry_status=verified")
 inventory = payload.get("artifact_inventory")
-if not isinstance(inventory, list) or len(inventory) != 4:
-    raise SystemExit("expected deterministic artifact inventory list with four required entries")
+if not isinstance(inventory, list) or len(inventory) != 6:
+    raise SystemExit("expected deterministic artifact inventory list with six required entries")
 required_ids = payload.get("required_artifact_ids")
 if not isinstance(required_ids, list) or sorted(required_ids) != sorted(
-    ["go_no_go_evidence", "rollback_readiness", "dr_readiness", "local_full_stack_integration"]
+    [
+        "go_no_go_evidence",
+        "rollback_readiness",
+        "dr_readiness",
+        "local_full_stack_integration",
+        "local_full_runtime_convergence",
+        "transport_fault_matrix",
+    ]
 ):
-    raise SystemExit("expected required_artifact_ids to include local_full_stack_integration")
+    raise SystemExit(
+        "expected required_artifact_ids to include local_full_stack_integration, local_full_runtime_convergence, and transport_fault_matrix"
+    )
 for entry in inventory:
     if not isinstance(entry, dict):
         raise SystemExit("artifact inventory entry must be an object")
@@ -234,6 +255,14 @@ if ! printf '%s\n' "$run_mode_output" | grep -q '^local_full_stack_integration_s
   echo "expected go/no-go gate lane run-mode local full-stack integration status marker" >&2
   exit 1
 fi
+if ! printf '%s\n' "$run_mode_output" | grep -q '^local_full_runtime_convergence_status=verified$'; then
+  echo "expected go/no-go gate lane run-mode local full-runtime convergence status marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$run_mode_output" | grep -q '^transport_fault_matrix_status=verified$'; then
+  echo "expected go/no-go gate lane run-mode transport fault-matrix status marker" >&2
+  exit 1
+fi
 if ! printf '%s\n' "$run_mode_output" | grep -q '^ci_fast_gate_eligible=false$'; then
   echo "expected go/no-go gate lane run-mode fast-gate exclusion marker" >&2
   exit 1
@@ -281,11 +310,24 @@ if payload.get("dr_readiness_status") != "verified":
     raise SystemExit("expected dr_readiness_status=verified in run-mode go/no-go gate report")
 if payload.get("local_full_stack_integration_status") != "verified":
     raise SystemExit("expected local_full_stack_integration_status=verified in run-mode go/no-go gate report")
+if payload.get("local_full_runtime_convergence_status") != "verified":
+    raise SystemExit("expected local_full_runtime_convergence_status=verified in run-mode go/no-go gate report")
+if payload.get("transport_fault_matrix_status") != "verified":
+    raise SystemExit("expected transport_fault_matrix_status=verified in run-mode go/no-go gate report")
 required_ids = payload.get("required_artifact_ids")
 if not isinstance(required_ids, list) or sorted(required_ids) != sorted(
-    ["go_no_go_evidence", "rollback_readiness", "dr_readiness", "local_full_stack_integration"]
+    [
+        "go_no_go_evidence",
+        "rollback_readiness",
+        "dr_readiness",
+        "local_full_stack_integration",
+        "local_full_runtime_convergence",
+        "transport_fault_matrix",
+    ]
 ):
-    raise SystemExit("expected run-mode required_artifact_ids to include local_full_stack_integration")
+    raise SystemExit(
+        "expected run-mode required_artifact_ids to include local_full_stack_integration, local_full_runtime_convergence, and transport_fault_matrix"
+    )
 PY
 
 set +e


### PR DESCRIPTION
Closes #3448

## Summary
Gate release go/no-go decisions on transport-fed convergence evidence by extending the release manifest and go/no-go evaluator to require and verify transport convergence + fault-matrix artifacts, while preserving local-only run-mode cost controls.

## Changes
- `scripts/runtime/go_no_go_gate_lane_contract.py`: expanded required artifact registry with:
  - `local_full_runtime_convergence` via `validate_local_full_runtime_live_contract_lane.sh --mode dry-run`
  - `transport_fault_matrix` via `validate_block_reconciliation_partition_rejoin_live_contract_lane.sh --mode dry-run`
  and emitted corresponding status markers in dry-run/run modes.
- `scripts/runtime/release_evidence_manifest.json`: added required artifact entries for transport-fed convergence and fault-matrix evidence.
- `scripts/runtime/test_run_go_no_go_gate_lane.sh`: extended baseline/run-mode assertions and inventory/required-artifact checks for the new artifact requirements.
- `docs/ci/strategy.md`: updated release evidence manifest artifact matrix.
- `docs/planning/kolme-devnet-ops.md`: updated operator linkage to include go/no-go consumption of transport convergence + fault matrix evidence and explicit run-mode command.
- `docs/plans/2026-02-14-production-service-next-steps.md`: updated Item 4 open-chain progression and remaining status.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command (running updated go/no-go contract test against pre-change implementation):
`bash scripts/runtime/test_run_go_no_go_gate_lane.sh`

Failing output excerpt:
- `expected go/no-go gate lane dry-run local full-runtime convergence status marker`

### 🟢 Green Phase
Command:
`bash scripts/runtime/test_run_go_no_go_gate_lane.sh`

Passing output summary:
- `go/no-go gate lane script tests passed.`

### 🔁 Regression
Commands:
- `cargo test -p kamn-core --test ci_strategy_docs`
- `cargo test -p kamn-core --test kolme_devnet_ops_docs`
- `bash scripts/ci/test_production_service_next_steps_contract.sh`
- `cargo fmt --all --check`

Result summary:
- all commands passed.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified                                                                 | Justification if N/A |
|--------------|--------|---------------------------------------------------------------------------------------|----------------------|
| Unit         | ✅     | go/no-go artifact inventory/required-id assertions and manifest contract checks in `test_run_go_no_go_gate_lane.sh` |                      |
| Functional   | ✅     | dry-run/run-mode go/no-go lane status marker validation for new artifacts            |                      |
| Integration  | ✅     | run-mode go/no-go lane consumes local full-runtime and block reconciliation contract lanes as release artifacts |                      |
| Regression   | ✅     | tampered manifest + waiver + fault-profile fail-closed checks retained and validated |                      |
| Performance  | ✅     | bounded lane budget guard behavior remains covered via go/no-go max-seconds policy paths |                      |

## Risks & Rollback
- Breaking changes: None.
- Rollback plan: revert commit `5ea595d`.

## Documentation Updates
- `docs/ci/strategy.md`
- `docs/planning/kolme-devnet-ops.md`
- `docs/plans/2026-02-14-production-service-next-steps.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (not required for this script/doc-only slice)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (relevant scope)
- [x] Docs updated (or justified why not)
