### PR TITLE
test(observability): add async negative-matrix contracts (#3514)

### DIFF
--- a/crates/kamn-node/src/main_tests/observability_endpoint_tests.rs
+++ b/crates/kamn-node/src/main_tests/observability_endpoint_tests.rs
@@ -41,6 +41,33 @@ fn send_http_get(addr: &str, path: &str) -> String {
     response
 }
 
+fn send_raw_http_request(addr: &str, request: &str) -> String {
+    let mut stream = TcpStream::connect(addr).expect("endpoint should accept connections");
+    stream
+        .set_read_timeout(Some(Duration::from_secs(2)))
+        .expect("read timeout should be configurable");
+    stream
+        .write_all(request.as_bytes())
+        .expect("request should write");
+    let mut response = String::new();
+    let mut chunk = [0_u8; 1024];
+    loop {
+        match stream.read(&mut chunk) {
+            Ok(0) => break,
+            Ok(read_count) => {
+                response.push_str(
+                    std::str::from_utf8(&chunk[..read_count]).expect("response must be utf-8"),
+                );
+            }
+            Err(error) if matches!(error.kind(), ErrorKind::WouldBlock | ErrorKind::TimedOut) => {
+                break;
+            }
+            Err(error) => panic!("response should be readable: {error}"),
+        }
+    }
+    response
+}
+
 fn wait_for_endpoint_ready(addr: &str) {
     let deadline = Instant::now() + Duration::from_secs(2);
     while Instant::now() < deadline {
@@ -592,6 +619,87 @@ fn integration_runtime_observability_endpoint_handles_concurrent_metrics_and_str
 }
 
 #[test]
+fn integration_runtime_observability_endpoint_returns_not_found_for_unknown_path() {
+    let snapshot = sample_observability_snapshot();
+    let bind_addr = reserve_loopback_addr();
+    let endpoint_config = ObservabilityEndpointConfig {
+        bind_addr: bind_addr.clone(),
+        metrics_path: "/metrics".to_owned(),
+        health_path: "/healthz".to_owned(),
+        max_requests: 2,
+        idle_timeout_ms: 2_000,
+    };
+
+    let server_snapshot = snapshot.clone();
+    let server =
+        thread::spawn(move || serve_observability_endpoint(&endpoint_config, &server_snapshot));
+    wait_for_endpoint_ready(bind_addr.as_str());
+
+    let unknown_response = send_http_get(bind_addr.as_str(), "/unknown");
+    assert!(unknown_response.contains("HTTP/1.1 404 Not Found"));
+    assert!(unknown_response.contains("not found"));
+
+    let server_result = server.join().expect("endpoint thread should complete");
+    assert!(
+        server_result.is_ok(),
+        "endpoint server should stop cleanly after configured request budget"
+    );
+}
+
+#[test]
+fn integration_runtime_observability_endpoint_returns_not_found_for_malformed_request_method() {
+    let snapshot = sample_observability_snapshot();
+    let bind_addr = reserve_loopback_addr();
+    let endpoint_config = ObservabilityEndpointConfig {
+        bind_addr: bind_addr.clone(),
+        metrics_path: "/metrics".to_owned(),
+        health_path: "/healthz".to_owned(),
+        max_requests: 2,
+        idle_timeout_ms: 2_000,
+    };
+
+    let server_snapshot = snapshot.clone();
+    let server =
+        thread::spawn(move || serve_observability_endpoint(&endpoint_config, &server_snapshot));
+    wait_for_endpoint_ready(bind_addr.as_str());
+
+    let malformed_response = send_raw_http_request(
+        bind_addr.as_str(),
+        "POST /metrics HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n",
+    );
+    assert!(malformed_response.contains("HTTP/1.1 404 Not Found"));
+    assert!(malformed_response.contains("not found"));
+
+    let server_result = server.join().expect("endpoint thread should complete");
+    assert!(
+        server_result.is_ok(),
+        "endpoint server should stop cleanly after configured request budget"
+    );
+}
+
+#[test]
+fn integration_runtime_observability_endpoint_fails_closed_on_idle_timeout() {
+    let snapshot = sample_observability_snapshot();
+    let bind_addr = reserve_loopback_addr();
+    let timeout_ms = 200_u64;
+    let endpoint_config = ObservabilityEndpointConfig {
+        bind_addr,
+        metrics_path: "/metrics".to_owned(),
+        health_path: "/healthz".to_owned(),
+        max_requests: 1,
+        idle_timeout_ms: timeout_ms,
+    };
+
+    let server = thread::spawn(move || serve_observability_endpoint(&endpoint_config, &snapshot));
+    let server_result = server.join().expect("endpoint thread should complete");
+    let error = server_result.expect_err("idle timeout should fail closed when no requests arrive");
+    assert_eq!(
+        error,
+        "observability endpoint timed out after 200 ms waiting for requests"
+    );
+}
+
+#[test]
 fn regression_observability_endpoint_export_keeps_bootstrap_report_rendering_unchanged() {
     // Regression: #2830
     let parsed = parse_args(vec![
@@ -655,5 +763,23 @@ fn regression_observability_endpoint_uses_async_metrics_health_stream_adapters()
     assert!(
         source.contains("async fn handle_observability_stream_path("),
         "observability endpoint should expose async stream handler adapter"
+    );
+}
+
+#[test]
+fn regression_observability_endpoint_keeps_async_negative_matrix_contracts() {
+    // Regression: #3514
+    let source = include_str!("../observability_endpoint.rs");
+    assert!(
+        source.contains("handle_observability_not_found_path().await"),
+        "async dispatch must route unsupported paths through deterministic not-found handler"
+    );
+    assert!(
+        source.contains("if method != \"GET\""),
+        "request parser must fail closed on malformed method contracts"
+    );
+    assert!(
+        source.contains("observability endpoint timed out after {} ms waiting for requests"),
+        "async serving loop must preserve deterministic idle-timeout failure contract"
     );
 }

--- a/docs/foundation/node-runtime-cli.md
+++ b/docs/foundation/node-runtime-cli.md
@@ -50,7 +50,7 @@ This document captures node-runtime productionization slices for machine-readabl
   - `--observability-endpoint-health-path </path>` (default: `/healthz`)
   - `--observability-endpoint-max-requests <positive-integer>` (default: `1`)
   - `--observability-endpoint-idle-timeout-ms <positive-integer>` (default: `5000`)
-- Legacy observability endpoint parser path remains synchronous and is migration-targeted; drift contracts enforce fail-closed visibility until framework ingress replacement lands.
+- Runtime observability endpoint ingress runs on async tokio listener path; drift contracts enforce fail-closed parity for unknown-path, malformed-request, and timeout compatibility behavior.
 - Added Kolme live runtime controls:
   - `--kolme-live-base-url <http(s)-endpoint>`
   - `--kolme-live-provider-hint <provider-hint>`

--- a/docs/foundation/observability-slo-dashboards.md
+++ b/docs/foundation/observability-slo-dashboards.md
@@ -111,11 +111,15 @@ Expected markers:
 - `status=pass`
 - `final_decision=GO`
 - `runtime_observability_stream_contract_status=verified`
+- `unknown_path_contract_status=verified`
+- `malformed_input_contract_status=verified`
+- `timeout_contract_status=verified`
 - `runtime_observability_policy_status=verified`
 - `runtime_observability_contract_lane_status=verified`
 - `fail_closed_status=verified`
 - `docs_contract_status=verified`
 - `fail_closed_reason_code=observability_endpoint_not_found`
+- `fail_closed_reason_codes_csv=observability_endpoint_not_found,observability_endpoint_malformed_request,observability_endpoint_idle_timeout`
 - `fail_closed_reason_code=runtime_observability_policy_final_decision_mismatch`
 - `metrics_reason_code_contract_status=verified`
 - `health_stream_reason_code_contract_status=verified`

--- a/docs/plans/2026-02-08-production-service-roadmap.md
+++ b/docs/plans/2026-02-08-production-service-roadmap.md
@@ -242,10 +242,10 @@ There is **zero async code** in the entire codebase. No tokio, no `async fn`, no
   - Policy checker: `scripts/runtime/check_local_observability_scrape_live_policy.sh`.
   - Deterministic GO markers validated: `status=pass`, `final_decision=GO`, `scrape_probe_status=verified`, `metrics_content_type_status=verified`, `stream_lifecycle_status=verified`, `readiness_probe_status=verified`, `readiness_failure_drill_status=verified`, `readiness_reason_taxonomy_status=verified`, `local_observability_scrape_policy_status=verified`, `performance_budget_status=verified`.
   - Fail-closed validation confirmed for tamper and local observability scrape guard drills: `local_observability_scrape_policy_marker_missing:readiness_failure_drill_status`.
-- Phase 2.13 observability endpoint legacy-parser drift contracts delivered:
+- Phase 2.13 observability endpoint async-ingress drift contracts delivered:
   - Drift checker: `scripts/ci/check_observability_endpoint_drift_contract.sh` and regression test `scripts/ci/test_check_observability_endpoint_drift_contract.sh` (Task #3335, Subtask #3337).
-  - Deterministic GO markers validated: `status=pass`, `final_decision=GO`, `observability_legacy_parser_contract_status=verified`, `observability_framework_parity_status=verified`, `docs_migration_contract_status=verified`.
-  - Fail-closed validation confirmed for source/docs drift drills: `observability_source_marker_missing:legacy_tcp_listener_import`, `observability_docs_marker_missing`.
+  - Deterministic GO markers validated: `status=pass`, `final_decision=GO`, `observability_async_ingress_contract_status=verified`, `observability_framework_parity_status=verified`, `docs_migration_contract_status=verified`.
+  - Fail-closed validation confirmed for source/docs drift drills: `observability_source_marker_missing:async_dispatch`, `observability_docs_marker_missing`.
 - Runtime decomposition wave 1 delivered:
   - Extracted network-fault simulation APIs from `crates/kamn-core/src/runtime_transport_coordination.rs` into `crates/kamn-core/src/runtime_network_fault.rs` with stable `runtime.rs` re-export compatibility (Task #3186, Subtask #3187).
   - Added extraction regression contract coverage for module declaration and re-export continuity (`runtime::tests::regression_runtime_source_routes_network_fault_domain_via_dedicated_module`).

--- a/docs/plans/2026-02-14-production-service-next-steps.md
+++ b/docs/plans/2026-02-14-production-service-next-steps.md
@@ -75,6 +75,18 @@ This refreshed version separates:
 - Key validation script: `scripts/runtime/test_validate_local_observability_scrape_live.sh`.
 - Validation marker remains tracked in `main_tests::observability_endpoint_tests::functional_observability_endpoint_readiness_reason_taxonomy_covers_dependency_probe_matrix` (issue `#3489`).
 
+### Async observability ingress compatibility hardening
+- Active chain: `#3508 -> #3509 -> #3513 -> #3514`.
+- Scope adds deterministic negative-matrix compatibility contracts for:
+  - unknown path (`/unknown`) -> `404 not found`
+  - malformed method/request parsing -> fail-closed route handling
+  - idle-timeout failure path -> deterministic timeout reason string
+- Reference validations:
+  - `scripts/runtime/test_validate_runtime_observability_endpoint_live.sh`
+  - `scripts/runtime/test_check_runtime_observability_endpoint_live_policy.sh`
+  - `scripts/runtime/test_validate_runtime_observability_endpoint_live_contract_lane.sh`
+  - `scripts/ci/test_check_observability_endpoint_drift_contract.sh`
+
 ### Docs truth synchronization (this tranche)
 - Delivered chain: `#3333 -> #3424 -> #3425 -> #3426`.
 - Scope: keep this document and CI docs-contract guards synchronized with real state as issue chains close.

--- a/scripts/ci/check_observability_endpoint_drift_contract.py
+++ b/scripts/ci/check_observability_endpoint_drift_contract.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Fail-closed drift checker for observability endpoint legacy parser and docs parity."""
+"""Fail-closed drift checker for async observability endpoint marker and docs parity."""
 
 from __future__ import annotations
 
@@ -21,17 +21,19 @@ from framework.contract_framework import (  # noqa: E402
 
 SCHEMA_VERSION = "kamn.ci.observability-endpoint-drift-report.v1"
 DOCS_MIGRATION_MARKER = (
-    "Legacy observability endpoint parser path remains synchronous and is "
-    "migration-targeted; drift contracts enforce fail-closed visibility "
-    "until framework ingress replacement lands."
+    "Runtime observability endpoint ingress runs on async tokio listener "
+    "path; drift contracts enforce fail-closed parity for unknown-path, "
+    "malformed-request, and timeout compatibility behavior."
 )
 
 SOURCE_MARKERS: dict[str, str] = {
-    "legacy_tcp_listener_import": "use std::net::{TcpListener, TcpStream};",
-    "legacy_listener_bind": "let listener = TcpListener::bind(config.bind_addr.as_str())",
-    "manual_request_parser": "fn read_http_request_path(",
-    "manual_response_writer": "fn write_http_response(",
-    "serve_entrypoint": "pub(crate) fn serve_observability_endpoint(",
+    "async_io_import": "use tokio::io::{AsyncReadExt, AsyncWriteExt};",
+    "async_listener_bind": "let listener = tokio::net::TcpListener::bind(config.bind_addr.as_str())",
+    "async_request_parser": "async fn read_http_request_path_async(",
+    "async_response_writer": "async fn write_http_response_async(",
+    "async_dispatch": "async fn dispatch_observability_endpoint_request(",
+    "async_not_found_handler": "handle_observability_not_found_path().await",
+    "async_idle_timeout_reason": "observability endpoint timed out after {} ms waiting for requests",
 }
 
 MAIN_WIRING_MARKER = "serve_observability_endpoint(&endpoint_config, &snapshot)"
@@ -99,7 +101,7 @@ def _run(args: argparse.Namespace) -> int:
         "schema_version": SCHEMA_VERSION,
         "status": status,
         "final_decision": final_decision,
-        "observability_legacy_parser_contract_status": (
+        "observability_async_ingress_contract_status": (
             "verified" if not missing_source_markers else "rejected"
         ),
         "observability_framework_parity_status": (
@@ -129,8 +131,8 @@ def _run(args: argparse.Namespace) -> int:
     print(f"status={status}")
     print(f"final_decision={final_decision}")
     print(
-        "observability_legacy_parser_contract_status="
-        f"{report['observability_legacy_parser_contract_status']}"
+        "observability_async_ingress_contract_status="
+        f"{report['observability_async_ingress_contract_status']}"
     )
     print(
         "observability_framework_parity_status="

--- a/scripts/ci/test_check_observability_endpoint_drift_contract.sh
+++ b/scripts/ci/test_check_observability_endpoint_drift_contract.sh
@@ -23,8 +23,8 @@ if ! printf '%s\n' "$check_output" | grep -q '^final_decision=GO$'; then
   echo "expected observability endpoint drift checker final_decision=GO marker" >&2
   exit 1
 fi
-if ! printf '%s\n' "$check_output" | grep -q '^observability_legacy_parser_contract_status=verified$'; then
-  echo "expected observability endpoint drift checker legacy-parser status marker" >&2
+if ! printf '%s\n' "$check_output" | grep -q '^observability_async_ingress_contract_status=verified$'; then
+  echo "expected observability endpoint drift checker async-ingress status marker" >&2
   exit 1
 fi
 if ! printf '%s\n' "$check_output" | grep -q '^observability_framework_parity_status=verified$'; then
@@ -48,8 +48,8 @@ if payload.get("status") != "pass":
     raise SystemExit("expected status=pass")
 if payload.get("final_decision") != "GO":
     raise SystemExit("expected final_decision=GO")
-if payload.get("observability_legacy_parser_contract_status") != "verified":
-    raise SystemExit("expected observability_legacy_parser_contract_status=verified")
+if payload.get("observability_async_ingress_contract_status") != "verified":
+    raise SystemExit("expected observability_async_ingress_contract_status=verified")
 if payload.get("observability_framework_parity_status") != "verified":
     raise SystemExit("expected observability_framework_parity_status=verified")
 if payload.get("docs_migration_contract_status") != "verified":
@@ -67,8 +67,8 @@ import sys
 path = pathlib.Path(sys.argv[1])
 text = path.read_text(encoding="utf-8")
 text = text.replace(
-    "use std::net::{TcpListener, TcpStream};",
-    "use std::net::{TcpStream};",
+    "async fn dispatch_observability_endpoint_request(",
+    "fn dispatch_observability_endpoint_request(",
     1,
 )
 path.write_text(text, encoding="utf-8")
@@ -84,7 +84,7 @@ if [ "$tampered_source_code" -eq 0 ]; then
   echo "expected observability endpoint drift checker to fail on source marker drift" >&2
   exit 1
 fi
-if ! printf '%s\n' "$tampered_source_output" | grep -q 'observability_source_marker_missing:legacy_tcp_listener_import'; then
+if ! printf '%s\n' "$tampered_source_output" | grep -q 'observability_source_marker_missing:async_dispatch'; then
   echo "expected deterministic source-marker drift reason code" >&2
   exit 1
 fi
@@ -97,7 +97,7 @@ import sys
 
 path = pathlib.Path(sys.argv[1])
 text = path.read_text(encoding="utf-8")
-needle = "Legacy observability endpoint parser path remains synchronous and is migration-targeted; drift contracts enforce fail-closed visibility until framework ingress replacement lands."
+needle = "Runtime observability endpoint ingress runs on async tokio listener path; drift contracts enforce fail-closed parity for unknown-path, malformed-request, and timeout compatibility behavior."
 if needle not in text:
     raise SystemExit("expected docs marker not found in baseline copy")
 path.write_text(text.replace(needle, "", 1), encoding="utf-8")

--- a/scripts/runtime/runtime_observability_endpoint_live_contract.py
+++ b/scripts/runtime/runtime_observability_endpoint_live_contract.py
@@ -26,21 +26,33 @@ from framework.contract_framework import (  # noqa: E402
 REPORT_SCHEMA = "kamn.runtime.observability-endpoint-live-validation.v1"
 POLICY_SCHEMA = "kamn.runtime.observability-endpoint-live-policy-report.v1"
 EXPECTED_FAIL_CLOSED_REASON_CODE = "observability_endpoint_not_found"
+EXPECTED_FAIL_CLOSED_REASON_CODES_CSV = (
+    "observability_endpoint_not_found,"
+    "observability_endpoint_malformed_request,"
+    "observability_endpoint_idle_timeout"
+)
 
 REQUIRED_REPORT_FIELDS = [
     "schema_version",
     "status",
     "final_decision",
     "runtime_observability_stream_contract_status",
+    "unknown_path_contract_status",
+    "malformed_input_contract_status",
+    "timeout_contract_status",
     "fail_closed_status",
     "docs_contract_status",
     "fail_closed_reason_code",
+    "fail_closed_reason_codes_csv",
     "performance_budget_status",
     "elapsed_seconds",
 ]
 
 REQUIRED_VERIFIED_FIELDS = [
     "runtime_observability_stream_contract_status",
+    "unknown_path_contract_status",
+    "malformed_input_contract_status",
+    "timeout_contract_status",
     "fail_closed_status",
     "docs_contract_status",
     "performance_budget_status",
@@ -100,6 +112,10 @@ def _check_policy(args: argparse.Namespace) -> int:
         "runtime_observability_policy_fail_closed_reason_code_mismatch",
     )
     decision.reject_if(
+        report.get("fail_closed_reason_codes_csv") != EXPECTED_FAIL_CLOSED_REASON_CODES_CSV,
+        "runtime_observability_policy_fail_closed_reason_codes_csv_mismatch",
+    )
+    decision.reject_if(
         not _is_non_negative_int(report.get("elapsed_seconds")),
         "runtime_observability_policy_elapsed_seconds_invalid",
     )
@@ -120,6 +136,7 @@ def _check_policy(args: argparse.Namespace) -> int:
         "reason_codes": reason_codes,
         "ci_fast_gate": ci_fast_gate,
         "fail_closed_reason_code": report.get("fail_closed_reason_code"),
+        "fail_closed_reason_codes_csv": report.get("fail_closed_reason_codes_csv"),
         "source_report_file": str(report_file),
         "generated_at_epoch": int(time.time()),
     }

--- a/scripts/runtime/test_check_runtime_observability_endpoint_live_policy.sh
+++ b/scripts/runtime/test_check_runtime_observability_endpoint_live_policy.sh
@@ -58,6 +58,8 @@ if payload.get("runtime_observability_policy_status") != "verified":
     raise SystemExit("expected runtime_observability_policy_status=verified")
 if payload.get("reason_codes") != ["none"]:
     raise SystemExit("expected policy checker success reason code ['none']")
+if payload.get("fail_closed_reason_codes_csv") != "observability_endpoint_not_found,observability_endpoint_malformed_request,observability_endpoint_idle_timeout":
+    raise SystemExit("expected deterministic fail-closed reason-code taxonomy")
 PY
 
 cp "$summary_report" "$tampered_report"
@@ -89,6 +91,73 @@ if [ "$tampered_code" -eq 0 ]; then
 fi
 if ! printf '%s\n' "$tampered_output" | grep -q 'runtime_observability_policy_final_decision_mismatch'; then
   echo "expected deterministic mismatch reason code for tampered policy validation" >&2
+  exit 1
+fi
+
+for marker_field in unknown_path_contract_status malformed_input_contract_status timeout_contract_status; do
+  tampered_marker_report="$TMP_DIR/runtime-observability-endpoint-live-summary.${marker_field}.json"
+  cp "$summary_report" "$tampered_marker_report"
+  python3 - "$tampered_marker_report" "$marker_field" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+marker_field = sys.argv[2]
+payload = json.loads(path.read_text(encoding="utf-8"))
+payload[marker_field] = "missing"
+path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+  set +e
+  tampered_marker_output="$(
+    bash "$POLICY_CHECKER" \
+      --report-file "$tampered_marker_report" \
+      --expected-final-decision GO \
+      --ci-fast-gate PASS \
+      --output-json "$TMP_DIR/runtime-observability-endpoint-live-policy.${marker_field}.json" 2>&1
+  )"
+  tampered_marker_code=$?
+  set -e
+  if [ "$tampered_marker_code" -eq 0 ]; then
+    echo "expected marker tamper for $marker_field to fail policy checker" >&2
+    exit 1
+  fi
+  if ! printf '%s\n' "$tampered_marker_output" | grep -q "runtime_observability_policy_marker_missing:${marker_field}"; then
+    echo "expected deterministic marker-missing reason code for tampered field $marker_field" >&2
+    exit 1
+  fi
+done
+
+tampered_taxonomy_report="$TMP_DIR/runtime-observability-endpoint-live-summary.fail-closed-taxonomy.json"
+cp "$summary_report" "$tampered_taxonomy_report"
+python3 - "$tampered_taxonomy_report" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+payload = json.loads(path.read_text(encoding="utf-8"))
+payload["fail_closed_reason_codes_csv"] = "observability_endpoint_not_found"
+path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+set +e
+tampered_taxonomy_output="$(
+  bash "$POLICY_CHECKER" \
+    --report-file "$tampered_taxonomy_report" \
+    --expected-final-decision GO \
+    --ci-fast-gate PASS \
+    --output-json "$TMP_DIR/runtime-observability-endpoint-live-policy.fail-closed-taxonomy.json" 2>&1
+)"
+tampered_taxonomy_code=$?
+set -e
+if [ "$tampered_taxonomy_code" -eq 0 ]; then
+  echo "expected fail-closed taxonomy tamper to fail policy checker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$tampered_taxonomy_output" | grep -q 'runtime_observability_policy_fail_closed_reason_codes_csv_mismatch'; then
+  echo "expected deterministic fail-closed taxonomy mismatch reason code" >&2
   exit 1
 fi
 

--- a/scripts/runtime/test_validate_runtime_observability_endpoint_live.sh
+++ b/scripts/runtime/test_validate_runtime_observability_endpoint_live.sh
@@ -24,6 +24,18 @@ if ! printf '%s\n' "$validation_output" | grep -q '^runtime_observability_stream
   echo "expected runtime observability stream contract marker" >&2
   exit 1
 fi
+if ! printf '%s\n' "$validation_output" | grep -q '^unknown_path_contract_status=verified$'; then
+  echo "expected unknown-path contract marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^malformed_input_contract_status=verified$'; then
+  echo "expected malformed-input contract marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^timeout_contract_status=verified$'; then
+  echo "expected timeout contract marker" >&2
+  exit 1
+fi
 if ! printf '%s\n' "$validation_output" | grep -q '^fail_closed_status=verified$'; then
   echo "expected fail-closed status marker" >&2
   exit 1
@@ -47,12 +59,20 @@ if payload.get("schema_version") != "kamn.runtime.observability-endpoint-live-va
     raise SystemExit("unexpected runtime observability endpoint live schema")
 if payload.get("runtime_observability_stream_contract_status") != "verified":
     raise SystemExit("expected runtime_observability_stream_contract_status=verified")
+if payload.get("unknown_path_contract_status") != "verified":
+    raise SystemExit("expected unknown_path_contract_status=verified")
+if payload.get("malformed_input_contract_status") != "verified":
+    raise SystemExit("expected malformed_input_contract_status=verified")
+if payload.get("timeout_contract_status") != "verified":
+    raise SystemExit("expected timeout_contract_status=verified")
 if payload.get("fail_closed_status") != "verified":
     raise SystemExit("expected fail_closed_status=verified")
 if payload.get("docs_contract_status") != "verified":
     raise SystemExit("expected docs_contract_status=verified")
 if payload.get("performance_budget_status") != "verified":
     raise SystemExit("expected performance_budget_status=verified")
+if payload.get("fail_closed_reason_codes_csv") != "observability_endpoint_not_found,observability_endpoint_malformed_request,observability_endpoint_idle_timeout":
+    raise SystemExit("expected deterministic fail_closed_reason_codes_csv taxonomy")
 PY
 
 set +e

--- a/scripts/runtime/test_validate_runtime_observability_endpoint_live_contract_lane.sh
+++ b/scripts/runtime/test_validate_runtime_observability_endpoint_live_contract_lane.sh
@@ -45,8 +45,24 @@ if ! printf '%s\n' "$lane_output" | grep -q '^runtime_observability_contract_lan
   echo "expected runtime observability endpoint contract lane status marker" >&2
   exit 1
 fi
+if ! printf '%s\n' "$lane_output" | grep -q '^unknown_path_contract_status=verified$'; then
+  echo "expected runtime observability endpoint unknown-path marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$lane_output" | grep -q '^malformed_input_contract_status=verified$'; then
+  echo "expected runtime observability endpoint malformed-input marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$lane_output" | grep -q '^timeout_contract_status=verified$'; then
+  echo "expected runtime observability endpoint timeout marker" >&2
+  exit 1
+fi
 if ! printf '%s\n' "$lane_output" | grep -q '^fail_closed_reason_code=runtime_observability_policy_final_decision_mismatch$'; then
   echo "expected runtime observability endpoint contract lane fail-closed reason marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$lane_output" | grep -q '^fail_closed_reason_codes_csv=observability_endpoint_not_found,observability_endpoint_malformed_request,observability_endpoint_idle_timeout$'; then
+  echo "expected runtime observability endpoint contract lane fail-closed taxonomy marker" >&2
   exit 1
 fi
 
@@ -66,8 +82,16 @@ if lane_payload.get("runtime_observability_policy_status") != "verified":
     raise SystemExit("expected runtime_observability_policy_status=verified")
 if lane_payload.get("runtime_observability_contract_lane_status") != "verified":
     raise SystemExit("expected runtime_observability_contract_lane_status=verified")
+if lane_payload.get("unknown_path_contract_status") != "verified":
+    raise SystemExit("expected unknown_path_contract_status=verified")
+if lane_payload.get("malformed_input_contract_status") != "verified":
+    raise SystemExit("expected malformed_input_contract_status=verified")
+if lane_payload.get("timeout_contract_status") != "verified":
+    raise SystemExit("expected timeout_contract_status=verified")
 if lane_payload.get("fail_closed_reason_code") != "runtime_observability_policy_final_decision_mismatch":
     raise SystemExit("expected deterministic fail-closed reason code marker")
+if lane_payload.get("fail_closed_reason_codes_csv") != "observability_endpoint_not_found,observability_endpoint_malformed_request,observability_endpoint_idle_timeout":
+    raise SystemExit("expected deterministic fail-closed reason-code taxonomy marker")
 if lane_payload.get("performance_budget_status") != "verified":
     raise SystemExit("expected performance_budget_status=verified")
 

--- a/scripts/runtime/validate_runtime_observability_endpoint_live.sh
+++ b/scripts/runtime/validate_runtime_observability_endpoint_live.sh
@@ -41,6 +41,9 @@ pushd "$ROOT_DIR" >/dev/null
 cargo test -p kamn-node functional_observability_endpoint_renders_stream_payload
 cargo test -p kamn-node integration_runtime_observability_endpoint_serves_stream_path
 cargo test -p kamn-node integration_runtime_observability_endpoint_serves_metrics_and_health_paths
+cargo test -p kamn-node integration_runtime_observability_endpoint_returns_not_found_for_unknown_path
+cargo test -p kamn-node integration_runtime_observability_endpoint_returns_not_found_for_malformed_request_method
+cargo test -p kamn-node integration_runtime_observability_endpoint_fails_closed_on_idle_timeout
 popd >/dev/null
 
 if ! grep -q "Runtime Endpoint Stream Contract (Issue #3047)" "$OBSERVABILITY_DOC"; then
@@ -77,9 +80,13 @@ cat >"$report_json" <<JSON
   "status": "pass",
   "final_decision": "GO",
   "runtime_observability_stream_contract_status": "verified",
+  "unknown_path_contract_status": "verified",
+  "malformed_input_contract_status": "verified",
+  "timeout_contract_status": "verified",
   "fail_closed_status": "verified",
   "docs_contract_status": "verified",
   "fail_closed_reason_code": "observability_endpoint_not_found",
+  "fail_closed_reason_codes_csv": "observability_endpoint_not_found,observability_endpoint_malformed_request,observability_endpoint_idle_timeout",
   "performance_budget_status": "verified",
   "elapsed_seconds": ${elapsed_seconds}
 }
@@ -93,7 +100,11 @@ rm -f "$report_json"
 echo "status=pass"
 echo "final_decision=GO"
 echo "runtime_observability_stream_contract_status=verified"
+echo "unknown_path_contract_status=verified"
+echo "malformed_input_contract_status=verified"
+echo "timeout_contract_status=verified"
 echo "fail_closed_status=verified"
 echo "docs_contract_status=verified"
 echo "fail_closed_reason_code=observability_endpoint_not_found"
+echo "fail_closed_reason_codes_csv=observability_endpoint_not_found,observability_endpoint_malformed_request,observability_endpoint_idle_timeout"
 echo "performance_budget_status=verified"

--- a/scripts/runtime/validate_runtime_observability_endpoint_live_contract_lane.sh
+++ b/scripts/runtime/validate_runtime_observability_endpoint_live_contract_lane.sh
@@ -196,6 +196,15 @@ lane_report = {
     "runtime_observability_stream_contract_status": summary_report.get(
         "runtime_observability_stream_contract_status"
     ),
+    "unknown_path_contract_status": summary_report.get(
+        "unknown_path_contract_status"
+    ),
+    "malformed_input_contract_status": summary_report.get(
+        "malformed_input_contract_status"
+    ),
+    "timeout_contract_status": summary_report.get(
+        "timeout_contract_status"
+    ),
     "runtime_observability_policy_status": policy_report.get(
         "runtime_observability_policy_status"
     ),
@@ -203,6 +212,7 @@ lane_report = {
     "docs_contract_status": "verified",
     "fail_closed_status": "verified",
     "fail_closed_reason_code": "runtime_observability_policy_final_decision_mismatch",
+    "fail_closed_reason_codes_csv": summary_report.get("fail_closed_reason_codes_csv"),
     "performance_budget_status": "verified",
     "elapsed_seconds": elapsed_seconds,
     "max_seconds": max_seconds,
@@ -220,9 +230,13 @@ fi
 echo "status=pass"
 echo "final_decision=GO"
 echo "runtime_observability_stream_contract_status=verified"
+echo "unknown_path_contract_status=verified"
+echo "malformed_input_contract_status=verified"
+echo "timeout_contract_status=verified"
 echo "runtime_observability_policy_status=verified"
 echo "runtime_observability_contract_lane_status=verified"
 echo "docs_contract_status=verified"
 echo "fail_closed_status=verified"
 echo "fail_closed_reason_code=runtime_observability_policy_final_decision_mismatch"
+echo "fail_closed_reason_codes_csv=observability_endpoint_not_found,observability_endpoint_malformed_request,observability_endpoint_idle_timeout"
 echo "performance_budget_status=verified"


### PR DESCRIPTION
## Summary
Adds async observability negative-matrix regression contracts for unknown-path, malformed-request, and idle-timeout behavior, and aligns CI drift markers/docs with the async ingress implementation.

## Changes
- `crates/kamn-node/src/main_tests/observability_endpoint_tests.rs`: added negative-path integration tests and async regression marker guard.
- `scripts/runtime/validate_runtime_observability_endpoint_live.sh`: added unknown/malformed/timeout selectors and fail-closed taxonomy markers.
- `scripts/runtime/runtime_observability_endpoint_live_contract.py`: expanded required policy fields and fail-closed taxonomy checks.
- `scripts/runtime/test_check_runtime_observability_endpoint_live_policy.sh`: added deterministic tamper drills for unknown/malformed/timeout marker drift and taxonomy mismatch.
- `scripts/runtime/validate_runtime_observability_endpoint_live_contract_lane.sh`: propagated negative-matrix status/taxonomy into lane reports and markers.
- `scripts/ci/check_observability_endpoint_drift_contract.py`: migrated drift guards from legacy sync parser markers to async ingress markers.
- `scripts/ci/test_check_observability_endpoint_drift_contract.sh`: updated regression tamper checks for async marker drift.
- `docs/foundation/node-runtime-cli.md`: replaced stale legacy sync marker with async ingress contract marker.
- `docs/foundation/observability-slo-dashboards.md`: documented new negative-matrix status/taxonomy markers.
- `docs/plans/2026-02-08-production-service-roadmap.md`: updated drift-contract marker naming to async ingress.
- `docs/plans/2026-02-14-production-service-next-steps.md`: added active issue chain and negative-matrix references.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-node -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual verification: ran observability runtime/policy/lane/drift contract scripts and verified deterministic tamper reason codes for unknown/malformed/timeout cases.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `cargo test -p kamn-node observability_endpoint_tests` |
| Functional  | ✅     | Runtime observability render + reason-code functional tests in `observability_endpoint_tests` |
| Integration | ✅     | New unknown-path/malformed/timeout endpoint integration tests |
| Regression  | ✅     | Runtime/CI contract lane tamper drills and async drift marker checks |

Closes #3514
