### PR TITLE
feat(observability): project readiness taxonomy across payload contracts (#3489)

### DIFF
--- a/crates/kamn-node/src/main_tests/observability_endpoint_tests.rs
+++ b/crates/kamn-node/src/main_tests/observability_endpoint_tests.rs
@@ -197,6 +197,10 @@ fn functional_observability_endpoint_renders_metrics_and_health_payloads() {
         .contains("kamn_observability_reason_code{reason_code=\"none\"} 1"));
     assert!(metrics
         .body
+        .contains("kamn_observability_readiness_reason_code{readiness_reason_code=\"none\"} 1"));
+    assert!(metrics.body.contains("kamn_observability_ready 1"));
+    assert!(metrics
+        .body
         .contains("kamn_observability_health{health=\"healthy\"} 1"));
 
     let health = render_observability_endpoint_response(&snapshot, "/healthz");
@@ -205,6 +209,17 @@ fn functional_observability_endpoint_renders_metrics_and_health_payloads() {
     assert!(health.body.contains("\"health\":\"healthy\""));
     assert!(health.body.contains("\"runtime_mode\":\"daemon\""));
     assert!(health.body.contains("\"reason_code\":\"none\""));
+    assert!(health.body.contains("\"ready\":true"));
+    assert!(health.body.contains("\"readiness_reason_code\":\"none\""));
+    assert!(health
+        .body
+        .contains("\"transport_dependency_status\":\"ready\""));
+    assert!(health
+        .body
+        .contains("\"signer_dependency_status\":\"ready\""));
+    assert!(health
+        .body
+        .contains("\"commit_dependency_status\":\"ready\""));
     assert!(health.body.contains("\"transport_checkpoint_failures\":0"));
     assert!(health.body.contains("\"signer_checkpoint_failures\":0"));
     assert!(health.body.contains("\"commit_checkpoint_failures\":0"));
@@ -252,6 +267,17 @@ fn functional_observability_endpoint_renders_stream_payload() {
         .body
         .contains("\"schema_version\":\"kamn.runtime.observability.stream.v1\""));
     assert!(stream.body.contains("\"reason_code\":\"none\""));
+    assert!(stream.body.contains("\"ready\":true"));
+    assert!(stream.body.contains("\"readiness_reason_code\":\"none\""));
+    assert!(stream
+        .body
+        .contains("\"transport_dependency_status\":\"ready\""));
+    assert!(stream
+        .body
+        .contains("\"signer_dependency_status\":\"ready\""));
+    assert!(stream
+        .body
+        .contains("\"commit_dependency_status\":\"ready\""));
     assert!(stream.body.contains("\"transport_checkpoint_failures\":0"));
     assert!(stream.body.contains("\"signer_checkpoint_failures\":0"));
     assert!(stream.body.contains("\"commit_checkpoint_failures\":0"));
@@ -305,6 +331,83 @@ fn functional_observability_endpoint_readiness_reports_degraded_timeout_reason_c
 }
 
 #[test]
+fn functional_observability_endpoint_readiness_reason_taxonomy_covers_dependency_probe_matrix() {
+    let mut transport_degraded = sample_observability_snapshot();
+    transport_degraded.health = "critical".to_owned();
+    transport_degraded.reason_code = "transport_finality_retry_unavailable".to_owned();
+    transport_degraded.transport_checkpoint_failures = 2;
+    let transport_readiness =
+        render_observability_endpoint_response(&transport_degraded, "/readyz");
+    assert!(transport_readiness.body.contains("\"ready\":false"));
+    assert!(transport_readiness
+        .body
+        .contains("\"readiness_reason_code\":\"readiness_transport_dependency_unhealthy\""));
+    assert!(transport_readiness
+        .body
+        .contains("\"transport_dependency_status\":\"degraded\""));
+    assert!(transport_readiness
+        .body
+        .contains("\"signer_dependency_status\":\"ready\""));
+    assert!(transport_readiness
+        .body
+        .contains("\"commit_dependency_status\":\"ready\""));
+
+    let mut signer_degraded = sample_observability_snapshot();
+    signer_degraded.health = "critical".to_owned();
+    signer_degraded.reason_code = "signer_rotation_stale".to_owned();
+    signer_degraded.signer_checkpoint_failures = 1;
+    let signer_readiness = render_observability_endpoint_response(&signer_degraded, "/readyz");
+    assert!(signer_readiness
+        .body
+        .contains("\"readiness_reason_code\":\"readiness_signer_dependency_unhealthy\""));
+    assert!(signer_readiness
+        .body
+        .contains("\"transport_dependency_status\":\"ready\""));
+    assert!(signer_readiness
+        .body
+        .contains("\"signer_dependency_status\":\"degraded\""));
+    assert!(signer_readiness
+        .body
+        .contains("\"commit_dependency_status\":\"ready\""));
+
+    let mut commit_degraded = sample_observability_snapshot();
+    commit_degraded.health = "critical".to_owned();
+    commit_degraded.reason_code = "daemon_shutdown_timeout".to_owned();
+    commit_degraded.commit_checkpoint_failures = 1;
+    let commit_readiness = render_observability_endpoint_response(&commit_degraded, "/readyz");
+    assert!(commit_readiness
+        .body
+        .contains("\"readiness_reason_code\":\"readiness_commit_dependency_unhealthy\""));
+    assert!(commit_readiness
+        .body
+        .contains("\"transport_dependency_status\":\"ready\""));
+    assert!(commit_readiness
+        .body
+        .contains("\"signer_dependency_status\":\"ready\""));
+    assert!(commit_readiness
+        .body
+        .contains("\"commit_dependency_status\":\"degraded\""));
+
+    let mut runtime_health_degraded = sample_observability_snapshot();
+    runtime_health_degraded.health = "degraded".to_owned();
+    runtime_health_degraded.reason_code = "daemon_slo_alert".to_owned();
+    let runtime_health_readiness =
+        render_observability_endpoint_response(&runtime_health_degraded, "/readyz");
+    assert!(runtime_health_readiness
+        .body
+        .contains("\"readiness_reason_code\":\"readiness_runtime_health_degraded\""));
+    assert!(runtime_health_readiness
+        .body
+        .contains("\"transport_dependency_status\":\"ready\""));
+    assert!(runtime_health_readiness
+        .body
+        .contains("\"signer_dependency_status\":\"ready\""));
+    assert!(runtime_health_readiness
+        .body
+        .contains("\"commit_dependency_status\":\"ready\""));
+}
+
+#[test]
 fn integration_runtime_observability_endpoint_serves_metrics_and_health_paths() {
     let parsed = parse_args(vec![
         "kamn-node".to_owned(),
@@ -345,12 +448,17 @@ fn integration_runtime_observability_endpoint_serves_metrics_and_health_paths() 
     );
     assert!(metrics_response.contains("kamn_observability_latency_p50_ms 25"));
     assert!(metrics_response.contains("kamn_observability_reason_code{reason_code=\"none\"} 1"));
+    assert!(metrics_response
+        .contains("kamn_observability_readiness_reason_code{readiness_reason_code=\"none\"} 1"));
+    assert!(metrics_response.contains("kamn_observability_ready 1"));
     assert!(
         health_response.contains("HTTP/1.1 200 OK"),
         "health endpoint should return 200 response"
     );
     assert!(health_response.contains("\"health\":\"healthy\""));
     assert!(health_response.contains("\"reason_code\":\"none\""));
+    assert!(health_response.contains("\"ready\":true"));
+    assert!(health_response.contains("\"readiness_reason_code\":\"none\""));
     assert!(readiness_response.contains("HTTP/1.1 200 OK"));
     assert!(readiness_response.contains("\"ready\":true"));
     assert!(readiness_response.contains("\"readiness_reason_code\":\"none\""));
@@ -401,6 +509,8 @@ fn integration_runtime_observability_endpoint_serves_stream_path() {
     assert!(stream_response.contains("application/x-ndjson"));
     assert!(stream_response.contains("kamn.runtime.observability.stream.v1"));
     assert!(stream_response.contains("\"reason_code\":\"none\""));
+    assert!(stream_response.contains("\"ready\":true"));
+    assert!(stream_response.contains("\"readiness_reason_code\":\"none\""));
 
     let server_result = server.join().expect("endpoint thread should complete");
     assert!(

--- a/crates/kamn-node/src/observability_endpoint.rs
+++ b/crates/kamn-node/src/observability_endpoint.rs
@@ -251,8 +251,13 @@ fn render_observability_endpoint_response_with_paths(
 
 fn render_metrics_body(snapshot: &RuntimeObservabilitySnapshot) -> String {
     let health_value = if snapshot.health == "healthy" { 1 } else { 0 };
+    let ready_value = if is_runtime_ready(snapshot) { 1 } else { 0 };
+    let readiness_reason_code = readiness_reason_code(snapshot);
+    let transport_status = transport_dependency_status(snapshot);
+    let signer_status = signer_dependency_status(snapshot);
+    let commit_status = commit_dependency_status(snapshot);
     format!(
-        "kamn_observability_latency_p50_ms {}\nkamn_observability_latency_p99_ms {}\nkamn_observability_throughput_tps {}\nkamn_observability_error_rate_bps {}\nkamn_observability_availability_bps {}\nkamn_observability_alert_count {}\nkamn_observability_transport_checkpoint_failures {}\nkamn_observability_signer_checkpoint_failures {}\nkamn_observability_commit_checkpoint_failures {}\nkamn_observability_source{{source=\"{}\"}} 1\nkamn_observability_runtime_mode{{runtime_mode=\"{}\"}} 1\nkamn_observability_reason_code{{reason_code=\"{}\"}} 1\nkamn_observability_health{{health=\"{}\"}} {}\n",
+        "kamn_observability_latency_p50_ms {}\nkamn_observability_latency_p99_ms {}\nkamn_observability_throughput_tps {}\nkamn_observability_error_rate_bps {}\nkamn_observability_availability_bps {}\nkamn_observability_alert_count {}\nkamn_observability_transport_checkpoint_failures {}\nkamn_observability_signer_checkpoint_failures {}\nkamn_observability_commit_checkpoint_failures {}\nkamn_observability_ready {}\nkamn_observability_source{{source=\"{}\"}} 1\nkamn_observability_runtime_mode{{runtime_mode=\"{}\"}} 1\nkamn_observability_reason_code{{reason_code=\"{}\"}} 1\nkamn_observability_readiness_reason_code{{readiness_reason_code=\"{}\"}} 1\nkamn_observability_transport_dependency_status{{status=\"{}\"}} 1\nkamn_observability_signer_dependency_status{{status=\"{}\"}} 1\nkamn_observability_commit_dependency_status{{status=\"{}\"}} 1\nkamn_observability_health{{health=\"{}\"}} {}\n",
         snapshot.latency_p50_ms,
         snapshot.latency_p99_ms,
         snapshot.throughput_tps,
@@ -262,22 +267,33 @@ fn render_metrics_body(snapshot: &RuntimeObservabilitySnapshot) -> String {
         snapshot.transport_checkpoint_failures,
         snapshot.signer_checkpoint_failures,
         snapshot.commit_checkpoint_failures,
+        ready_value,
         escape_metrics_label(snapshot.source.as_str()),
         escape_metrics_label(snapshot.runtime_mode.as_str()),
         escape_metrics_label(snapshot.reason_code.as_str()),
+        escape_metrics_label(readiness_reason_code),
+        escape_metrics_label(transport_status),
+        escape_metrics_label(signer_status),
+        escape_metrics_label(commit_status),
         escape_metrics_label(snapshot.health.as_str()),
         health_value
     )
 }
 
 fn render_health_body(snapshot: &RuntimeObservabilitySnapshot) -> String {
+    let readiness_reason_code = readiness_reason_code(snapshot);
     format!(
-        "{{\"source\":\"{}\",\"runtime_mode\":\"{}\",\"health\":\"{}\",\"alert_count\":{},\"reason_code\":\"{}\",\"transport_checkpoint_failures\":{},\"signer_checkpoint_failures\":{},\"commit_checkpoint_failures\":{},\"latency_p50_ms\":{},\"latency_p99_ms\":{},\"throughput_tps\":{},\"error_rate_bps\":{},\"availability_bps\":{}}}",
+        "{{\"source\":\"{}\",\"runtime_mode\":\"{}\",\"health\":\"{}\",\"alert_count\":{},\"reason_code\":\"{}\",\"ready\":{},\"readiness_reason_code\":\"{}\",\"transport_dependency_status\":\"{}\",\"signer_dependency_status\":\"{}\",\"commit_dependency_status\":\"{}\",\"transport_checkpoint_failures\":{},\"signer_checkpoint_failures\":{},\"commit_checkpoint_failures\":{},\"latency_p50_ms\":{},\"latency_p99_ms\":{},\"throughput_tps\":{},\"error_rate_bps\":{},\"availability_bps\":{}}}",
         escape_json_string(snapshot.source.as_str()),
         escape_json_string(snapshot.runtime_mode.as_str()),
         escape_json_string(snapshot.health.as_str()),
         snapshot.alert_count,
         escape_json_string(snapshot.reason_code.as_str()),
+        is_runtime_ready(snapshot),
+        escape_json_string(readiness_reason_code),
+        transport_dependency_status(snapshot),
+        signer_dependency_status(snapshot),
+        commit_dependency_status(snapshot),
         snapshot.transport_checkpoint_failures,
         snapshot.signer_checkpoint_failures,
         snapshot.commit_checkpoint_failures,
@@ -290,13 +306,19 @@ fn render_health_body(snapshot: &RuntimeObservabilitySnapshot) -> String {
 }
 
 fn render_stream_body(snapshot: &RuntimeObservabilitySnapshot) -> String {
+    let readiness_reason_code = readiness_reason_code(snapshot);
     format!(
-        "{{\"schema_version\":\"kamn.runtime.observability.stream.v1\",\"source\":\"{}\",\"runtime_mode\":\"{}\",\"health\":\"{}\",\"alert_count\":{},\"reason_code\":\"{}\",\"transport_checkpoint_failures\":{},\"signer_checkpoint_failures\":{},\"commit_checkpoint_failures\":{},\"latency_p50_ms\":{},\"latency_p99_ms\":{},\"throughput_tps\":{},\"error_rate_bps\":{},\"availability_bps\":{}}}\n",
+        "{{\"schema_version\":\"kamn.runtime.observability.stream.v1\",\"source\":\"{}\",\"runtime_mode\":\"{}\",\"health\":\"{}\",\"alert_count\":{},\"reason_code\":\"{}\",\"ready\":{},\"readiness_reason_code\":\"{}\",\"transport_dependency_status\":\"{}\",\"signer_dependency_status\":\"{}\",\"commit_dependency_status\":\"{}\",\"transport_checkpoint_failures\":{},\"signer_checkpoint_failures\":{},\"commit_checkpoint_failures\":{},\"latency_p50_ms\":{},\"latency_p99_ms\":{},\"throughput_tps\":{},\"error_rate_bps\":{},\"availability_bps\":{}}}\n",
         escape_json_string(snapshot.source.as_str()),
         escape_json_string(snapshot.runtime_mode.as_str()),
         escape_json_string(snapshot.health.as_str()),
         snapshot.alert_count,
         escape_json_string(snapshot.reason_code.as_str()),
+        is_runtime_ready(snapshot),
+        escape_json_string(readiness_reason_code),
+        transport_dependency_status(snapshot),
+        signer_dependency_status(snapshot),
+        commit_dependency_status(snapshot),
         snapshot.transport_checkpoint_failures,
         snapshot.signer_checkpoint_failures,
         snapshot.commit_checkpoint_failures,

--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -550,7 +550,7 @@ Versioned thresholds are defined in `.ci/ci-budget.env`.
 - Cost controls:
   - dry-run mode executes no nested local observability scrape commands and emits deterministic `dry_run_no_commands_executed`.
   - run mode is explicit local-only and requires `KAMN_LOCAL_OBSERVABILITY_SCRAPE_OPT_IN=1`.
-  - bounded to four targeted `kamn-node` observability endpoint tests when run mode is enabled (metrics/health scrape, stream projection, and readiness failure-drill degradation taxonomy).
+  - bounded to five targeted `kamn-node` observability endpoint tests when run mode is enabled (metrics/health scrape, stream projection, readiness failure-drill degradation taxonomy, and readiness dependency-probe taxonomy matrix coverage).
   - local observability scrape run-mode commands remain excluded from ci-fast-gate and ci-tools fast mode.
 - Readiness/failure-drill contracts:
   - lane emits deterministic readiness probe marker (`readiness_probe_status=verified`).

--- a/docs/plans/2026-02-14-production-service-next-steps.md
+++ b/docs/plans/2026-02-14-production-service-next-steps.md
@@ -93,7 +93,8 @@ This refreshed version separates:
 - Validation:
   - local-focused targeted tests in `kamn-node` for daemon and `kolme-live` runtime execution status mapping,
   - endpoint rendering contract tests for metrics/health/stream payload parity,
-  - readiness degradation/failure-drill marker coverage in the local observability scrape lane and policy checker.
+  - readiness degradation/failure-drill marker coverage in the local observability scrape lane and policy checker,
+  - readiness dependency-probe taxonomy matrix coverage (`main_tests::observability_endpoint_tests::functional_observability_endpoint_readiness_reason_taxonomy_covers_dependency_probe_matrix`) tracked under #3489.
 
 ### Docs truth synchronization (this tranche)
 - Open chain: `#3333 -> #3424 -> #3425 -> #3426`.

--- a/scripts/runtime/local_observability_scrape_live_contract.py
+++ b/scripts/runtime/local_observability_scrape_live_contract.py
@@ -46,6 +46,10 @@ LOCAL_OBSERVABILITY_SCRAPE_TESTS: list[tuple[str, str]] = [
         "readiness_failure_drill",
         "main_tests::observability_endpoint_tests::functional_observability_endpoint_readiness_reports_degraded_timeout_reason_codes",
     ),
+    (
+        "readiness_reason_taxonomy",
+        "main_tests::observability_endpoint_tests::functional_observability_endpoint_readiness_reason_taxonomy_covers_dependency_probe_matrix",
+    ),
 ]
 
 

--- a/scripts/runtime/validate_local_observability_scrape_live_contract_lane.sh
+++ b/scripts/runtime/validate_local_observability_scrape_live_contract_lane.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 VALIDATION_SCRIPT="$ROOT_DIR/scripts/runtime/validate_local_observability_scrape_live.sh"
 POLICY_CHECKER="$ROOT_DIR/scripts/runtime/check_local_observability_scrape_live_policy.sh"
+CONTRACT_IMPL="$ROOT_DIR/scripts/runtime/local_observability_scrape_live_contract.py"
 STRATEGY_DOC="$ROOT_DIR/docs/ci/strategy.md"
 ROADMAP_DOC="$ROOT_DIR/docs/plans/2026-02-08-production-service-roadmap.md"
 NEXT_STEPS_DOC="$ROOT_DIR/docs/plans/2026-02-14-production-service-next-steps.md"
@@ -66,6 +67,10 @@ for required_exec in "$VALIDATION_SCRIPT" "$POLICY_CHECKER"; do
     exit 1
   fi
 done
+if [ ! -f "$CONTRACT_IMPL" ]; then
+  echo "expected local observability scrape contract implementation '$CONTRACT_IMPL'" >&2
+  exit 1
+fi
 for required_doc in "$STRATEGY_DOC" "$ROADMAP_DOC" "$NEXT_STEPS_DOC"; do
   if [ ! -f "$required_doc" ]; then
     echo "expected required documentation file '$required_doc'" >&2
@@ -196,6 +201,10 @@ if ! grep -q "local observability scrape run-mode commands remain excluded from 
   echo "expected CI strategy docs to include local observability scrape run-mode exclusion marker" >&2
   exit 1
 fi
+if ! grep -q "bounded to five targeted \`kamn-node\` observability endpoint tests when run mode is enabled" "$STRATEGY_DOC"; then
+  echo "expected CI strategy docs to include five-test local observability scrape run-mode budget marker" >&2
+  exit 1
+fi
 
 if ! grep -q "Task #3335, Subtask #3336" "$ROADMAP_DOC"; then
   echo "expected roadmap marker for Task #3335, Subtask #3336" >&2
@@ -215,6 +224,14 @@ if ! grep -q "#3333 -> #3471 -> #3472 -> #3473 -> #3474 -> #3490" "$NEXT_STEPS_D
 fi
 if ! grep -q "scripts/runtime/test_validate_local_observability_scrape_live.sh" "$NEXT_STEPS_DOC"; then
   echo "expected next-steps plan to reference local observability scrape lane-runner test script" >&2
+  exit 1
+fi
+if ! grep -q "functional_observability_endpoint_readiness_reason_taxonomy_covers_dependency_probe_matrix" "$NEXT_STEPS_DOC"; then
+  echo "expected next-steps plan to reference readiness dependency-probe taxonomy matrix selector" >&2
+  exit 1
+fi
+if ! grep -q "functional_observability_endpoint_readiness_reason_taxonomy_covers_dependency_probe_matrix" "$CONTRACT_IMPL"; then
+  echo "expected local observability scrape contract implementation to include readiness dependency-probe taxonomy selector" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- Projects readiness dependency probe and reason-taxonomy fields beyond `/readyz` into observability metrics, health, and stream payload contracts.
- Extends local observability scrape lane coverage to include an explicit readiness dependency-probe taxonomy matrix selector.

## Linked Issues
- Closes #3489

## Validation
- [x] Relevant local checks passed.
- [x] CI fast-gate checks expected to pass.

## CI Impact Declaration
- [ ] No CI scope impact.
- [x] CI scope impact present (explain below).

CI scope impact details (required when CI scope impact is present):
- Workflow(s) touched: `Fast Gate (PR)` via `scripts/runtime/*` contract lane checks and strategy/next-steps docs-contract parity checks.
- Expected runtime delta: negligible (selector list adds one targeted test only in explicit local run-mode paths; dry-run CI path remains lightweight).
- Expected runner-minute delta: negligible for fast-gate path; near-zero change expected.
- Rollback plan if CI cost/runtime regresses: revert this PR to restore prior selector list and docs-contract expectations.

## Changes
- `crates/kamn-node/src/observability_endpoint.rs`: adds readiness projection markers to metrics/health/stream payloads:
  - `kamn_observability_ready`
  - `kamn_observability_readiness_reason_code{...}`
  - dependency status metrics for transport/signer/commit.
  - health/stream JSON now include `ready`, `readiness_reason_code`, and dependency status fields.
- `crates/kamn-node/src/main_tests/observability_endpoint_tests.rs`:
  - extends payload assertions for metrics/health/stream readiness projection.
  - adds taxonomy matrix functional test covering transport/signer/commit/runtime-health degraded reason-code mapping.
- `scripts/runtime/local_observability_scrape_live_contract.py`: adds `readiness_reason_taxonomy` selector.
- `scripts/runtime/validate_local_observability_scrape_live_contract_lane.sh`: enforces new strategy/docs markers and selector presence.
- `docs/ci/strategy.md`: updates local observability scrape run-mode targeted-test budget marker (4 -> 5).
- `docs/plans/2026-02-14-production-service-next-steps.md`: adds #3489 readiness dependency-probe taxonomy matrix crosswalk entry.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
cargo test -p kamn-node observability_endpoint_tests
```
Failing assertions included:
```text
assertion failed: metrics.body.contains("kamn_observability_readiness_reason_code{readiness_reason_code=\"none\"} 1")
assertion failed: stream.body.contains("\"ready\":true")
assertion failed: metrics_response.contains("kamn_observability_readiness_reason_code{readiness_reason_code=\"none\"} 1")
```

### 🟢 Green Phase
Commands:
```bash
cargo test -p kamn-node observability_endpoint_tests
bash scripts/runtime/test_validate_local_observability_scrape_live.sh
bash scripts/runtime/test_check_local_observability_scrape_live_policy.sh
bash scripts/runtime/test_validate_local_observability_scrape_live_contract_lane.sh
```
Output (key lines):
```text
test result: ok. 12 passed; 0 failed
local observability scrape live validation tests passed.
local observability scrape live policy checker tests passed.
local observability scrape contract lane tests passed.
```

### 🔁 Regression
Commands:
```bash
cargo fmt --check
cargo clippy -p kamn-node -- -D warnings
bash scripts/ci/test_ci_strategy_contract.sh
bash scripts/ci/test_production_service_next_steps_contract.sh
```
Output (key lines):
```text
Finished `dev` profile ...
CI strategy contract tests passed.
production-service next-steps docs contract tests passed.
```

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | `main_tests::observability_endpoint_tests` payload assertions | |
| Functional   | ✅ | `functional_observability_endpoint_readiness_reason_taxonomy_covers_dependency_probe_matrix` | |
| Integration  | ✅ | endpoint server-path assertions in `integration_runtime_observability_endpoint_serves_*` tests | |
| Regression   | ✅ | local observability lane policy/contract tests + CI/docs contract checks | |
| Performance  | N/A | | No hot-path algorithmic change; only payload projection and contract assertions |

## Risks & Rollback
- Low risk: payload shape expansion (additive fields/metrics).
- Rollback: revert this PR if downstream payload parsers require strict field whitelists.

## Documentation Updates
- `docs/ci/strategy.md`
- `docs/plans/2026-02-14-production-service-next-steps.md`
