### PR TITLE
feat(core): add kademlia bootstrap discovery contracts (#3319)

### DIFF
--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -344,8 +344,9 @@ pub use operator_dashboard_ui::{
     OperatorTaskTimelineEntry, ReputationRiskTier,
 };
 pub use p2p_transport::{
-    build_p2p_swarm_deterministic_config, compose_libp2p_swarm_behavior_stack,
-    InMemoryPeerLifecycleTransport, P2pSwarmBehaviorStack, P2pSwarmDeterministicConfig,
+    build_p2p_swarm_deterministic_config, compose_kademlia_discovery_bootstrap,
+    compose_libp2p_swarm_behavior_stack, InMemoryPeerLifecycleTransport, KademliaBootstrapSeedSet,
+    KademliaDiscoveryBootstrapPlan, P2pSwarmBehaviorStack, P2pSwarmDeterministicConfig,
     P2pSwarmHarnessMode, P2pSwarmHarnessReport, P2pSwarmHarnessTask, P2pTransportError,
     PeerDiscoveryRecord, PeerGossipFrame, PeerLifecycleTransport,
     PeerLifecycleTransportCoordinator,

--- a/crates/kamn-core/src/p2p_transport.rs
+++ b/crates/kamn-core/src/p2p_transport.rs
@@ -427,6 +427,66 @@ pub fn compose_libp2p_swarm_behavior_stack(
     }
 }
 
+/// Canonical Kademlia bootstrap seed set for deterministic discovery startup.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KademliaBootstrapSeedSet {
+    seed_peers: Vec<String>,
+}
+
+impl KademliaBootstrapSeedSet {
+    /// Builds a validated deterministic Kademlia bootstrap seed set.
+    pub fn new(seed_peers: Vec<String>) -> Result<Self, P2pTransportError> {
+        if seed_peers.is_empty() {
+            return Err(P2pTransportError::MissingKademliaBootstrapSeeds);
+        }
+
+        let mut normalized = BTreeSet::new();
+        for peer in seed_peers {
+            validate_swarm_bootstrap_peer_address(peer.as_str())?;
+            normalized.insert(peer.trim().to_owned());
+        }
+
+        Ok(Self {
+            seed_peers: normalized.into_iter().collect(),
+        })
+    }
+
+    /// Returns canonical bootstrap peer ordering.
+    pub fn seed_peers(&self) -> Vec<String> {
+        self.seed_peers.clone()
+    }
+}
+
+/// Deterministic Kademlia discovery bootstrap plan.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KademliaDiscoveryBootstrapPlan {
+    discovery_backend: &'static str,
+    seed_peers: Vec<String>,
+}
+
+impl KademliaDiscoveryBootstrapPlan {
+    /// Returns the deterministic discovery backend marker.
+    pub fn discovery_backend(&self) -> &'static str {
+        self.discovery_backend
+    }
+
+    /// Returns canonical Kademlia bootstrap seed ordering.
+    pub fn seed_peers(&self) -> Vec<String> {
+        self.seed_peers.clone()
+    }
+}
+
+/// Composes deterministic Kademlia bootstrap behavior from swarm config seed peers.
+pub fn compose_kademlia_discovery_bootstrap(
+    config: &P2pSwarmDeterministicConfig,
+) -> Result<KademliaDiscoveryBootstrapPlan, P2pTransportError> {
+    let seed_set = KademliaBootstrapSeedSet::new(config.bootstrap_peers().to_vec())?;
+    Ok(KademliaDiscoveryBootstrapPlan {
+        discovery_backend: "kademlia",
+        seed_peers: seed_set.seed_peers(),
+    })
+}
+
 /// Swarm harness execution mode.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum P2pSwarmHarnessMode {
@@ -523,6 +583,8 @@ pub enum P2pTransportError {
     UnknownSenderPeer(String),
     /// Recipient peer has not been advertised.
     UnknownRecipientPeer(String),
+    /// Kademlia discovery bootstrap requires at least one seed peer.
+    MissingKademliaBootstrapSeeds,
     /// Swarm listen address is empty or malformed for deterministic multiaddr handling.
     InvalidSwarmListenAddress,
     /// Swarm bootstrap peer address is malformed for deterministic multiaddr handling.
@@ -557,6 +619,9 @@ impl Display for P2pTransportError {
             }
             Self::UnknownRecipientPeer(peer_id) => {
                 write!(f, "p2p recipient peer is not advertised: {peer_id}")
+            }
+            Self::MissingKademliaBootstrapSeeds => {
+                write!(f, "p2p kademlia bootstrap seed set cannot be empty")
             }
             Self::InvalidSwarmListenAddress => {
                 write!(f, "p2p swarm listen address must be a tcp multiaddr")

--- a/crates/kamn-core/tests/ci_strategy_docs.rs
+++ b/crates/kamn-core/tests/ci_strategy_docs.rs
@@ -545,8 +545,12 @@ fn doc_contains_runtime_libp2p_three_node_discovery_contract_lane_ci_mode_marker
     assert!(DOC.contains(
         "libp2p three-node discovery run-mode commands remain excluded from ci-fast-gate and ci-tools fast mode."
     ));
+    assert!(DOC.contains(
+        "Kademlia bootstrap contracts are covered by `cargo test -p kamn-core --test p2p_kademlia_bootstrap`."
+    ));
     assert!(DOC
         .contains("libp2p_three_node_discovery_policy_marker_missing:three_node_discovery_status"));
+    assert!(DOC.contains("MissingKademliaBootstrapSeeds"));
 }
 
 #[test]

--- a/crates/kamn-core/tests/p2p_kademlia_bootstrap.rs
+++ b/crates/kamn-core/tests/p2p_kademlia_bootstrap.rs
@@ -1,0 +1,127 @@
+use kamn_core::{
+    build_p2p_swarm_deterministic_config, compose_kademlia_discovery_bootstrap, NodeConfig,
+    NodeRole, P2pSwarmHarnessMode, P2pSwarmHarnessTask, P2pTransportError, SyncMode,
+};
+
+fn config_for(role: NodeRole, gossip_enabled: bool) -> NodeConfig {
+    NodeConfig {
+        chain_id: "kamn-devnet".to_owned(),
+        chain_version: "v0.1.0".to_owned(),
+        role,
+        storage_dir: "/tmp/kamn".to_owned(),
+        enable_gossip: gossip_enabled,
+        sync_mode: SyncMode::Fast,
+    }
+}
+
+#[test]
+fn unit_kademlia_bootstrap_rejects_empty_seed_set() {
+    let config = build_p2p_swarm_deterministic_config(
+        &config_for(NodeRole::Processor, true),
+        "peer-processor",
+        "/ip4/127.0.0.1/tcp/9100",
+        vec![],
+        vec!["messages".to_owned()],
+        2,
+    )
+    .expect("swarm config should build");
+
+    let result = compose_kademlia_discovery_bootstrap(&config);
+    assert_eq!(
+        result,
+        Err(P2pTransportError::MissingKademliaBootstrapSeeds)
+    );
+}
+
+#[test]
+fn unit_kademlia_bootstrap_rejects_invalid_seed_multiaddr() {
+    let result = build_p2p_swarm_deterministic_config(
+        &config_for(NodeRole::Processor, true),
+        "peer-processor",
+        "/ip4/127.0.0.1/tcp/9100",
+        vec!["127.0.0.1:9101".to_owned()],
+        vec!["messages".to_owned()],
+        2,
+    );
+
+    assert_eq!(
+        result,
+        Err(P2pTransportError::InvalidSwarmBootstrapPeerAddress(
+            "127.0.0.1:9101".to_owned()
+        ))
+    );
+}
+
+#[test]
+fn functional_kademlia_bootstrap_plan_normalizes_seed_order() {
+    let config = build_p2p_swarm_deterministic_config(
+        &config_for(NodeRole::Processor, true),
+        "peer-processor",
+        "/ip4/127.0.0.1/tcp/9100",
+        vec![
+            "/ip4/127.0.0.1/tcp/9102/p2p/peer-c".to_owned(),
+            "/ip4/127.0.0.1/tcp/9101/p2p/peer-b".to_owned(),
+            "/ip4/127.0.0.1/tcp/9101/p2p/peer-b".to_owned(),
+        ],
+        vec!["messages".to_owned(), "blocks".to_owned()],
+        3,
+    )
+    .expect("swarm config should build");
+
+    let plan = compose_kademlia_discovery_bootstrap(&config)
+        .expect("kademlia bootstrap plan should build");
+    assert_eq!(plan.discovery_backend(), "kademlia");
+    assert_eq!(
+        plan.seed_peers(),
+        vec![
+            "/ip4/127.0.0.1/tcp/9101/p2p/peer-b".to_owned(),
+            "/ip4/127.0.0.1/tcp/9102/p2p/peer-c".to_owned(),
+        ]
+    );
+}
+
+#[test]
+fn integration_kademlia_bootstrap_plan_composes_with_swarm_harness_startup() {
+    let config = build_p2p_swarm_deterministic_config(
+        &config_for(NodeRole::Processor, true),
+        "peer-processor",
+        "/ip4/127.0.0.1/tcp/9100",
+        vec![
+            "/ip4/127.0.0.1/tcp/9101/p2p/peer-listener".to_owned(),
+            "/ip4/127.0.0.1/tcp/9102/p2p/peer-approver".to_owned(),
+        ],
+        vec!["messages".to_owned(), "blocks".to_owned()],
+        3,
+    )
+    .expect("swarm config should build");
+
+    let plan = compose_kademlia_discovery_bootstrap(&config)
+        .expect("kademlia bootstrap plan should build");
+    assert_eq!(plan.seed_peers().len(), 2);
+
+    let task = P2pSwarmHarnessTask::new(config);
+    let report = task
+        .start(P2pSwarmHarnessMode::Run)
+        .expect("swarm harness start should pass");
+    assert!(report.started());
+    assert_eq!(report.executed_ticks(), 3);
+}
+
+#[test]
+fn regression_kademlia_bootstrap_requires_seeded_discovery_plan() {
+    // Regression: #3319
+    let config = build_p2p_swarm_deterministic_config(
+        &config_for(NodeRole::Processor, true),
+        "peer-processor",
+        "/ip4/127.0.0.1/tcp/9100",
+        vec![],
+        vec!["messages".to_owned()],
+        1,
+    )
+    .expect("swarm config should build");
+
+    assert_eq!(
+        compose_kademlia_discovery_bootstrap(&config),
+        Err(P2pTransportError::MissingKademliaBootstrapSeeds)
+    );
+}

--- a/crates/kamn-core/tests/p2p_transport_docs.rs
+++ b/crates/kamn-core/tests/p2p_transport_docs.rs
@@ -11,6 +11,8 @@ fn architecture_doc_contains_p2p_transport_core_components() {
     assert!(DOC.contains("P2pSwarmDeterministicConfig"));
     assert!(DOC.contains("P2pSwarmBehaviorStack"));
     assert!(DOC.contains("P2pSwarmHarnessTask"));
+    assert!(DOC.contains("KademliaBootstrapSeedSet"));
+    assert!(DOC.contains("KademliaDiscoveryBootstrapPlan"));
 }
 
 #[test]
@@ -27,8 +29,10 @@ fn architecture_doc_contains_runtime_wiring_and_guardrails() {
     assert!(DOC.contains("P2pTransportError::InvalidSwarmBootstrapPeerAddress"));
     assert!(DOC.contains("P2pTransportError::InvalidSwarmHarnessTickBudget"));
     assert!(DOC.contains("P2pTransportError::GossipTransportDisabled"));
+    assert!(DOC.contains("P2pTransportError::MissingKademliaBootstrapSeeds"));
     assert!(DOC.contains("validate_p2p_transport_live.sh"));
     assert!(DOC.contains("test_validate_p2p_transport_live.sh"));
+    assert!(DOC.contains("cargo test -p kamn-core --test p2p_kademlia_bootstrap"));
 }
 
 #[test]

--- a/crates/kamn-node/tests/node_runtime_cli_docs.rs
+++ b/crates/kamn-node/tests/node_runtime_cli_docs.rs
@@ -188,6 +188,7 @@ fn doc_contains_p2p_swarm_harness_contracts() {
     assert!(DOC.contains("## P2P Swarm Harness Contracts"));
     assert!(DOC.contains("build_p2p_swarm_deterministic_config"));
     assert!(DOC.contains("compose_libp2p_swarm_behavior_stack"));
+    assert!(DOC.contains("compose_kademlia_discovery_bootstrap"));
     assert!(DOC.contains("P2pSwarmHarnessTask::start"));
     assert!(DOC.contains("p2p-libp2p-swarm-stack"));
     assert!(DOC.contains("p2p-libp2p-harness-ready"));
@@ -195,6 +196,8 @@ fn doc_contains_p2p_swarm_harness_contracts() {
     assert!(DOC.contains("P2pTransportError::InvalidSwarmBootstrapPeerAddress"));
     assert!(DOC.contains("P2pTransportError::InvalidSwarmHarnessTickBudget"));
     assert!(DOC.contains("P2pTransportError::GossipTransportDisabled"));
+    assert!(DOC.contains("P2pTransportError::MissingKademliaBootstrapSeeds"));
+    assert!(DOC.contains("discovery backend marker remains deterministic: `kademlia`."));
 }
 
 #[test]

--- a/docs/architecture/p2p-transport.md
+++ b/docs/architecture/p2p-transport.md
@@ -52,6 +52,10 @@ the default fast test lane.
 - `P2pSwarmHarnessTask`
   - controlled runtime-harness startup surface for deterministic `DryRun` / `Run`
     execution modes used by local integration tests.
+- `KademliaBootstrapSeedSet`
+  - deterministic seed-set normalization for discovery bootstrap startup.
+- `KademliaDiscoveryBootstrapPlan`
+  - deterministic Kademlia backend marker + canonical seed-peer ordering.
 
 ## Runtime Wiring Integration
 
@@ -85,6 +89,8 @@ enabled for a node profile.
   `P2pTransportError::InvalidSwarmHarnessTickBudget`.
 - Swarm config requests with `enable_gossip=false` fail closed with
   `P2pTransportError::GossipTransportDisabled`.
+- Empty Kademlia seed sets fail closed with
+  `P2pTransportError::MissingKademliaBootstrapSeeds`.
 
 Regression marker:
 - `Regression: #2922` ensures disconnected peers cannot broadcast gossip frames.
@@ -94,6 +100,7 @@ Regression marker:
 ```bash
 cargo test -p kamn-core --test p2p_transport_runtime
 cargo test -p kamn-core --test p2p_swarm_stack_runtime
+cargo test -p kamn-core --test p2p_kademlia_bootstrap
 cargo test -p kamn-core p2p_transport
 cargo clippy -p kamn-core -- -D warnings
 cargo fmt --check

--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -299,6 +299,8 @@ Versioned thresholds are defined in `.ci/ci-budget.env`.
   - lane emits deterministic gossip propagation marker (`gossip_propagation_status=verified`).
   - lane emits deterministic lifecycle transition marker (`lifecycle_transition_status=verified`).
   - lane emits deterministic runtime transport marker (`runtime_transport_mode=libp2p_discovery_gossip_three_node`).
+  - Kademlia bootstrap contracts are covered by `cargo test -p kamn-core --test p2p_kademlia_bootstrap`.
+  - bootstrap seed validation remains fail-closed for empty/invalid seed sets before discovery startup.
   - policy checker fails closed on schema/marker drift and decision mismatches.
 - Cost controls:
   - dry-run mode executes no nested commands and emits deterministic `dry_run_no_commands_executed`.
@@ -307,6 +309,7 @@ Versioned thresholds are defined in `.ci/ci-budget.env`.
   - libp2p three-node discovery run-mode commands remain excluded from ci-fast-gate and ci-tools fast mode.
 - Deterministic fail-closed marker for policy tamper drills:
   - `libp2p_three_node_discovery_policy_marker_missing:three_node_discovery_status`
+  - `MissingKademliaBootstrapSeeds`
 
 ## Process Harness Primitive Contract
 - Entry commands:

--- a/docs/foundation/node-runtime-cli.md
+++ b/docs/foundation/node-runtime-cli.md
@@ -225,6 +225,11 @@ This document captures node-runtime productionization slices for machine-readabl
   - `P2pTransportError::InvalidSwarmBootstrapPeerAddress`
   - `P2pTransportError::InvalidSwarmHarnessTickBudget`
   - `P2pTransportError::GossipTransportDisabled`
+- Kademlia bootstrap contracts:
+  - `compose_kademlia_discovery_bootstrap(...)` composes deterministic discovery plans from configured seed peers.
+  - bootstrap seed list is canonicalized and deduplicated before startup.
+  - empty seed lists fail closed with `P2pTransportError::MissingKademliaBootstrapSeeds`.
+  - discovery backend marker remains deterministic: `kademlia`.
 - Harness startup modes:
   - `DryRun`: validates deterministic composition and reports `started=false`.
   - `Run`: starts bounded harness loop and reports deterministic `executed_ticks`.


### PR DESCRIPTION
## Summary
Implements deterministic Kademlia bootstrap discovery contracts for the libp2p transport surface in `kamn-core`, including explicit seed-set validation and fail-closed behavior for empty/invalid seeds. This extends the existing swarm composition path with typed Kademlia bootstrap planning and test/documentation coverage.

Closes #3319

## Changes
- `crates/kamn-core/src/p2p_transport.rs`:
  - added `KademliaBootstrapSeedSet` and `KademliaDiscoveryBootstrapPlan`.
  - added `compose_kademlia_discovery_bootstrap(...)`.
  - added `P2pTransportError::MissingKademliaBootstrapSeeds` fail-closed variant.
- `crates/kamn-core/src/lib.rs`: exported new Kademlia bootstrap contracts.
- `crates/kamn-core/tests/p2p_kademlia_bootstrap.rs`: added unit/functional/integration/regression coverage for empty/invalid/valid seed behavior and harness composition.
- `docs/foundation/node-runtime-cli.md` + `crates/kamn-node/tests/node_runtime_cli_docs.rs`: documented and contract-tested Kademlia bootstrap options/error semantics.
- `docs/ci/strategy.md` + `crates/kamn-core/tests/ci_strategy_docs.rs`: documented and contract-tested Kademlia bootstrap validation scope in CI strategy.
- `docs/architecture/p2p-transport.md` + `crates/kamn-core/tests/p2p_transport_docs.rs`: documented and contract-tested Kademlia bootstrap architecture surfaces and fail-closed marker.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
- `cargo test -p kamn-core --test p2p_kademlia_bootstrap`

Failing output excerpt:
- unresolved import: `compose_kademlia_discovery_bootstrap`
- missing error variant: `P2pTransportError::MissingKademliaBootstrapSeeds`

### 🟢 Green Phase
Commands:
- `cargo test -p kamn-core --test p2p_kademlia_bootstrap`
- `cargo test -p kamn-core --test p2p_transport_docs`
- `cargo test -p kamn-core --test ci_strategy_docs doc_contains_runtime_libp2p_three_node_discovery_contract_lane_ci_mode_markers -- --exact`
- `cargo test -p kamn-node --test node_runtime_cli_docs doc_contains_p2p_swarm_harness_contracts -- --exact`

Result:
- all commands pass.

### 🔁 Regression
Commands:
- `cargo fmt --check`
- `cargo clippy -p kamn-core -p kamn-node -- -D warnings`

Result:
- both pass cleanly.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `unit_kademlia_bootstrap_rejects_empty_seed_set`, `unit_kademlia_bootstrap_rejects_invalid_seed_multiaddr` | |
| Functional   | ✅     | `functional_kademlia_bootstrap_plan_normalizes_seed_order` | |
| Integration  | ✅     | `integration_kademlia_bootstrap_plan_composes_with_swarm_harness_startup` | |
| Regression   | ✅     | `regression_kademlia_bootstrap_requires_seeded_discovery_plan` + updated docs contracts | |
| Performance  | N/A    | None | No algorithmic throughput/latency path change; this subtask is deterministic validation/composition surface only. |

## Risks & Rollback
- Additive contract surface only; no removal/breaking rename of existing APIs.
- Rollback plan: revert commit `feat(core): add kademlia bootstrap discovery contracts (#3319)`.

## Documentation Updates
- `docs/architecture/p2p-transport.md`
- `docs/ci/strategy.md`
- `docs/foundation/node-runtime-cli.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-core -p kamn-node -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (issue-relevant scope)
- [x] Docs updated
