### PR TITLE
test(runtime): add local observability scrape lane-runner contract coverage (#3490)

### DIFF
--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -541,6 +541,7 @@ Versioned thresholds are defined in `.ci/ci-budget.env`.
   - `KAMN_LOCAL_OBSERVABILITY_SCRAPE_OPT_IN=1 bash scripts/runtime/validate_local_observability_scrape_live.sh --mode run --output-json /tmp/local-observability-scrape-live-summary.json`
   - `bash scripts/runtime/check_local_observability_scrape_live_policy.sh --report-file /tmp/local-observability-scrape-live-summary.json --expected-final-decision GO --ci-fast-gate PASS --output-json /tmp/local-observability-scrape-live-policy.json`
   - `bash scripts/runtime/validate_local_observability_scrape_live_contract_lane.sh --output-json /tmp/local-observability-scrape-live-contract-lane-report.json --policy-output-json /tmp/local-observability-scrape-live-policy.json`
+  - `bash scripts/runtime/test_validate_local_observability_scrape_live.sh`
   - `bash scripts/runtime/test_validate_local_observability_scrape_live_contract_lane.sh`
   - `bash scripts/runtime/test_check_local_observability_scrape_live_policy.sh`
 - ci-fast-gate mode: fast

--- a/docs/plans/2026-02-14-production-service-next-steps.md
+++ b/docs/plans/2026-02-14-production-service-next-steps.md
@@ -84,14 +84,16 @@ This refreshed version separates:
 - Remaining work is tracked under the parent story until stacked PR chain merges.
 
 ### Runtime observability reason-code/checkpoint projection
-- Active chain: `#3333 -> #3471 -> #3472 -> #3473`.
+- Active chain: `#3333 -> #3471 -> #3472 -> #3473 -> #3474 -> #3490`.
 - Scope:
   - include deterministic `reason_code` and checkpoint-failure counters across daemon and `kolme-live` runtime reports,
   - project the same fields into `/metrics`, `/healthz`, and `/metrics.stream`,
-  - keep report text/json output deterministic while expanding observability payload contracts.
+  - keep report text/json output deterministic while expanding observability payload contracts,
+  - maintain local observability scrape failure-drill contract-lane parity (`scripts/runtime/validate_local_observability_scrape_live_contract_lane.sh`, `scripts/runtime/test_validate_local_observability_scrape_live.sh`, `scripts/runtime/test_validate_local_observability_scrape_live_contract_lane.sh`).
 - Validation:
   - local-focused targeted tests in `kamn-node` for daemon and `kolme-live` runtime execution status mapping,
-  - endpoint rendering contract tests for metrics/health/stream payload parity.
+  - endpoint rendering contract tests for metrics/health/stream payload parity,
+  - readiness degradation/failure-drill marker coverage in the local observability scrape lane and policy checker.
 
 ### Docs truth synchronization (this tranche)
 - Open chain: `#3333 -> #3424 -> #3425 -> #3426`.

--- a/scripts/ci/test_ci_tools.sh
+++ b/scripts/ci/test_ci_tools.sh
@@ -391,6 +391,7 @@ bash "$ROOT_DIR/scripts/runtime/test_validate_live_transport_fault_matrix_live_c
 bash "$ROOT_DIR/scripts/runtime/test_check_local_metrics_scrape_live_policy.sh"
 bash "$ROOT_DIR/scripts/runtime/test_validate_local_metrics_scrape_live_contract_lane.sh"
 bash "$ROOT_DIR/scripts/runtime/test_check_local_observability_scrape_live_policy.sh"
+bash "$ROOT_DIR/scripts/runtime/test_validate_local_observability_scrape_live.sh"
 bash "$ROOT_DIR/scripts/runtime/test_validate_local_observability_scrape_live_contract_lane.sh"
 bash "$ROOT_DIR/scripts/runtime/test_check_service_api_serde_payload_parity_live_policy.sh"
 bash "$ROOT_DIR/scripts/runtime/test_validate_service_api_serde_payload_parity_live_contract_lane.sh"

--- a/scripts/ci/test_ci_tools_command_surface_contract.sh
+++ b/scripts/ci/test_ci_tools_command_surface_contract.sh
@@ -112,6 +112,7 @@ required_commands=(
   'bash "$ROOT_DIR/scripts/runtime/test_check_local_metrics_scrape_live_policy.sh"'
   'bash "$ROOT_DIR/scripts/runtime/test_validate_local_metrics_scrape_live_contract_lane.sh"'
   'bash "$ROOT_DIR/scripts/runtime/test_check_local_observability_scrape_live_policy.sh"'
+  'bash "$ROOT_DIR/scripts/runtime/test_validate_local_observability_scrape_live.sh"'
   'bash "$ROOT_DIR/scripts/runtime/test_validate_local_observability_scrape_live_contract_lane.sh"'
   'bash "$ROOT_DIR/scripts/runtime/test_check_service_api_serde_payload_parity_live_policy.sh"'
   'bash "$ROOT_DIR/scripts/runtime/test_validate_service_api_serde_payload_parity_live_contract_lane.sh"'

--- a/scripts/runtime/test_validate_local_observability_scrape_live.sh
+++ b/scripts/runtime/test_validate_local_observability_scrape_live.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+VALIDATION_SCRIPT="$ROOT_DIR/scripts/runtime/validate_local_observability_scrape_live.sh"
+POLICY_CHECKER="$ROOT_DIR/scripts/runtime/check_local_observability_scrape_live_policy.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+if [ ! -x "$VALIDATION_SCRIPT" ]; then
+  echo "expected local observability scrape live validation script to be executable" >&2
+  exit 1
+fi
+if [ ! -x "$POLICY_CHECKER" ]; then
+  echo "expected local observability scrape live policy checker script to be executable" >&2
+  exit 1
+fi
+
+if ! grep -q 'local_observability_scrape_live_contract.py" run-lane' "$VALIDATION_SCRIPT"; then
+  echo "expected local observability scrape validation wrapper to dispatch to python run-lane contract" >&2
+  exit 1
+fi
+
+dry_run_report="$TMP_DIR/local-observability-scrape-live-summary.dry-run.json"
+dry_run_output="$(
+  bash "$VALIDATION_SCRIPT" \
+    --mode dry-run \
+    --max-seconds 60 \
+    --output-json "$dry_run_report"
+)"
+if ! printf '%s\n' "$dry_run_output" | grep -q '^status=pass$'; then
+  echo "expected local observability scrape dry-run status marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$dry_run_output" | grep -q '^final_decision=GO$'; then
+  echo "expected local observability scrape dry-run final decision marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$dry_run_output" | grep -q '^lane_mode=dry-run$'; then
+  echo "expected local observability scrape dry-run mode marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$dry_run_output" | grep -q '^readiness_probe_status=verified$'; then
+  echo "expected local observability scrape dry-run readiness probe marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$dry_run_output" | grep -q '^readiness_failure_drill_status=verified$'; then
+  echo "expected local observability scrape dry-run readiness failure-drill marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$dry_run_output" | grep -q '^readiness_reason_taxonomy_status=verified$'; then
+  echo "expected local observability scrape dry-run readiness reason taxonomy marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$dry_run_output" | grep -q '^execution_reason_code=dry_run_no_commands_executed$'; then
+  echo "expected local observability scrape dry-run execution reason marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$dry_run_output" | grep -q '^command_count=0$'; then
+  echo "expected local observability scrape dry-run command count marker" >&2
+  exit 1
+fi
+
+python3 - "$dry_run_report" <<'PY'
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+if payload.get("schema_version") != "kamn.runtime.local-observability-scrape-live-report.v1":
+    raise SystemExit("unexpected local observability scrape dry-run schema")
+if payload.get("status") != "pass":
+    raise SystemExit("expected local observability scrape dry-run status=pass")
+if payload.get("final_decision") != "GO":
+    raise SystemExit("expected local observability scrape dry-run final_decision=GO")
+if payload.get("lane_mode") != "dry-run":
+    raise SystemExit("expected local observability scrape dry-run lane_mode=dry-run")
+if payload.get("execution_reason_code") != "dry_run_no_commands_executed":
+    raise SystemExit("expected local observability scrape dry-run reason code")
+if payload.get("command_count") != 0:
+    raise SystemExit("expected local observability scrape dry-run command_count=0")
+if payload.get("commands") != []:
+    raise SystemExit("expected local observability scrape dry-run command list to be empty")
+PY
+
+policy_report="$TMP_DIR/local-observability-scrape-live-policy.dry-run.json"
+policy_output="$(
+  bash "$POLICY_CHECKER" \
+    --report-file "$dry_run_report" \
+    --expected-final-decision GO \
+    --ci-fast-gate PASS \
+    --output-json "$policy_report"
+)"
+if ! printf '%s\n' "$policy_output" | grep -q '^status=ok$'; then
+  echo "expected local observability scrape dry-run policy status marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$policy_output" | grep -q '^final_decision=GO$'; then
+  echo "expected local observability scrape dry-run policy final decision marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$policy_output" | grep -q '^local_observability_scrape_policy_status=verified$'; then
+  echo "expected local observability scrape dry-run policy status marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$policy_output" | grep -q '^reason_codes=none$'; then
+  echo "expected local observability scrape dry-run policy reason code marker" >&2
+  exit 1
+fi
+
+python3 - "$policy_report" <<'PY'
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+if payload.get("schema_version") != "kamn.runtime.local-observability-scrape-live-policy-report.v1":
+    raise SystemExit("unexpected local observability scrape policy schema")
+if payload.get("status") != "pass":
+    raise SystemExit("expected local observability scrape policy status=pass")
+if payload.get("final_decision") != "GO":
+    raise SystemExit("expected local observability scrape policy final_decision=GO")
+if payload.get("local_observability_scrape_policy_status") != "verified":
+    raise SystemExit("expected local_observability_scrape_policy_status=verified")
+if payload.get("reason_codes") != ["none"]:
+    raise SystemExit("expected local observability scrape policy reason code ['none']")
+PY
+
+set +e
+missing_opt_in_output="$(
+  bash "$VALIDATION_SCRIPT" \
+    --mode run \
+    --max-seconds 60 2>&1
+)"
+missing_opt_in_code=$?
+set -e
+if [ "$missing_opt_in_code" -eq 0 ]; then
+  echo "expected local observability scrape run mode without opt-in to fail closed" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$missing_opt_in_output" | grep -q 'run mode requires explicit local-only opt-in via KAMN_LOCAL_OBSERVABILITY_SCRAPE_OPT_IN=1'; then
+  echo "expected deterministic opt-in failure marker for local observability scrape run mode" >&2
+  exit 1
+fi
+
+set +e
+invalid_mode_output="$(
+  bash "$VALIDATION_SCRIPT" \
+    --mode invalid 2>&1
+)"
+invalid_mode_code=$?
+set -e
+if [ "$invalid_mode_code" -eq 0 ]; then
+  echo "expected local observability scrape validation to reject invalid mode" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$invalid_mode_output" | grep -q -- '--mode must be one of: dry-run, run'; then
+  echo "expected deterministic invalid-mode marker for local observability scrape validation" >&2
+  exit 1
+fi
+
+set +e
+invalid_budget_output="$(
+  bash "$VALIDATION_SCRIPT" \
+    --max-seconds nope 2>&1
+)"
+invalid_budget_code=$?
+set -e
+if [ "$invalid_budget_code" -eq 0 ]; then
+  echo "expected local observability scrape validation to reject invalid max-seconds" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$invalid_budget_output" | grep -q 'KAMN_LOCAL_OBSERVABILITY_SCRAPE_MAX_SECONDS must be an integer'; then
+  echo "expected deterministic invalid max-seconds marker for local observability scrape validation" >&2
+  exit 1
+fi
+
+echo "local observability scrape live validation tests passed."

--- a/scripts/runtime/validate_local_observability_scrape_live_contract_lane.sh
+++ b/scripts/runtime/validate_local_observability_scrape_live_contract_lane.sh
@@ -6,6 +6,7 @@ VALIDATION_SCRIPT="$ROOT_DIR/scripts/runtime/validate_local_observability_scrape
 POLICY_CHECKER="$ROOT_DIR/scripts/runtime/check_local_observability_scrape_live_policy.sh"
 STRATEGY_DOC="$ROOT_DIR/docs/ci/strategy.md"
 ROADMAP_DOC="$ROOT_DIR/docs/plans/2026-02-08-production-service-roadmap.md"
+NEXT_STEPS_DOC="$ROOT_DIR/docs/plans/2026-02-14-production-service-next-steps.md"
 
 output_json=""
 policy_output_json=""
@@ -65,7 +66,7 @@ for required_exec in "$VALIDATION_SCRIPT" "$POLICY_CHECKER"; do
     exit 1
   fi
 done
-for required_doc in "$STRATEGY_DOC" "$ROADMAP_DOC"; do
+for required_doc in "$STRATEGY_DOC" "$ROADMAP_DOC" "$NEXT_STEPS_DOC"; do
   if [ ! -f "$required_doc" ]; then
     echo "expected required documentation file '$required_doc'" >&2
     exit 1
@@ -182,6 +183,7 @@ fi
 for required_ref in \
   "validate_local_observability_scrape_live.sh" \
   "check_local_observability_scrape_live_policy.sh" \
+  "test_validate_local_observability_scrape_live.sh" \
   "validate_local_observability_scrape_live_contract_lane.sh" \
   "test_validate_local_observability_scrape_live_contract_lane.sh" \
   "test_check_local_observability_scrape_live_policy.sh"; do
@@ -205,6 +207,14 @@ if ! grep -q "scripts/runtime/validate_local_observability_scrape_live_contract_
 fi
 if ! grep -q "scripts/runtime/check_local_observability_scrape_live_policy.sh" "$ROADMAP_DOC"; then
   echo "expected roadmap to reference local observability scrape policy checker script" >&2
+  exit 1
+fi
+if ! grep -q "#3333 -> #3471 -> #3472 -> #3473 -> #3474 -> #3490" "$NEXT_STEPS_DOC"; then
+  echo "expected next-steps plan to include runtime observability chain marker through #3490" >&2
+  exit 1
+fi
+if ! grep -q "scripts/runtime/test_validate_local_observability_scrape_live.sh" "$NEXT_STEPS_DOC"; then
+  echo "expected next-steps plan to reference local observability scrape lane-runner test script" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- Adds explicit local observability scrape lane-runner test coverage and wires it into CI command-surface contracts.
- Closes the remaining #3490 acceptance gap for lane runner/checker/docs parity by extending local docs crosswalk validation through the 2026-02-14 next-steps plan.

## Linked Issues
- Closes #3490

## Validation
- [x] Relevant local checks passed.
- [x] CI fast-gate checks expected to pass.

## CI Impact Declaration
- [ ] No CI scope impact.
- [x] CI scope impact present (explain below).

CI scope impact details (required when CI scope impact is present):
- Workflow(s) touched: `Fast Gate (PR)` command-surface coverage via `scripts/ci/test_ci_tools.sh` and `scripts/ci/test_ci_tools_command_surface_contract.sh`
- Expected runtime delta: negligible (one additional lightweight shell test invocation)
- Expected runner-minute delta: negligible (< 0.1 min expected)
- Rollback plan if CI cost/runtime regresses: revert this PR to remove the added lane-runner command-surface requirement and test invocation.

## Changes
- `scripts/runtime/test_validate_local_observability_scrape_live.sh`: new lane-runner validation test covering dry-run output/report markers, policy-check compatibility, and fail-closed argument/opt-in errors.
- `scripts/ci/test_ci_tools.sh`: includes `test_validate_local_observability_scrape_live.sh` in ci-tools regression execution.
- `scripts/ci/test_ci_tools_command_surface_contract.sh`: requires new ci-tools command-surface entry for the lane-runner test.
- `scripts/runtime/validate_local_observability_scrape_live_contract_lane.sh`: enforces docs-contract presence for the new lane-runner test and 2026-02-14 chain marker through `#3490`.
- `docs/ci/strategy.md`: adds lane-runner test entry command in the Runtime Local Observability Scrape Contract Lane section.
- `docs/plans/2026-02-14-production-service-next-steps.md`: updates runtime observability chain and validation crosswalk to include `#3474 -> #3490` plus lane-runner coverage.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
bash scripts/ci/test_ci_tools_command_surface_contract.sh
```
Output:
```text
expected ci tools regression lane to include command: bash "$ROOT_DIR/scripts/runtime/test_validate_local_observability_scrape_live.sh"
```

### 🟢 Green Phase
Commands:
```bash
bash scripts/runtime/test_validate_local_observability_scrape_live.sh
bash scripts/runtime/test_check_local_observability_scrape_live_policy.sh
bash scripts/runtime/test_validate_local_observability_scrape_live_contract_lane.sh
bash scripts/ci/test_ci_tools_command_surface_contract.sh
```
Output (key lines):
```text
local observability scrape live validation tests passed.
local observability scrape live policy checker tests passed.
local observability scrape contract lane tests passed.
ci tools command surface contract tests passed.
```

### 🔁 Regression
Commands:
```bash
bash scripts/ci/test_ci_strategy_contract.sh
bash scripts/ci/test_production_service_next_steps_contract.sh
```
Output (key lines):
```text
CI strategy contract tests passed.
production-service next-steps docs contract tests passed.
```

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | `scripts/runtime/test_validate_local_observability_scrape_live.sh` validates lane wrapper markers and input guards | |
| Functional   | ✅ | Dry-run lane + policy compatibility path validated via new lane-runner test | |
| Integration  | ✅ | `scripts/runtime/test_validate_local_observability_scrape_live_contract_lane.sh` validates lane/checker/docs composition | |
| Regression   | ✅ | `scripts/ci/test_ci_tools_command_surface_contract.sh`, `scripts/ci/test_ci_strategy_contract.sh`, `scripts/ci/test_production_service_next_steps_contract.sh` | |
| Performance  | N/A | | No runtime behavior or load path changed; local-heavy run mode remains unchanged and opt-in-only |

## Risks & Rollback
- None.
- Rollback: revert this PR to restore prior command-surface and docs-contract scope.

## Documentation Updates
- `docs/ci/strategy.md`
- `docs/plans/2026-02-14-production-service-next-steps.md`
