### PR TITLE
feat(observability): add readiness degradation contracts and drills (#3474)

### DIFF
--- a/crates/kamn-node/src/main_tests/observability_endpoint_tests.rs
+++ b/crates/kamn-node/src/main_tests/observability_endpoint_tests.rs
@@ -208,6 +208,23 @@ fn functional_observability_endpoint_renders_metrics_and_health_payloads() {
     assert!(health.body.contains("\"transport_checkpoint_failures\":0"));
     assert!(health.body.contains("\"signer_checkpoint_failures\":0"));
     assert!(health.body.contains("\"commit_checkpoint_failures\":0"));
+
+    let readiness = render_observability_endpoint_response(&snapshot, "/readyz");
+    assert_eq!(readiness.status_code, 200);
+    assert_eq!(readiness.content_type, "application/json");
+    assert!(readiness.body.contains("\"ready\":true"));
+    assert!(readiness
+        .body
+        .contains("\"readiness_reason_code\":\"none\""));
+    assert!(readiness
+        .body
+        .contains("\"transport_dependency_status\":\"ready\""));
+    assert!(readiness
+        .body
+        .contains("\"signer_dependency_status\":\"ready\""));
+    assert!(readiness
+        .body
+        .contains("\"commit_dependency_status\":\"ready\""));
 }
 
 #[test]
@@ -242,6 +259,52 @@ fn functional_observability_endpoint_renders_stream_payload() {
 }
 
 #[test]
+fn functional_observability_endpoint_readiness_reports_degraded_timeout_reason_codes() {
+    let parsed = parse_args(vec![
+        "kamn-node".to_owned(),
+        "--role".to_owned(),
+        "processor".to_owned(),
+        "--runtime-mode".to_owned(),
+        "daemon".to_owned(),
+        "--daemon-max-ticks".to_owned(),
+        "100".to_owned(),
+        "--daemon-tick-interval-ms".to_owned(),
+        "1".to_owned(),
+        "--daemon-shutdown-signal-tick".to_owned(),
+        "7".to_owned(),
+        "--daemon-shutdown-drain-ticks".to_owned(),
+        "4".to_owned(),
+        "--daemon-shutdown-timeout-ticks".to_owned(),
+        "2".to_owned(),
+    ])
+    .expect("daemon timeout args should parse");
+    let report = execute(parsed).expect("daemon timeout execution should succeed");
+    let snapshot =
+        build_runtime_observability_snapshot(&report).expect("timeout report should map snapshot");
+
+    let readiness = render_observability_endpoint_response(&snapshot, "/readyz");
+    assert_eq!(readiness.status_code, 200);
+    assert_eq!(readiness.content_type, "application/json");
+    assert!(readiness.body.contains("\"ready\":false"));
+    assert!(readiness.body.contains("\"health\":\"critical\""));
+    assert!(readiness
+        .body
+        .contains("\"reason_code\":\"daemon_shutdown_timeout\""));
+    assert!(readiness
+        .body
+        .contains("\"readiness_reason_code\":\"readiness_commit_dependency_unhealthy\""));
+    assert!(readiness
+        .body
+        .contains("\"transport_dependency_status\":\"ready\""));
+    assert!(readiness
+        .body
+        .contains("\"signer_dependency_status\":\"ready\""));
+    assert!(readiness
+        .body
+        .contains("\"commit_dependency_status\":\"degraded\""));
+}
+
+#[test]
 fn integration_runtime_observability_endpoint_serves_metrics_and_health_paths() {
     let parsed = parse_args(vec![
         "kamn-node".to_owned(),
@@ -263,7 +326,7 @@ fn integration_runtime_observability_endpoint_serves_metrics_and_health_paths() 
         bind_addr: bind_addr.clone(),
         metrics_path: "/metrics".to_owned(),
         health_path: "/healthz".to_owned(),
-        max_requests: 3,
+        max_requests: 4,
         idle_timeout_ms: 2_000,
     };
 
@@ -274,6 +337,7 @@ fn integration_runtime_observability_endpoint_serves_metrics_and_health_paths() 
 
     let metrics_response = send_http_get(bind_addr.as_str(), "/metrics");
     let health_response = send_http_get(bind_addr.as_str(), "/healthz");
+    let readiness_response = send_http_get(bind_addr.as_str(), "/readyz");
 
     assert!(
         metrics_response.contains("HTTP/1.1 200 OK"),
@@ -287,6 +351,9 @@ fn integration_runtime_observability_endpoint_serves_metrics_and_health_paths() 
     );
     assert!(health_response.contains("\"health\":\"healthy\""));
     assert!(health_response.contains("\"reason_code\":\"none\""));
+    assert!(readiness_response.contains("HTTP/1.1 200 OK"));
+    assert!(readiness_response.contains("\"ready\":true"));
+    assert!(readiness_response.contains("\"readiness_reason_code\":\"none\""));
 
     let server_result = server.join().expect("endpoint thread should complete");
     assert!(

--- a/crates/kamn-node/src/observability_endpoint.rs
+++ b/crates/kamn-node/src/observability_endpoint.rs
@@ -6,6 +6,7 @@ use std::time::{Duration, Instant};
 
 pub(crate) const DEFAULT_OBSERVABILITY_ENDPOINT_METRICS_PATH: &str = "/metrics";
 pub(crate) const DEFAULT_OBSERVABILITY_ENDPOINT_HEALTH_PATH: &str = "/healthz";
+pub(crate) const DEFAULT_OBSERVABILITY_ENDPOINT_READINESS_PATH: &str = "/readyz";
 pub(crate) const DEFAULT_OBSERVABILITY_ENDPOINT_STREAM_PATH: &str = "/metrics.stream";
 pub(crate) const DEFAULT_OBSERVABILITY_ENDPOINT_MAX_REQUESTS: u64 = 1;
 pub(crate) const DEFAULT_OBSERVABILITY_ENDPOINT_IDLE_TIMEOUT_MS: u64 = 5_000;
@@ -143,6 +144,7 @@ pub(crate) fn render_observability_endpoint_response(
         path,
         DEFAULT_OBSERVABILITY_ENDPOINT_METRICS_PATH,
         DEFAULT_OBSERVABILITY_ENDPOINT_HEALTH_PATH,
+        DEFAULT_OBSERVABILITY_ENDPOINT_READINESS_PATH,
         DEFAULT_OBSERVABILITY_ENDPOINT_STREAM_PATH,
     )
 }
@@ -187,6 +189,7 @@ pub(crate) fn serve_observability_endpoint(
                     path.as_str(),
                     config.metrics_path.as_str(),
                     config.health_path.as_str(),
+                    DEFAULT_OBSERVABILITY_ENDPOINT_READINESS_PATH,
                     DEFAULT_OBSERVABILITY_ENDPOINT_STREAM_PATH,
                 );
                 write_http_response(&mut stream, &response)?;
@@ -208,6 +211,7 @@ fn render_observability_endpoint_response_with_paths(
     path: &str,
     metrics_path: &str,
     health_path: &str,
+    readiness_path: &str,
     stream_path: &str,
 ) -> ObservabilityEndpointResponse {
     if path == metrics_path {
@@ -222,6 +226,13 @@ fn render_observability_endpoint_response_with_paths(
             status_code: 200,
             content_type: "application/json",
             body: render_health_body(snapshot),
+        };
+    }
+    if path == readiness_path {
+        return ObservabilityEndpointResponse {
+            status_code: 200,
+            content_type: "application/json",
+            body: render_readiness_body(snapshot),
         };
     }
     if path == stream_path {
@@ -295,6 +306,70 @@ fn render_stream_body(snapshot: &RuntimeObservabilitySnapshot) -> String {
         snapshot.error_rate_bps,
         snapshot.availability_bps
     )
+}
+
+fn render_readiness_body(snapshot: &RuntimeObservabilitySnapshot) -> String {
+    let readiness_reason_code = readiness_reason_code(snapshot);
+    format!(
+        "{{\"source\":\"{}\",\"runtime_mode\":\"{}\",\"ready\":{},\"health\":\"{}\",\"reason_code\":\"{}\",\"readiness_reason_code\":\"{}\",\"transport_dependency_status\":\"{}\",\"signer_dependency_status\":\"{}\",\"commit_dependency_status\":\"{}\",\"transport_checkpoint_failures\":{},\"signer_checkpoint_failures\":{},\"commit_checkpoint_failures\":{}}}",
+        escape_json_string(snapshot.source.as_str()),
+        escape_json_string(snapshot.runtime_mode.as_str()),
+        is_runtime_ready(snapshot),
+        escape_json_string(snapshot.health.as_str()),
+        escape_json_string(snapshot.reason_code.as_str()),
+        escape_json_string(readiness_reason_code),
+        transport_dependency_status(snapshot),
+        signer_dependency_status(snapshot),
+        commit_dependency_status(snapshot),
+        snapshot.transport_checkpoint_failures,
+        snapshot.signer_checkpoint_failures,
+        snapshot.commit_checkpoint_failures
+    )
+}
+
+fn is_runtime_ready(snapshot: &RuntimeObservabilitySnapshot) -> bool {
+    snapshot.transport_checkpoint_failures == 0
+        && snapshot.signer_checkpoint_failures == 0
+        && snapshot.commit_checkpoint_failures == 0
+        && snapshot.health == "healthy"
+}
+
+fn readiness_reason_code(snapshot: &RuntimeObservabilitySnapshot) -> &'static str {
+    if snapshot.transport_checkpoint_failures > 0 {
+        "readiness_transport_dependency_unhealthy"
+    } else if snapshot.signer_checkpoint_failures > 0 {
+        "readiness_signer_dependency_unhealthy"
+    } else if snapshot.commit_checkpoint_failures > 0 {
+        "readiness_commit_dependency_unhealthy"
+    } else if snapshot.health != "healthy" {
+        "readiness_runtime_health_degraded"
+    } else {
+        "none"
+    }
+}
+
+fn transport_dependency_status(snapshot: &RuntimeObservabilitySnapshot) -> &'static str {
+    if snapshot.transport_checkpoint_failures > 0 {
+        "degraded"
+    } else {
+        "ready"
+    }
+}
+
+fn signer_dependency_status(snapshot: &RuntimeObservabilitySnapshot) -> &'static str {
+    if snapshot.signer_checkpoint_failures > 0 {
+        "degraded"
+    } else {
+        "ready"
+    }
+}
+
+fn commit_dependency_status(snapshot: &RuntimeObservabilitySnapshot) -> &'static str {
+    if snapshot.commit_checkpoint_failures > 0 {
+        "degraded"
+    } else {
+        "ready"
+    }
 }
 
 fn write_http_response(
@@ -430,6 +505,59 @@ mod tests {
         let response = render_observability_endpoint_response(&snapshot, "/unknown");
         assert_eq!(response.status_code, 404);
         assert_eq!(response.content_type, "text/plain; charset=utf-8");
+    }
+
+    #[test]
+    fn unit_observability_endpoint_readiness_reports_ready_with_none_reason_code() {
+        let snapshot = RuntimeObservabilitySnapshot {
+            source: "daemon".to_owned(),
+            runtime_mode: "daemon".to_owned(),
+            latency_p50_ms: 25,
+            latency_p99_ms: 50,
+            throughput_tps: 2_000,
+            error_rate_bps: 50,
+            availability_bps: 9_990,
+            health: "healthy".to_owned(),
+            alert_count: 0,
+            reason_code: "none".to_owned(),
+            transport_checkpoint_failures: 0,
+            signer_checkpoint_failures: 0,
+            commit_checkpoint_failures: 0,
+        };
+        let response = render_observability_endpoint_response(&snapshot, "/readyz");
+        assert_eq!(response.status_code, 200);
+        assert_eq!(response.content_type, "application/json");
+        assert!(response.body.contains("\"ready\":true"));
+        assert!(response.body.contains("\"readiness_reason_code\":\"none\""));
+    }
+
+    #[test]
+    fn unit_observability_endpoint_readiness_reports_commit_degraded_reason_code() {
+        let snapshot = RuntimeObservabilitySnapshot {
+            source: "daemon".to_owned(),
+            runtime_mode: "daemon".to_owned(),
+            latency_p50_ms: 145,
+            latency_p99_ms: 425,
+            throughput_tps: 900,
+            error_rate_bps: 250,
+            availability_bps: 9_800,
+            health: "critical".to_owned(),
+            alert_count: 4,
+            reason_code: "daemon_shutdown_timeout".to_owned(),
+            transport_checkpoint_failures: 0,
+            signer_checkpoint_failures: 0,
+            commit_checkpoint_failures: 1,
+        };
+        let response = render_observability_endpoint_response(&snapshot, "/readyz");
+        assert_eq!(response.status_code, 200);
+        assert_eq!(response.content_type, "application/json");
+        assert!(response.body.contains("\"ready\":false"));
+        assert!(response
+            .body
+            .contains("\"readiness_reason_code\":\"readiness_commit_dependency_unhealthy\""));
+        assert!(response
+            .body
+            .contains("\"commit_dependency_status\":\"degraded\""));
     }
 
     #[test]

--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -549,10 +549,14 @@ Versioned thresholds are defined in `.ci/ci-budget.env`.
 - Cost controls:
   - dry-run mode executes no nested local observability scrape commands and emits deterministic `dry_run_no_commands_executed`.
   - run mode is explicit local-only and requires `KAMN_LOCAL_OBSERVABILITY_SCRAPE_OPT_IN=1`.
-  - bounded to three targeted `kamn-node` observability endpoint scrape/content-type/stream tests when run mode is enabled.
+  - bounded to four targeted `kamn-node` observability endpoint tests when run mode is enabled (metrics/health scrape, stream projection, and readiness failure-drill degradation taxonomy).
   - local observability scrape run-mode commands remain excluded from ci-fast-gate and ci-tools fast mode.
+- Readiness/failure-drill contracts:
+  - lane emits deterministic readiness probe marker (`readiness_probe_status=verified`).
+  - lane emits deterministic readiness degradation drill marker (`readiness_failure_drill_status=verified`).
+  - lane emits deterministic readiness reason taxonomy marker (`readiness_reason_taxonomy_status=verified`).
 - Deterministic fail-closed marker for policy tamper drills:
-  - `local_observability_scrape_policy_marker_missing:scrape_probe_status`
+  - `local_observability_scrape_policy_marker_missing:readiness_failure_drill_status`
 
 ## Runtime Service API Axum Ingress Contract Lane
 - Entry commands:

--- a/docs/foundation/observability-slo-dashboards.md
+++ b/docs/foundation/observability-slo-dashboards.md
@@ -27,6 +27,7 @@ This document captures the first implementation slice for deterministic observab
 - Endpoint paths:
   - metrics: `/metrics` (Prometheus text format)
   - health: `/healthz` (JSON payload)
+  - readiness: `/readyz` (JSON payload)
 - Metrics payload keys:
   - `kamn_observability_latency_p50_ms`
   - `kamn_observability_latency_p99_ms`
@@ -49,6 +50,25 @@ This document captures the first implementation slice for deterministic observab
   - `signer_checkpoint_failures`
   - `commit_checkpoint_failures`
   - latency/throughput/error/availability numeric fields
+- Readiness payload fields:
+  - `source`
+  - `runtime_mode`
+  - `ready` (boolean)
+  - `health`
+  - `reason_code` (runtime telemetry reason)
+  - `readiness_reason_code` (dependency-derived readiness taxonomy)
+  - `transport_dependency_status`
+  - `signer_dependency_status`
+  - `commit_dependency_status`
+  - `transport_checkpoint_failures`
+  - `signer_checkpoint_failures`
+  - `commit_checkpoint_failures`
+- Readiness reason-code taxonomy:
+  - `none`
+  - `readiness_transport_dependency_unhealthy`
+  - `readiness_signer_dependency_unhealthy`
+  - `readiness_commit_dependency_unhealthy`
+  - `readiness_runtime_health_degraded`
 - Export characteristics:
   - deterministic payloads derived from runtime report telemetry fields.
   - bounded endpoint lifetime controlled by `--observability-endpoint-max-requests` and `--observability-endpoint-idle-timeout-ms`.

--- a/docs/plans/2026-02-08-production-service-roadmap.md
+++ b/docs/plans/2026-02-08-production-service-roadmap.md
@@ -240,8 +240,8 @@ There is **zero async code** in the entire codebase. No tokio, no `async fn`, no
 - Phase 2.12 local observability scrape contract-lane policy delivered:
   - Runtime lane: `scripts/runtime/validate_local_observability_scrape_live.sh`, `scripts/runtime/validate_local_observability_scrape_live_contract_lane.sh`, and tests `scripts/runtime/test_validate_local_observability_scrape_live_contract_lane.sh`, `scripts/runtime/test_check_local_observability_scrape_live_policy.sh` (Task #3335, Subtask #3336).
   - Policy checker: `scripts/runtime/check_local_observability_scrape_live_policy.sh`.
-  - Deterministic GO markers validated: `status=pass`, `final_decision=GO`, `scrape_probe_status=verified`, `metrics_content_type_status=verified`, `stream_lifecycle_status=verified`, `local_observability_scrape_policy_status=verified`, `performance_budget_status=verified`.
-  - Fail-closed validation confirmed for tamper and local observability scrape guard drills: `local_observability_scrape_policy_marker_missing:scrape_probe_status`.
+  - Deterministic GO markers validated: `status=pass`, `final_decision=GO`, `scrape_probe_status=verified`, `metrics_content_type_status=verified`, `stream_lifecycle_status=verified`, `readiness_probe_status=verified`, `readiness_failure_drill_status=verified`, `readiness_reason_taxonomy_status=verified`, `local_observability_scrape_policy_status=verified`, `performance_budget_status=verified`.
+  - Fail-closed validation confirmed for tamper and local observability scrape guard drills: `local_observability_scrape_policy_marker_missing:readiness_failure_drill_status`.
 - Phase 2.13 observability endpoint legacy-parser drift contracts delivered:
   - Drift checker: `scripts/ci/check_observability_endpoint_drift_contract.sh` and regression test `scripts/ci/test_check_observability_endpoint_drift_contract.sh` (Task #3335, Subtask #3337).
   - Deterministic GO markers validated: `status=pass`, `final_decision=GO`, `observability_legacy_parser_contract_status=verified`, `observability_framework_parity_status=verified`, `docs_migration_contract_status=verified`.

--- a/scripts/runtime/local_observability_scrape_live_contract.py
+++ b/scripts/runtime/local_observability_scrape_live_contract.py
@@ -42,6 +42,10 @@ LOCAL_OBSERVABILITY_SCRAPE_TESTS: list[tuple[str, str]] = [
         "stream_lifecycle",
         "main_tests::observability_endpoint_tests::integration_runtime_observability_endpoint_serves_stream_path",
     ),
+    (
+        "readiness_failure_drill",
+        "main_tests::observability_endpoint_tests::functional_observability_endpoint_readiness_reports_degraded_timeout_reason_codes",
+    ),
 ]
 
 
@@ -107,6 +111,9 @@ def _run_lane(args: argparse.Namespace) -> int:
         "scrape_probe_status": "verified",
         "metrics_content_type_status": "verified",
         "stream_lifecycle_status": "verified",
+        "readiness_probe_status": "verified",
+        "readiness_failure_drill_status": "verified",
+        "readiness_reason_taxonomy_status": "verified",
         "fail_closed_status": "verified",
         "ci_fast_gate_exclusion_status": "verified",
         "performance_budget_status": "verified",
@@ -128,6 +135,9 @@ def _run_lane(args: argparse.Namespace) -> int:
     print("scrape_probe_status=verified")
     print("metrics_content_type_status=verified")
     print("stream_lifecycle_status=verified")
+    print("readiness_probe_status=verified")
+    print("readiness_failure_drill_status=verified")
+    print("readiness_reason_taxonomy_status=verified")
     print("fail_closed_status=verified")
     print("ci_fast_gate_exclusion_status=verified")
     print("performance_budget_status=verified")
@@ -163,6 +173,9 @@ def _check_policy(args: argparse.Namespace) -> int:
         "scrape_probe_status",
         "metrics_content_type_status",
         "stream_lifecycle_status",
+        "readiness_probe_status",
+        "readiness_failure_drill_status",
+        "readiness_reason_taxonomy_status",
         "fail_closed_status",
         "ci_fast_gate_exclusion_status",
         "performance_budget_status",
@@ -196,6 +209,9 @@ def _check_policy(args: argparse.Namespace) -> int:
         "scrape_probe_status",
         "metrics_content_type_status",
         "stream_lifecycle_status",
+        "readiness_probe_status",
+        "readiness_failure_drill_status",
+        "readiness_reason_taxonomy_status",
         "fail_closed_status",
         "ci_fast_gate_exclusion_status",
         "performance_budget_status",

--- a/scripts/runtime/test_check_local_observability_scrape_live_policy.sh
+++ b/scripts/runtime/test_check_local_observability_scrape_live_policy.sh
@@ -21,6 +21,9 @@ cat >"$report_file" <<'JSON'
   "scrape_probe_status": "verified",
   "metrics_content_type_status": "verified",
   "stream_lifecycle_status": "verified",
+  "readiness_probe_status": "verified",
+  "readiness_failure_drill_status": "verified",
+  "readiness_reason_taxonomy_status": "verified",
   "fail_closed_status": "verified",
   "ci_fast_gate_exclusion_status": "verified",
   "performance_budget_status": "verified",
@@ -78,7 +81,7 @@ import sys
 
 path = pathlib.Path(sys.argv[1])
 payload = json.loads(path.read_text(encoding="utf-8"))
-payload["scrape_probe_status"] = "missing"
+payload["readiness_failure_drill_status"] = "missing"
 path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
 PY
 
@@ -97,7 +100,7 @@ if [ "$tampered_code" -eq 0 ]; then
   echo "expected tampered local observability scrape report to fail policy checker" >&2
   exit 1
 fi
-if ! printf '%s\n' "$tampered_output" | grep -q 'local_observability_scrape_policy_marker_missing:scrape_probe_status'; then
+if ! printf '%s\n' "$tampered_output" | grep -q 'local_observability_scrape_policy_marker_missing:readiness_failure_drill_status'; then
   echo "expected deterministic mismatch reason code for tampered local observability scrape policy validation" >&2
   exit 1
 fi

--- a/scripts/runtime/test_validate_local_observability_scrape_live_contract_lane.sh
+++ b/scripts/runtime/test_validate_local_observability_scrape_live_contract_lane.sh
@@ -50,7 +50,7 @@ if ! printf '%s\n' "$lane_output" | grep -q '^local_observability_scrape_policy_
   echo "expected local observability scrape contract lane policy marker" >&2
   exit 1
 fi
-if ! printf '%s\n' "$lane_output" | grep -q '^fail_closed_reason_code=local_observability_scrape_policy_marker_missing:scrape_probe_status$'; then
+if ! printf '%s\n' "$lane_output" | grep -q '^fail_closed_reason_code=local_observability_scrape_policy_marker_missing:readiness_failure_drill_status$'; then
   echo "expected local observability scrape contract lane fail-closed reason marker" >&2
   exit 1
 fi
@@ -75,6 +75,8 @@ if lane_payload.get("docs_contract_status") != "verified":
     raise SystemExit("expected docs_contract_status=verified")
 if lane_payload.get("performance_budget_status") != "verified":
     raise SystemExit("expected performance_budget_status=verified")
+if lane_payload.get("fail_closed_reason_code") != "local_observability_scrape_policy_marker_missing:readiness_failure_drill_status":
+    raise SystemExit("expected deterministic readiness failure-drill fail-closed reason code")
 
 policy_payload = json.loads(pathlib.Path(sys.argv[2]).read_text(encoding="utf-8"))
 if policy_payload.get("schema_version") != "kamn.runtime.local-observability-scrape-live-policy-report.v1":

--- a/scripts/runtime/validate_local_observability_scrape_live_contract_lane.sh
+++ b/scripts/runtime/validate_local_observability_scrape_live_contract_lane.sh
@@ -110,6 +110,18 @@ if ! printf '%s\n' "$validation_output" | grep -q '^stream_lifecycle_status=veri
   echo "expected local observability scrape validation stream marker" >&2
   exit 1
 fi
+if ! printf '%s\n' "$validation_output" | grep -q '^readiness_probe_status=verified$'; then
+  echo "expected local observability scrape validation readiness probe marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^readiness_failure_drill_status=verified$'; then
+  echo "expected local observability scrape validation readiness failure-drill marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^readiness_reason_taxonomy_status=verified$'; then
+  echo "expected local observability scrape validation readiness reason taxonomy marker" >&2
+  exit 1
+fi
 if ! printf '%s\n' "$validation_output" | grep -q '^fail_closed_status=verified$'; then
   echo "expected local observability scrape validation fail-closed marker" >&2
   exit 1
@@ -143,7 +155,7 @@ import sys
 
 path = pathlib.Path(sys.argv[1])
 payload = json.loads(path.read_text(encoding="utf-8"))
-payload["scrape_probe_status"] = "missing"
+payload["readiness_failure_drill_status"] = "missing"
 path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
 PY
 
@@ -162,7 +174,7 @@ if [ "$tampered_policy_code" -eq 0 ]; then
   echo "expected tampered local observability scrape report to fail policy validation" >&2
   exit 1
 fi
-if ! printf '%s\n' "$tampered_policy_output" | grep -q 'local_observability_scrape_policy_marker_missing:scrape_probe_status'; then
+if ! printf '%s\n' "$tampered_policy_output" | grep -q 'local_observability_scrape_policy_marker_missing:readiness_failure_drill_status'; then
   echo "expected deterministic fail-closed reason for tampered local observability scrape report" >&2
   exit 1
 fi
@@ -235,7 +247,7 @@ lane_report = {
     ),
     "docs_contract_status": "verified",
     "fail_closed_status": "verified",
-    "fail_closed_reason_code": "local_observability_scrape_policy_marker_missing:scrape_probe_status",
+    "fail_closed_reason_code": "local_observability_scrape_policy_marker_missing:readiness_failure_drill_status",
     "performance_budget_status": "verified",
     "elapsed_seconds": elapsed_seconds,
     "max_seconds": max_seconds,
@@ -257,7 +269,7 @@ echo "local_observability_scrape_contract_status=verified"
 echo "local_observability_scrape_policy_status=verified"
 echo "docs_contract_status=verified"
 echo "fail_closed_status=verified"
-echo "fail_closed_reason_code=local_observability_scrape_policy_marker_missing:scrape_probe_status"
+echo "fail_closed_reason_code=local_observability_scrape_policy_marker_missing:readiness_failure_drill_status"
 echo "performance_budget_status=verified"
 if [[ -n "$output_json" ]]; then
   echo "contract_lane_report=$output_json"


### PR DESCRIPTION
## Summary
Adds a deterministic runtime readiness endpoint and readiness degradation taxonomy to observability exports, then extends local observability scrape contracts to validate readiness failure-drill behavior and fail closed on tampered readiness markers.

Closes #3474

## Changes
- `crates/kamn-node/src/observability_endpoint.rs`: added `/readyz` response projection with deterministic readiness/dependency status and readiness reason-code mapping.
- `crates/kamn-node/src/main_tests/observability_endpoint_tests.rs`: added functional/integration readiness assertions, including timeout degradation failure-drill validation.
- `scripts/runtime/local_observability_scrape_live_contract.py`: extended lane/policy schema to require readiness probe/failure-drill/taxonomy markers.
- `scripts/runtime/validate_local_observability_scrape_live_contract_lane.sh`: enforced readiness marker checks and tamper drill on readiness failure-drill marker.
- `scripts/runtime/test_check_local_observability_scrape_live_policy.sh`: added readiness marker expectations and tamper coverage.
- `scripts/runtime/test_validate_local_observability_scrape_live_contract_lane.sh`: aligned fail-closed reason-code expectations with readiness marker tamper drills.
- `docs/ci/strategy.md`: documented readiness failure-drill coverage and updated deterministic fail-closed marker.
- `docs/foundation/observability-slo-dashboards.md`: documented `/readyz` payload contract and readiness reason-code taxonomy.
- `docs/plans/2026-02-08-production-service-roadmap.md`: refreshed local observability scrape delivered markers/reason-code reference.

## Risks & Compatibility
- None.

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-node -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: readiness endpoint contract markers and local scrape failure-drill policy markers verified in lane outputs.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `cargo test -p kamn-node observability_endpoint` |
| Functional  | ✅     | readiness payload + timeout degradation assertions in `observability_endpoint_tests` |
| Integration | ✅     | endpoint serve-path integration assertions + full `cargo test -p kamn-node` |
| Regression  | ✅     | local observability scrape policy/contract lane tamper drills |
