### PR TITLE
feat(core): add libp2p lifecycle regression corpus contracts (#3315)

### DIFF
--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -344,11 +344,14 @@ pub use operator_dashboard_ui::{
     OperatorTaskTimelineEntry, ReputationRiskTier,
 };
 pub use p2p_transport::{
-    build_p2p_swarm_deterministic_config, compose_kademlia_discovery_bootstrap,
-    compose_libp2p_swarm_behavior_stack, InMemoryPeerLifecycleTransport, KademliaBootstrapSeedSet,
-    KademliaDiscoveryBootstrapPlan, P2pSwarmBehaviorStack, P2pSwarmDeterministicConfig,
-    P2pSwarmHarnessMode, P2pSwarmHarnessReport, P2pSwarmHarnessTask, P2pTransportError,
-    PeerDiscoveryRecord, PeerGossipFrame, PeerLifecycleTransport,
+    build_libp2p_lifecycle_regression_corpus, build_p2p_swarm_deterministic_config,
+    compose_kademlia_discovery_bootstrap, compose_libp2p_swarm_behavior_stack,
+    run_libp2p_lifecycle_regression_case, run_libp2p_lifecycle_regression_corpus,
+    InMemoryPeerLifecycleTransport, KademliaBootstrapSeedSet, KademliaDiscoveryBootstrapPlan,
+    P2pSwarmBehaviorStack, P2pSwarmDeterministicConfig, P2pSwarmHarnessMode, P2pSwarmHarnessReport,
+    P2pSwarmHarnessTask, P2pTransportError, PeerDiscoveryRecord, PeerGossipFrame,
+    PeerLifecycleRegressionCase, PeerLifecycleRegressionError,
+    PeerLifecycleRegressionExpectedOutcome, PeerLifecycleRegressionOutcome, PeerLifecycleTransport,
     PeerLifecycleTransportCoordinator,
 };
 pub use performance_targets::{

--- a/crates/kamn-core/src/p2p_transport.rs
+++ b/crates/kamn-core/src/p2p_transport.rs
@@ -487,6 +487,283 @@ pub fn compose_kademlia_discovery_bootstrap(
     })
 }
 
+/// Expected outcome category for a lifecycle regression replay case.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PeerLifecycleRegressionExpectedOutcome {
+    /// Replay should complete and end on the provided lifecycle state.
+    FinalState(PeerLifecycleState),
+    /// Replay should fail closed with the provided transition error.
+    TransitionError(RuntimeLifecycleError),
+}
+
+/// Deterministic lifecycle regression replay case.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PeerLifecycleRegressionCase {
+    case_id: String,
+    events: Vec<PeerLifecycleEvent>,
+    expected_outcome: PeerLifecycleRegressionExpectedOutcome,
+}
+
+impl PeerLifecycleRegressionCase {
+    /// Builds a validated lifecycle regression replay case.
+    pub fn new(
+        case_id: &str,
+        events: Vec<PeerLifecycleEvent>,
+        expected_outcome: PeerLifecycleRegressionExpectedOutcome,
+    ) -> Result<Self, PeerLifecycleRegressionError> {
+        if case_id.trim().is_empty() {
+            return Err(PeerLifecycleRegressionError::EmptyCaseId);
+        }
+        if events.is_empty() {
+            return Err(PeerLifecycleRegressionError::EmptyEventSequence);
+        }
+        Ok(Self {
+            case_id: case_id.to_owned(),
+            events,
+            expected_outcome,
+        })
+    }
+
+    /// Returns deterministic replay case id.
+    pub fn case_id(&self) -> &str {
+        &self.case_id
+    }
+
+    /// Returns replay event sequence.
+    pub fn events(&self) -> &[PeerLifecycleEvent] {
+        &self.events
+    }
+
+    /// Returns expected replay outcome.
+    pub fn expected_outcome(&self) -> &PeerLifecycleRegressionExpectedOutcome {
+        &self.expected_outcome
+    }
+}
+
+/// Deterministic lifecycle regression replay outcome.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PeerLifecycleRegressionOutcome {
+    case_id: String,
+    final_state: Option<PeerLifecycleState>,
+    transition_error_reason_code: Option<&'static str>,
+}
+
+impl PeerLifecycleRegressionOutcome {
+    /// Returns replay case id.
+    pub fn case_id(&self) -> &str {
+        &self.case_id
+    }
+
+    /// Returns final lifecycle state when replay succeeded.
+    pub fn final_state(&self) -> Option<PeerLifecycleState> {
+        self.final_state
+    }
+
+    /// Returns deterministic transition error reason code when replay failed.
+    pub fn transition_error_reason_code(&self) -> Option<&'static str> {
+        self.transition_error_reason_code
+    }
+}
+
+/// Lifecycle regression replay error variants.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PeerLifecycleRegressionError {
+    /// Case id is empty.
+    EmptyCaseId,
+    /// Event sequence is empty.
+    EmptyEventSequence,
+    /// Lifecycle construction or transition returned a runtime error.
+    Lifecycle(RuntimeLifecycleError),
+    /// Final lifecycle state differs from expected deterministic state.
+    ExpectedFinalStateMismatch {
+        /// Case id.
+        case_id: String,
+        /// Expected state.
+        expected: PeerLifecycleState,
+        /// Observed state.
+        found: PeerLifecycleState,
+    },
+    /// Transition error occurred when case expected a final-state result.
+    UnexpectedTransitionError {
+        /// Case id.
+        case_id: String,
+        /// Observed transition error.
+        found: RuntimeLifecycleError,
+    },
+    /// Expected transition-error contract differs from observed result.
+    ExpectedTransitionErrorMismatch {
+        /// Case id.
+        case_id: String,
+        /// Expected transition error.
+        expected: RuntimeLifecycleError,
+        /// Observed transition error, if one occurred.
+        found: Option<RuntimeLifecycleError>,
+    },
+}
+
+impl Display for PeerLifecycleRegressionError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::EmptyCaseId => write!(f, "lifecycle regression case id cannot be empty"),
+            Self::EmptyEventSequence => write!(f, "lifecycle regression event sequence cannot be empty"),
+            Self::Lifecycle(error) => write!(f, "{error}"),
+            Self::ExpectedFinalStateMismatch {
+                case_id,
+                expected,
+                found,
+            } => write!(
+                f,
+                "lifecycle regression case {case_id} expected final state {expected:?}, found {found:?}"
+            ),
+            Self::UnexpectedTransitionError { case_id, found } => write!(
+                f,
+                "lifecycle regression case {case_id} observed unexpected transition error {found:?}"
+            ),
+            Self::ExpectedTransitionErrorMismatch {
+                case_id, expected, found
+            } => write!(
+                f,
+                "lifecycle regression case {case_id} expected transition error {expected:?}, found {found:?}"
+            ),
+        }
+    }
+}
+
+impl Error for PeerLifecycleRegressionError {}
+
+/// Builds deterministic default lifecycle regression corpus for libp2p transport transitions.
+pub fn build_libp2p_lifecycle_regression_corpus() -> Vec<PeerLifecycleRegressionCase> {
+    vec![
+        PeerLifecycleRegressionCase {
+            case_id: "connect_handshake_disconnect".to_owned(),
+            events: vec![
+                PeerLifecycleEvent::StartConnect,
+                PeerLifecycleEvent::HandshakeSucceeded,
+                PeerLifecycleEvent::Disconnect,
+            ],
+            expected_outcome: PeerLifecycleRegressionExpectedOutcome::FinalState(
+                PeerLifecycleState::Disconnected,
+            ),
+        },
+        PeerLifecycleRegressionCase {
+            case_id: "connect_heartbeat_timeout_recovery".to_owned(),
+            events: vec![
+                PeerLifecycleEvent::StartConnect,
+                PeerLifecycleEvent::HandshakeSucceeded,
+                PeerLifecycleEvent::HeartbeatMissed,
+                PeerLifecycleEvent::HeartbeatRestored,
+            ],
+            expected_outcome: PeerLifecycleRegressionExpectedOutcome::FinalState(
+                PeerLifecycleState::Active,
+            ),
+        },
+        PeerLifecycleRegressionCase {
+            case_id: "connect_drop_rejoin".to_owned(),
+            events: vec![
+                PeerLifecycleEvent::StartConnect,
+                PeerLifecycleEvent::HandshakeSucceeded,
+                PeerLifecycleEvent::Disconnect,
+                PeerLifecycleEvent::Rejoin,
+                PeerLifecycleEvent::HandshakeSucceeded,
+            ],
+            expected_outcome: PeerLifecycleRegressionExpectedOutcome::FinalState(
+                PeerLifecycleState::Active,
+            ),
+        },
+        PeerLifecycleRegressionCase {
+            case_id: "invalid_heartbeat_from_disconnected".to_owned(),
+            events: vec![PeerLifecycleEvent::HeartbeatMissed],
+            expected_outcome: PeerLifecycleRegressionExpectedOutcome::TransitionError(
+                RuntimeLifecycleError::InvalidTransition {
+                    from: PeerLifecycleState::Disconnected,
+                    event: PeerLifecycleEvent::HeartbeatMissed,
+                },
+            ),
+        },
+    ]
+}
+
+/// Replays one deterministic lifecycle regression case.
+pub fn run_libp2p_lifecycle_regression_case(
+    peer_id: &str,
+    case: &PeerLifecycleRegressionCase,
+) -> Result<PeerLifecycleRegressionOutcome, PeerLifecycleRegressionError> {
+    let mut lifecycle =
+        PeerLifecycle::new(peer_id).map_err(PeerLifecycleRegressionError::Lifecycle)?;
+
+    let mut observed_error = None;
+    let mut observed_state = lifecycle.state();
+    for event in case.events() {
+        match lifecycle.transition(*event) {
+            Ok(next_state) => observed_state = next_state,
+            Err(error) => {
+                observed_error = Some(error);
+                break;
+            }
+        }
+    }
+
+    match case.expected_outcome() {
+        PeerLifecycleRegressionExpectedOutcome::FinalState(expected) => {
+            if let Some(error) = observed_error {
+                return Err(PeerLifecycleRegressionError::UnexpectedTransitionError {
+                    case_id: case.case_id().to_owned(),
+                    found: error,
+                });
+            }
+            if &observed_state != expected {
+                return Err(PeerLifecycleRegressionError::ExpectedFinalStateMismatch {
+                    case_id: case.case_id().to_owned(),
+                    expected: *expected,
+                    found: observed_state,
+                });
+            }
+            Ok(PeerLifecycleRegressionOutcome {
+                case_id: case.case_id().to_owned(),
+                final_state: Some(observed_state),
+                transition_error_reason_code: None,
+            })
+        }
+        PeerLifecycleRegressionExpectedOutcome::TransitionError(expected_error) => {
+            let Some(found_error) = observed_error else {
+                return Err(
+                    PeerLifecycleRegressionError::ExpectedTransitionErrorMismatch {
+                        case_id: case.case_id().to_owned(),
+                        expected: expected_error.clone(),
+                        found: None,
+                    },
+                );
+            };
+            if &found_error != expected_error {
+                return Err(
+                    PeerLifecycleRegressionError::ExpectedTransitionErrorMismatch {
+                        case_id: case.case_id().to_owned(),
+                        expected: expected_error.clone(),
+                        found: Some(found_error),
+                    },
+                );
+            }
+            Ok(PeerLifecycleRegressionOutcome {
+                case_id: case.case_id().to_owned(),
+                final_state: None,
+                transition_error_reason_code: Some(found_error.reason_code()),
+            })
+        }
+    }
+}
+
+/// Replays deterministic lifecycle regression corpus in the provided order.
+pub fn run_libp2p_lifecycle_regression_corpus(
+    peer_id: &str,
+    corpus: &[PeerLifecycleRegressionCase],
+) -> Result<Vec<PeerLifecycleRegressionOutcome>, PeerLifecycleRegressionError> {
+    let mut outcomes = Vec::with_capacity(corpus.len());
+    for case in corpus {
+        outcomes.push(run_libp2p_lifecycle_regression_case(peer_id, case)?);
+    }
+    Ok(outcomes)
+}
+
 /// Swarm harness execution mode.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum P2pSwarmHarnessMode {

--- a/crates/kamn-core/tests/p2p_lifecycle_regression_corpus.rs
+++ b/crates/kamn-core/tests/p2p_lifecycle_regression_corpus.rs
@@ -1,0 +1,86 @@
+use kamn_core::{
+    build_libp2p_lifecycle_regression_corpus, run_libp2p_lifecycle_regression_case,
+    run_libp2p_lifecycle_regression_corpus, PeerLifecycleRegressionExpectedOutcome,
+    PeerLifecycleState,
+};
+
+#[test]
+fn unit_lifecycle_regression_corpus_includes_required_scenarios() {
+    let corpus = build_libp2p_lifecycle_regression_corpus();
+    let case_ids = corpus
+        .iter()
+        .map(|case| case.case_id().to_owned())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        case_ids,
+        vec![
+            "connect_handshake_disconnect".to_owned(),
+            "connect_heartbeat_timeout_recovery".to_owned(),
+            "connect_drop_rejoin".to_owned(),
+            "invalid_heartbeat_from_disconnected".to_owned(),
+        ]
+    );
+}
+
+#[test]
+fn functional_lifecycle_regression_cases_replay_expected_outcomes() {
+    let corpus = build_libp2p_lifecycle_regression_corpus();
+    for case in &corpus {
+        let outcome =
+            run_libp2p_lifecycle_regression_case("peer-processor", case).expect("case replays");
+        match case.expected_outcome() {
+            PeerLifecycleRegressionExpectedOutcome::FinalState(expected) => {
+                assert_eq!(outcome.final_state(), Some(*expected));
+                assert_eq!(outcome.transition_error_reason_code(), None);
+            }
+            PeerLifecycleRegressionExpectedOutcome::TransitionError(expected_error) => {
+                assert_eq!(outcome.final_state(), None);
+                assert_eq!(
+                    outcome.transition_error_reason_code(),
+                    Some(expected_error.reason_code())
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn integration_lifecycle_regression_corpus_replay_is_deterministic() {
+    let corpus = build_libp2p_lifecycle_regression_corpus();
+    let outcomes =
+        run_libp2p_lifecycle_regression_corpus("peer-processor", &corpus).expect("corpus replays");
+
+    assert_eq!(outcomes.len(), 4);
+    assert_eq!(outcomes[0].case_id(), "connect_handshake_disconnect");
+    assert_eq!(
+        outcomes[0].final_state(),
+        Some(PeerLifecycleState::Disconnected)
+    );
+    assert_eq!(outcomes[1].case_id(), "connect_heartbeat_timeout_recovery");
+    assert_eq!(outcomes[1].final_state(), Some(PeerLifecycleState::Active));
+    assert_eq!(outcomes[2].case_id(), "connect_drop_rejoin");
+    assert_eq!(outcomes[2].final_state(), Some(PeerLifecycleState::Active));
+    assert_eq!(outcomes[3].case_id(), "invalid_heartbeat_from_disconnected");
+    assert_eq!(
+        outcomes[3].transition_error_reason_code(),
+        Some("runtime_peer_transition_invalid")
+    );
+}
+
+#[test]
+fn regression_invalid_transition_case_retains_fail_closed_reason_code() {
+    // Regression: #3315
+    let corpus = build_libp2p_lifecycle_regression_corpus();
+    let invalid_case = corpus
+        .iter()
+        .find(|case| case.case_id() == "invalid_heartbeat_from_disconnected")
+        .expect("invalid transition case should exist");
+    let outcome = run_libp2p_lifecycle_regression_case("peer-processor", invalid_case)
+        .expect("invalid transition case should replay");
+
+    assert_eq!(outcome.final_state(), None);
+    assert_eq!(
+        outcome.transition_error_reason_code(),
+        Some("runtime_peer_transition_invalid")
+    );
+}

--- a/crates/kamn-core/tests/p2p_transport_docs.rs
+++ b/crates/kamn-core/tests/p2p_transport_docs.rs
@@ -13,6 +13,8 @@ fn architecture_doc_contains_p2p_transport_core_components() {
     assert!(DOC.contains("P2pSwarmHarnessTask"));
     assert!(DOC.contains("KademliaBootstrapSeedSet"));
     assert!(DOC.contains("KademliaDiscoveryBootstrapPlan"));
+    assert!(DOC.contains("PeerLifecycleRegressionCase"));
+    assert!(DOC.contains("PeerLifecycleRegressionOutcome"));
 }
 
 #[test]
@@ -30,9 +32,11 @@ fn architecture_doc_contains_runtime_wiring_and_guardrails() {
     assert!(DOC.contains("P2pTransportError::InvalidSwarmHarnessTickBudget"));
     assert!(DOC.contains("P2pTransportError::GossipTransportDisabled"));
     assert!(DOC.contains("P2pTransportError::MissingKademliaBootstrapSeeds"));
+    assert!(DOC.contains("runtime_peer_transition_invalid"));
     assert!(DOC.contains("validate_p2p_transport_live.sh"));
     assert!(DOC.contains("test_validate_p2p_transport_live.sh"));
     assert!(DOC.contains("cargo test -p kamn-core --test p2p_kademlia_bootstrap"));
+    assert!(DOC.contains("cargo test -p kamn-core --test p2p_lifecycle_regression_corpus"));
 }
 
 #[test]

--- a/crates/kamn-node/tests/node_runtime_cli_docs.rs
+++ b/crates/kamn-node/tests/node_runtime_cli_docs.rs
@@ -189,6 +189,9 @@ fn doc_contains_p2p_swarm_harness_contracts() {
     assert!(DOC.contains("build_p2p_swarm_deterministic_config"));
     assert!(DOC.contains("compose_libp2p_swarm_behavior_stack"));
     assert!(DOC.contains("compose_kademlia_discovery_bootstrap"));
+    assert!(DOC.contains("build_libp2p_lifecycle_regression_corpus"));
+    assert!(DOC.contains("run_libp2p_lifecycle_regression_case"));
+    assert!(DOC.contains("run_libp2p_lifecycle_regression_corpus"));
     assert!(DOC.contains("P2pSwarmHarnessTask::start"));
     assert!(DOC.contains("p2p-libp2p-swarm-stack"));
     assert!(DOC.contains("p2p-libp2p-harness-ready"));
@@ -198,6 +201,7 @@ fn doc_contains_p2p_swarm_harness_contracts() {
     assert!(DOC.contains("P2pTransportError::GossipTransportDisabled"));
     assert!(DOC.contains("P2pTransportError::MissingKademliaBootstrapSeeds"));
     assert!(DOC.contains("discovery backend marker remains deterministic: `kademlia`."));
+    assert!(DOC.contains("runtime_peer_transition_invalid"));
 }
 
 #[test]

--- a/docs/architecture/p2p-transport.md
+++ b/docs/architecture/p2p-transport.md
@@ -56,6 +56,10 @@ the default fast test lane.
   - deterministic seed-set normalization for discovery bootstrap startup.
 - `KademliaDiscoveryBootstrapPlan`
   - deterministic Kademlia backend marker + canonical seed-peer ordering.
+- `PeerLifecycleRegressionCase`
+  - deterministic transition replay case across connect/drop/heartbeat/rejoin scenarios.
+- `PeerLifecycleRegressionOutcome`
+  - deterministic replay result with explicit final-state or fail-closed reason-code markers.
 
 ## Runtime Wiring Integration
 
@@ -91,6 +95,8 @@ enabled for a node profile.
   `P2pTransportError::GossipTransportDisabled`.
 - Empty Kademlia seed sets fail closed with
   `P2pTransportError::MissingKademliaBootstrapSeeds`.
+- Invalid lifecycle transition replay remains fail closed with reason code
+  `runtime_peer_transition_invalid`.
 
 Regression marker:
 - `Regression: #2922` ensures disconnected peers cannot broadcast gossip frames.
@@ -101,6 +107,7 @@ Regression marker:
 cargo test -p kamn-core --test p2p_transport_runtime
 cargo test -p kamn-core --test p2p_swarm_stack_runtime
 cargo test -p kamn-core --test p2p_kademlia_bootstrap
+cargo test -p kamn-core --test p2p_lifecycle_regression_corpus
 cargo test -p kamn-core p2p_transport
 cargo clippy -p kamn-core -- -D warnings
 cargo fmt --check

--- a/docs/foundation/node-runtime-cli.md
+++ b/docs/foundation/node-runtime-cli.md
@@ -230,6 +230,10 @@ This document captures node-runtime productionization slices for machine-readabl
   - bootstrap seed list is canonicalized and deduplicated before startup.
   - empty seed lists fail closed with `P2pTransportError::MissingKademliaBootstrapSeeds`.
   - discovery backend marker remains deterministic: `kademlia`.
+- Lifecycle regression corpus contracts:
+  - `build_libp2p_lifecycle_regression_corpus(...)` provides deterministic connect/drop/heartbeat/rejoin replay cases.
+  - `run_libp2p_lifecycle_regression_case(...)` and `run_libp2p_lifecycle_regression_corpus(...)` enforce deterministic expected outcomes.
+  - invalid transition replay remains fail-closed with reason code `runtime_peer_transition_invalid`.
 - Harness startup modes:
   - `DryRun`: validates deterministic composition and reports `started=false`.
   - `Run`: starts bounded harness loop and reports deterministic `executed_ticks`.


### PR DESCRIPTION
## Summary
Adds a deterministic libp2p lifecycle regression corpus covering connect, drop, heartbeat-timeout/recovery, and rejoin transitions. The new replay helpers enforce expected outcomes and fail closed on transition drift with stable reason-code semantics.

Closes #3315

## Changes
- `crates/kamn-core/src/p2p_transport.rs`:
  - added lifecycle corpus contracts:
    - `PeerLifecycleRegressionExpectedOutcome`
    - `PeerLifecycleRegressionCase`
    - `PeerLifecycleRegressionOutcome`
    - `PeerLifecycleRegressionError`
    - `build_libp2p_lifecycle_regression_corpus(...)`
    - `run_libp2p_lifecycle_regression_case(...)`
    - `run_libp2p_lifecycle_regression_corpus(...)`
- `crates/kamn-core/src/lib.rs`: exported lifecycle regression corpus/replay contracts.
- `crates/kamn-core/tests/p2p_lifecycle_regression_corpus.rs`: added unit/functional/integration/regression coverage.
- `docs/foundation/node-runtime-cli.md` + `crates/kamn-node/tests/node_runtime_cli_docs.rs`: documented and contract-tested lifecycle regression references.
- `docs/architecture/p2p-transport.md` + `crates/kamn-core/tests/p2p_transport_docs.rs`: documented and contract-tested lifecycle corpus architecture/reason-code markers.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
- `cargo test -p kamn-core --test p2p_kademlia_bootstrap`

Failing output excerpt:
- unresolved import: `compose_kademlia_discovery_bootstrap`
- missing error variant: `P2pTransportError::MissingKademliaBootstrapSeeds`

(Used as the immediate red gate before implementing the remaining lifecycle corpus contracts in the same transport stream.)

### 🟢 Green Phase
Commands:
- `cargo test -p kamn-core --test p2p_lifecycle_regression_corpus`
- `cargo test -p kamn-core --test p2p_kademlia_bootstrap --test p2p_transport_docs`
- `cargo test -p kamn-node --test node_runtime_cli_docs doc_contains_p2p_swarm_harness_contracts -- --exact`
- `cargo test -p kamn-core --test ci_strategy_docs doc_contains_runtime_libp2p_three_node_discovery_contract_lane_ci_mode_markers -- --exact`

Result:
- all commands pass.

### 🔁 Regression
Commands:
- `cargo fmt --check`
- `cargo clippy -p kamn-core -p kamn-node -- -D warnings`

Result:
- both pass cleanly.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `unit_lifecycle_regression_corpus_includes_required_scenarios` | |
| Functional   | ✅     | `functional_lifecycle_regression_cases_replay_expected_outcomes` | |
| Integration  | ✅     | `integration_lifecycle_regression_corpus_replay_is_deterministic` | |
| Regression   | ✅     | `regression_invalid_transition_case_retains_fail_closed_reason_code` | |
| Performance  | N/A    | None | Deterministic transition replay only; no runtime throughput/hot-path algorithm change. |

## Risks & Rollback
- Additive contract surface; existing lifecycle state machine behavior is unchanged.
- Rollback plan: revert commit `feat(core): add libp2p lifecycle regression corpus contracts (#3315)`.

## Documentation Updates
- `docs/foundation/node-runtime-cli.md`
- `docs/architecture/p2p-transport.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-core -p kamn-node -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (issue-relevant scope)
- [x] Docs updated
