### PR TITLE
test(ci): enforce telemetry schema docs drift markers (#3518)

### DIFF
--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -475,7 +475,8 @@ Versioned thresholds are defined in `.ci/ci-budget.env`.
   - explicit runtime budget cap via `KAMN_RUNTIME_OBSERVABILITY_ENDPOINT_CONTRACT_MAX_SECONDS`
   - deterministic fail-closed policy tamper drill executed in-process
 - Deterministic fail-closed marker for drift tamper drills:
-  - `observability_source_marker_missing:legacy_tcp_listener_import`
+  - `observability_source_marker_missing:async_dispatch`
+  - telemetry schema docs-contract marker set remains fail-closed for stream schema_version and readiness_reason_code taxonomy.
 
 ## Runtime Local Retry/Diagnostics Contract Lane
 - Entry commands:

--- a/scripts/ci/check_observability_endpoint_drift_contract.py
+++ b/scripts/ci/check_observability_endpoint_drift_contract.py
@@ -36,6 +36,26 @@ SOURCE_MARKERS: dict[str, str] = {
     "async_idle_timeout_reason": "observability endpoint timed out after {} ms waiting for requests",
 }
 
+TELEMETRY_SOURCE_MARKERS: dict[str, str] = {
+    "stream_schema_marker": "{\\\"schema_version\\\":\\\"kamn.runtime.observability.stream.v1\\\"",
+    "metrics_readiness_reason_code_marker": "kamn_observability_readiness_reason_code{{readiness_reason_code=\\\"{}\\\"}} 1",
+    "readiness_reason_projection_fn": "fn readiness_reason_code(snapshot: &RuntimeObservabilitySnapshot) -> &'static str {",
+}
+
+TELEMETRY_DOC_MARKERS: dict[str, str] = {
+    "stream_schema_marker": "schema_version=\"kamn.runtime.observability.stream.v1\"",
+    "readiness_reason_taxonomy_marker": "`readiness_reason_code` (dependency-derived readiness taxonomy)",
+    "readiness_transport_marker": "`readiness_transport_dependency_unhealthy`",
+    "readiness_signer_marker": "`readiness_signer_dependency_unhealthy`",
+    "readiness_commit_marker": "`readiness_commit_dependency_unhealthy`",
+    "readiness_runtime_health_marker": "`readiness_runtime_health_degraded`",
+}
+
+TELEMETRY_STRATEGY_MARKER = (
+    "telemetry schema docs-contract marker set remains fail-closed for stream "
+    "schema_version and readiness_reason_code taxonomy."
+)
+
 MAIN_WIRING_MARKER = "serve_observability_endpoint(&endpoint_config, &snapshot)"
 FRAMEWORK_INGRESS_MARKER = "tokio::net::TcpListener::bind(config.bind_addr.as_str())"
 
@@ -51,6 +71,8 @@ def _run(args: argparse.Namespace) -> int:
     main_file = Path(args.main_file).resolve()
     framework_file = Path(args.framework_file).resolve()
     docs_file = Path(args.docs_file).resolve()
+    observability_doc_file = Path(args.observability_doc_file).resolve()
+    strategy_doc_file = Path(args.strategy_doc_file).resolve()
 
     source_text = _read_text(
         source_file,
@@ -69,6 +91,14 @@ def _run(args: argparse.Namespace) -> int:
         docs_file,
         reason_code="observability_docs_file_missing",
     )
+    observability_docs_text = _read_text(
+        observability_doc_file,
+        reason_code="observability_schema_docs_file_missing",
+    )
+    strategy_doc_text = _read_text(
+        strategy_doc_file,
+        reason_code="observability_strategy_doc_file_missing",
+    )
 
     decision = DecisionAccumulator()
 
@@ -79,6 +109,24 @@ def _run(args: argparse.Namespace) -> int:
             decision.reject_if(
                 True,
                 f"observability_source_marker_missing:{marker_key}",
+            )
+
+    missing_telemetry_source_markers: list[str] = []
+    for marker_key, marker_value in TELEMETRY_SOURCE_MARKERS.items():
+        if marker_value not in source_contract_text:
+            missing_telemetry_source_markers.append(marker_key)
+            decision.reject_if(
+                True,
+                f"observability_source_marker_missing:{marker_key}",
+            )
+
+    missing_telemetry_doc_markers: list[str] = []
+    for marker_key, marker_value in TELEMETRY_DOC_MARKERS.items():
+        if marker_value not in observability_docs_text:
+            missing_telemetry_doc_markers.append(marker_key)
+            decision.reject_if(
+                True,
+                f"observability_schema_docs_marker_missing:{marker_key}",
             )
 
     decision.reject_if(
@@ -92,6 +140,10 @@ def _run(args: argparse.Namespace) -> int:
     decision.reject_if(
         DOCS_MIGRATION_MARKER not in docs_text,
         "observability_docs_marker_missing",
+    )
+    decision.reject_if(
+        TELEMETRY_STRATEGY_MARKER not in strategy_doc_text,
+        "observability_strategy_marker_missing:telemetry_schema_contract_marker",
     )
 
     final_decision, reason_codes = decision.finalize("none")
@@ -112,13 +164,32 @@ def _run(args: argparse.Namespace) -> int:
         "docs_migration_contract_status": (
             "verified" if DOCS_MIGRATION_MARKER in docs_text else "rejected"
         ),
+        "telemetry_schema_contract_status": (
+            "verified"
+            if (
+                not missing_telemetry_source_markers
+                and not missing_telemetry_doc_markers
+                and TELEMETRY_STRATEGY_MARKER in strategy_doc_text
+            )
+            else "rejected"
+        ),
         "source_marker_count": len(SOURCE_MARKERS) - len(missing_source_markers),
         "expected_source_marker_count": len(SOURCE_MARKERS),
+        "telemetry_source_marker_count": (
+            len(TELEMETRY_SOURCE_MARKERS) - len(missing_telemetry_source_markers)
+        ),
+        "expected_telemetry_source_marker_count": len(TELEMETRY_SOURCE_MARKERS),
+        "telemetry_doc_marker_count": (
+            len(TELEMETRY_DOC_MARKERS) - len(missing_telemetry_doc_markers)
+        ),
+        "expected_telemetry_doc_marker_count": len(TELEMETRY_DOC_MARKERS),
         "reason_codes": reason_codes,
         "source_file": str(source_file),
         "main_file": str(main_file),
         "framework_file": str(framework_file),
         "docs_file": str(docs_file),
+        "observability_doc_file": str(observability_doc_file),
+        "strategy_doc_file": str(strategy_doc_file),
         "generated_at_epoch": int(time.time()),
     }
 
@@ -139,6 +210,7 @@ def _run(args: argparse.Namespace) -> int:
         f"{report['observability_framework_parity_status']}"
     )
     print(f"docs_migration_contract_status={report['docs_migration_contract_status']}")
+    print(f"telemetry_schema_contract_status={report['telemetry_schema_contract_status']}")
     print(f"reason_codes={reason_codes_csv}")
     if output_json is not None:
         print(f"report_file={output_json}")
@@ -172,6 +244,16 @@ def main() -> int:
         "--docs-file",
         default=str(ROOT_DIR / "docs/foundation/node-runtime-cli.md"),
         help="Node runtime CLI documentation path.",
+    )
+    parser.add_argument(
+        "--observability-doc-file",
+        default=str(ROOT_DIR / "docs/foundation/observability-slo-dashboards.md"),
+        help="Observability telemetry schema documentation path.",
+    )
+    parser.add_argument(
+        "--strategy-doc-file",
+        default=str(ROOT_DIR / "docs/ci/strategy.md"),
+        help="CI strategy documentation path for telemetry schema contract markers.",
     )
     parser.add_argument(
         "--output-json",

--- a/scripts/ci/test_check_observability_endpoint_drift_contract.sh
+++ b/scripts/ci/test_check_observability_endpoint_drift_contract.sh
@@ -3,6 +3,8 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 CHECK_SCRIPT="$ROOT_DIR/scripts/ci/check_observability_endpoint_drift_contract.sh"
+OBSERVABILITY_DOC="$ROOT_DIR/docs/foundation/observability-slo-dashboards.md"
+STRATEGY_DOC="$ROOT_DIR/docs/ci/strategy.md"
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
 
@@ -35,6 +37,10 @@ if ! printf '%s\n' "$check_output" | grep -q '^docs_migration_contract_status=ve
   echo "expected observability endpoint drift checker docs status marker" >&2
   exit 1
 fi
+if ! printf '%s\n' "$check_output" | grep -q '^telemetry_schema_contract_status=verified$'; then
+  echo "expected observability endpoint drift checker telemetry schema status marker" >&2
+  exit 1
+fi
 
 python3 - "$report_file" <<'PY'
 import json
@@ -54,6 +60,8 @@ if payload.get("observability_framework_parity_status") != "verified":
     raise SystemExit("expected observability_framework_parity_status=verified")
 if payload.get("docs_migration_contract_status") != "verified":
     raise SystemExit("expected docs_migration_contract_status=verified")
+if payload.get("telemetry_schema_contract_status") != "verified":
+    raise SystemExit("expected telemetry_schema_contract_status=verified")
 if payload.get("reason_codes") != ["none"]:
     raise SystemExit("expected reason_codes=['none']")
 PY
@@ -115,6 +123,95 @@ if [ "$tampered_docs_code" -eq 0 ]; then
 fi
 if ! printf '%s\n' "$tampered_docs_output" | grep -q 'observability_docs_marker_missing'; then
   echo "expected deterministic docs-marker drift reason code" >&2
+  exit 1
+fi
+
+tampered_schema_source="$TMP_DIR/observability_endpoint.schema.rs"
+cp "$ROOT_DIR/crates/kamn-node/src/observability_endpoint.rs" "$tampered_schema_source"
+python3 - "$tampered_schema_source" <<'PY'
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+text = text.replace(
+    "{\\\"schema_version\\\":\\\"kamn.runtime.observability.stream.v1\\\"",
+    "{\\\"schema_version\\\":\\\"kamn.runtime.observability.stream.vX\\\"",
+    1,
+)
+path.write_text(text, encoding="utf-8")
+PY
+
+set +e
+tampered_schema_source_output="$(
+  bash "$CHECK_SCRIPT" --source-file "$tampered_schema_source" --output-json "$TMP_DIR/observability-endpoint-drift-report.tampered-schema-source.json" 2>&1
+)"
+tampered_schema_source_code=$?
+set -e
+if [ "$tampered_schema_source_code" -eq 0 ]; then
+  echo "expected observability endpoint drift checker to fail on telemetry schema source marker drift" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$tampered_schema_source_output" | grep -q 'observability_source_marker_missing:stream_schema_marker'; then
+  echo "expected deterministic telemetry schema source-marker drift reason code" >&2
+  exit 1
+fi
+
+tampered_observability_docs="$TMP_DIR/observability-slo-dashboards.md"
+cp "$OBSERVABILITY_DOC" "$tampered_observability_docs"
+python3 - "$tampered_observability_docs" <<'PY'
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+needle = "`readiness_reason_code` (dependency-derived readiness taxonomy)"
+if needle not in text:
+    raise SystemExit("expected observability schema docs marker not found in baseline copy")
+path.write_text(text.replace(needle, "", 1), encoding="utf-8")
+PY
+
+set +e
+tampered_observability_docs_output="$(
+  bash "$CHECK_SCRIPT" --observability-doc-file "$tampered_observability_docs" --output-json "$TMP_DIR/observability-endpoint-drift-report.tampered-observability-docs.json" 2>&1
+)"
+tampered_observability_docs_code=$?
+set -e
+if [ "$tampered_observability_docs_code" -eq 0 ]; then
+  echo "expected observability endpoint drift checker to fail on telemetry observability docs marker drift" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$tampered_observability_docs_output" | grep -q 'observability_schema_docs_marker_missing:readiness_reason_taxonomy_marker'; then
+  echo "expected deterministic telemetry observability docs-marker drift reason code" >&2
+  exit 1
+fi
+
+tampered_strategy_docs="$TMP_DIR/ci-strategy.md"
+cp "$STRATEGY_DOC" "$tampered_strategy_docs"
+python3 - "$tampered_strategy_docs" <<'PY'
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+needle = "telemetry schema docs-contract marker set remains fail-closed for stream schema_version and readiness_reason_code taxonomy."
+if needle not in text:
+    raise SystemExit("expected telemetry strategy marker not found in baseline copy")
+path.write_text(text.replace(needle, "", 1), encoding="utf-8")
+PY
+
+set +e
+tampered_strategy_docs_output="$(
+  bash "$CHECK_SCRIPT" --strategy-doc-file "$tampered_strategy_docs" --output-json "$TMP_DIR/observability-endpoint-drift-report.tampered-strategy-docs.json" 2>&1
+)"
+tampered_strategy_docs_code=$?
+set -e
+if [ "$tampered_strategy_docs_code" -eq 0 ]; then
+  echo "expected observability endpoint drift checker to fail on telemetry strategy docs marker drift" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$tampered_strategy_docs_output" | grep -q 'observability_strategy_marker_missing:telemetry_schema_contract_marker'; then
+  echo "expected deterministic telemetry strategy docs-marker drift reason code" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
Extends the observability drift checker to enforce canonical telemetry schema/readiness marker parity across source, observability docs, and CI strategy docs, with deterministic fail-closed tamper reason codes.

## Changes
- `scripts/ci/check_observability_endpoint_drift_contract.py`: added telemetry schema marker validation for source + docs + strategy, new report marker `telemetry_schema_contract_status`, and explicit reason-code taxonomy for missing markers.
- `scripts/ci/test_check_observability_endpoint_drift_contract.sh`: added regression checks for telemetry schema contract marker output and tamper drills for source schema marker, observability doc taxonomy marker, and CI strategy marker.
- `docs/ci/strategy.md`: updated runtime observability endpoint section with canonical telemetry schema docs-contract marker statement and current async drift marker taxonomy.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — N/A (no Rust changes)
- [x] `cargo clippy -- -D warnings` — N/A (no Rust changes)
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual verification: executed drift contract tamper matrix and CI strategy/tooling contract tests.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | Marker/key assertions in drift contract test harness |
| Functional  | ✅     | Drift checker pass-path emits canonical telemetry schema marker status |
| Integration | ✅     | `test_check_observability_endpoint_drift_contract.sh` end-to-end wrapper + checker execution |
| Regression  | ✅     | Deterministic tamper reason-code checks for source/docs/strategy marker drift |

Closes #3518
