### PR TITLE
fix(node): enforce declared signer provenance path selection (#3471)

### DIFF
--- a/crates/kamn-node/src/main.rs
+++ b/crates/kamn-node/src/main.rs
@@ -1166,23 +1166,31 @@ fn execute(cli: NodeCli) -> Result<NodeBootstrapReport, ConfigError> {
                 allow_local_signer_testing_override,
                 cfg!(test),
             )?;
+            let declared_signer_profile = kolme_live_signer_profile
+                .as_deref()
+                .map(normalize_kolme_live_signer_profile_selector)
+                .transpose()?;
+            let declared_signer_key_source = kolme_live_signer_key_source
+                .as_deref()
+                .map(normalize_kolme_live_signer_key_source)
+                .transpose()?;
             let strict_signer_profile = if kolme_live_strict_signer_contracts {
-                Some(normalize_kolme_live_signer_profile_selector(
-                    kolme_live_signer_profile.as_deref().ok_or(
-                        ConfigError::MissingArgumentValue("--kolme-live-signer-profile"),
-                    )?,
-                )?)
+                Some(
+                    declared_signer_profile.ok_or(ConfigError::MissingArgumentValue(
+                        "--kolme-live-signer-profile",
+                    ))?,
+                )
             } else {
-                None
+                declared_signer_profile
             };
             let strict_signer_key_source = if kolme_live_strict_signer_contracts {
-                Some(normalize_kolme_live_signer_key_source(
-                    kolme_live_signer_key_source.as_deref().ok_or(
-                        ConfigError::MissingArgumentValue("--kolme-live-signer-key-source"),
-                    )?,
-                )?)
+                Some(
+                    declared_signer_key_source.ok_or(ConfigError::MissingArgumentValue(
+                        "--kolme-live-signer-key-source",
+                    ))?,
+                )
             } else {
-                None
+                declared_signer_key_source
             };
             enforce_kolme_live_signer_key_source_policy(
                 kolme_live_strict_signer_contracts,

--- a/crates/kamn-node/src/main_tests/core_behavior_tests.rs
+++ b/crates/kamn-node/src/main_tests/core_behavior_tests.rs
@@ -329,6 +329,53 @@ fn integration_kolme_live_strict_managed_external_key_source_policy_passes() {
 }
 
 #[test]
+fn regression_runtime_kolme_live_honors_declared_managed_external_key_source_without_strict_flag() {
+    let _lock = signer_env_lock()
+        .lock()
+        .expect("signer env lock should guard test mutation");
+    let _profile_env_guard =
+        EnvVarGuard::set("KAMN_KOLME_LIVE_SIGNER_PROFILE", Some("ops-primary"));
+    let _primary_key_guard = EnvVarGuard::set("KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX", None);
+    let _fallback_key_guard =
+        EnvVarGuard::set("KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK", None);
+    let _key_ref_guard = EnvVarGuard::set(
+        "KAMN_KOLME_LIVE_SIGNER_KEY_REF",
+        Some(TEST_KOLME_LIVE_MANAGED_KEY_REFERENCE),
+    );
+    let _signer_public_key_guard = EnvVarGuard::set(
+        "KAMN_KOLME_LIVE_SIGNER_PUBLIC_KEY_HEX",
+        Some(managed_signer_public_key_hex(TEST_KOLME_LIVE_MANAGED_KEY_REFERENCE).as_str()),
+    );
+    let _managed_command_guard = EnvVarGuard::set("KAMN_KOLME_LIVE_MANAGED_SIGNER_COMMAND", None);
+
+    let parsed = parse_args(vec![
+        "kamn-node".to_owned(),
+        "--role".to_owned(),
+        "processor".to_owned(),
+        "--runtime-mode".to_owned(),
+        "kolme-live".to_owned(),
+        "--kolme-live-base-url".to_owned(),
+        "http://127.0.0.1:39000".to_owned(),
+        "--kolme-live-provider-hint".to_owned(),
+        "kolme-fork-local".to_owned(),
+        "--kolme-live-signing-profile".to_owned(),
+        "kolme-fork-secp256k1-v1".to_owned(),
+        "--kolme-live-signer-profile".to_owned(),
+        "ops-primary".to_owned(),
+        "--kolme-live-signer-key-source".to_owned(),
+        "managed-external".to_owned(),
+    ])
+    .expect("kolme-live args should parse");
+    let error = execute(parsed).expect_err(
+        "declared managed-external key source must be honored without strict flag in local/test execution",
+    );
+    assert!(
+        matches!(error, ConfigError::RuntimeKolmeLive(message) if message.contains("managed_signer_backend_required_missing")),
+        "declared managed-external key source must not silently fall back to env-local signer path"
+    );
+}
+
+#[test]
 fn unit_log_config_parses_level_and_format_inputs() {
     let config = resolve_log_config_from_inputs(Some("debug"), Some("json"))
         .expect("log config inputs should parse");

--- a/crates/kamn-node/tests/kolme_runtime_commit_docs.rs
+++ b/crates/kamn-node/tests/kolme_runtime_commit_docs.rs
@@ -1,0 +1,17 @@
+const DOC: &str = include_str!("../../../docs/architecture/kolme-runtime-commit.md");
+
+#[test]
+fn doc_contains_signer_provenance_failure_taxonomy_markers() {
+    assert!(DOC.contains("### Signer Provenance Failure Taxonomy"));
+    assert!(DOC.contains("production_signer_key_source_env_local_forbidden"));
+    assert!(DOC.contains("fallback_signer_secret_present_violation"));
+    assert!(DOC.contains("managed_signer_raw_private_key_forbidden"));
+    assert!(DOC.contains("managed_signer_backend_required_missing"));
+    assert!(DOC.contains("managed_signer_key_reference_missing"));
+    assert!(DOC.contains("managed_signer_key_reference_invalid"));
+    assert!(DOC.contains("managed_signer_public_key_marker_missing"));
+    assert!(DOC.contains("managed_signer_public_key_marker_invalid"));
+    assert!(DOC.contains("managed_signer_backend_response_provenance_missing"));
+    assert!(DOC.contains("managed_signer_backend_response_provenance_malformed"));
+    assert!(DOC.contains("managed_signer_backend_response_provenance_mismatch"));
+}

--- a/crates/kamn-node/tests/node_runtime_cli_docs.rs
+++ b/crates/kamn-node/tests/node_runtime_cli_docs.rs
@@ -160,6 +160,12 @@ fn doc_contains_runtime_kolme_live_rules() {
     assert!(DOC.contains("managed_signer_backend_required_invalid"));
     assert!(DOC.contains("managed_signer_public_key_marker_missing"));
     assert!(DOC.contains("managed_signer_public_key_marker_invalid"));
+    assert!(DOC.contains("production_signer_key_source_env_local_forbidden"));
+    assert!(DOC.contains("fallback_signer_secret_present_violation"));
+    assert!(DOC.contains("managed_signer_raw_private_key_forbidden"));
+    assert!(DOC.contains("KAMN_KOLME_LIVE_ALLOW_LOCAL_SIGNER_TESTING=true"));
+    assert!(DOC.contains("signer key-source provenance matrix"));
+    assert!(DOC.contains("runtime must not silently fall back to `env-local`"));
     assert!(DOC.contains("/runtime-commit/status"));
     assert!(DOC.contains("max-attempt budget `2`"));
     assert!(DOC.contains("finality-polled"));

--- a/docs/architecture/kolme-runtime-commit.md
+++ b/docs/architecture/kolme-runtime-commit.md
@@ -50,6 +50,25 @@ Fail-closed behavior is preserved for continuous and single-cycle modes:
 - unsupported signer/profile declarations fail immediately
 - transient submit/finality transport errors retry with bounded deterministic backoff
 
+### Signer Provenance Failure Taxonomy
+
+Signer contracts are fail-closed and reason-code stable:
+
+- `production_signer_key_source_env_local_forbidden`:
+  production-targeted strict signer contracts reject `env-local` key-source declarations.
+- `fallback_signer_secret_present_violation`:
+  fallback private-key env marker `KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK` must remain unset.
+- `managed_signer_raw_private_key_forbidden`:
+  managed-external profiles reject raw private-key env markers for the selected signer profile.
+- `managed_signer_backend_required_missing`:
+  managed-external execution requires `KAMN_KOLME_LIVE_MANAGED_SIGNER_COMMAND`.
+- `managed_signer_key_reference_missing` / `managed_signer_key_reference_invalid`:
+  managed-external signer key-reference contracts are missing or malformed.
+- `managed_signer_public_key_marker_missing` / `managed_signer_public_key_marker_invalid`:
+  managed-external signer public-key provenance markers are missing or malformed.
+- `managed_signer_backend_response_provenance_missing` / `managed_signer_backend_response_provenance_malformed` / `managed_signer_backend_response_provenance_mismatch`:
+  managed-external backend output provenance is missing, malformed, or does not match expected signer key material.
+
 ## Validation Evidence
 
 Primary tests:

--- a/docs/foundation/node-runtime-cli.md
+++ b/docs/foundation/node-runtime-cli.md
@@ -411,6 +411,7 @@ This document captures node-runtime productionization slices for machine-readabl
   - when `--kolme-live-strict-signer-contracts` is present, `--kolme-live-signer-profile` and `--kolme-live-signer-key-source` are both required
   - supported signer profiles: `ops-primary`, `ops-secondary`
   - supported key source markers: `env-local`, `managed-external`
+  - declared signer-profile/key-source markers are honored in local/test execution even without `--kolme-live-strict-signer-contracts`; runtime must not silently fall back to `env-local` when `managed-external` is explicitly declared
   - managed-external key-reference env markers:
     - `ops-primary`: `KAMN_KOLME_LIVE_SIGNER_KEY_REF`
     - `ops-secondary`: `KAMN_KOLME_LIVE_SIGNER_KEY_REF_SECONDARY`
@@ -420,6 +421,8 @@ This document captures node-runtime productionization slices for machine-readabl
     - missing marker fails closed with `managed_signer_public_key_marker_missing`
     - invalid/empty/non-secp256k1 marker fails closed with `managed_signer_public_key_marker_invalid`
   - managed-external mode rejects raw private-key env markers for the selected profile with deterministic reason code `managed_signer_raw_private_key_forbidden`
+  - fallback private-key env marker `KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK` must remain unset across signer paths; when present runtime fails closed with `fallback_signer_secret_present_violation`
+  - production-targeted strict contracts reject `--kolme-live-signer-key-source=env-local` with deterministic reason code `production_signer_key_source_env_local_forbidden` unless explicit local override `KAMN_KOLME_LIVE_ALLOW_LOCAL_SIGNER_TESTING=true` is set
   - managed-external signer mode requires `KAMN_KOLME_LIVE_MANAGED_SIGNER_COMMAND`; if absent, runtime fails closed with `managed_signer_backend_required_missing`
   - managed-external compatibility marker parsing:
     - `KAMN_KOLME_LIVE_MANAGED_SIGNER_REQUIRED=true|false`
@@ -436,6 +439,11 @@ This document captures node-runtime productionization slices for machine-readabl
     - empty profile/source declarations are rejected
     - unsupported profile/source declarations are rejected
     - strict profile declaration must not conflict with `KAMN_KOLME_LIVE_SIGNER_PROFILE` when that env marker is set
+  - signer key-source provenance matrix:
+    - strict + `managed-external`: allowed in production (requires managed signer markers and command contracts)
+    - strict + `env-local`: fail closed in production unless `KAMN_KOLME_LIVE_ALLOW_LOCAL_SIGNER_TESTING=true`
+    - local/test + explicit `managed-external`: allowed and audited via managed-signer fail-closed markers
+    - any mode + fallback private-key env marker present: fail closed
 - Provider wiring is fail-closed:
   - runtime config must reject in-memory provider-hint markers such as `InMemoryKolmeRuntimeCommitClient`
   - signing profile must match `kolme-fork-secp256k1-v1`


### PR DESCRIPTION
## Summary
Enforces declared signer key-source/profile selection in `kolme-live` execution so local/test/explicit override runs cannot silently fall back to `env-local` when `managed-external` is explicitly declared.
Also adds signer-provenance docs updates and rustdoc contract tests for fail-closed reason-code taxonomy.

## Changes
- `crates/kamn-node/src/main.rs`: preserve normalized declared signer profile/key-source outside strict-only branch and pass them through runtime execution wiring.
- `crates/kamn-node/src/main_tests/core_behavior_tests.rs`: add regression test proving declared `managed-external` selection is honored without strict flag and does not silently route through env-local.
- `docs/foundation/node-runtime-cli.md`: add signer key-source provenance matrix and explicit fallback/private-key fail-closed markers.
- `docs/architecture/kolme-runtime-commit.md`: add signer provenance failure taxonomy section and deterministic reason-code markers.
- `crates/kamn-node/tests/node_runtime_cli_docs.rs`: expand docs contract assertions for signer provenance markers.
- `crates/kamn-node/tests/kolme_runtime_commit_docs.rs`: add architecture docs contract test for signer provenance taxonomy markers.

## Risks & Compatibility
- Low: behavior change only affects runs that declare signer profile/key-source without strict mode (local/test/explicit override paths), aligning runtime behavior with explicit declarations.

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: targeted signer-path + docs contract commands

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅ | signer-path regression in `core_behavior_tests` |
| Functional  | ✅ | strict env-local rejection and fallback-secret rejection remain green |
| Integration | ✅ | `execute(...)` runtime path selection validated under declared key-source inputs |
| Regression  | ✅ | rustdoc contracts for CLI and runtime-commit provenance markers |

### Executed Commands
- `cargo test -p kamn-node main_tests::core_behavior_tests::regression_runtime_kolme_live_honors_declared_managed_external_key_source_without_strict_flag -- --exact`
- `cargo test -p kamn-node main_tests::core_behavior_tests::regression_runtime_kolme_live_rejects_fallback_signer_secret_env_with_reason_code -- --exact`
- `cargo test -p kamn-node main_tests::core_behavior_tests::functional_kolme_live_strict_env_local_key_source_rejects_with_reason_code -- --exact`
- `cargo test -p kamn-node --test node_runtime_cli_docs doc_contains_runtime_kolme_live_rules -- --exact`
- `cargo test -p kamn-node --test kolme_runtime_commit_docs`
- `cargo fmt --check`
- `cargo clippy -p kamn-node -- -D warnings`

Closes #3471
