### PR TITLE
test(observability): add readiness projection parity coverage (#3519)

### DIFF
--- a/crates/kamn-node/src/main_tests/observability_endpoint_tests.rs
+++ b/crates/kamn-node/src/main_tests/observability_endpoint_tests.rs
@@ -436,6 +436,61 @@ fn functional_observability_endpoint_readiness_reason_taxonomy_covers_dependency
 }
 
 #[test]
+fn functional_observability_endpoint_projects_readiness_reason_code_parity_across_endpoint_surfaces(
+) {
+    let assert_projection_parity = |snapshot: &RuntimeObservabilitySnapshot,
+                                    expected_reason_code: &str| {
+        let metrics = render_observability_endpoint_response(snapshot, "/metrics");
+        let health = render_observability_endpoint_response(snapshot, "/healthz");
+        let readiness = render_observability_endpoint_response(snapshot, "/readyz");
+        let stream = render_observability_endpoint_response(snapshot, "/metrics.stream");
+
+        let metrics_marker = format!(
+            "kamn_observability_readiness_reason_code{{readiness_reason_code=\"{}\"}} 1",
+            expected_reason_code
+        );
+        let json_marker = format!("\"readiness_reason_code\":\"{}\"", expected_reason_code);
+
+        assert!(metrics.body.contains(metrics_marker.as_str()));
+        assert!(health.body.contains(json_marker.as_str()));
+        assert!(readiness.body.contains(json_marker.as_str()));
+        assert!(stream.body.contains(json_marker.as_str()));
+    };
+
+    let healthy = sample_observability_snapshot();
+    assert_projection_parity(&healthy, "none");
+
+    let mut transport_degraded = sample_observability_snapshot();
+    transport_degraded.health = "critical".to_owned();
+    transport_degraded.reason_code = "transport_finality_retry_unavailable".to_owned();
+    transport_degraded.transport_checkpoint_failures = 1;
+    assert_projection_parity(
+        &transport_degraded,
+        "readiness_transport_dependency_unhealthy",
+    );
+
+    let mut signer_degraded = sample_observability_snapshot();
+    signer_degraded.health = "critical".to_owned();
+    signer_degraded.reason_code = "signer_rotation_stale".to_owned();
+    signer_degraded.signer_checkpoint_failures = 1;
+    assert_projection_parity(&signer_degraded, "readiness_signer_dependency_unhealthy");
+
+    let mut commit_degraded = sample_observability_snapshot();
+    commit_degraded.health = "critical".to_owned();
+    commit_degraded.reason_code = "daemon_shutdown_timeout".to_owned();
+    commit_degraded.commit_checkpoint_failures = 1;
+    assert_projection_parity(&commit_degraded, "readiness_commit_dependency_unhealthy");
+
+    let mut runtime_health_degraded = sample_observability_snapshot();
+    runtime_health_degraded.health = "degraded".to_owned();
+    runtime_health_degraded.reason_code = "daemon_slo_alert".to_owned();
+    assert_projection_parity(
+        &runtime_health_degraded,
+        "readiness_runtime_health_degraded",
+    );
+}
+
+#[test]
 fn integration_runtime_observability_endpoint_serves_metrics_and_health_paths() {
     let parsed = parse_args(vec![
         "kamn-node".to_owned(),

--- a/docs/plans/2026-02-14-production-service-next-steps.md
+++ b/docs/plans/2026-02-14-production-service-next-steps.md
@@ -86,6 +86,8 @@ This refreshed version separates:
   - `scripts/runtime/test_check_runtime_observability_endpoint_live_policy.sh`
   - `scripts/runtime/test_validate_runtime_observability_endpoint_live_contract_lane.sh`
   - `scripts/ci/test_check_observability_endpoint_drift_contract.sh`
+- Readiness parity selector coverage:
+  - `main_tests::observability_endpoint_tests::functional_observability_endpoint_projects_readiness_reason_code_parity_across_endpoint_surfaces` (issue `#3519`).
 
 ### Docs truth synchronization (this tranche)
 - Delivered chain: `#3333 -> #3424 -> #3425 -> #3426`.

--- a/scripts/runtime/validate_runtime_observability_endpoint_live.sh
+++ b/scripts/runtime/validate_runtime_observability_endpoint_live.sh
@@ -41,6 +41,7 @@ pushd "$ROOT_DIR" >/dev/null
 cargo test -p kamn-node functional_observability_endpoint_renders_stream_payload
 cargo test -p kamn-node integration_runtime_observability_endpoint_serves_stream_path
 cargo test -p kamn-node integration_runtime_observability_endpoint_serves_metrics_and_health_paths
+cargo test -p kamn-node functional_observability_endpoint_projects_readiness_reason_code_parity_across_endpoint_surfaces
 cargo test -p kamn-node integration_runtime_observability_endpoint_returns_not_found_for_unknown_path
 cargo test -p kamn-node integration_runtime_observability_endpoint_returns_not_found_for_malformed_request_method
 cargo test -p kamn-node integration_runtime_observability_endpoint_fails_closed_on_idle_timeout


### PR DESCRIPTION
## Summary
Adds functional readiness reason-code parity coverage across observability endpoint surfaces and wires that selector into the runtime observability live contract lane validation set.

## Changes
- `crates/kamn-node/src/main_tests/observability_endpoint_tests.rs`: added `functional_observability_endpoint_projects_readiness_reason_code_parity_across_endpoint_surfaces` validating parity across `/metrics`, `/healthz`, `/readyz`, and `/metrics.stream` for healthy and degraded dependency scenarios.
- `scripts/runtime/validate_runtime_observability_endpoint_live.sh`: added parity selector execution to runtime observability contract lane validation.
- `docs/plans/2026-02-14-production-service-next-steps.md`: added readiness parity selector reference for issue chain tracking.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-node -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual verification: ran parity selector, runtime observability lane tests/policy/lane scripts, and next-steps docs contract.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | Readiness projection assertions at response-surface granularity |
| Functional  | ✅     | New cross-surface readiness parity functional test |
| Integration | ✅     | Runtime observability live validation + contract lane scripts |
| Regression  | ✅     | Existing readiness taxonomy matrix selector remains covered and documented |

Closes #3519
