### PR TITLE
feat(ci): add combined shell-surface trend guard

### DIFF
--- a/docs/ci/ci-cost-and-lane-framework.md
+++ b/docs/ci/ci-cost-and-lane-framework.md
@@ -275,9 +275,28 @@ The checker fails closed when any metric exceeds its configured threshold and em
   - `scripts/runtime/validate_service_api_reason_code_compatibility_live_contract_lane.sh`
   - `scripts/runtime/validate_service_api_serde_payload_parity_live_contract_lane.sh`
 - Latest local budget evidence after migration:
-  - `shell_line_total=31253` (down from `31599`)
-  - `script_count=381`
+  - `shell_line_total=31657` (remains below `32000` cap after #3450 guard tooling additions)
+  - `script_count=383`
   - `violations=none`
+
+## Combined Shell-Surface Trend Guard (`#3450`)
+- Combined trend artifact:
+  - `bash scripts/ci/generate_combined_shell_surface_trend_report.sh --output-json /tmp/combined-shell-surface-trend-report.json`
+  - schema: `kamn.ci.combined-shell-surface-trend-report.v1`
+  - tracked dimensions:
+    - `script_count`
+    - `shell_line_total`
+    - `rust_line_total`
+    - `shell_to_rust_ratio`
+- Combined trend policy checker:
+  - `bash scripts/ci/check_combined_shell_surface_trend_policy.sh --report-file /tmp/combined-shell-surface-trend-report.json --threshold-file fixtures/ci/combined_shell_surface_trend_thresholds.json --output-json /tmp/combined-shell-surface-trend-policy-report.json`
+  - schema: `kamn.ci.combined-shell-surface-trend-policy-report.v1`
+  - fail-closed reason codes:
+    - `combined_shell_surface_script_count_delta_fail_exceeded`
+    - `combined_shell_surface_shell_line_total_delta_fail_exceeded`
+    - `combined_shell_surface_ratio_fail_ceiling_exceeded`
+    - `combined_shell_surface_ratio_delta_fail_exceeded`
+    - `combined_shell_surface_budget_status_fail`
 
 ## Waiver Rules
 Temporary exceptions are allowed through `.ci/script-surface-budget-waiver.json`.
@@ -312,6 +331,8 @@ Run these before opening a PR that modifies CI/lane surfaces:
 ```bash
 bash scripts/ci/check_script_duplication_budget.sh
 bash scripts/ci/test_check_script_duplication_budget.sh
+bash scripts/ci/test_generate_combined_shell_surface_trend_report.sh
+bash scripts/ci/test_check_combined_shell_surface_trend_policy.sh
 bash scripts/ci/test_generate_fast_gate_budget_delta_report.sh
 bash scripts/ci/test_check_fast_gate_budget_delta_threshold.sh
 bash scripts/ci/test_run_fast_gate_budget_delta_contract_lane.sh

--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -2584,6 +2584,18 @@ Fast-mode CI tooling regression coverage includes:
 - Kolme harness trend-report generator (`test_generate_kolme_test_harness_loc_trend_report.sh`)
 - Test-harness LOC soft-budget checker (`test_check_test_harness_loc_soft_budget.sh`)
 - Kolme test-harness LOC soft-budget checker (`test_check_kolme_test_harness_loc_soft_budget.sh`)
+- Combined shell-surface trend report generator (`test_generate_combined_shell_surface_trend_report.sh`)
+  - generator command:
+    - `bash scripts/ci/generate_combined_shell_surface_trend_report.sh --output-json /tmp/combined-shell-surface-trend-report.json`
+- Combined shell-surface trend policy checker (`test_check_combined_shell_surface_trend_policy.sh`)
+  - policy command:
+    - `bash scripts/ci/check_combined_shell_surface_trend_policy.sh --report-file /tmp/combined-shell-surface-trend-report.json --threshold-file fixtures/ci/combined_shell_surface_trend_thresholds.json --output-json /tmp/combined-shell-surface-trend-policy-report.json`
+  - deterministic reason-code surface:
+    - `reason_codes=combined_shell_surface_script_count_delta_fail_exceeded`
+    - `reason_codes=combined_shell_surface_shell_line_total_delta_fail_exceeded`
+    - `reason_codes=combined_shell_surface_ratio_fail_ceiling_exceeded`
+    - `reason_codes=combined_shell_surface_ratio_delta_fail_exceeded`
+    - `reason_codes=combined_shell_surface_budget_status_fail`
 - Ignored-test inventory drift checker (`test_check_ignored_test_inventory_drift.sh`)
   - generator command:
     - `bash scripts/ci/generate_ignored_test_inventory_baseline.sh --output-json /tmp/ignored-test-inventory-baseline.json`

--- a/fixtures/ci/combined_shell_surface_trend_baseline.json
+++ b/fixtures/ci/combined_shell_surface_trend_baseline.json
@@ -1,0 +1,7 @@
+{
+  "schema_version": "kamn.ci.combined-shell-surface-trend-baseline.v1",
+  "script_count": 383,
+  "shell_line_total": 31657,
+  "rust_line_total": 105232,
+  "shell_to_rust_ratio": 0.300831
+}

--- a/fixtures/ci/combined_shell_surface_trend_thresholds.json
+++ b/fixtures/ci/combined_shell_surface_trend_thresholds.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": "kamn.ci.combined-shell-surface-trend-thresholds.v1",
+  "warn_script_count_increase": 5,
+  "fail_script_count_increase": 15,
+  "warn_shell_line_total_increase": 150,
+  "fail_shell_line_total_increase": 400,
+  "warn_shell_to_rust_ratio": 0.305,
+  "fail_shell_to_rust_ratio": 0.34,
+  "warn_shell_to_rust_ratio_increase": 0.005,
+  "fail_shell_to_rust_ratio_increase": 0.02
+}

--- a/scripts/ci/check_combined_shell_surface_trend_policy.sh
+++ b/scripts/ci/check_combined_shell_surface_trend_policy.sh
@@ -1,0 +1,216 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DEFAULT_THRESHOLD_FILE="$ROOT_DIR/fixtures/ci/combined_shell_surface_trend_thresholds.json"
+DEFAULT_REPORT_GENERATOR="$ROOT_DIR/scripts/ci/generate_combined_shell_surface_trend_report.sh"
+
+report_file=""
+threshold_file="$DEFAULT_THRESHOLD_FILE"
+output_json=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --report-file)
+      report_file="${2:-}"
+      shift 2
+      ;;
+    --threshold-file)
+      threshold_file="${2:-}"
+      shift 2
+      ;;
+    --output-json)
+      output_json="${2:-}"
+      shift 2
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+tmp_dir="$(mktemp -d)"
+cleanup_tmp_dir=true
+trap '[ "$cleanup_tmp_dir" = true ] && rm -rf "$tmp_dir"' EXIT
+
+if [[ -z "$report_file" ]]; then
+  report_file="$tmp_dir/combined-shell-surface-trend-report.json"
+  bash "$DEFAULT_REPORT_GENERATOR" --output-json "$report_file" >/dev/null
+fi
+
+if [[ ! -f "$report_file" ]]; then
+  echo "report file not found: $report_file" >&2
+  exit 2
+fi
+if [[ ! -f "$threshold_file" ]]; then
+  echo "threshold file not found: $threshold_file" >&2
+  exit 2
+fi
+
+if [[ -z "$output_json" ]]; then
+  output_json="$tmp_dir/combined-shell-surface-trend-policy-report.json"
+fi
+mkdir -p "$(dirname "$output_json")"
+
+python3 - "$report_file" "$threshold_file" "$output_json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+report_path = Path(sys.argv[1])
+threshold_path = Path(sys.argv[2])
+output_path = Path(sys.argv[3])
+
+report = json.loads(report_path.read_text(encoding="utf-8"))
+thresholds = json.loads(threshold_path.read_text(encoding="utf-8"))
+
+reason_codes: list[str] = []
+
+if report.get("schema_version") != "kamn.ci.combined-shell-surface-trend-report.v1":
+    reason_codes.append("combined_shell_surface_report_schema_mismatch")
+if thresholds.get("schema_version") != "kamn.ci.combined-shell-surface-trend-thresholds.v1":
+    reason_codes.append("combined_shell_surface_threshold_schema_mismatch")
+
+current = report.get("current", {})
+deltas = report.get("deltas", {})
+script_budget = report.get("script_budget", {})
+
+script_count = current.get("script_count")
+shell_line_total = current.get("shell_line_total")
+rust_line_total = current.get("rust_line_total")
+shell_to_rust_ratio = current.get("shell_to_rust_ratio")
+delta_script_count = deltas.get("script_count")
+delta_shell_line_total = deltas.get("shell_line_total")
+delta_shell_to_rust_ratio = deltas.get("shell_to_rust_ratio")
+script_budget_status = script_budget.get("status")
+
+if script_budget_status != "pass":
+    reason_codes.append("combined_shell_surface_budget_status_fail")
+
+warn_codes: list[str] = []
+fail_codes: list[str] = []
+
+try:
+    warn_script_count_increase = int(thresholds["warn_script_count_increase"])
+    fail_script_count_increase = int(thresholds["fail_script_count_increase"])
+    warn_shell_line_total_increase = int(thresholds["warn_shell_line_total_increase"])
+    fail_shell_line_total_increase = int(thresholds["fail_shell_line_total_increase"])
+    warn_shell_to_rust_ratio = float(thresholds["warn_shell_to_rust_ratio"])
+    fail_shell_to_rust_ratio = float(thresholds["fail_shell_to_rust_ratio"])
+    warn_shell_to_rust_ratio_increase = float(thresholds["warn_shell_to_rust_ratio_increase"])
+    fail_shell_to_rust_ratio_increase = float(thresholds["fail_shell_to_rust_ratio_increase"])
+except Exception:
+    reason_codes.append("combined_shell_surface_threshold_value_invalid")
+    warn_script_count_increase = fail_script_count_increase = 0
+    warn_shell_line_total_increase = fail_shell_line_total_increase = 0
+    warn_shell_to_rust_ratio = fail_shell_to_rust_ratio = 0.0
+    warn_shell_to_rust_ratio_increase = fail_shell_to_rust_ratio_increase = 0.0
+
+if not isinstance(script_count, int):
+    reason_codes.append("combined_shell_surface_script_count_invalid")
+if not isinstance(shell_line_total, int):
+    reason_codes.append("combined_shell_surface_shell_line_total_invalid")
+if not isinstance(rust_line_total, int) or rust_line_total <= 0:
+    reason_codes.append("combined_shell_surface_rust_line_total_invalid")
+if not isinstance(shell_to_rust_ratio, (int, float)):
+    reason_codes.append("combined_shell_surface_ratio_invalid")
+if not isinstance(delta_script_count, int):
+    reason_codes.append("combined_shell_surface_delta_script_count_invalid")
+if not isinstance(delta_shell_line_total, int):
+    reason_codes.append("combined_shell_surface_delta_shell_line_total_invalid")
+if not isinstance(delta_shell_to_rust_ratio, (int, float)):
+    reason_codes.append("combined_shell_surface_delta_ratio_invalid")
+
+if not reason_codes:
+    if delta_script_count > fail_script_count_increase:
+        fail_codes.append("combined_shell_surface_script_count_delta_fail_exceeded")
+    elif delta_script_count > warn_script_count_increase:
+        warn_codes.append("combined_shell_surface_script_count_delta_warn_exceeded")
+
+    if delta_shell_line_total > fail_shell_line_total_increase:
+        fail_codes.append("combined_shell_surface_shell_line_total_delta_fail_exceeded")
+    elif delta_shell_line_total > warn_shell_line_total_increase:
+        warn_codes.append("combined_shell_surface_shell_line_total_delta_warn_exceeded")
+
+    if shell_to_rust_ratio > fail_shell_to_rust_ratio:
+        fail_codes.append("combined_shell_surface_ratio_fail_ceiling_exceeded")
+    elif shell_to_rust_ratio > warn_shell_to_rust_ratio:
+        warn_codes.append("combined_shell_surface_ratio_warn_ceiling_exceeded")
+
+    if delta_shell_to_rust_ratio > fail_shell_to_rust_ratio_increase:
+        fail_codes.append("combined_shell_surface_ratio_delta_fail_exceeded")
+    elif delta_shell_to_rust_ratio > warn_shell_to_rust_ratio_increase:
+        warn_codes.append("combined_shell_surface_ratio_delta_warn_exceeded")
+
+all_reason_codes = reason_codes + fail_codes + warn_codes
+
+if reason_codes or fail_codes:
+    trend_status = "fail"
+    policy_decision = "NO-GO"
+    status = "fail"
+elif warn_codes:
+    trend_status = "warn"
+    policy_decision = "WARN"
+    status = "ok"
+else:
+    trend_status = "within"
+    policy_decision = "GO"
+    status = "ok"
+
+if fail_codes:
+    remediation = "Prioritize wrapper-family consolidation and shared dispatch extraction in non-Kolme lanes."
+elif warn_codes:
+    remediation = "Monitor shell-surface growth and schedule next tranche before fail threshold breach."
+else:
+    remediation = "none"
+
+policy_report = {
+    "schema_version": "kamn.ci.combined-shell-surface-trend-policy-report.v1",
+    "status": status,
+    "policy_decision": policy_decision,
+    "trend_status": trend_status,
+    "reason_codes": all_reason_codes,
+    "remediation": remediation,
+    "current": {
+        "script_count": script_count,
+        "shell_line_total": shell_line_total,
+        "rust_line_total": rust_line_total,
+        "shell_to_rust_ratio": shell_to_rust_ratio,
+    },
+    "deltas": {
+        "script_count": delta_script_count,
+        "shell_line_total": delta_shell_line_total,
+        "shell_to_rust_ratio": delta_shell_to_rust_ratio,
+    },
+    "thresholds": {
+        "warn_script_count_increase": warn_script_count_increase,
+        "fail_script_count_increase": fail_script_count_increase,
+        "warn_shell_line_total_increase": warn_shell_line_total_increase,
+        "fail_shell_line_total_increase": fail_shell_line_total_increase,
+        "warn_shell_to_rust_ratio": warn_shell_to_rust_ratio,
+        "fail_shell_to_rust_ratio": fail_shell_to_rust_ratio,
+        "warn_shell_to_rust_ratio_increase": warn_shell_to_rust_ratio_increase,
+        "fail_shell_to_rust_ratio_increase": fail_shell_to_rust_ratio_increase,
+    },
+}
+
+output_path.write_text(json.dumps(policy_report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+reason_marker = "none" if not all_reason_codes else ",".join(all_reason_codes)
+print(f"status={status}")
+print(f"policy_decision={policy_decision}")
+print(f"trend_status={trend_status}")
+print(f"reason_codes={reason_marker}")
+print(f"script_count={script_count}")
+print(f"shell_line_total={shell_line_total}")
+print(f"rust_line_total={rust_line_total}")
+print(f"shell_to_rust_ratio={shell_to_rust_ratio}")
+print(f"delta_script_count={delta_script_count}")
+print(f"delta_shell_line_total={delta_shell_line_total}")
+print(f"delta_shell_to_rust_ratio={delta_shell_to_rust_ratio}")
+print(f"remediation={remediation}")
+
+if status != "ok":
+    raise SystemExit(1)
+PY

--- a/scripts/ci/generate_combined_shell_surface_trend_report.sh
+++ b/scripts/ci/generate_combined_shell_surface_trend_report.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CHECK_SCRIPT="$ROOT_DIR/scripts/ci/check_script_duplication_budget.py"
+DEFAULT_BUDGET_FILE="$ROOT_DIR/.ci/script-surface-budget.env"
+DEFAULT_SCRIPT_BASELINE_FILE="$ROOT_DIR/.ci/script-surface-baseline.env"
+DEFAULT_COMBINED_BASELINE_FILE="$ROOT_DIR/fixtures/ci/combined_shell_surface_trend_baseline.json"
+
+output_json=""
+scripts_root="$ROOT_DIR/scripts"
+rust_root="$ROOT_DIR"
+budget_file="$DEFAULT_BUDGET_FILE"
+script_baseline_file="$DEFAULT_SCRIPT_BASELINE_FILE"
+combined_baseline_file="$DEFAULT_COMBINED_BASELINE_FILE"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output-json)
+      output_json="${2:-}"
+      shift 2
+      ;;
+    --scripts-root)
+      scripts_root="${2:-}"
+      shift 2
+      ;;
+    --rust-root)
+      rust_root="${2:-}"
+      shift 2
+      ;;
+    --budget-file)
+      budget_file="${2:-}"
+      shift 2
+      ;;
+    --script-baseline-file)
+      script_baseline_file="${2:-}"
+      shift 2
+      ;;
+    --combined-baseline-file)
+      combined_baseline_file="${2:-}"
+      shift 2
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$output_json" ]]; then
+  echo "--output-json is required" >&2
+  exit 2
+fi
+
+if [[ ! -f "$budget_file" ]]; then
+  echo "budget file not found: $budget_file" >&2
+  exit 2
+fi
+if [[ ! -f "$script_baseline_file" ]]; then
+  echo "script baseline file not found: $script_baseline_file" >&2
+  exit 2
+fi
+if [[ ! -f "$combined_baseline_file" ]]; then
+  echo "combined baseline file not found: $combined_baseline_file" >&2
+  exit 2
+fi
+if [[ ! -d "$scripts_root" ]]; then
+  echo "scripts root not found: $scripts_root" >&2
+  exit 2
+fi
+if [[ ! -d "$rust_root" ]]; then
+  echo "rust root not found: $rust_root" >&2
+  exit 2
+fi
+
+tmp_dir="$(mktemp -d)"
+cleanup_tmp_dir=true
+trap '[ "$cleanup_tmp_dir" = true ] && rm -rf "$tmp_dir"' EXIT
+
+script_budget_report="$tmp_dir/script-surface-budget-report.json"
+set +e
+python3 "$CHECK_SCRIPT" \
+  --scripts-root "$scripts_root" \
+  --budget-file "$budget_file" \
+  --baseline-file "$script_baseline_file" \
+  --output-json "$script_budget_report" >/dev/null
+script_budget_exit_code=$?
+set -e
+
+if [[ ! -f "$script_budget_report" ]]; then
+  echo "script budget checker did not emit report: $script_budget_report" >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname "$output_json")"
+
+python3 - "$script_budget_report" "$combined_baseline_file" "$output_json" "$script_budget_exit_code" "$rust_root" <<'PY'
+import datetime as dt
+import json
+import sys
+from pathlib import Path
+
+script_budget_path = Path(sys.argv[1])
+combined_baseline_path = Path(sys.argv[2])
+output_path = Path(sys.argv[3])
+script_budget_exit_code = int(sys.argv[4])
+rust_root = Path(sys.argv[5])
+
+script_budget = json.loads(script_budget_path.read_text(encoding="utf-8"))
+baseline = json.loads(combined_baseline_path.read_text(encoding="utf-8"))
+
+if baseline.get("schema_version") != "kamn.ci.combined-shell-surface-trend-baseline.v1":
+    raise SystemExit("combined baseline schema mismatch")
+
+metrics = script_budget.get("metrics", {})
+if not isinstance(metrics, dict):
+    raise SystemExit("script budget report missing metrics object")
+
+script_count = int(metrics.get("script_count", 0))
+shell_line_total = int(metrics.get("shell_line_total", 0))
+
+rust_line_total = 0
+for path in rust_root.rglob("*.rs"):
+    rel_parts = set(path.parts)
+    if ".git" in rel_parts or "target" in rel_parts:
+        continue
+    rust_line_total += sum(1 for _ in path.open("r", encoding="utf-8", errors="ignore"))
+
+if rust_line_total <= 0:
+    raise SystemExit("rust_line_total must be positive")
+
+shell_to_rust_ratio = round(shell_line_total / rust_line_total, 6)
+baseline_script_count = int(baseline.get("script_count", 0))
+baseline_shell_line_total = int(baseline.get("shell_line_total", 0))
+baseline_rust_line_total = int(baseline.get("rust_line_total", 0))
+baseline_shell_to_rust_ratio = float(baseline.get("shell_to_rust_ratio", 0.0))
+
+delta_script_count = script_count - baseline_script_count
+delta_shell_line_total = shell_line_total - baseline_shell_line_total
+delta_rust_line_total = rust_line_total - baseline_rust_line_total
+delta_shell_to_rust_ratio = round(shell_to_rust_ratio - baseline_shell_to_rust_ratio, 6)
+
+report = {
+    "schema_version": "kamn.ci.combined-shell-surface-trend-report.v1",
+    "status": "generated",
+    "generated_at_utc": dt.datetime.now(tz=dt.timezone.utc).isoformat(),
+    "current": {
+        "script_count": script_count,
+        "shell_line_total": shell_line_total,
+        "rust_line_total": rust_line_total,
+        "shell_to_rust_ratio": shell_to_rust_ratio,
+    },
+    "baseline": {
+        "script_count": baseline_script_count,
+        "shell_line_total": baseline_shell_line_total,
+        "rust_line_total": baseline_rust_line_total,
+        "shell_to_rust_ratio": baseline_shell_to_rust_ratio,
+    },
+    "deltas": {
+        "script_count": delta_script_count,
+        "shell_line_total": delta_shell_line_total,
+        "rust_line_total": delta_rust_line_total,
+        "shell_to_rust_ratio": delta_shell_to_rust_ratio,
+    },
+    "script_budget": {
+        "status": script_budget.get("status", "fail"),
+        "checker_exit_code": script_budget_exit_code,
+        "violations": script_budget.get("violations", []),
+        "waived": script_budget.get("waived", []),
+        "pending": script_budget.get("pending", []),
+        "remediation": script_budget.get("remediation", "none"),
+    },
+}
+
+output_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+print("status=generated")
+print(f"script_count={script_count}")
+print(f"shell_line_total={shell_line_total}")
+print(f"rust_line_total={rust_line_total}")
+print(f"shell_to_rust_ratio={shell_to_rust_ratio}")
+print(f"delta_script_count={delta_script_count}")
+print(f"delta_shell_line_total={delta_shell_line_total}")
+print(f"delta_rust_line_total={delta_rust_line_total}")
+print(f"delta_shell_to_rust_ratio={delta_shell_to_rust_ratio}")
+print(f"script_budget_status={report['script_budget']['status']}")
+print(f"script_budget_checker_exit_code={script_budget_exit_code}")
+PY

--- a/scripts/ci/test_check_combined_shell_surface_trend_policy.sh
+++ b/scripts/ci/test_check_combined_shell_surface_trend_policy.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+GENERATOR="$ROOT_DIR/scripts/ci/generate_combined_shell_surface_trend_report.sh"
+CHECKER="$ROOT_DIR/scripts/ci/check_combined_shell_surface_trend_policy.sh"
+THRESHOLDS="$ROOT_DIR/fixtures/ci/combined_shell_surface_trend_thresholds.json"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+if [[ ! -x "$GENERATOR" ]]; then
+  echo "expected combined shell-surface trend report generator to be executable" >&2
+  exit 1
+fi
+if [[ ! -x "$CHECKER" ]]; then
+  echo "expected combined shell-surface trend policy checker to be executable" >&2
+  exit 1
+fi
+if [[ ! -f "$THRESHOLDS" ]]; then
+  echo "expected combined shell-surface trend thresholds fixture to exist" >&2
+  exit 1
+fi
+
+report_file="$TMP_DIR/combined-shell-surface-trend-report.json"
+policy_file="$TMP_DIR/combined-shell-surface-trend-policy.json"
+
+bash "$GENERATOR" --output-json "$report_file" >/dev/null
+
+policy_output="$(bash "$CHECKER" --report-file "$report_file" --threshold-file "$THRESHOLDS" --output-json "$policy_file")"
+if ! printf '%s\n' "$policy_output" | grep -q '^status=ok$'; then
+  echo "expected combined shell-surface policy checker status=ok marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$policy_output" | grep -q '^policy_decision=GO$'; then
+  echo "expected combined shell-surface policy checker policy_decision=GO marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$policy_output" | grep -q '^trend_status=within$'; then
+  echo "expected combined shell-surface policy checker trend_status=within marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$policy_output" | grep -q '^reason_codes=none$'; then
+  echo "expected combined shell-surface policy checker reason_codes=none marker" >&2
+  exit 1
+fi
+
+python3 - "$policy_file" <<'PY'
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+if payload.get("schema_version") != "kamn.ci.combined-shell-surface-trend-policy-report.v1":
+    raise SystemExit("unexpected combined shell-surface policy schema")
+if payload.get("status") != "ok":
+    raise SystemExit("expected status=ok")
+if payload.get("policy_decision") != "GO":
+    raise SystemExit("expected policy_decision=GO")
+if payload.get("trend_status") != "within":
+    raise SystemExit("expected trend_status=within")
+if payload.get("reason_codes") not in ([], None):
+    raise SystemExit("expected empty reason_codes for passing policy")
+PY
+
+tampered_report="$TMP_DIR/combined-shell-surface-trend-report.tampered.json"
+cp "$report_file" "$tampered_report"
+python3 - "$tampered_report" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+payload = json.loads(path.read_text(encoding="utf-8"))
+payload["current"]["shell_to_rust_ratio"] = 0.9
+payload["deltas"]["shell_to_rust_ratio"] = 0.4
+payload["deltas"]["shell_line_total"] = 100000
+path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+PY
+
+set +e
+tampered_output="$(bash "$CHECKER" --report-file "$tampered_report" --threshold-file "$THRESHOLDS" --output-json "$TMP_DIR/tampered-policy.json" 2>&1)"
+tampered_code=$?
+set -e
+if [[ "$tampered_code" -eq 0 ]]; then
+  echo "expected tampered combined shell-surface report to fail policy validation" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$tampered_output" | grep -q 'combined_shell_surface_ratio_fail_ceiling_exceeded'; then
+  echo "expected deterministic ratio fail reason code for tampered report" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$tampered_output" | grep -q 'combined_shell_surface_shell_line_total_delta_fail_exceeded'; then
+  echo "expected deterministic shell_line_total fail reason code for tampered report" >&2
+  exit 1
+fi
+
+echo "combined shell-surface trend policy checker tests passed."

--- a/scripts/ci/test_ci_tools.sh
+++ b/scripts/ci/test_ci_tools.sh
@@ -19,6 +19,8 @@ run_non_kolme_lightweight_wave_wrapper_matrix_contracts() {
 if [ "${KAMN_CI_TOOLS_FAST_MODE:-false}" = "true" ]; then
   bash "$ROOT_DIR/scripts/ci/test_evaluate_budget.sh"
   bash "$ROOT_DIR/scripts/ci/test_check_script_duplication_budget.sh"
+  bash "$ROOT_DIR/scripts/ci/test_generate_combined_shell_surface_trend_report.sh"
+  bash "$ROOT_DIR/scripts/ci/test_check_combined_shell_surface_trend_policy.sh"
   bash "$ROOT_DIR/scripts/ci/test_check_legacy_ingress_parser_drift.sh"
   bash "$ROOT_DIR/scripts/ci/test_check_observability_endpoint_drift_contract.sh"
   bash "$ROOT_DIR/scripts/ci/test_generate_test_harness_loc_report.sh"
@@ -119,6 +121,8 @@ fi
 
 bash "$ROOT_DIR/scripts/ci/test_evaluate_budget.sh"
 bash "$ROOT_DIR/scripts/ci/test_check_script_duplication_budget.sh"
+bash "$ROOT_DIR/scripts/ci/test_generate_combined_shell_surface_trend_report.sh"
+bash "$ROOT_DIR/scripts/ci/test_check_combined_shell_surface_trend_policy.sh"
 bash "$ROOT_DIR/scripts/ci/test_check_legacy_ingress_parser_drift.sh"
 bash "$ROOT_DIR/scripts/ci/test_check_observability_endpoint_drift_contract.sh"
 bash "$ROOT_DIR/scripts/ci/test_generate_test_harness_loc_report.sh"

--- a/scripts/ci/test_ci_tools_command_surface_contract.sh
+++ b/scripts/ci/test_ci_tools_command_surface_contract.sh
@@ -79,6 +79,8 @@ required_commands=(
   'bash "$ROOT_DIR/scripts/kolme/test_run_signature_parity_contract_lane.sh"'
   'bash "$ROOT_DIR/scripts/ci/test_generate_test_harness_loc_report.sh"'
   'bash "$ROOT_DIR/scripts/ci/test_generate_kolme_test_harness_loc_trend_report.sh"'
+  'bash "$ROOT_DIR/scripts/ci/test_generate_combined_shell_surface_trend_report.sh"'
+  'bash "$ROOT_DIR/scripts/ci/test_check_combined_shell_surface_trend_policy.sh"'
   'bash "$ROOT_DIR/scripts/ci/test_check_test_harness_loc_soft_budget.sh"'
   'bash "$ROOT_DIR/scripts/ci/test_check_kolme_test_harness_loc_soft_budget.sh"'
   'bash "$ROOT_DIR/scripts/ci/test_check_legacy_ingress_parser_drift.sh"'

--- a/scripts/ci/test_generate_combined_shell_surface_trend_report.sh
+++ b/scripts/ci/test_generate_combined_shell_surface_trend_report.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+GENERATOR="$ROOT_DIR/scripts/ci/generate_combined_shell_surface_trend_report.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+if [[ ! -x "$GENERATOR" ]]; then
+  echo "expected combined shell-surface trend report generator to be executable" >&2
+  exit 1
+fi
+
+report_file="$TMP_DIR/combined-shell-surface-trend-report.json"
+output="$(bash "$GENERATOR" --output-json "$report_file")"
+
+if ! printf '%s\n' "$output" | grep -q '^status=generated$'; then
+  echo "expected combined shell-surface trend generator status=generated marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$output" | grep -Eq '^script_count=[0-9]+$'; then
+  echo "expected combined shell-surface trend generator script_count marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$output" | grep -Eq '^shell_line_total=[0-9]+$'; then
+  echo "expected combined shell-surface trend generator shell_line_total marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$output" | grep -Eq '^rust_line_total=[0-9]+$'; then
+  echo "expected combined shell-surface trend generator rust_line_total marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$output" | grep -Eq '^shell_to_rust_ratio=[0-9]+(\.[0-9]+)?$'; then
+  echo "expected combined shell-surface trend generator shell_to_rust_ratio marker" >&2
+  exit 1
+fi
+
+python3 - "$report_file" <<'PY'
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+if payload.get("schema_version") != "kamn.ci.combined-shell-surface-trend-report.v1":
+    raise SystemExit("unexpected combined trend report schema")
+if payload.get("status") != "generated":
+    raise SystemExit("expected status=generated")
+
+current = payload.get("current", {})
+baseline = payload.get("baseline", {})
+deltas = payload.get("deltas", {})
+script_budget = payload.get("script_budget", {})
+
+for key in ("script_count", "shell_line_total", "rust_line_total"):
+    if not isinstance(current.get(key), int) or current.get(key) <= 0:
+        raise SystemExit(f"expected positive integer current[{key}]")
+
+if not isinstance(current.get("shell_to_rust_ratio"), float):
+    raise SystemExit("expected float current[shell_to_rust_ratio]")
+if script_budget.get("status") not in {"pass", "fail"}:
+    raise SystemExit("expected script budget status to be pass/fail")
+
+expected_delta_script_count = current["script_count"] - int(baseline["script_count"])
+expected_delta_shell_line_total = current["shell_line_total"] - int(baseline["shell_line_total"])
+if deltas.get("script_count") != expected_delta_script_count:
+    raise SystemExit("script_count delta mismatch")
+if deltas.get("shell_line_total") != expected_delta_shell_line_total:
+    raise SystemExit("shell_line_total delta mismatch")
+PY
+
+set +e
+missing_baseline_output="$(bash "$GENERATOR" --combined-baseline-file "$TMP_DIR/missing-baseline.json" --output-json "$TMP_DIR/missing.json" 2>&1)"
+missing_baseline_code=$?
+set -e
+if [[ "$missing_baseline_code" -eq 0 ]]; then
+  echo "expected generator to fail when combined baseline file is missing" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$missing_baseline_output" | grep -q 'combined baseline file not found'; then
+  echo "expected deterministic missing-baseline failure marker" >&2
+  exit 1
+fi
+
+echo "combined shell-surface trend report generator tests passed."


### PR DESCRIPTION
Closes #3450

## Summary
Adds a combined shell-surface trend guard that tracks `script_count`, `shell_line_total`, and shell-to-Rust ratio in one deterministic artifact and policy decision. Integrates the new guard into CI tools fast/full regression for low-cost, fail-closed enforcement.

## Changes
- `scripts/ci/generate_combined_shell_surface_trend_report.sh`: generates combined trend artifact with current/baseline/delta metrics and script-budget status linkage.
- `scripts/ci/check_combined_shell_surface_trend_policy.sh`: evaluates combined trend thresholds and emits deterministic GO/WARN/NO-GO reason codes.
- `fixtures/ci/combined_shell_surface_trend_baseline.json`: baseline for combined trend metrics.
- `fixtures/ci/combined_shell_surface_trend_thresholds.json`: warn/fail thresholds for combined trend policy.
- `scripts/ci/test_generate_combined_shell_surface_trend_report.sh`: generator contract tests.
- `scripts/ci/test_check_combined_shell_surface_trend_policy.sh`: policy checker contract tests including tampered fail-closed scenarios.
- `scripts/ci/test_ci_tools.sh`: runs combined trend generator/policy tests in fast and full modes.
- `scripts/ci/test_ci_tools_command_surface_contract.sh`: locks new combined trend test commands into CI command-surface contract.
- `docs/ci/ci-cost-and-lane-framework.md`, `docs/ci/strategy.md`: documents combined trend guard commands, schemas, and reason-code surface.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
```bash
bash scripts/ci/test_check_combined_shell_surface_trend_policy.sh
# (tampered report branch inside test expects checker failure with deterministic reason codes)
# expected reasons asserted:
# - combined_shell_surface_ratio_fail_ceiling_exceeded
# - combined_shell_surface_shell_line_total_delta_fail_exceeded
```

### 🟢 Green Phase
```bash
bash scripts/ci/test_generate_combined_shell_surface_trend_report.sh
# combined shell-surface trend report generator tests passed.

bash scripts/ci/test_check_combined_shell_surface_trend_policy.sh
# combined shell-surface trend policy checker tests passed.

bash scripts/ci/test_ci_tools_command_surface_contract.sh
# ci tools command surface contract tests passed.
```

### 🔁 Regression
```bash
bash scripts/ci/check_script_duplication_budget.sh
# status=pass
# script_count=383
# shell_line_total=31657
# violations=none

bash scripts/ci/test_ci_strategy_contract.sh
# CI strategy contract tests passed.

KAMN_CI_TOOLS_FAST_MODE=true bash scripts/ci/test_ci_tools.sh
# Fast-mode CI tool regression tests passed.
```

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | N/A | N/A | Shell governance lanes are exercised through deterministic policy/contract scripts |
| Functional   | ✅ | `scripts/ci/test_generate_combined_shell_surface_trend_report.sh`, `scripts/ci/test_check_combined_shell_surface_trend_policy.sh` | |
| Integration  | ✅ | `KAMN_CI_TOOLS_FAST_MODE=true bash scripts/ci/test_ci_tools.sh` | |
| Regression   | ✅ | `scripts/ci/test_ci_tools_command_surface_contract.sh`, `scripts/ci/check_script_duplication_budget.sh`, `scripts/ci/test_ci_strategy_contract.sh` | |
| Performance  | N/A | N/A | Guard runs in existing fast-mode CI tools path and does not add local-heavy execution |

## Risks & Rollback
- Risk: Threshold tuning could cause unexpected NO-GO decisions if baseline/limits drift.
- Rollback: Revert this PR to remove combined guard scripts and restore pre-guard CI tool command surface.

## Documentation Updates
- `docs/ci/ci-cost-and-lane-framework.md`
- `docs/ci/strategy.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean (not applicable; no Rust changes)
- [x] `cargo clippy -- -D warnings` — clean (not applicable; no Rust changes)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (relevant CI/tools + contract lanes)
- [x] Docs updated (or justified why not)
