### PR TITLE
feat(observability): add async handler parity adapters (#3512)

### DIFF
--- a/crates/kamn-node/src/main_tests/observability_endpoint_tests.rs
+++ b/crates/kamn-node/src/main_tests/observability_endpoint_tests.rs
@@ -2,6 +2,7 @@ use super::*;
 use crate::observability_endpoint::RuntimeObservabilitySnapshot;
 use std::io::{ErrorKind, Read, Write};
 use std::net::{TcpListener, TcpStream};
+use std::sync::{Arc, Barrier};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -520,6 +521,77 @@ fn integration_runtime_observability_endpoint_serves_stream_path() {
 }
 
 #[test]
+fn integration_runtime_observability_endpoint_handles_concurrent_metrics_and_stream_requests() {
+    let parsed = parse_args(vec![
+        "kamn-node".to_owned(),
+        "--role".to_owned(),
+        "processor".to_owned(),
+        "--runtime-mode".to_owned(),
+        "daemon".to_owned(),
+        "--daemon-max-ticks".to_owned(),
+        "3".to_owned(),
+        "--daemon-tick-interval-ms".to_owned(),
+        "25".to_owned(),
+    ])
+    .expect("daemon args should parse");
+    let report = execute(parsed).expect("daemon execution should succeed");
+    let snapshot =
+        build_runtime_observability_snapshot(&report).expect("daemon report should map snapshot");
+    let bind_addr = reserve_loopback_addr();
+    let endpoint_config = ObservabilityEndpointConfig {
+        bind_addr: bind_addr.clone(),
+        metrics_path: "/metrics".to_owned(),
+        health_path: "/healthz".to_owned(),
+        max_requests: 5,
+        idle_timeout_ms: 2_000,
+    };
+
+    let server_snapshot = snapshot.clone();
+    let server =
+        thread::spawn(move || serve_observability_endpoint(&endpoint_config, &server_snapshot));
+    wait_for_endpoint_ready(bind_addr.as_str());
+
+    let barrier = Arc::new(Barrier::new(3));
+    let metrics_barrier = Arc::clone(&barrier);
+    let metrics_addr = bind_addr.clone();
+    let metrics_worker = thread::spawn(move || {
+        metrics_barrier.wait();
+        send_http_get(metrics_addr.as_str(), "/metrics")
+    });
+
+    let stream_barrier = Arc::clone(&barrier);
+    let stream_addr = bind_addr.clone();
+    let stream_worker = thread::spawn(move || {
+        stream_barrier.wait();
+        send_http_get(stream_addr.as_str(), "/metrics.stream")
+    });
+
+    barrier.wait();
+    let metrics_response = metrics_worker
+        .join()
+        .expect("metrics worker thread should complete");
+    let stream_response = stream_worker
+        .join()
+        .expect("stream worker thread should complete");
+    assert!(metrics_response.contains("HTTP/1.1 200 OK"));
+    assert!(metrics_response.contains("kamn_observability_ready 1"));
+    assert!(stream_response.contains("HTTP/1.1 200 OK"));
+    assert!(stream_response.contains("kamn.runtime.observability.stream.v1"));
+
+    let health_response = send_http_get(bind_addr.as_str(), "/healthz");
+    let readiness_response = send_http_get(bind_addr.as_str(), "/readyz");
+    assert!(health_response.contains("HTTP/1.1 200 OK"));
+    assert!(readiness_response.contains("HTTP/1.1 200 OK"));
+    assert!(readiness_response.contains("\"ready\":true"));
+
+    let server_result = server.join().expect("endpoint thread should complete");
+    assert!(
+        server_result.is_ok(),
+        "endpoint server should stop cleanly after configured request budget"
+    );
+}
+
+#[test]
 fn regression_observability_endpoint_export_keeps_bootstrap_report_rendering_unchanged() {
     // Regression: #2830
     let parsed = parse_args(vec![
@@ -561,5 +633,27 @@ fn regression_observability_endpoint_uses_async_listener_serving_path() {
     assert!(
         source.contains("runtime.block_on(serve_observability_endpoint_async("),
         "sync wrapper must drive async observability serving via runtime block_on"
+    );
+}
+
+#[test]
+fn regression_observability_endpoint_uses_async_metrics_health_stream_adapters() {
+    // Regression: #3512
+    let source = include_str!("../observability_endpoint.rs");
+    assert!(
+        source.contains("async fn dispatch_observability_endpoint_request("),
+        "observability endpoint should dispatch requests through async adapter routing"
+    );
+    assert!(
+        source.contains("async fn handle_observability_metrics_path("),
+        "observability endpoint should expose async metrics handler adapter"
+    );
+    assert!(
+        source.contains("async fn handle_observability_health_path("),
+        "observability endpoint should expose async health handler adapter"
+    );
+    assert!(
+        source.contains("async fn handle_observability_stream_path("),
+        "observability endpoint should expose async stream handler adapter"
     );
 }

--- a/crates/kamn-node/src/observability_endpoint.rs
+++ b/crates/kamn-node/src/observability_endpoint.rs
@@ -207,18 +207,90 @@ async fn serve_observability_endpoint_async(
         let path = read_http_request_path_async(&mut stream)
             .await
             .unwrap_or_else(|_| "/".to_owned());
-        let response = render_observability_endpoint_response_with_paths(
+        let response = dispatch_observability_endpoint_request(
             &snapshot,
             path.as_str(),
             config.metrics_path.as_str(),
             config.health_path.as_str(),
             DEFAULT_OBSERVABILITY_ENDPOINT_READINESS_PATH,
             DEFAULT_OBSERVABILITY_ENDPOINT_STREAM_PATH,
-        );
+        )
+        .await;
         write_http_response_async(&mut stream, &response).await?;
         served_requests = served_requests.saturating_add(1);
     }
     Ok(())
+}
+
+async fn dispatch_observability_endpoint_request(
+    snapshot: &RuntimeObservabilitySnapshot,
+    request_path: &str,
+    metrics_path: &str,
+    health_path: &str,
+    readiness_path: &str,
+    stream_path: &str,
+) -> ObservabilityEndpointResponse {
+    if request_path == metrics_path {
+        return handle_observability_metrics_path(snapshot).await;
+    }
+    if request_path == health_path {
+        return handle_observability_health_path(snapshot).await;
+    }
+    if request_path == readiness_path {
+        return handle_observability_readiness_path(snapshot).await;
+    }
+    if request_path == stream_path {
+        return handle_observability_stream_path(snapshot).await;
+    }
+    handle_observability_not_found_path().await
+}
+
+async fn handle_observability_metrics_path(
+    snapshot: &RuntimeObservabilitySnapshot,
+) -> ObservabilityEndpointResponse {
+    ObservabilityEndpointResponse {
+        status_code: 200,
+        content_type: "text/plain; version=0.0.4",
+        body: render_metrics_body(snapshot),
+    }
+}
+
+async fn handle_observability_health_path(
+    snapshot: &RuntimeObservabilitySnapshot,
+) -> ObservabilityEndpointResponse {
+    ObservabilityEndpointResponse {
+        status_code: 200,
+        content_type: "application/json",
+        body: render_health_body(snapshot),
+    }
+}
+
+async fn handle_observability_readiness_path(
+    snapshot: &RuntimeObservabilitySnapshot,
+) -> ObservabilityEndpointResponse {
+    ObservabilityEndpointResponse {
+        status_code: 200,
+        content_type: "application/json",
+        body: render_readiness_body(snapshot),
+    }
+}
+
+async fn handle_observability_stream_path(
+    snapshot: &RuntimeObservabilitySnapshot,
+) -> ObservabilityEndpointResponse {
+    ObservabilityEndpointResponse {
+        status_code: 200,
+        content_type: "application/x-ndjson",
+        body: render_stream_body(snapshot),
+    }
+}
+
+async fn handle_observability_not_found_path() -> ObservabilityEndpointResponse {
+    ObservabilityEndpointResponse {
+        status_code: 404,
+        content_type: "text/plain; charset=utf-8",
+        body: "not found\n".to_owned(),
+    }
 }
 
 fn render_observability_endpoint_response_with_paths(

--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -551,6 +551,7 @@ Versioned thresholds are defined in `.ci/ci-budget.env`.
   - dry-run mode executes no nested local observability scrape commands and emits deterministic `dry_run_no_commands_executed`.
   - run mode is explicit local-only and requires `KAMN_LOCAL_OBSERVABILITY_SCRAPE_OPT_IN=1`.
   - bounded to five targeted `kamn-node` observability endpoint tests when run mode is enabled (metrics/health scrape, stream projection, readiness failure-drill degradation taxonomy, and readiness dependency-probe taxonomy matrix coverage).
+  - async handler parity checks remain in the bounded test scope, including concurrent metrics/stream request handling against the async observability adapter path.
   - local observability scrape run-mode commands remain excluded from ci-fast-gate and ci-tools fast mode.
 - Readiness/failure-drill contracts:
   - lane emits deterministic readiness probe marker (`readiness_probe_status=verified`).


### PR DESCRIPTION
## Summary
Adds explicit async observability handler adapters for metrics/health/readiness/stream dispatch, plus parity-focused integration/regression tests to ensure the async adapter path remains stable under concurrent scrape/stream requests.

## Changes
- `crates/kamn-node/src/observability_endpoint.rs`: added async adapter dispatch (`dispatch_observability_endpoint_request`) and async path handlers for metrics/health/readiness/stream/not-found.
- `crates/kamn-node/src/main_tests/observability_endpoint_tests.rs`: added concurrent metrics/stream integration test and regression marker test for async adapter functions.
- `docs/ci/strategy.md`: updated local observability scrape lane cost-controls section with async handler parity coverage note.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- Command: `cargo test -p kamn-node regression_observability_endpoint_uses_async_metrics_health_stream_adapters -- --nocapture`
- Result: failed with `observability endpoint should dispatch requests through async adapter routing`.

### 🟢 Green Phase
- Command: `cargo test -p kamn-node observability_endpoint_tests`
- Result: passed (`15 passed; 0 failed`).

### 🔁 Regression
- `cargo fmt --check` — clean
- `cargo clippy -p kamn-node -- -D warnings` — clean
- `cargo test -p kamn-node observability_endpoint_tests` — clean
- `bash scripts/ci/test_ci_strategy_contract.sh` — clean
- `bash scripts/runtime/test_validate_local_observability_scrape_live_contract_lane.sh` — clean

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | existing observability endpoint unit tests remained green | |
| Functional   | ✅     | existing readiness/metrics/stream functional tests remained green | |
| Integration  | ✅     | added concurrent metrics/stream integration test for async adapter parity | |
| Regression   | ✅     | added `regression_observability_endpoint_uses_async_metrics_health_stream_adapters` | |
| Performance  | ✅     | bounded request-budget semantics preserved; local-heavy lane remains excluded from fast-gate | |

## Risks & Rollback
- Risk: low; handler dispatch path now routes through explicit async adapters.
- Rollback: revert this PR commit to return to direct render dispatch in serve loop.

## Documentation Updates
- Updated `docs/ci/strategy.md` local observability scrape lane notes to include async adapter parity coverage.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (`cargo clippy -p kamn-node -- -D warnings`)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (scoped to touched surfaces)
- [x] Docs updated (ci strategy parity note)

Closes #3512
Refs #3510
Refs #3509
