### PR TITLE
refactor(runtime): consolidate service API contract-lane wrappers

### DIFF
--- a/docs/ci/ci-cost-and-lane-framework.md
+++ b/docs/ci/ci-cost-and-lane-framework.md
@@ -267,6 +267,18 @@ The checker also computes per-PR deltas against `.ci/script-surface-baseline.env
 
 The checker fails closed when any metric exceeds its configured threshold and emits deterministic remediation guidance.
 
+## Post-Waiver Tranche-2 Snapshot (`#3449`)
+- Migrated the highest-LOC non-Kolme service-api contract-lane wrapper family (`axum_ingress`, `reason_code_compatibility`, `serde_payload_parity`) to a shared runner:
+  - `scripts/runtime/service_api_contract_lane_runner.sh`
+- Command-surface compatibility is preserved by keeping existing wrapper entrypoints:
+  - `scripts/runtime/validate_service_api_axum_ingress_live_contract_lane.sh`
+  - `scripts/runtime/validate_service_api_reason_code_compatibility_live_contract_lane.sh`
+  - `scripts/runtime/validate_service_api_serde_payload_parity_live_contract_lane.sh`
+- Latest local budget evidence after migration:
+  - `shell_line_total=31253` (down from `31599`)
+  - `script_count=381`
+  - `violations=none`
+
 ## Waiver Rules
 Temporary exceptions are allowed through `.ci/script-surface-budget-waiver.json`.
 Required fields:

--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -503,6 +503,7 @@ Versioned thresholds are defined in `.ci/ci-budget.env`.
 - local-dev mode: local
 - manual-hardened mode: manual
 - Cost controls:
+  - lane orchestration is centralized in `scripts/runtime/service_api_contract_lane_runner.sh`; wrapper entrypoints remain stable for command-surface compatibility.
   - uses only localhost process-level probes against `runtime-mode api`.
   - no external Kolme node, remote service, or internet dependency.
   - ingress limit config matrix defaults remain parity-checked against source constants and API docs (`api_max_requests_default=1`, `api_idle_timeout_default_ms=5000`, `body_size_limit_bytes=65536`, `api_concurrency_limit_default=32`, `api_rate_limit_per_second_default=120`).
@@ -523,6 +524,7 @@ Versioned thresholds are defined in `.ci/ci-budget.env`.
 - local-dev mode: local
 - manual-hardened mode: manual
 - Cost controls:
+  - lane orchestration is centralized in `scripts/runtime/service_api_contract_lane_runner.sh`; wrapper entrypoints remain stable for command-surface compatibility.
   - bounded to three targeted `kamn-node` serde payload tests.
   - source-marker checks run locally and avoid external network dependencies.
   - runtime budget is bounded via `KAMN_SERVICE_API_SERDE_PAYLOAD_CONTRACT_MAX_SECONDS`.
@@ -541,6 +543,7 @@ Versioned thresholds are defined in `.ci/ci-budget.env`.
 - local-dev mode: local
 - manual-hardened mode: manual
 - Cost controls:
+  - lane orchestration is centralized in `scripts/runtime/service_api_contract_lane_runner.sh`; wrapper entrypoints remain stable for command-surface compatibility.
   - bounded to seven targeted local-only checks (five `kamn-node` contract tests + one Rust SDK regression + one Python SDK regression).
   - source-marker checks run locally and avoid external network dependencies.
   - includes SDK parity marker checks for structured envelope decoding in `crates/kamn-sdk/src/service.rs` and `kamn_sdk.py`.

--- a/scripts/runtime/service_api_contract_lane_runner.sh
+++ b/scripts/runtime/service_api_contract_lane_runner.sh
@@ -1,0 +1,316 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+require_env_var() {
+  local var_name="$1"
+  if [[ -z "${!var_name:-}" ]]; then
+    echo "missing required lane configuration variable: $var_name" >&2
+    exit 1
+  fi
+}
+
+service_api_contract_lane_run() {
+  require_env_var "ROOT_DIR"
+  require_env_var "LANE_LABEL"
+  require_env_var "LANE_SLUG"
+  require_env_var "VALIDATION_SCRIPT"
+  require_env_var "POLICY_CHECKER"
+  require_env_var "STRATEGY_DOC"
+  require_env_var "ROADMAP_DOC"
+  require_env_var "MAX_SECONDS_ENV"
+  require_env_var "MAX_SECONDS_DEFAULT"
+  require_env_var "CONTRACT_STATUS_KEY"
+  require_env_var "POLICY_STATUS_KEY"
+  require_env_var "SUMMARY_SCHEMA"
+  require_env_var "POLICY_SCHEMA"
+  require_env_var "LANE_REPORT_SCHEMA"
+  require_env_var "TAMPER_FIELD"
+  require_env_var "TAMPER_REASON_CODE"
+  require_env_var "ROADMAP_TASK_MARKER"
+  require_env_var "ROADMAP_CONTRACT_SCRIPT_REF"
+  require_env_var "ROADMAP_POLICY_SCRIPT_REF"
+
+  local output_json=""
+  local policy_output_json=""
+  local max_seconds
+  local ci_fast_gate="PASS"
+  local allow_mode="${ALLOW_MODE:-0}"
+  local mode="${DEFAULT_MODE:-dry-run}"
+
+  # shellcheck disable=SC2086
+  max_seconds="${!MAX_SECONDS_ENV:-$MAX_SECONDS_DEFAULT}"
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --output-json)
+        output_json="${2:-}"
+        shift 2
+        ;;
+      --policy-output-json)
+        policy_output_json="${2:-}"
+        shift 2
+        ;;
+      --max-seconds)
+        max_seconds="${2:-}"
+        shift 2
+        ;;
+      --ci-fast-gate)
+        ci_fast_gate="${2:-}"
+        shift 2
+        ;;
+      --mode)
+        if [[ "$allow_mode" != "1" ]]; then
+          echo "unknown argument: --mode" >&2
+          exit 1
+        fi
+        mode="${2:-}"
+        shift 2
+        ;;
+      *)
+        echo "unknown argument: $1" >&2
+        exit 1
+        ;;
+    esac
+  done
+
+  if ! [[ "$max_seconds" =~ ^[0-9]+$ ]]; then
+    echo "max-seconds must be an integer" >&2
+    exit 1
+  fi
+  if (( max_seconds <= 0 )); then
+    echo "max-seconds must be greater than zero" >&2
+    exit 1
+  fi
+  if [[ "$ci_fast_gate" != "PASS" && "$ci_fast_gate" != "FAIL" ]]; then
+    echo "ci-fast-gate must be PASS or FAIL" >&2
+    exit 1
+  fi
+  if [[ "$allow_mode" == "1" && "$mode" != "dry-run" && "$mode" != "run" ]]; then
+    echo "mode must be dry-run or run" >&2
+    exit 1
+  fi
+
+  local required_exec
+  for required_exec in "$VALIDATION_SCRIPT" "$POLICY_CHECKER"; do
+    if [[ ! -x "$required_exec" ]]; then
+      echo "expected required executable script '$required_exec'" >&2
+      exit 1
+    fi
+  done
+
+  local required_doc
+  for required_doc in "$STRATEGY_DOC" "$ROADMAP_DOC"; do
+    if [[ ! -f "$required_doc" ]]; then
+      echo "expected required documentation file '$required_doc'" >&2
+      exit 1
+    fi
+  done
+
+  local start_epoch
+  start_epoch="$(date +%s)"
+  local tmp_dir
+  tmp_dir="$(mktemp -d)"
+  trap "rm -rf '$tmp_dir'" EXIT
+
+  local summary_report="$tmp_dir/${LANE_SLUG}-summary.json"
+  local policy_report="$tmp_dir/${LANE_SLUG}-policy.json"
+  local tampered_report="$tmp_dir/${LANE_SLUG}-summary.tampered.json"
+
+  local -a validation_cmd=(bash "$VALIDATION_SCRIPT" --output-json "$summary_report" --max-seconds "$max_seconds")
+  if [[ "$allow_mode" == "1" ]]; then
+    validation_cmd+=(--mode "$mode")
+  fi
+
+  local validation_output
+  validation_output="$("${validation_cmd[@]}")"
+
+  local marker
+  for marker in "${VALIDATION_REQUIRED_MARKERS[@]}"; do
+    if ! printf '%s\n' "$validation_output" | grep -q "^${marker}$"; then
+      echo "expected ${LANE_LABEL} validation marker ${marker}" >&2
+      exit 1
+    fi
+  done
+
+  local regex_marker
+  for regex_marker in "${VALIDATION_REQUIRED_REGEX_MARKERS[@]}"; do
+    if ! printf '%s\n' "$validation_output" | grep -Eq "$regex_marker"; then
+      echo "expected ${LANE_LABEL} validation regex marker ${regex_marker}" >&2
+      exit 1
+    fi
+  done
+
+  local policy_output
+  policy_output="$(
+    bash "$POLICY_CHECKER" \
+      --report-file "$summary_report" \
+      --expected-final-decision GO \
+      --ci-fast-gate "$ci_fast_gate" \
+      --output-json "$policy_report"
+  )"
+
+  for marker in "${POLICY_REQUIRED_MARKERS[@]}"; do
+    if ! printf '%s\n' "$policy_output" | grep -q "^${marker}$"; then
+      echo "expected ${LANE_LABEL} policy marker ${marker}" >&2
+      exit 1
+    fi
+  done
+
+  cp "$summary_report" "$tampered_report"
+  python3 - "$tampered_report" "$TAMPER_FIELD" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+field = sys.argv[2]
+payload = json.loads(path.read_text(encoding="utf-8"))
+payload[field] = "missing"
+path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+  set +e
+  local tampered_policy_output
+  tampered_policy_output="$(
+    bash "$POLICY_CHECKER" \
+      --report-file "$tampered_report" \
+      --expected-final-decision GO \
+      --ci-fast-gate "$ci_fast_gate" \
+      --output-json "$tmp_dir/${LANE_SLUG}-policy.tampered.json" 2>&1
+  )"
+  local tampered_policy_code=$?
+  set -e
+
+  if [[ "$tampered_policy_code" -eq 0 ]]; then
+    echo "expected tampered ${LANE_LABEL} report to fail policy validation" >&2
+    exit 1
+  fi
+  if ! printf '%s\n' "$tampered_policy_output" | grep -q "$TAMPER_REASON_CODE"; then
+    echo "expected deterministic fail-closed reason for tampered ${LANE_LABEL} report" >&2
+    exit 1
+  fi
+
+  local required_ref
+  for required_ref in "${STRATEGY_REQUIRED_REFS[@]}"; do
+    if ! grep -q "$required_ref" "$STRATEGY_DOC"; then
+      echo "expected CI strategy docs to reference ${required_ref}" >&2
+      exit 1
+    fi
+  done
+
+  local required_marker
+  for required_marker in "${STRATEGY_REQUIRED_MARKERS[@]}"; do
+    if ! grep -q "$required_marker" "$STRATEGY_DOC"; then
+      echo "expected CI strategy docs to include marker: ${required_marker}" >&2
+      exit 1
+    fi
+  done
+
+  if ! grep -q "$ROADMAP_TASK_MARKER" "$ROADMAP_DOC"; then
+    echo "expected roadmap marker ${ROADMAP_TASK_MARKER}" >&2
+    exit 1
+  fi
+  if ! grep -q "$ROADMAP_CONTRACT_SCRIPT_REF" "$ROADMAP_DOC"; then
+    echo "expected roadmap to reference ${ROADMAP_CONTRACT_SCRIPT_REF}" >&2
+    exit 1
+  fi
+  if ! grep -q "$ROADMAP_POLICY_SCRIPT_REF" "$ROADMAP_DOC"; then
+    echo "expected roadmap to reference ${ROADMAP_POLICY_SCRIPT_REF}" >&2
+    exit 1
+  fi
+
+  local elapsed_seconds
+  elapsed_seconds="$(( $(date +%s) - start_epoch ))"
+  if (( elapsed_seconds > max_seconds )); then
+    echo "${LANE_LABEL} contract lane exceeded runtime budget: ${elapsed_seconds}s" >&2
+    exit 1
+  fi
+
+  local lane_report="$tmp_dir/${LANE_SLUG}-contract-lane-report.json"
+  python3 - \
+    "$summary_report" \
+    "$policy_report" \
+    "$lane_report" \
+    "$elapsed_seconds" \
+    "$max_seconds" \
+    "$SUMMARY_SCHEMA" \
+    "$POLICY_SCHEMA" \
+    "$LANE_REPORT_SCHEMA" \
+    "$CONTRACT_STATUS_KEY" \
+    "$POLICY_STATUS_KEY" \
+    "$TAMPER_REASON_CODE" \
+    "${LANE_REPORT_SUMMARY_FIELDS[@]}" <<'PY'
+import json
+import pathlib
+import sys
+
+summary_report = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+policy_report = json.loads(pathlib.Path(sys.argv[2]).read_text(encoding="utf-8"))
+lane_report_file = pathlib.Path(sys.argv[3])
+elapsed_seconds = int(sys.argv[4])
+max_seconds = int(sys.argv[5])
+summary_schema = sys.argv[6]
+policy_schema = sys.argv[7]
+lane_report_schema = sys.argv[8]
+contract_status_key = sys.argv[9]
+policy_status_key = sys.argv[10]
+tamper_reason = sys.argv[11]
+summary_fields = sys.argv[12:]
+
+if summary_report.get("schema_version") != summary_schema:
+    raise SystemExit(f"unexpected summary schema: {summary_report.get('schema_version')}")
+if policy_report.get("schema_version") != policy_schema:
+    raise SystemExit(f"unexpected policy schema: {policy_report.get('schema_version')}")
+if summary_report.get("final_decision") != "GO":
+    raise SystemExit("expected summary final_decision=GO")
+if policy_report.get("final_decision") != "GO":
+    raise SystemExit("expected policy final_decision=GO")
+
+lane_report = {
+    "schema_version": lane_report_schema,
+    "status": "pass",
+    "final_decision": "GO",
+    contract_status_key: "verified",
+    policy_status_key: policy_report.get(policy_status_key),
+    "docs_contract_status": "verified",
+    "fail_closed_status": "verified",
+    "fail_closed_reason_code": tamper_reason,
+    "performance_budget_status": "verified",
+    "elapsed_seconds": elapsed_seconds,
+    "max_seconds": max_seconds,
+}
+for field in summary_fields:
+    lane_report[field] = summary_report.get(field)
+
+lane_report_file.write_text(json.dumps(lane_report, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+  if [[ -n "$output_json" ]]; then
+    cp "$lane_report" "$output_json"
+  fi
+  if [[ -n "$policy_output_json" ]]; then
+    cp "$policy_report" "$policy_output_json"
+  fi
+
+  echo "status=pass"
+  echo "final_decision=GO"
+  echo "${CONTRACT_STATUS_KEY}=verified"
+  echo "${POLICY_STATUS_KEY}=verified"
+
+  if (( ${#OUTPUT_SUMMARY_FIELDS[@]} > 0 )); then
+    python3 - "$summary_report" "${OUTPUT_SUMMARY_FIELDS[@]}" <<'PY'
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+for key in sys.argv[2:]:
+    print(f"{key}={payload.get(key, 0)}")
+PY
+  fi
+
+  echo "docs_contract_status=verified"
+  echo "fail_closed_status=verified"
+  echo "fail_closed_reason_code=${TAMPER_REASON_CODE}"
+  echo "performance_budget_status=verified"
+}

--- a/scripts/runtime/validate_service_api_axum_ingress_live_contract_lane.sh
+++ b/scripts/runtime/validate_service_api_axum_ingress_live_contract_lane.sh
@@ -2,333 +2,80 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# Shared runner for service-api contract lanes.
+source "$ROOT_DIR/scripts/runtime/service_api_contract_lane_runner.sh"
+
 VALIDATION_SCRIPT="$ROOT_DIR/scripts/runtime/validate_service_api_axum_ingress_live.sh"
 POLICY_CHECKER="$ROOT_DIR/scripts/runtime/check_service_api_axum_ingress_live_policy.sh"
 STRATEGY_DOC="$ROOT_DIR/docs/ci/strategy.md"
 ROADMAP_DOC="$ROOT_DIR/docs/plans/2026-02-08-production-service-roadmap.md"
 
-output_json=""
-policy_output_json=""
-max_seconds="${KAMN_SERVICE_API_AXUM_INGRESS_CONTRACT_MAX_SECONDS:-180}"
-ci_fast_gate="PASS"
+LANE_LABEL="service api axum ingress"
+LANE_SLUG="service-api-axum-ingress-live"
+MAX_SECONDS_ENV="KAMN_SERVICE_API_AXUM_INGRESS_CONTRACT_MAX_SECONDS"
+MAX_SECONDS_DEFAULT="180"
+CONTRACT_STATUS_KEY="service_api_axum_ingress_contract_status"
+POLICY_STATUS_KEY="service_api_axum_ingress_policy_status"
+SUMMARY_SCHEMA="kamn.runtime.service-api-axum-ingress-live-validation.v1"
+POLICY_SCHEMA="kamn.runtime.service-api-axum-ingress-live-policy-report.v1"
+LANE_REPORT_SCHEMA="kamn.runtime.service-api-axum-ingress-live-contract-lane-report.v1"
+TAMPER_FIELD="concurrency_status"
+TAMPER_REASON_CODE="service_api_axum_policy_marker_missing:concurrency_status"
+ROADMAP_TASK_MARKER="Task #3308"
+ROADMAP_CONTRACT_SCRIPT_REF="scripts/runtime/validate_service_api_axum_ingress_live_contract_lane.sh"
+ROADMAP_POLICY_SCRIPT_REF="scripts/runtime/check_service_api_axum_ingress_live_policy.sh"
+ALLOW_MODE="0"
 
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    --output-json)
-      output_json="${2:-}"
-      shift 2
-      ;;
-    --policy-output-json)
-      policy_output_json="${2:-}"
-      shift 2
-      ;;
-    --max-seconds)
-      max_seconds="${2:-}"
-      shift 2
-      ;;
-    --ci-fast-gate)
-      ci_fast_gate="${2:-}"
-      shift 2
-      ;;
-    *)
-      echo "unknown argument: $1" >&2
-      exit 1
-      ;;
-  esac
-done
+VALIDATION_REQUIRED_MARKERS=(
+  "status=pass"
+  "final_decision=GO"
+  "keep_alive_status=verified"
+  "body_size_guard_status=verified"
+  "concurrency_status=verified"
+  "websocket_status=verified"
+  "ingress_limit_config_status=verified"
+  "docs_ingress_limit_matrix_status=verified"
+)
+VALIDATION_REQUIRED_REGEX_MARKERS=(
+  '^api_max_requests_default=[1-9][0-9]*$'
+  '^api_idle_timeout_default_ms=[1-9][0-9]*$'
+  '^body_size_limit_bytes=[1-9][0-9]*$'
+  '^api_concurrency_limit_default=[1-9][0-9]*$'
+  '^api_rate_limit_per_second_default=[1-9][0-9]*$'
+)
+POLICY_REQUIRED_MARKERS=(
+  "status=ok"
+  "final_decision=GO"
+  "service_api_axum_ingress_policy_status=verified"
+)
+STRATEGY_REQUIRED_REFS=(
+  "validate_service_api_axum_ingress_live.sh"
+  "check_service_api_axum_ingress_live_policy.sh"
+  "validate_service_api_axum_ingress_live_contract_lane.sh"
+  "test_validate_service_api_axum_ingress_live_contract_lane.sh"
+  "test_check_service_api_axum_ingress_live_policy.sh"
+)
+STRATEGY_REQUIRED_MARKERS=(
+  "service api axum ingress run-mode commands remain excluded from ci-fast-gate and ci-tools fast mode."
+  "ingress limit config matrix defaults remain parity-checked against source constants and API docs"
+)
+LANE_REPORT_SUMMARY_FIELDS=(
+  ingress_limit_config_status
+  docs_ingress_limit_matrix_status
+  api_max_requests_default
+  api_idle_timeout_default_ms
+  body_size_limit_bytes
+  api_concurrency_limit_default
+  api_rate_limit_per_second_default
+)
+OUTPUT_SUMMARY_FIELDS=(
+  ingress_limit_config_status
+  docs_ingress_limit_matrix_status
+  api_max_requests_default
+  api_idle_timeout_default_ms
+  body_size_limit_bytes
+  api_concurrency_limit_default
+  api_rate_limit_per_second_default
+)
 
-if ! [[ "$max_seconds" =~ ^[0-9]+$ ]]; then
-  echo "max-seconds must be an integer" >&2
-  exit 1
-fi
-if [ "$max_seconds" -le 0 ]; then
-  echo "max-seconds must be greater than zero" >&2
-  exit 1
-fi
-if [[ "$ci_fast_gate" != "PASS" && "$ci_fast_gate" != "FAIL" ]]; then
-  echo "ci-fast-gate must be PASS or FAIL" >&2
-  exit 1
-fi
-
-for required_exec in "$VALIDATION_SCRIPT" "$POLICY_CHECKER"; do
-  if [ ! -x "$required_exec" ]; then
-    echo "expected required executable script '$required_exec'" >&2
-    exit 1
-  fi
-done
-for required_doc in "$STRATEGY_DOC" "$ROADMAP_DOC"; do
-  if [ ! -f "$required_doc" ]; then
-    echo "expected required documentation file '$required_doc'" >&2
-    exit 1
-  fi
-done
-
-start_epoch="$(date +%s)"
-TMP_DIR="$(mktemp -d)"
-trap 'rm -rf "$TMP_DIR"' EXIT
-
-summary_report="$TMP_DIR/service-api-axum-ingress-live-summary.json"
-policy_report="$TMP_DIR/service-api-axum-ingress-live-policy.json"
-tampered_report="$TMP_DIR/service-api-axum-ingress-live-summary.tampered.json"
-
-validation_output="$(
-  bash "$VALIDATION_SCRIPT" \
-    --output-json "$summary_report" \
-    --max-seconds "$max_seconds"
-)"
-if ! printf '%s\n' "$validation_output" | grep -q '^status=pass$'; then
-  echo "expected service api axum ingress live validation status=pass marker" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$validation_output" | grep -q '^final_decision=GO$'; then
-  echo "expected service api axum ingress live validation final_decision=GO marker" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$validation_output" | grep -q '^keep_alive_status=verified$'; then
-  echo "expected service api axum ingress keep-alive marker" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$validation_output" | grep -q '^body_size_guard_status=verified$'; then
-  echo "expected service api axum ingress body-size marker" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$validation_output" | grep -q '^concurrency_status=verified$'; then
-  echo "expected service api axum ingress concurrency marker" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$validation_output" | grep -q '^websocket_status=verified$'; then
-  echo "expected service api axum ingress websocket marker" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$validation_output" | grep -q '^ingress_limit_config_status=verified$'; then
-  echo "expected service api axum ingress config-matrix marker" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$validation_output" | grep -q '^docs_ingress_limit_matrix_status=verified$'; then
-  echo "expected service api axum ingress docs parity marker" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$validation_output" | grep -Eq '^api_max_requests_default=[1-9][0-9]*$'; then
-  echo "expected service api axum ingress max-requests default marker" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$validation_output" | grep -Eq '^api_idle_timeout_default_ms=[1-9][0-9]*$'; then
-  echo "expected service api axum ingress idle-timeout default marker" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$validation_output" | grep -Eq '^body_size_limit_bytes=[1-9][0-9]*$'; then
-  echo "expected service api axum ingress body-size limit marker" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$validation_output" | grep -Eq '^api_concurrency_limit_default=[1-9][0-9]*$'; then
-  echo "expected service api axum ingress concurrency-limit default marker" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$validation_output" | grep -Eq '^api_rate_limit_per_second_default=[1-9][0-9]*$'; then
-  echo "expected service api axum ingress rate-limit default marker" >&2
-  exit 1
-fi
-
-policy_output="$(
-  bash "$POLICY_CHECKER" \
-    --report-file "$summary_report" \
-    --expected-final-decision GO \
-    --ci-fast-gate "$ci_fast_gate" \
-    --output-json "$policy_report"
-)"
-if ! printf '%s\n' "$policy_output" | grep -q '^status=ok$'; then
-  echo "expected service api axum ingress policy checker status=ok marker" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$policy_output" | grep -q '^final_decision=GO$'; then
-  echo "expected service api axum ingress policy checker final_decision=GO marker" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$policy_output" | grep -q '^service_api_axum_ingress_policy_status=verified$'; then
-  echo "expected service api axum ingress policy checker status marker" >&2
-  exit 1
-fi
-
-cp "$summary_report" "$tampered_report"
-python3 - "$tampered_report" <<'PY'
-import json
-import pathlib
-import sys
-
-path = pathlib.Path(sys.argv[1])
-payload = json.loads(path.read_text(encoding="utf-8"))
-payload["concurrency_status"] = "missing"
-path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
-PY
-
-set +e
-tampered_policy_output="$(
-  bash "$POLICY_CHECKER" \
-    --report-file "$tampered_report" \
-    --expected-final-decision GO \
-    --ci-fast-gate "$ci_fast_gate" \
-    --output-json "$TMP_DIR/service-api-axum-ingress-live-policy.tampered.json" 2>&1
-)"
-tampered_policy_code=$?
-set -e
-
-if [ "$tampered_policy_code" -eq 0 ]; then
-  echo "expected tampered service api axum ingress report to fail policy validation" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$tampered_policy_output" | grep -q 'service_api_axum_policy_marker_missing:concurrency_status'; then
-  echo "expected deterministic fail-closed reason for tampered service api axum ingress report" >&2
-  exit 1
-fi
-
-for required_ref in \
-  "validate_service_api_axum_ingress_live.sh" \
-  "check_service_api_axum_ingress_live_policy.sh" \
-  "validate_service_api_axum_ingress_live_contract_lane.sh" \
-  "test_validate_service_api_axum_ingress_live_contract_lane.sh" \
-  "test_check_service_api_axum_ingress_live_policy.sh"; do
-  if ! grep -q "$required_ref" "$STRATEGY_DOC"; then
-    echo "expected CI strategy docs to reference $required_ref" >&2
-    exit 1
-  fi
-done
-if ! grep -q "service api axum ingress run-mode commands remain excluded from ci-fast-gate and ci-tools fast mode." "$STRATEGY_DOC"; then
-  echo "expected CI strategy docs to include service api axum ingress run-mode exclusion marker" >&2
-  exit 1
-fi
-if ! grep -q "ingress limit config matrix defaults remain parity-checked against source constants and API docs" "$STRATEGY_DOC"; then
-  echo "expected CI strategy docs to include ingress-limit config matrix parity marker" >&2
-  exit 1
-fi
-
-if ! grep -q "Task #3308" "$ROADMAP_DOC"; then
-  echo "expected roadmap marker for Task #3308" >&2
-  exit 1
-fi
-if ! grep -q "scripts/runtime/validate_service_api_axum_ingress_live_contract_lane.sh" "$ROADMAP_DOC"; then
-  echo "expected roadmap to reference service api axum ingress contract lane script" >&2
-  exit 1
-fi
-if ! grep -q "scripts/runtime/check_service_api_axum_ingress_live_policy.sh" "$ROADMAP_DOC"; then
-  echo "expected roadmap to reference service api axum ingress policy checker script" >&2
-  exit 1
-fi
-
-elapsed_seconds="$(( $(date +%s) - start_epoch ))"
-if [ "$elapsed_seconds" -gt "$max_seconds" ]; then
-  echo "service api axum ingress contract lane exceeded runtime budget: ${elapsed_seconds}s" >&2
-  exit 1
-fi
-
-lane_report="$TMP_DIR/service-api-axum-ingress-live-contract-lane-report.json"
-python3 - "$summary_report" "$policy_report" "$lane_report" "$elapsed_seconds" "$max_seconds" <<'PY'
-import json
-import pathlib
-import sys
-
-summary_report = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
-policy_report = json.loads(pathlib.Path(sys.argv[2]).read_text(encoding="utf-8"))
-lane_report_file = pathlib.Path(sys.argv[3])
-elapsed_seconds = int(sys.argv[4])
-max_seconds = int(sys.argv[5])
-
-if summary_report.get("schema_version") != "kamn.runtime.service-api-axum-ingress-live-validation.v1":
-    raise SystemExit("unexpected service api axum ingress live summary schema")
-if policy_report.get("schema_version") != "kamn.runtime.service-api-axum-ingress-live-policy-report.v1":
-    raise SystemExit("unexpected service api axum ingress live policy schema")
-if summary_report.get("final_decision") != "GO":
-    raise SystemExit("expected service api axum ingress summary final_decision=GO")
-if policy_report.get("final_decision") != "GO":
-    raise SystemExit("expected service api axum ingress policy final_decision=GO")
-
-lane_report = {
-    "schema_version": "kamn.runtime.service-api-axum-ingress-live-contract-lane-report.v1",
-    "status": "pass",
-    "final_decision": "GO",
-    "service_api_axum_ingress_contract_status": "verified",
-    "service_api_axum_ingress_policy_status": policy_report.get(
-        "service_api_axum_ingress_policy_status"
-    ),
-    "ingress_limit_config_status": summary_report.get("ingress_limit_config_status"),
-    "docs_ingress_limit_matrix_status": summary_report.get(
-        "docs_ingress_limit_matrix_status"
-    ),
-    "api_max_requests_default": summary_report.get("api_max_requests_default"),
-    "api_idle_timeout_default_ms": summary_report.get("api_idle_timeout_default_ms"),
-    "body_size_limit_bytes": summary_report.get("body_size_limit_bytes"),
-    "api_concurrency_limit_default": summary_report.get("api_concurrency_limit_default"),
-    "api_rate_limit_per_second_default": summary_report.get(
-        "api_rate_limit_per_second_default"
-    ),
-    "docs_contract_status": "verified",
-    "fail_closed_status": "verified",
-    "fail_closed_reason_code": "service_api_axum_policy_marker_missing:concurrency_status",
-    "performance_budget_status": "verified",
-    "elapsed_seconds": elapsed_seconds,
-    "max_seconds": max_seconds,
-}
-lane_report_file.write_text(json.dumps(lane_report, sort_keys=True, indent=2) + "\n", encoding="utf-8")
-PY
-
-if [[ -n "$output_json" ]]; then
-  cp "$lane_report" "$output_json"
-fi
-if [[ -n "$policy_output_json" ]]; then
-  cp "$policy_report" "$policy_output_json"
-fi
-
-echo "status=pass"
-echo "final_decision=GO"
-echo "service_api_axum_ingress_contract_status=verified"
-echo "service_api_axum_ingress_policy_status=verified"
-echo "ingress_limit_config_status=verified"
-echo "docs_ingress_limit_matrix_status=verified"
-echo "api_max_requests_default=$(python3 - "$summary_report" <<'PY'
-import json
-import pathlib
-import sys
-
-payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
-print(payload.get("api_max_requests_default", 0))
-PY
-)"
-echo "api_idle_timeout_default_ms=$(python3 - "$summary_report" <<'PY'
-import json
-import pathlib
-import sys
-
-payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
-print(payload.get("api_idle_timeout_default_ms", 0))
-PY
-)"
-echo "body_size_limit_bytes=$(python3 - "$summary_report" <<'PY'
-import json
-import pathlib
-import sys
-
-payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
-print(payload.get("body_size_limit_bytes", 0))
-PY
-)"
-echo "api_concurrency_limit_default=$(python3 - "$summary_report" <<'PY'
-import json
-import pathlib
-import sys
-
-payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
-print(payload.get("api_concurrency_limit_default", 0))
-PY
-)"
-echo "api_rate_limit_per_second_default=$(python3 - "$summary_report" <<'PY'
-import json
-import pathlib
-import sys
-
-payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
-print(payload.get("api_rate_limit_per_second_default", 0))
-PY
-)"
-echo "docs_contract_status=verified"
-echo "fail_closed_status=verified"
-echo "fail_closed_reason_code=service_api_axum_policy_marker_missing:concurrency_status"
-echo "performance_budget_status=verified"
+service_api_contract_lane_run "$@"

--- a/scripts/runtime/validate_service_api_reason_code_compatibility_live_contract_lane.sh
+++ b/scripts/runtime/validate_service_api_reason_code_compatibility_live_contract_lane.sh
@@ -2,295 +2,77 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# Shared runner for service-api contract lanes.
+source "$ROOT_DIR/scripts/runtime/service_api_contract_lane_runner.sh"
+
 VALIDATION_SCRIPT="$ROOT_DIR/scripts/runtime/validate_service_api_reason_code_compatibility_live.sh"
 POLICY_CHECKER="$ROOT_DIR/scripts/runtime/check_service_api_reason_code_compatibility_live_policy.sh"
 STRATEGY_DOC="$ROOT_DIR/docs/ci/strategy.md"
 ROADMAP_DOC="$ROOT_DIR/docs/plans/2026-02-08-production-service-roadmap.md"
 
-output_json=""
-policy_output_json=""
-max_seconds="${KAMN_SERVICE_API_REASON_CODE_CONTRACT_MAX_SECONDS:-240}"
-ci_fast_gate="PASS"
+LANE_LABEL="service api reason-code compatibility"
+LANE_SLUG="service-api-reason-code-compatibility-live"
+MAX_SECONDS_ENV="KAMN_SERVICE_API_REASON_CODE_CONTRACT_MAX_SECONDS"
+MAX_SECONDS_DEFAULT="240"
+CONTRACT_STATUS_KEY="service_api_reason_code_contract_status"
+POLICY_STATUS_KEY="service_api_reason_code_policy_status"
+SUMMARY_SCHEMA="kamn.runtime.service-api-reason-code-compatibility-live-validation.v1"
+POLICY_SCHEMA="kamn.runtime.service-api-reason-code-compatibility-live-policy-report.v1"
+LANE_REPORT_SCHEMA="kamn.runtime.service-api-reason-code-compatibility-live-contract-lane-report.v1"
+TAMPER_FIELD="route_error_mapping_status"
+TAMPER_REASON_CODE="service_api_reason_code_policy_marker_missing:route_error_mapping_status"
+ROADMAP_TASK_MARKER="Task #3278"
+ROADMAP_CONTRACT_SCRIPT_REF="scripts/runtime/validate_service_api_reason_code_compatibility_live_contract_lane.sh"
+ROADMAP_POLICY_SCRIPT_REF="scripts/runtime/check_service_api_reason_code_compatibility_live_policy.sh"
+ALLOW_MODE="0"
 
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    --output-json)
-      output_json="${2:-}"
-      shift 2
-      ;;
-    --policy-output-json)
-      policy_output_json="${2:-}"
-      shift 2
-      ;;
-    --max-seconds)
-      max_seconds="${2:-}"
-      shift 2
-      ;;
-    --ci-fast-gate)
-      ci_fast_gate="${2:-}"
-      shift 2
-      ;;
-    *)
-      echo "unknown argument: $1" >&2
-      exit 1
-      ;;
-  esac
-done
+VALIDATION_REQUIRED_MARKERS=(
+  "status=pass"
+  "final_decision=GO"
+  "reason_registry_status=verified"
+  "error_envelope_field_status=verified"
+  "rust_sdk_reason_code_status=verified"
+  "python_sdk_reason_code_status=verified"
+  "regression_corpus_status=verified"
+  "regression_drift_diagnostics_status=verified"
+  "route_error_mapping_status=verified"
+  "replay_error_mapping_status=verified"
+  "websocket_error_mapping_status=verified"
+  "fail_closed_status=verified"
+)
+VALIDATION_REQUIRED_REGEX_MARKERS=(
+  '^regression_corpus_scenario_count=[1-9][0-9]*$'
+)
+POLICY_REQUIRED_MARKERS=(
+  "status=ok"
+  "final_decision=GO"
+  "service_api_reason_code_policy_status=verified"
+)
+STRATEGY_REQUIRED_REFS=(
+  "validate_service_api_reason_code_compatibility_live.sh"
+  "check_service_api_reason_code_compatibility_live_policy.sh"
+  "validate_service_api_reason_code_compatibility_live_contract_lane.sh"
+  "test_validate_service_api_reason_code_compatibility_live_contract_lane.sh"
+  "test_check_service_api_reason_code_compatibility_live_policy.sh"
+)
+STRATEGY_REQUIRED_MARKERS=(
+  "service api reason-code compatibility contract-lane commands remain excluded from ci-fast-gate and ci-tools fast mode."
+)
+LANE_REPORT_SUMMARY_FIELDS=(
+  error_envelope_field_status
+  rust_sdk_reason_code_status
+  python_sdk_reason_code_status
+  regression_corpus_status
+  regression_drift_diagnostics_status
+  regression_corpus_scenario_count
+)
+OUTPUT_SUMMARY_FIELDS=(
+  error_envelope_field_status
+  rust_sdk_reason_code_status
+  python_sdk_reason_code_status
+  regression_corpus_status
+  regression_drift_diagnostics_status
+  regression_corpus_scenario_count
+)
 
-if ! [[ "$max_seconds" =~ ^[0-9]+$ ]]; then
-  echo "max-seconds must be an integer" >&2
-  exit 1
-fi
-if [ "$max_seconds" -le 0 ]; then
-  echo "max-seconds must be greater than zero" >&2
-  exit 1
-fi
-if [[ "$ci_fast_gate" != "PASS" && "$ci_fast_gate" != "FAIL" ]]; then
-  echo "ci-fast-gate must be PASS or FAIL" >&2
-  exit 1
-fi
-
-for required_exec in "$VALIDATION_SCRIPT" "$POLICY_CHECKER"; do
-  if [ ! -x "$required_exec" ]; then
-    echo "expected required executable script '$required_exec'" >&2
-    exit 1
-  fi
-done
-for required_doc in "$STRATEGY_DOC" "$ROADMAP_DOC"; do
-  if [ ! -f "$required_doc" ]; then
-    echo "expected required documentation file '$required_doc'" >&2
-    exit 1
-  fi
-done
-
-start_epoch="$(date +%s)"
-TMP_DIR="$(mktemp -d)"
-trap 'rm -rf "$TMP_DIR"' EXIT
-
-summary_report="$TMP_DIR/service-api-reason-code-compatibility-live-summary.json"
-policy_report="$TMP_DIR/service-api-reason-code-compatibility-live-policy.json"
-tampered_report="$TMP_DIR/service-api-reason-code-compatibility-live-summary.tampered.json"
-
-validation_output="$(
-  bash "$VALIDATION_SCRIPT" \
-    --output-json "$summary_report" \
-    --max-seconds "$max_seconds"
-)"
-if ! printf '%s\n' "$validation_output" | grep -q '^status=pass$'; then
-  echo "expected service api reason-code compatibility live validation status=pass marker" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$validation_output" | grep -q '^final_decision=GO$'; then
-  echo "expected service api reason-code compatibility live validation final_decision=GO marker" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$validation_output" | grep -q '^reason_registry_status=verified$'; then
-  echo "expected service api reason-code compatibility reason registry marker" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$validation_output" | grep -q '^error_envelope_field_status=verified$'; then
-  echo "expected service api reason-code compatibility envelope field marker" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$validation_output" | grep -q '^rust_sdk_reason_code_status=verified$'; then
-  echo "expected service api reason-code compatibility rust sdk marker" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$validation_output" | grep -q '^python_sdk_reason_code_status=verified$'; then
-  echo "expected service api reason-code compatibility python sdk marker" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$validation_output" | grep -q '^regression_corpus_status=verified$'; then
-  echo "expected service api reason-code compatibility regression corpus marker" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$validation_output" | grep -q '^regression_drift_diagnostics_status=verified$'; then
-  echo "expected service api reason-code compatibility regression drift diagnostics marker" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$validation_output" | grep -Eq '^regression_corpus_scenario_count=[1-9][0-9]*$'; then
-  echo "expected service api reason-code compatibility regression corpus scenario count marker" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$validation_output" | grep -q '^route_error_mapping_status=verified$'; then
-  echo "expected service api reason-code compatibility route mapping marker" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$validation_output" | grep -q '^replay_error_mapping_status=verified$'; then
-  echo "expected service api reason-code compatibility replay mapping marker" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$validation_output" | grep -q '^websocket_error_mapping_status=verified$'; then
-  echo "expected service api reason-code compatibility websocket mapping marker" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$validation_output" | grep -q '^fail_closed_status=verified$'; then
-  echo "expected service api reason-code compatibility fail-closed marker" >&2
-  exit 1
-fi
-
-policy_output="$(
-  bash "$POLICY_CHECKER" \
-    --report-file "$summary_report" \
-    --expected-final-decision GO \
-    --ci-fast-gate "$ci_fast_gate" \
-    --output-json "$policy_report"
-)"
-if ! printf '%s\n' "$policy_output" | grep -q '^status=ok$'; then
-  echo "expected service api reason-code compatibility policy checker status=ok marker" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$policy_output" | grep -q '^final_decision=GO$'; then
-  echo "expected service api reason-code compatibility policy checker final_decision=GO marker" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$policy_output" | grep -q '^service_api_reason_code_policy_status=verified$'; then
-  echo "expected service api reason-code compatibility policy checker status marker" >&2
-  exit 1
-fi
-
-cp "$summary_report" "$tampered_report"
-python3 - "$tampered_report" <<'PY'
-import json
-import pathlib
-import sys
-
-path = pathlib.Path(sys.argv[1])
-payload = json.loads(path.read_text(encoding="utf-8"))
-payload["route_error_mapping_status"] = "missing"
-path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
-PY
-
-set +e
-tampered_policy_output="$(
-  bash "$POLICY_CHECKER" \
-    --report-file "$tampered_report" \
-    --expected-final-decision GO \
-    --ci-fast-gate "$ci_fast_gate" \
-    --output-json "$TMP_DIR/service-api-reason-code-compatibility-live-policy.tampered.json" 2>&1
-)"
-tampered_policy_code=$?
-set -e
-
-if [ "$tampered_policy_code" -eq 0 ]; then
-  echo "expected tampered service api reason-code compatibility report to fail policy validation" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$tampered_policy_output" | grep -q 'service_api_reason_code_policy_marker_missing:route_error_mapping_status'; then
-  echo "expected deterministic fail-closed reason for tampered service api reason-code compatibility report" >&2
-  exit 1
-fi
-
-for required_ref in \
-  "validate_service_api_reason_code_compatibility_live.sh" \
-  "check_service_api_reason_code_compatibility_live_policy.sh" \
-  "validate_service_api_reason_code_compatibility_live_contract_lane.sh" \
-  "test_validate_service_api_reason_code_compatibility_live_contract_lane.sh" \
-  "test_check_service_api_reason_code_compatibility_live_policy.sh"; do
-  if ! grep -q "$required_ref" "$STRATEGY_DOC"; then
-    echo "expected CI strategy docs to reference $required_ref" >&2
-    exit 1
-  fi
-done
-if ! grep -q "service api reason-code compatibility contract-lane commands remain excluded from ci-fast-gate and ci-tools fast mode." "$STRATEGY_DOC"; then
-  echo "expected CI strategy docs to include service api reason-code compatibility contract-lane exclusion marker" >&2
-  exit 1
-fi
-
-if ! grep -q "Task #3278" "$ROADMAP_DOC"; then
-  echo "expected roadmap marker for Task #3278" >&2
-  exit 1
-fi
-if ! grep -q "scripts/runtime/validate_service_api_reason_code_compatibility_live_contract_lane.sh" "$ROADMAP_DOC"; then
-  echo "expected roadmap to reference service api reason-code compatibility contract lane script" >&2
-  exit 1
-fi
-if ! grep -q "scripts/runtime/check_service_api_reason_code_compatibility_live_policy.sh" "$ROADMAP_DOC"; then
-  echo "expected roadmap to reference service api reason-code compatibility policy checker script" >&2
-  exit 1
-fi
-
-elapsed_seconds="$(( $(date +%s) - start_epoch ))"
-if [ "$elapsed_seconds" -gt "$max_seconds" ]; then
-  echo "service api reason-code compatibility contract lane exceeded runtime budget: ${elapsed_seconds}s" >&2
-  exit 1
-fi
-
-lane_report="$TMP_DIR/service-api-reason-code-compatibility-live-contract-lane-report.json"
-python3 - "$summary_report" "$policy_report" "$lane_report" "$elapsed_seconds" "$max_seconds" <<'PY'
-import json
-import pathlib
-import sys
-
-summary_report = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
-policy_report = json.loads(pathlib.Path(sys.argv[2]).read_text(encoding="utf-8"))
-lane_report_file = pathlib.Path(sys.argv[3])
-elapsed_seconds = int(sys.argv[4])
-max_seconds = int(sys.argv[5])
-
-if summary_report.get("schema_version") != "kamn.runtime.service-api-reason-code-compatibility-live-validation.v1":
-    raise SystemExit("unexpected service api reason-code compatibility live summary schema")
-if policy_report.get("schema_version") != "kamn.runtime.service-api-reason-code-compatibility-live-policy-report.v1":
-    raise SystemExit("unexpected service api reason-code compatibility live policy schema")
-if summary_report.get("final_decision") != "GO":
-    raise SystemExit("expected service api reason-code compatibility summary final_decision=GO")
-if policy_report.get("final_decision") != "GO":
-    raise SystemExit("expected service api reason-code compatibility policy final_decision=GO")
-
-lane_report = {
-    "schema_version": "kamn.runtime.service-api-reason-code-compatibility-live-contract-lane-report.v1",
-    "status": "pass",
-    "final_decision": "GO",
-    "service_api_reason_code_contract_status": "verified",
-    "error_envelope_field_status": summary_report.get("error_envelope_field_status"),
-    "rust_sdk_reason_code_status": summary_report.get("rust_sdk_reason_code_status"),
-    "python_sdk_reason_code_status": summary_report.get("python_sdk_reason_code_status"),
-    "regression_corpus_status": summary_report.get("regression_corpus_status"),
-    "regression_drift_diagnostics_status": summary_report.get(
-        "regression_drift_diagnostics_status"
-    ),
-    "regression_corpus_scenario_count": summary_report.get(
-        "regression_corpus_scenario_count"
-    ),
-    "service_api_reason_code_policy_status": policy_report.get(
-        "service_api_reason_code_policy_status"
-    ),
-    "docs_contract_status": "verified",
-    "fail_closed_status": "verified",
-    "fail_closed_reason_code": "service_api_reason_code_policy_marker_missing:route_error_mapping_status",
-    "performance_budget_status": "verified",
-    "elapsed_seconds": elapsed_seconds,
-    "max_seconds": max_seconds,
-}
-lane_report_file.write_text(json.dumps(lane_report, sort_keys=True, indent=2) + "\n", encoding="utf-8")
-PY
-
-if [[ -n "$output_json" ]]; then
-  cp "$lane_report" "$output_json"
-fi
-if [[ -n "$policy_output_json" ]]; then
-  cp "$policy_report" "$policy_output_json"
-fi
-
-echo "status=pass"
-echo "final_decision=GO"
-echo "service_api_reason_code_contract_status=verified"
-echo "error_envelope_field_status=verified"
-echo "rust_sdk_reason_code_status=verified"
-echo "python_sdk_reason_code_status=verified"
-echo "regression_corpus_status=verified"
-echo "regression_drift_diagnostics_status=verified"
-echo "regression_corpus_scenario_count=$(python3 - "$summary_report" <<'PY'
-import json
-import pathlib
-import sys
-
-payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
-print(payload.get("regression_corpus_scenario_count", 0))
-PY
-)"
-echo "service_api_reason_code_policy_status=verified"
-echo "docs_contract_status=verified"
-echo "fail_closed_status=verified"
-echo "fail_closed_reason_code=service_api_reason_code_policy_marker_missing:route_error_mapping_status"
-echo "performance_budget_status=verified"
+service_api_contract_lane_run "$@"

--- a/scripts/runtime/validate_service_api_serde_payload_parity_live_contract_lane.sh
+++ b/scripts/runtime/validate_service_api_serde_payload_parity_live_contract_lane.sh
@@ -2,247 +2,56 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# Shared runner for service-api contract lanes.
+source "$ROOT_DIR/scripts/runtime/service_api_contract_lane_runner.sh"
+
 VALIDATION_SCRIPT="$ROOT_DIR/scripts/runtime/validate_service_api_serde_payload_parity_live.sh"
 POLICY_CHECKER="$ROOT_DIR/scripts/runtime/check_service_api_serde_payload_parity_live_policy.sh"
 STRATEGY_DOC="$ROOT_DIR/docs/ci/strategy.md"
 ROADMAP_DOC="$ROOT_DIR/docs/plans/2026-02-08-production-service-roadmap.md"
 
-output_json=""
-policy_output_json=""
-max_seconds="${KAMN_SERVICE_API_SERDE_PAYLOAD_CONTRACT_MAX_SECONDS:-240}"
-ci_fast_gate="PASS"
+LANE_LABEL="service api serde payload parity"
+LANE_SLUG="service-api-serde-payload-parity-live"
+MAX_SECONDS_ENV="KAMN_SERVICE_API_SERDE_PAYLOAD_CONTRACT_MAX_SECONDS"
+MAX_SECONDS_DEFAULT="240"
+CONTRACT_STATUS_KEY="service_api_serde_payload_contract_status"
+POLICY_STATUS_KEY="service_api_serde_payload_policy_status"
+SUMMARY_SCHEMA="kamn.runtime.service-api-serde-payload-parity-live-validation.v1"
+POLICY_SCHEMA="kamn.runtime.service-api-serde-payload-parity-live-policy-report.v1"
+LANE_REPORT_SCHEMA="kamn.runtime.service-api-serde-payload-parity-live-contract-lane-report.v1"
+TAMPER_FIELD="route_payload_parity_status"
+TAMPER_REASON_CODE="service_api_serde_payload_policy_marker_missing:route_payload_parity_status"
+ROADMAP_TASK_MARKER="Task #3267"
+ROADMAP_CONTRACT_SCRIPT_REF="scripts/runtime/validate_service_api_serde_payload_parity_live_contract_lane.sh"
+ROADMAP_POLICY_SCRIPT_REF="scripts/runtime/check_service_api_serde_payload_parity_live_policy.sh"
+ALLOW_MODE="0"
 
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    --output-json)
-      output_json="${2:-}"
-      shift 2
-      ;;
-    --policy-output-json)
-      policy_output_json="${2:-}"
-      shift 2
-      ;;
-    --max-seconds)
-      max_seconds="${2:-}"
-      shift 2
-      ;;
-    --ci-fast-gate)
-      ci_fast_gate="${2:-}"
-      shift 2
-      ;;
-    *)
-      echo "unknown argument: $1" >&2
-      exit 1
-      ;;
-  esac
-done
+VALIDATION_REQUIRED_MARKERS=(
+  "status=pass"
+  "final_decision=GO"
+  "serde_dto_status=verified"
+  "serde_serializer_status=verified"
+  "serde_parser_status=verified"
+  "route_payload_parity_status=verified"
+  "fail_closed_status=verified"
+)
+VALIDATION_REQUIRED_REGEX_MARKERS=()
+POLICY_REQUIRED_MARKERS=(
+  "status=ok"
+  "final_decision=GO"
+  "service_api_serde_payload_policy_status=verified"
+)
+STRATEGY_REQUIRED_REFS=(
+  "validate_service_api_serde_payload_parity_live.sh"
+  "check_service_api_serde_payload_parity_live_policy.sh"
+  "validate_service_api_serde_payload_parity_live_contract_lane.sh"
+  "test_validate_service_api_serde_payload_parity_live_contract_lane.sh"
+  "test_check_service_api_serde_payload_parity_live_policy.sh"
+)
+STRATEGY_REQUIRED_MARKERS=(
+  "service api serde payload parity contract-lane commands remain excluded from ci-fast-gate and ci-tools fast mode."
+)
+LANE_REPORT_SUMMARY_FIELDS=()
+OUTPUT_SUMMARY_FIELDS=()
 
-if ! [[ "$max_seconds" =~ ^[0-9]+$ ]]; then
-  echo "max-seconds must be an integer" >&2
-  exit 1
-fi
-if [ "$max_seconds" -le 0 ]; then
-  echo "max-seconds must be greater than zero" >&2
-  exit 1
-fi
-if [[ "$ci_fast_gate" != "PASS" && "$ci_fast_gate" != "FAIL" ]]; then
-  echo "ci-fast-gate must be PASS or FAIL" >&2
-  exit 1
-fi
-
-for required_exec in "$VALIDATION_SCRIPT" "$POLICY_CHECKER"; do
-  if [ ! -x "$required_exec" ]; then
-    echo "expected required executable script '$required_exec'" >&2
-    exit 1
-  fi
-done
-for required_doc in "$STRATEGY_DOC" "$ROADMAP_DOC"; do
-  if [ ! -f "$required_doc" ]; then
-    echo "expected required documentation file '$required_doc'" >&2
-    exit 1
-  fi
-done
-
-start_epoch="$(date +%s)"
-TMP_DIR="$(mktemp -d)"
-trap 'rm -rf "$TMP_DIR"' EXIT
-
-summary_report="$TMP_DIR/service-api-serde-payload-parity-live-summary.json"
-policy_report="$TMP_DIR/service-api-serde-payload-parity-live-policy.json"
-tampered_report="$TMP_DIR/service-api-serde-payload-parity-live-summary.tampered.json"
-
-validation_output="$(
-  bash "$VALIDATION_SCRIPT" \
-    --output-json "$summary_report" \
-    --max-seconds "$max_seconds"
-)"
-if ! printf '%s\n' "$validation_output" | grep -q '^status=pass$'; then
-  echo "expected service api serde payload parity live validation status=pass marker" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$validation_output" | grep -q '^final_decision=GO$'; then
-  echo "expected service api serde payload parity live validation final_decision=GO marker" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$validation_output" | grep -q '^serde_dto_status=verified$'; then
-  echo "expected service api serde payload parity dto marker" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$validation_output" | grep -q '^serde_serializer_status=verified$'; then
-  echo "expected service api serde payload parity serializer marker" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$validation_output" | grep -q '^serde_parser_status=verified$'; then
-  echo "expected service api serde payload parity parser marker" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$validation_output" | grep -q '^route_payload_parity_status=verified$'; then
-  echo "expected service api serde payload parity route marker" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$validation_output" | grep -q '^fail_closed_status=verified$'; then
-  echo "expected service api serde payload parity fail-closed marker" >&2
-  exit 1
-fi
-
-policy_output="$(
-  bash "$POLICY_CHECKER" \
-    --report-file "$summary_report" \
-    --expected-final-decision GO \
-    --ci-fast-gate "$ci_fast_gate" \
-    --output-json "$policy_report"
-)"
-if ! printf '%s\n' "$policy_output" | grep -q '^status=ok$'; then
-  echo "expected service api serde payload parity policy checker status=ok marker" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$policy_output" | grep -q '^final_decision=GO$'; then
-  echo "expected service api serde payload parity policy checker final_decision=GO marker" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$policy_output" | grep -q '^service_api_serde_payload_policy_status=verified$'; then
-  echo "expected service api serde payload parity policy checker status marker" >&2
-  exit 1
-fi
-
-cp "$summary_report" "$tampered_report"
-python3 - "$tampered_report" <<'PY'
-import json
-import pathlib
-import sys
-
-path = pathlib.Path(sys.argv[1])
-payload = json.loads(path.read_text(encoding="utf-8"))
-payload["route_payload_parity_status"] = "missing"
-path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
-PY
-
-set +e
-tampered_policy_output="$(
-  bash "$POLICY_CHECKER" \
-    --report-file "$tampered_report" \
-    --expected-final-decision GO \
-    --ci-fast-gate "$ci_fast_gate" \
-    --output-json "$TMP_DIR/service-api-serde-payload-parity-live-policy.tampered.json" 2>&1
-)"
-tampered_policy_code=$?
-set -e
-
-if [ "$tampered_policy_code" -eq 0 ]; then
-  echo "expected tampered service api serde payload parity report to fail policy validation" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$tampered_policy_output" | grep -q 'service_api_serde_payload_policy_marker_missing:route_payload_parity_status'; then
-  echo "expected deterministic fail-closed reason for tampered service api serde payload parity report" >&2
-  exit 1
-fi
-
-for required_ref in \
-  "validate_service_api_serde_payload_parity_live.sh" \
-  "check_service_api_serde_payload_parity_live_policy.sh" \
-  "validate_service_api_serde_payload_parity_live_contract_lane.sh" \
-  "test_validate_service_api_serde_payload_parity_live_contract_lane.sh" \
-  "test_check_service_api_serde_payload_parity_live_policy.sh"; do
-  if ! grep -q "$required_ref" "$STRATEGY_DOC"; then
-    echo "expected CI strategy docs to reference $required_ref" >&2
-    exit 1
-  fi
-done
-if ! grep -q "service api serde payload parity contract-lane commands remain excluded from ci-fast-gate and ci-tools fast mode." "$STRATEGY_DOC"; then
-  echo "expected CI strategy docs to include service api serde payload parity contract-lane exclusion marker" >&2
-  exit 1
-fi
-
-if ! grep -q "Task #3267" "$ROADMAP_DOC"; then
-  echo "expected roadmap marker for Task #3267" >&2
-  exit 1
-fi
-if ! grep -q "scripts/runtime/validate_service_api_serde_payload_parity_live_contract_lane.sh" "$ROADMAP_DOC"; then
-  echo "expected roadmap to reference service api serde payload parity contract lane script" >&2
-  exit 1
-fi
-if ! grep -q "scripts/runtime/check_service_api_serde_payload_parity_live_policy.sh" "$ROADMAP_DOC"; then
-  echo "expected roadmap to reference service api serde payload parity policy checker script" >&2
-  exit 1
-fi
-
-elapsed_seconds="$(( $(date +%s) - start_epoch ))"
-if [ "$elapsed_seconds" -gt "$max_seconds" ]; then
-  echo "service api serde payload parity contract lane exceeded runtime budget: ${elapsed_seconds}s" >&2
-  exit 1
-fi
-
-lane_report="$TMP_DIR/service-api-serde-payload-parity-live-contract-lane-report.json"
-python3 - "$summary_report" "$policy_report" "$lane_report" "$elapsed_seconds" "$max_seconds" <<'PY'
-import json
-import pathlib
-import sys
-
-summary_report = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
-policy_report = json.loads(pathlib.Path(sys.argv[2]).read_text(encoding="utf-8"))
-lane_report_file = pathlib.Path(sys.argv[3])
-elapsed_seconds = int(sys.argv[4])
-max_seconds = int(sys.argv[5])
-
-if summary_report.get("schema_version") != "kamn.runtime.service-api-serde-payload-parity-live-validation.v1":
-    raise SystemExit("unexpected service api serde payload parity live summary schema")
-if policy_report.get("schema_version") != "kamn.runtime.service-api-serde-payload-parity-live-policy-report.v1":
-    raise SystemExit("unexpected service api serde payload parity live policy schema")
-if summary_report.get("final_decision") != "GO":
-    raise SystemExit("expected service api serde payload parity summary final_decision=GO")
-if policy_report.get("final_decision") != "GO":
-    raise SystemExit("expected service api serde payload parity policy final_decision=GO")
-
-lane_report = {
-    "schema_version": "kamn.runtime.service-api-serde-payload-parity-live-contract-lane-report.v1",
-    "status": "pass",
-    "final_decision": "GO",
-    "service_api_serde_payload_contract_status": "verified",
-    "service_api_serde_payload_policy_status": policy_report.get(
-        "service_api_serde_payload_policy_status"
-    ),
-    "docs_contract_status": "verified",
-    "fail_closed_status": "verified",
-    "fail_closed_reason_code": "service_api_serde_payload_policy_marker_missing:route_payload_parity_status",
-    "performance_budget_status": "verified",
-    "elapsed_seconds": elapsed_seconds,
-    "max_seconds": max_seconds,
-}
-lane_report_file.write_text(json.dumps(lane_report, sort_keys=True, indent=2) + "\n", encoding="utf-8")
-PY
-
-if [[ -n "$output_json" ]]; then
-  cp "$lane_report" "$output_json"
-fi
-if [[ -n "$policy_output_json" ]]; then
-  cp "$policy_report" "$policy_output_json"
-fi
-
-echo "status=pass"
-echo "final_decision=GO"
-echo "service_api_serde_payload_contract_status=verified"
-echo "service_api_serde_payload_policy_status=verified"
-echo "docs_contract_status=verified"
-echo "fail_closed_status=verified"
-echo "fail_closed_reason_code=service_api_serde_payload_policy_marker_missing:route_payload_parity_status"
-echo "performance_budget_status=verified"
+service_api_contract_lane_run "$@"


### PR DESCRIPTION
Closes #3449

## Summary
Consolidates the highest-LOC non-Kolme service API contract-lane wrapper family into a shared runtime runner while preserving existing wrapper entrypoints and contract behavior. This reduces shell command-surface LOC and keeps fast-gate/local-heavy boundaries unchanged.

## Changes
- `scripts/runtime/service_api_contract_lane_runner.sh`: new shared runner for service API contract-lane orchestration (arg validation, marker checks, tamper drills, docs checks, report emission).
- `scripts/runtime/validate_service_api_axum_ingress_live_contract_lane.sh`: migrated to shared runner with lane-specific configuration.
- `scripts/runtime/validate_service_api_reason_code_compatibility_live_contract_lane.sh`: migrated to shared runner with lane-specific configuration.
- `scripts/runtime/validate_service_api_serde_payload_parity_live_contract_lane.sh`: migrated to shared runner with lane-specific configuration.
- `docs/ci/strategy.md`: documented shared-runner orchestration for migrated service API lanes.
- `docs/ci/ci-cost-and-lane-framework.md`: added tranche-2 snapshot with updated shell-surface metrics.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
```bash
bash scripts/runtime/test_validate_service_api_axum_ingress_live_contract_lane.sh
# /tmp/kamn-next/scripts/runtime/validate_service_api_axum_ingress_live_contract_lane.sh: line 1: tmp_dir: unbound variable

bash scripts/runtime/test_validate_service_api_reason_code_compatibility_live_contract_lane.sh
# /tmp/kamn-next/scripts/runtime/validate_service_api_reason_code_compatibility_live_contract_lane.sh: line 1: tmp_dir: unbound variable

bash scripts/runtime/test_validate_service_api_serde_payload_parity_live_contract_lane.sh
# /tmp/kamn-next/scripts/runtime/validate_service_api_serde_payload_parity_live_contract_lane.sh: line 1: tmp_dir: unbound variable
```

### 🟢 Green Phase
```bash
bash scripts/runtime/test_validate_service_api_axum_ingress_live_contract_lane.sh
# service api axum ingress contract lane tests passed.

bash scripts/runtime/test_validate_service_api_reason_code_compatibility_live_contract_lane.sh
# service api reason-code compatibility contract lane tests passed.

bash scripts/runtime/test_validate_service_api_serde_payload_parity_live_contract_lane.sh
# service api serde payload parity contract lane tests passed.
```

### 🔁 Regression
```bash
bash scripts/ci/check_script_duplication_budget.sh
# status=pass
# script_count=381
# shell_line_total=31253
# violations=none

bash scripts/ci/test_ci_strategy_contract.sh
# CI strategy contract tests passed.

bash scripts/ci/test_ci_strategy_wave_range_marker_contract.sh
# ci strategy wave-range marker contract regression tests passed.

bash scripts/ci/test_production_service_next_steps_contract.sh
# production-service next-steps docs contract tests passed.

KAMN_CI_TOOLS_FAST_MODE=true bash scripts/ci/test_ci_tools.sh
# Fast-mode CI tool regression tests passed.
```

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | N/A | Existing shell contract lanes are behavior/integration oriented | Wrapper orchestration path has no standalone unit harness in this tranche |
| Functional   | ✅ | `scripts/runtime/test_validate_service_api_axum_ingress_live_contract_lane.sh`, `scripts/runtime/test_validate_service_api_reason_code_compatibility_live_contract_lane.sh`, `scripts/runtime/test_validate_service_api_serde_payload_parity_live_contract_lane.sh` | |
| Integration  | ✅ | `KAMN_CI_TOOLS_FAST_MODE=true bash scripts/ci/test_ci_tools.sh` | |
| Regression   | ✅ | `scripts/ci/check_script_duplication_budget.sh`, `scripts/ci/test_ci_strategy_contract.sh`, `scripts/ci/test_ci_strategy_wave_range_marker_contract.sh`, `scripts/ci/test_production_service_next_steps_contract.sh` | |
| Performance  | N/A | N/A | Existing contract-lane max-seconds budgets remain enforced; no throughput/latency algorithm change |

## Risks & Rollback
- Risk: Shared runner regression could affect migrated lane wrappers if lane-specific marker config drifts.
- Rollback: Revert this PR to restore per-lane inline implementations.

## Documentation Updates
- `docs/ci/strategy.md`
- `docs/ci/ci-cost-and-lane-framework.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean (not applicable; no Rust changes)
- [x] `cargo clippy -- -D warnings` — clean (not applicable; no Rust changes)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (relevant CI/tools + lane contracts)
- [x] Docs updated (or justified why not)
