### PR TITLE
test(observability): add stream reconnect queue-bound matrix (#3521)

### DIFF
--- a/crates/kamn-node/src/main_tests/observability_endpoint_tests.rs
+++ b/crates/kamn-node/src/main_tests/observability_endpoint_tests.rs
@@ -41,6 +41,36 @@ fn send_http_get(addr: &str, path: &str) -> String {
     response
 }
 
+fn try_send_http_get(addr: &str, path: &str) -> Result<String, String> {
+    let mut stream =
+        TcpStream::connect(addr).map_err(|error| format!("connect should succeed: {error}"))?;
+    stream
+        .set_read_timeout(Some(Duration::from_secs(2)))
+        .map_err(|error| format!("read timeout should be configurable: {error}"))?;
+    let request = format!("GET {path} HTTP/1.1\r\nHost: {addr}\r\nConnection: close\r\n\r\n");
+    stream
+        .write_all(request.as_bytes())
+        .map_err(|error| format!("request should write: {error}"))?;
+    let mut response = String::new();
+    let mut chunk = [0_u8; 1024];
+    loop {
+        match stream.read(&mut chunk) {
+            Ok(0) => break,
+            Ok(read_count) => {
+                response.push_str(
+                    std::str::from_utf8(&chunk[..read_count])
+                        .map_err(|error| format!("response must be utf-8: {error}"))?,
+                );
+            }
+            Err(error) if matches!(error.kind(), ErrorKind::WouldBlock | ErrorKind::TimedOut) => {
+                break;
+            }
+            Err(error) => return Err(format!("response should be readable: {error}")),
+        }
+    }
+    Ok(response)
+}
+
 fn send_raw_http_request(addr: &str, request: &str) -> String {
     let mut stream = TcpStream::connect(addr).expect("endpoint should accept connections");
     stream
@@ -670,6 +700,74 @@ fn integration_runtime_observability_endpoint_handles_concurrent_metrics_and_str
     assert!(
         server_result.is_ok(),
         "endpoint server should stop cleanly after configured request budget"
+    );
+}
+
+#[test]
+fn integration_runtime_observability_endpoint_supports_stream_reconnect_churn_sequence() {
+    let snapshot = sample_observability_snapshot();
+    let bind_addr = reserve_loopback_addr();
+    let endpoint_config = ObservabilityEndpointConfig {
+        bind_addr: bind_addr.clone(),
+        metrics_path: "/metrics".to_owned(),
+        health_path: "/healthz".to_owned(),
+        max_requests: 4,
+        idle_timeout_ms: 2_000,
+    };
+
+    let server_snapshot = snapshot.clone();
+    let server =
+        thread::spawn(move || serve_observability_endpoint(&endpoint_config, &server_snapshot));
+    wait_for_endpoint_ready(bind_addr.as_str());
+
+    let first_stream_response = send_http_get(bind_addr.as_str(), "/metrics.stream");
+    let second_stream_response = send_http_get(bind_addr.as_str(), "/metrics.stream");
+    let readiness_response = send_http_get(bind_addr.as_str(), "/readyz");
+    assert!(first_stream_response.contains("HTTP/1.1 200 OK"));
+    assert!(first_stream_response.contains("kamn.runtime.observability.stream.v1"));
+    assert!(second_stream_response.contains("HTTP/1.1 200 OK"));
+    assert!(second_stream_response.contains("kamn.runtime.observability.stream.v1"));
+    assert!(readiness_response.contains("HTTP/1.1 200 OK"));
+    assert!(readiness_response.contains("\"readiness_reason_code\":\"none\""));
+
+    let server_result = server.join().expect("endpoint thread should complete");
+    assert!(
+        server_result.is_ok(),
+        "endpoint server should stop cleanly after configured request budget"
+    );
+}
+
+#[test]
+fn integration_runtime_observability_endpoint_enforces_queue_bound_request_budget() {
+    let snapshot = sample_observability_snapshot();
+    let bind_addr = reserve_loopback_addr();
+    let endpoint_config = ObservabilityEndpointConfig {
+        bind_addr: bind_addr.clone(),
+        metrics_path: "/metrics".to_owned(),
+        health_path: "/healthz".to_owned(),
+        max_requests: 2,
+        idle_timeout_ms: 2_000,
+    };
+
+    let server_snapshot = snapshot.clone();
+    let server =
+        thread::spawn(move || serve_observability_endpoint(&endpoint_config, &server_snapshot));
+    wait_for_endpoint_ready(bind_addr.as_str());
+
+    let first_request_response = send_http_get(bind_addr.as_str(), "/metrics");
+    assert!(first_request_response.contains("HTTP/1.1 200 OK"));
+    assert!(first_request_response.contains("kamn_observability_ready 1"));
+
+    let server_result = server.join().expect("endpoint thread should complete");
+    assert!(
+        server_result.is_ok(),
+        "endpoint server should stop cleanly once bounded request budget is exhausted"
+    );
+
+    let second_request_result = try_send_http_get(bind_addr.as_str(), "/metrics");
+    assert!(
+        second_request_result.is_err(),
+        "request budget exhaustion should close listener and reject additional requests"
     );
 }
 

--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -553,7 +553,7 @@ Versioned thresholds are defined in `.ci/ci-budget.env`.
   - dry-run mode executes no nested local observability scrape commands and emits deterministic `dry_run_no_commands_executed`.
   - run mode is explicit local-only and requires `KAMN_LOCAL_OBSERVABILITY_SCRAPE_OPT_IN=1`.
   - soak run-mode profile is local-only (`--lane-profile soak`) and emits deterministic `local_heavy_soak_lane_status=verified` plus iteration markers (`soak_iterations_requested`, `soak_iterations_executed`).
-  - bounded to five targeted `kamn-node` observability endpoint tests when run mode is enabled (metrics/health scrape, stream projection, readiness failure-drill degradation taxonomy, and readiness dependency-probe taxonomy matrix coverage).
+  - bounded to seven targeted `kamn-node` observability endpoint tests when run mode is enabled (metrics/health scrape, stream projection, stream reconnect churn sequence, queue-bound budget enforcement, readiness failure-drill degradation taxonomy, and readiness dependency-probe taxonomy matrix coverage).
   - async handler parity checks remain in the bounded test scope, including concurrent metrics/stream request handling against the async observability adapter path.
   - local observability scrape run-mode commands remain excluded from ci-fast-gate and ci-tools fast mode.
   - local observability soak run-mode commands remain excluded from ci-fast-gate and ci-tools fast mode.

--- a/docs/foundation/observability-slo-dashboards.md
+++ b/docs/foundation/observability-slo-dashboards.md
@@ -97,6 +97,8 @@ This document captures the first implementation slice for deterministic observab
     - `availability_bps`
 - Fail-closed behavior:
   - unknown endpoint paths return `404 not found`.
+  - stream reconnect churn preserves deterministic stream schema/reason-code markers across reconnect attempts.
+  - queue-bound request budget remains deterministic: endpoint listener closes once bounded request budget is exhausted.
   - request budget and idle timeout controls remain bounded and deterministic.
 
 Live validation lane:

--- a/scripts/runtime/local_observability_scrape_live_contract.py
+++ b/scripts/runtime/local_observability_scrape_live_contract.py
@@ -43,6 +43,14 @@ LOCAL_OBSERVABILITY_SCRAPE_TESTS: list[tuple[str, str]] = [
         "main_tests::observability_endpoint_tests::integration_runtime_observability_endpoint_serves_stream_path",
     ),
     (
+        "stream_reconnect_churn",
+        "main_tests::observability_endpoint_tests::integration_runtime_observability_endpoint_supports_stream_reconnect_churn_sequence",
+    ),
+    (
+        "queue_bound_budget",
+        "main_tests::observability_endpoint_tests::integration_runtime_observability_endpoint_enforces_queue_bound_request_budget",
+    ),
+    (
         "readiness_failure_drill",
         "main_tests::observability_endpoint_tests::functional_observability_endpoint_readiness_reports_degraded_timeout_reason_codes",
     ),
@@ -133,6 +141,8 @@ def _run_lane(args: argparse.Namespace) -> int:
         "scrape_probe_status": "verified",
         "metrics_content_type_status": "verified",
         "stream_lifecycle_status": "verified",
+        "stream_reconnect_churn_status": "verified",
+        "queue_bound_budget_status": "verified",
         "readiness_probe_status": "verified",
         "readiness_failure_drill_status": "verified",
         "readiness_reason_taxonomy_status": "verified",
@@ -163,6 +173,8 @@ def _run_lane(args: argparse.Namespace) -> int:
     print("scrape_probe_status=verified")
     print("metrics_content_type_status=verified")
     print("stream_lifecycle_status=verified")
+    print("stream_reconnect_churn_status=verified")
+    print("queue_bound_budget_status=verified")
     print("readiness_probe_status=verified")
     print("readiness_failure_drill_status=verified")
     print("readiness_reason_taxonomy_status=verified")
@@ -208,6 +220,8 @@ def _check_policy(args: argparse.Namespace) -> int:
         "scrape_probe_status",
         "metrics_content_type_status",
         "stream_lifecycle_status",
+        "stream_reconnect_churn_status",
+        "queue_bound_budget_status",
         "readiness_probe_status",
         "readiness_failure_drill_status",
         "readiness_reason_taxonomy_status",
@@ -247,6 +261,8 @@ def _check_policy(args: argparse.Namespace) -> int:
         "scrape_probe_status",
         "metrics_content_type_status",
         "stream_lifecycle_status",
+        "stream_reconnect_churn_status",
+        "queue_bound_budget_status",
         "readiness_probe_status",
         "readiness_failure_drill_status",
         "readiness_reason_taxonomy_status",

--- a/scripts/runtime/test_check_local_observability_scrape_live_policy.sh
+++ b/scripts/runtime/test_check_local_observability_scrape_live_policy.sh
@@ -22,6 +22,8 @@ cat >"$report_file" <<'JSON'
   "scrape_probe_status": "verified",
   "metrics_content_type_status": "verified",
   "stream_lifecycle_status": "verified",
+  "stream_reconnect_churn_status": "verified",
+  "queue_bound_budget_status": "verified",
   "readiness_probe_status": "verified",
   "readiness_failure_drill_status": "verified",
   "readiness_reason_taxonomy_status": "verified",
@@ -106,6 +108,39 @@ if [ "$tampered_code" -eq 0 ]; then
 fi
 if ! printf '%s\n' "$tampered_output" | grep -q 'local_observability_scrape_policy_marker_missing:readiness_failure_drill_status'; then
   echo "expected deterministic mismatch reason code for tampered local observability scrape policy validation" >&2
+  exit 1
+fi
+
+tampered_queue_bound_report="$TMP_DIR/local-observability-scrape-live-summary.queue-bound.tampered.json"
+cp "$report_file" "$tampered_queue_bound_report"
+python3 - "$tampered_queue_bound_report" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+payload = json.loads(path.read_text(encoding="utf-8"))
+payload["queue_bound_budget_status"] = "missing"
+path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+set +e
+tampered_queue_bound_output="$(
+  bash "$POLICY_CHECKER" \
+    --report-file "$tampered_queue_bound_report" \
+    --expected-final-decision GO \
+    --ci-fast-gate PASS \
+    --output-json "$TMP_DIR/local-observability-scrape-live-policy.queue-bound.tampered.json" 2>&1
+)"
+tampered_queue_bound_code=$?
+set -e
+
+if [ "$tampered_queue_bound_code" -eq 0 ]; then
+  echo "expected tampered local observability queue-bound marker report to fail policy checker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$tampered_queue_bound_output" | grep -q 'local_observability_scrape_policy_marker_missing:queue_bound_budget_status'; then
+  echo "expected deterministic queue-bound marker mismatch reason code for tampered local observability policy validation" >&2
   exit 1
 fi
 

--- a/scripts/runtime/test_validate_local_observability_scrape_live.sh
+++ b/scripts/runtime/test_validate_local_observability_scrape_live.sh
@@ -56,6 +56,14 @@ if ! printf '%s\n' "$dry_run_output" | grep -q '^readiness_reason_taxonomy_statu
   echo "expected local observability scrape dry-run readiness reason taxonomy marker" >&2
   exit 1
 fi
+if ! printf '%s\n' "$dry_run_output" | grep -q '^stream_reconnect_churn_status=verified$'; then
+  echo "expected local observability scrape dry-run stream reconnect churn marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$dry_run_output" | grep -q '^queue_bound_budget_status=verified$'; then
+  echo "expected local observability scrape dry-run queue-bound budget marker" >&2
+  exit 1
+fi
 if ! printf '%s\n' "$dry_run_output" | grep -q '^local_heavy_soak_lane_status=not_enabled$'; then
   echo "expected local observability scrape dry-run soak lane status marker" >&2
   exit 1
@@ -99,6 +107,10 @@ if payload.get("soak_iterations_requested") != 1:
     raise SystemExit("expected local observability scrape dry-run soak_iterations_requested=1")
 if payload.get("soak_iterations_executed") != 0:
     raise SystemExit("expected local observability scrape dry-run soak_iterations_executed=0")
+if payload.get("stream_reconnect_churn_status") != "verified":
+    raise SystemExit("expected local observability scrape dry-run stream_reconnect_churn_status=verified")
+if payload.get("queue_bound_budget_status") != "verified":
+    raise SystemExit("expected local observability scrape dry-run queue_bound_budget_status=verified")
 if payload.get("execution_reason_code") != "dry_run_no_commands_executed":
     raise SystemExit("expected local observability scrape dry-run reason code")
 if payload.get("command_count") != 0:
@@ -173,6 +185,14 @@ if ! printf '%s\n' "$soak_dry_run_output" | grep -q '^soak_iterations_requested=
 fi
 if ! printf '%s\n' "$soak_dry_run_output" | grep -q '^soak_iterations_executed=0$'; then
   echo "expected local observability scrape soak dry-run executed-iterations marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$soak_dry_run_output" | grep -q '^stream_reconnect_churn_status=verified$'; then
+  echo "expected local observability scrape soak dry-run stream reconnect churn marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$soak_dry_run_output" | grep -q '^queue_bound_budget_status=verified$'; then
+  echo "expected local observability scrape soak dry-run queue-bound budget marker" >&2
   exit 1
 fi
 

--- a/scripts/runtime/test_validate_local_observability_scrape_live_contract_lane.sh
+++ b/scripts/runtime/test_validate_local_observability_scrape_live_contract_lane.sh
@@ -66,6 +66,14 @@ if ! printf '%s\n' "$lane_output" | grep -q '^soak_iterations_executed=0$'; then
   echo "expected local observability scrape contract lane soak executed marker" >&2
   exit 1
 fi
+if ! printf '%s\n' "$lane_output" | grep -q '^stream_reconnect_churn_status=verified$'; then
+  echo "expected local observability scrape contract lane stream reconnect churn marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$lane_output" | grep -q '^queue_bound_budget_status=verified$'; then
+  echo "expected local observability scrape contract lane queue-bound marker" >&2
+  exit 1
+fi
 if ! printf '%s\n' "$lane_output" | grep -q '^fail_closed_reason_code=local_observability_scrape_policy_marker_missing:readiness_failure_drill_status$'; then
   echo "expected local observability scrape contract lane fail-closed reason marker" >&2
   exit 1
@@ -95,6 +103,10 @@ if lane_payload.get("soak_iterations_requested") != 1:
     raise SystemExit("expected soak_iterations_requested=1")
 if lane_payload.get("soak_iterations_executed") != 0:
     raise SystemExit("expected soak_iterations_executed=0")
+if lane_payload.get("stream_reconnect_churn_status") != "verified":
+    raise SystemExit("expected stream_reconnect_churn_status=verified")
+if lane_payload.get("queue_bound_budget_status") != "verified":
+    raise SystemExit("expected queue_bound_budget_status=verified")
 if lane_payload.get("docs_contract_status") != "verified":
     raise SystemExit("expected docs_contract_status=verified")
 if lane_payload.get("performance_budget_status") != "verified":
@@ -142,6 +154,14 @@ if ! printf '%s\n' "$soak_lane_output" | grep -q '^soak_iterations_requested=2$'
 fi
 if ! printf '%s\n' "$soak_lane_output" | grep -q '^soak_iterations_executed=0$'; then
   echo "expected local observability scrape contract lane soak executed-iterations marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$soak_lane_output" | grep -q '^stream_reconnect_churn_status=verified$'; then
+  echo "expected local observability scrape contract lane soak stream reconnect churn marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$soak_lane_output" | grep -q '^queue_bound_budget_status=verified$'; then
+  echo "expected local observability scrape contract lane soak queue-bound marker" >&2
   exit 1
 fi
 

--- a/scripts/runtime/validate_local_observability_scrape_live_contract_lane.sh
+++ b/scripts/runtime/validate_local_observability_scrape_live_contract_lane.sh
@@ -144,6 +144,14 @@ if ! printf '%s\n' "$validation_output" | grep -q '^stream_lifecycle_status=veri
   echo "expected local observability scrape validation stream marker" >&2
   exit 1
 fi
+if ! printf '%s\n' "$validation_output" | grep -q '^stream_reconnect_churn_status=verified$'; then
+  echo "expected local observability scrape validation stream reconnect churn marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^queue_bound_budget_status=verified$'; then
+  echo "expected local observability scrape validation queue-bound budget marker" >&2
+  exit 1
+fi
 if ! printf '%s\n' "$validation_output" | grep -q '^readiness_probe_status=verified$'; then
   echo "expected local observability scrape validation readiness probe marker" >&2
   exit 1
@@ -237,8 +245,8 @@ if ! grep -q "local observability soak run-mode commands remain excluded from ci
   echo "expected CI strategy docs to include local observability soak run-mode exclusion marker" >&2
   exit 1
 fi
-if ! grep -q "bounded to five targeted \`kamn-node\` observability endpoint tests when run mode is enabled" "$STRATEGY_DOC"; then
-  echo "expected CI strategy docs to include five-test local observability scrape run-mode budget marker" >&2
+if ! grep -q "bounded to seven targeted \`kamn-node\` observability endpoint tests when run mode is enabled" "$STRATEGY_DOC"; then
+  echo "expected CI strategy docs to include seven-test local observability scrape run-mode budget marker" >&2
   exit 1
 fi
 
@@ -309,6 +317,12 @@ lane_report = {
     "local_heavy_soak_lane_status": summary_report.get(
         "local_heavy_soak_lane_status"
     ),
+    "stream_reconnect_churn_status": summary_report.get(
+        "stream_reconnect_churn_status"
+    ),
+    "queue_bound_budget_status": summary_report.get(
+        "queue_bound_budget_status"
+    ),
     "soak_iterations_requested": summary_report.get(
         "soak_iterations_requested"
     ),
@@ -356,6 +370,8 @@ if [[ "$mode" == "run" ]]; then
 else
   echo "soak_iterations_executed=0"
 fi
+echo "stream_reconnect_churn_status=verified"
+echo "queue_bound_budget_status=verified"
 echo "local_observability_scrape_contract_status=verified"
 echo "local_observability_scrape_policy_status=verified"
 echo "docs_contract_status=verified"


### PR DESCRIPTION
## Summary
Adds a deterministic stream reconnect/churn and queue-bound integration matrix for observability ingress and propagates those markers through local observability lane/policy/contract validations with updated docs contracts.

## Changes
- `crates/kamn-node/src/main_tests/observability_endpoint_tests.rs`: added reconnect-churn stream integration test and queue-bound request-budget integration test.
- `scripts/runtime/local_observability_scrape_live_contract.py`: added matrix selectors and status markers `stream_reconnect_churn_status` and `queue_bound_budget_status`.
- `scripts/runtime/validate_local_observability_scrape_live_contract_lane.sh`: added matrix marker assertions and lane report projection for reconnect/queue-bound statuses.
- `scripts/runtime/test_validate_local_observability_scrape_live.sh`: added dry-run marker checks for reconnect/queue-bound statuses.
- `scripts/runtime/test_check_local_observability_scrape_live_policy.sh`: added queue-bound marker tamper fail-closed regression.
- `scripts/runtime/test_validate_local_observability_scrape_live_contract_lane.sh`: added reconnect/queue-bound lane marker checks.
- `docs/ci/strategy.md`: updated local observability lane bounded test budget and matrix scope.
- `docs/foundation/observability-slo-dashboards.md`: documented stream reconnect churn and queue-bound budget guarantees.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-node -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual verification: executed scoped Rust selectors plus local observability lane/policy/contract and CI exclusion/strategy contracts.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | Marker and field checks in runtime lane policy/contract test scripts |
| Functional  | ✅     | Local observability dry-run marker assertions for reconnect/queue-bound statuses |
| Integration | ✅     | New reconnect-churn and queue-bound ingress integration tests in `observability_endpoint_tests` |
| Regression  | ✅     | Queue-bound marker tamper fails closed with deterministic reason code |

Closes #3521
