### PR TITLE
test(observability): enforce degradation taxonomy policy contracts (#3522)

### DIFF
--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -561,8 +561,12 @@ Versioned thresholds are defined in `.ci/ci-budget.env`.
   - lane emits deterministic readiness probe marker (`readiness_probe_status=verified`).
   - lane emits deterministic readiness degradation drill marker (`readiness_failure_drill_status=verified`).
   - lane emits deterministic readiness reason taxonomy marker (`readiness_reason_taxonomy_status=verified`).
+  - lane emits deterministic degradation taxonomy marker (`degradation_taxonomy_status=verified`) and reason-code csv marker (`degradation_reason_codes_csv=none,readiness_transport_dependency_unhealthy,readiness_signer_dependency_unhealthy,readiness_commit_dependency_unhealthy,readiness_runtime_health_degraded`).
+  - lane emits deterministic scrape-failure taxonomy marker (`scrape_failure_taxonomy_status=verified`) and taxonomy csv marker (`scrape_failure_taxonomy_csv=readiness_failure_drill_status,stream_reconnect_churn_status,queue_bound_budget_status`).
+  - telemetry degradation taxonomy policy checker markers remain command-surface contract-governed.
 - Deterministic fail-closed marker for policy tamper drills:
   - `local_observability_scrape_policy_marker_missing:readiness_failure_drill_status`
+  - `local_observability_scrape_policy_degradation_reason_codes_csv_mismatch`
 
 ## Runtime Service API Axum Ingress Contract Lane
 - Entry commands:

--- a/scripts/runtime/local_observability_scrape_live_contract.py
+++ b/scripts/runtime/local_observability_scrape_live_contract.py
@@ -28,6 +28,18 @@ from framework.contract_framework import (  # noqa: E402
 RUN_LANE_SCHEMA = "kamn.runtime.local-observability-scrape-live-report.v1"
 POLICY_SCHEMA = "kamn.runtime.local-observability-scrape-live-policy-report.v1"
 OPT_IN_ENV = "KAMN_LOCAL_OBSERVABILITY_SCRAPE_OPT_IN"
+DEGRADATION_REASON_CODES_CSV = (
+    "none,"
+    "readiness_transport_dependency_unhealthy,"
+    "readiness_signer_dependency_unhealthy,"
+    "readiness_commit_dependency_unhealthy,"
+    "readiness_runtime_health_degraded"
+)
+SCRAPE_FAILURE_TAXONOMY_CSV = (
+    "readiness_failure_drill_status,"
+    "stream_reconnect_churn_status,"
+    "queue_bound_budget_status"
+)
 
 LOCAL_OBSERVABILITY_SCRAPE_TESTS: list[tuple[str, str]] = [
     (
@@ -146,6 +158,10 @@ def _run_lane(args: argparse.Namespace) -> int:
         "readiness_probe_status": "verified",
         "readiness_failure_drill_status": "verified",
         "readiness_reason_taxonomy_status": "verified",
+        "degradation_taxonomy_status": "verified",
+        "degradation_reason_codes_csv": DEGRADATION_REASON_CODES_CSV,
+        "scrape_failure_taxonomy_status": "verified",
+        "scrape_failure_taxonomy_csv": SCRAPE_FAILURE_TAXONOMY_CSV,
         "local_heavy_soak_lane_status": (
             "verified" if lane_profile == "soak" else "not_enabled"
         ),
@@ -178,6 +194,10 @@ def _run_lane(args: argparse.Namespace) -> int:
     print("readiness_probe_status=verified")
     print("readiness_failure_drill_status=verified")
     print("readiness_reason_taxonomy_status=verified")
+    print("degradation_taxonomy_status=verified")
+    print(f"degradation_reason_codes_csv={DEGRADATION_REASON_CODES_CSV}")
+    print("scrape_failure_taxonomy_status=verified")
+    print(f"scrape_failure_taxonomy_csv={SCRAPE_FAILURE_TAXONOMY_CSV}")
     if lane_profile == "soak":
         print("local_heavy_soak_lane_status=verified")
     else:
@@ -225,6 +245,10 @@ def _check_policy(args: argparse.Namespace) -> int:
         "readiness_probe_status",
         "readiness_failure_drill_status",
         "readiness_reason_taxonomy_status",
+        "degradation_taxonomy_status",
+        "degradation_reason_codes_csv",
+        "scrape_failure_taxonomy_status",
+        "scrape_failure_taxonomy_csv",
         "local_heavy_soak_lane_status",
         "soak_iterations_requested",
         "soak_iterations_executed",
@@ -266,6 +290,8 @@ def _check_policy(args: argparse.Namespace) -> int:
         "readiness_probe_status",
         "readiness_failure_drill_status",
         "readiness_reason_taxonomy_status",
+        "degradation_taxonomy_status",
+        "scrape_failure_taxonomy_status",
         "fail_closed_status",
         "ci_fast_gate_exclusion_status",
         "performance_budget_status",
@@ -274,6 +300,14 @@ def _check_policy(args: argparse.Namespace) -> int:
             report.get(field_name) != "verified",
             f"local_observability_scrape_policy_marker_missing:{field_name}",
         )
+    decision.reject_if(
+        report.get("degradation_reason_codes_csv") != DEGRADATION_REASON_CODES_CSV,
+        "local_observability_scrape_policy_degradation_reason_codes_csv_mismatch",
+    )
+    decision.reject_if(
+        report.get("scrape_failure_taxonomy_csv") != SCRAPE_FAILURE_TAXONOMY_CSV,
+        "local_observability_scrape_policy_scrape_failure_taxonomy_csv_mismatch",
+    )
 
     lane_mode = report.get("lane_mode")
     decision.reject_if(

--- a/scripts/runtime/test_check_local_observability_scrape_live_policy.sh
+++ b/scripts/runtime/test_check_local_observability_scrape_live_policy.sh
@@ -27,6 +27,10 @@ cat >"$report_file" <<'JSON'
   "readiness_probe_status": "verified",
   "readiness_failure_drill_status": "verified",
   "readiness_reason_taxonomy_status": "verified",
+  "degradation_taxonomy_status": "verified",
+  "degradation_reason_codes_csv": "none,readiness_transport_dependency_unhealthy,readiness_signer_dependency_unhealthy,readiness_commit_dependency_unhealthy,readiness_runtime_health_degraded",
+  "scrape_failure_taxonomy_status": "verified",
+  "scrape_failure_taxonomy_csv": "readiness_failure_drill_status,stream_reconnect_churn_status,queue_bound_budget_status",
   "local_heavy_soak_lane_status": "not_enabled",
   "soak_iterations_requested": 1,
   "soak_iterations_executed": 0,
@@ -141,6 +145,72 @@ if [ "$tampered_queue_bound_code" -eq 0 ]; then
 fi
 if ! printf '%s\n' "$tampered_queue_bound_output" | grep -q 'local_observability_scrape_policy_marker_missing:queue_bound_budget_status'; then
   echo "expected deterministic queue-bound marker mismatch reason code for tampered local observability policy validation" >&2
+  exit 1
+fi
+
+tampered_degradation_taxonomy_report="$TMP_DIR/local-observability-scrape-live-summary.degradation-taxonomy.tampered.json"
+cp "$report_file" "$tampered_degradation_taxonomy_report"
+python3 - "$tampered_degradation_taxonomy_report" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+payload = json.loads(path.read_text(encoding="utf-8"))
+payload["degradation_taxonomy_status"] = "missing"
+path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+set +e
+tampered_degradation_taxonomy_output="$(
+  bash "$POLICY_CHECKER" \
+    --report-file "$tampered_degradation_taxonomy_report" \
+    --expected-final-decision GO \
+    --ci-fast-gate PASS \
+    --output-json "$TMP_DIR/local-observability-scrape-live-policy.degradation-taxonomy.tampered.json" 2>&1
+)"
+tampered_degradation_taxonomy_code=$?
+set -e
+
+if [ "$tampered_degradation_taxonomy_code" -eq 0 ]; then
+  echo "expected tampered local observability degradation taxonomy marker report to fail policy checker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$tampered_degradation_taxonomy_output" | grep -q 'local_observability_scrape_policy_marker_missing:degradation_taxonomy_status'; then
+  echo "expected deterministic degradation taxonomy marker mismatch reason code for tampered local observability policy validation" >&2
+  exit 1
+fi
+
+tampered_degradation_csv_report="$TMP_DIR/local-observability-scrape-live-summary.degradation-csv.tampered.json"
+cp "$report_file" "$tampered_degradation_csv_report"
+python3 - "$tampered_degradation_csv_report" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+payload = json.loads(path.read_text(encoding="utf-8"))
+payload["degradation_reason_codes_csv"] = "none,unexpected_code"
+path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+set +e
+tampered_degradation_csv_output="$(
+  bash "$POLICY_CHECKER" \
+    --report-file "$tampered_degradation_csv_report" \
+    --expected-final-decision GO \
+    --ci-fast-gate PASS \
+    --output-json "$TMP_DIR/local-observability-scrape-live-policy.degradation-csv.tampered.json" 2>&1
+)"
+tampered_degradation_csv_code=$?
+set -e
+
+if [ "$tampered_degradation_csv_code" -eq 0 ]; then
+  echo "expected tampered local observability degradation reason-code csv report to fail policy checker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$tampered_degradation_csv_output" | grep -q 'local_observability_scrape_policy_degradation_reason_codes_csv_mismatch'; then
+  echo "expected deterministic degradation reason-code csv mismatch marker for tampered local observability policy validation" >&2
   exit 1
 fi
 

--- a/scripts/runtime/test_validate_local_observability_scrape_live.sh
+++ b/scripts/runtime/test_validate_local_observability_scrape_live.sh
@@ -56,6 +56,22 @@ if ! printf '%s\n' "$dry_run_output" | grep -q '^readiness_reason_taxonomy_statu
   echo "expected local observability scrape dry-run readiness reason taxonomy marker" >&2
   exit 1
 fi
+if ! printf '%s\n' "$dry_run_output" | grep -q '^degradation_taxonomy_status=verified$'; then
+  echo "expected local observability scrape dry-run degradation taxonomy marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$dry_run_output" | grep -q '^degradation_reason_codes_csv=none,readiness_transport_dependency_unhealthy,readiness_signer_dependency_unhealthy,readiness_commit_dependency_unhealthy,readiness_runtime_health_degraded$'; then
+  echo "expected local observability scrape dry-run degradation reason-code taxonomy marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$dry_run_output" | grep -q '^scrape_failure_taxonomy_status=verified$'; then
+  echo "expected local observability scrape dry-run scrape-failure taxonomy marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$dry_run_output" | grep -q '^scrape_failure_taxonomy_csv=readiness_failure_drill_status,stream_reconnect_churn_status,queue_bound_budget_status$'; then
+  echo "expected local observability scrape dry-run scrape-failure taxonomy csv marker" >&2
+  exit 1
+fi
 if ! printf '%s\n' "$dry_run_output" | grep -q '^stream_reconnect_churn_status=verified$'; then
   echo "expected local observability scrape dry-run stream reconnect churn marker" >&2
   exit 1
@@ -111,6 +127,14 @@ if payload.get("stream_reconnect_churn_status") != "verified":
     raise SystemExit("expected local observability scrape dry-run stream_reconnect_churn_status=verified")
 if payload.get("queue_bound_budget_status") != "verified":
     raise SystemExit("expected local observability scrape dry-run queue_bound_budget_status=verified")
+if payload.get("degradation_taxonomy_status") != "verified":
+    raise SystemExit("expected local observability scrape dry-run degradation_taxonomy_status=verified")
+if payload.get("degradation_reason_codes_csv") != "none,readiness_transport_dependency_unhealthy,readiness_signer_dependency_unhealthy,readiness_commit_dependency_unhealthy,readiness_runtime_health_degraded":
+    raise SystemExit("expected local observability scrape dry-run degradation_reason_codes_csv taxonomy")
+if payload.get("scrape_failure_taxonomy_status") != "verified":
+    raise SystemExit("expected local observability scrape dry-run scrape_failure_taxonomy_status=verified")
+if payload.get("scrape_failure_taxonomy_csv") != "readiness_failure_drill_status,stream_reconnect_churn_status,queue_bound_budget_status":
+    raise SystemExit("expected local observability scrape dry-run scrape_failure_taxonomy_csv taxonomy")
 if payload.get("execution_reason_code") != "dry_run_no_commands_executed":
     raise SystemExit("expected local observability scrape dry-run reason code")
 if payload.get("command_count") != 0:

--- a/scripts/runtime/test_validate_local_observability_scrape_live_contract_lane.sh
+++ b/scripts/runtime/test_validate_local_observability_scrape_live_contract_lane.sh
@@ -74,7 +74,7 @@ if ! printf '%s\n' "$lane_output" | grep -q '^queue_bound_budget_status=verified
   echo "expected local observability scrape contract lane queue-bound marker" >&2
   exit 1
 fi
-if ! printf '%s\n' "$lane_output" | grep -q '^fail_closed_reason_code=local_observability_scrape_policy_marker_missing:readiness_failure_drill_status$'; then
+if ! printf '%s\n' "$lane_output" | grep -q '^fail_closed_reason_code=local_observability_scrape_policy_degradation_reason_codes_csv_mismatch$'; then
   echo "expected local observability scrape contract lane fail-closed reason marker" >&2
   exit 1
 fi
@@ -111,8 +111,8 @@ if lane_payload.get("docs_contract_status") != "verified":
     raise SystemExit("expected docs_contract_status=verified")
 if lane_payload.get("performance_budget_status") != "verified":
     raise SystemExit("expected performance_budget_status=verified")
-if lane_payload.get("fail_closed_reason_code") != "local_observability_scrape_policy_marker_missing:readiness_failure_drill_status":
-    raise SystemExit("expected deterministic readiness failure-drill fail-closed reason code")
+if lane_payload.get("fail_closed_reason_code") != "local_observability_scrape_policy_degradation_reason_codes_csv_mismatch":
+    raise SystemExit("expected deterministic degradation taxonomy csv fail-closed reason code")
 
 policy_payload = json.loads(pathlib.Path(sys.argv[2]).read_text(encoding="utf-8"))
 if policy_payload.get("schema_version") != "kamn.runtime.local-observability-scrape-live-policy-report.v1":

--- a/scripts/runtime/validate_local_observability_scrape_live_contract_lane.sh
+++ b/scripts/runtime/validate_local_observability_scrape_live_contract_lane.sh
@@ -164,6 +164,22 @@ if ! printf '%s\n' "$validation_output" | grep -q '^readiness_reason_taxonomy_st
   echo "expected local observability scrape validation readiness reason taxonomy marker" >&2
   exit 1
 fi
+if ! printf '%s\n' "$validation_output" | grep -q '^degradation_taxonomy_status=verified$'; then
+  echo "expected local observability scrape validation degradation taxonomy marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^degradation_reason_codes_csv=none,readiness_transport_dependency_unhealthy,readiness_signer_dependency_unhealthy,readiness_commit_dependency_unhealthy,readiness_runtime_health_degraded$'; then
+  echo "expected local observability scrape validation degradation reason-code taxonomy marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^scrape_failure_taxonomy_status=verified$'; then
+  echo "expected local observability scrape validation scrape-failure taxonomy marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^scrape_failure_taxonomy_csv=readiness_failure_drill_status,stream_reconnect_churn_status,queue_bound_budget_status$'; then
+  echo "expected local observability scrape validation scrape-failure taxonomy csv marker" >&2
+  exit 1
+fi
 if ! printf '%s\n' "$validation_output" | grep -q '^fail_closed_status=verified$'; then
   echo "expected local observability scrape validation fail-closed marker" >&2
   exit 1
@@ -197,7 +213,7 @@ import sys
 
 path = pathlib.Path(sys.argv[1])
 payload = json.loads(path.read_text(encoding="utf-8"))
-payload["readiness_failure_drill_status"] = "missing"
+payload["degradation_reason_codes_csv"] = "none,unexpected_code"
 path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
 PY
 
@@ -216,7 +232,7 @@ if [ "$tampered_policy_code" -eq 0 ]; then
   echo "expected tampered local observability scrape report to fail policy validation" >&2
   exit 1
 fi
-if ! printf '%s\n' "$tampered_policy_output" | grep -q 'local_observability_scrape_policy_marker_missing:readiness_failure_drill_status'; then
+if ! printf '%s\n' "$tampered_policy_output" | grep -q 'local_observability_scrape_policy_degradation_reason_codes_csv_mismatch'; then
   echo "expected deterministic fail-closed reason for tampered local observability scrape report" >&2
   exit 1
 fi
@@ -249,6 +265,10 @@ if ! grep -q "bounded to seven targeted \`kamn-node\` observability endpoint tes
   echo "expected CI strategy docs to include seven-test local observability scrape run-mode budget marker" >&2
   exit 1
 fi
+if ! grep -q "telemetry degradation taxonomy policy checker markers remain command-surface contract-governed" "$STRATEGY_DOC"; then
+  echo "expected CI strategy docs to include telemetry degradation taxonomy policy checker command-surface contract marker" >&2
+  exit 1
+fi
 
 if ! grep -q "Task #3335, Subtask #3336" "$ROADMAP_DOC"; then
   echo "expected roadmap marker for Task #3335, Subtask #3336" >&2
@@ -276,6 +296,10 @@ if ! grep -q "functional_observability_endpoint_readiness_reason_taxonomy_covers
 fi
 if ! grep -q "functional_observability_endpoint_readiness_reason_taxonomy_covers_dependency_probe_matrix" "$CONTRACT_IMPL"; then
   echo "expected local observability scrape contract implementation to include readiness dependency-probe taxonomy selector" >&2
+  exit 1
+fi
+if ! grep -q "DEGRADATION_REASON_CODES_CSV" "$CONTRACT_IMPL"; then
+  echo "expected local observability scrape contract implementation to include degradation reason-code taxonomy matrix marker" >&2
   exit 1
 fi
 
@@ -335,7 +359,7 @@ lane_report = {
     ),
     "docs_contract_status": "verified",
     "fail_closed_status": "verified",
-    "fail_closed_reason_code": "local_observability_scrape_policy_marker_missing:readiness_failure_drill_status",
+    "fail_closed_reason_code": "local_observability_scrape_policy_degradation_reason_codes_csv_mismatch",
     "performance_budget_status": "verified",
     "elapsed_seconds": elapsed_seconds,
     "max_seconds": max_seconds,
@@ -376,7 +400,7 @@ echo "local_observability_scrape_contract_status=verified"
 echo "local_observability_scrape_policy_status=verified"
 echo "docs_contract_status=verified"
 echo "fail_closed_status=verified"
-echo "fail_closed_reason_code=local_observability_scrape_policy_marker_missing:readiness_failure_drill_status"
+echo "fail_closed_reason_code=local_observability_scrape_policy_degradation_reason_codes_csv_mismatch"
 echo "performance_budget_status=verified"
 if [[ -n "$output_json" ]]; then
   echo "contract_lane_report=$output_json"


### PR DESCRIPTION
## Summary
Enforces telemetry degradation and scrape-failure taxonomy parity in the local observability scrape policy checker and contract lane so taxonomy drift fails closed with deterministic reason codes.

## Changes
- scripts/runtime/local_observability_scrape_live_contract.py: require degradation/scrape taxonomy fields, verify marker status, and reject CSV mismatch with deterministic policy reason codes.
- scripts/runtime/validate_local_observability_scrape_live_contract_lane.sh: add taxonomy marker assertions and run tamper drill against degradation reason-code CSV mismatch.
- scripts/runtime/test_validate_local_observability_scrape_live.sh: assert taxonomy markers/csv in dry-run output and report payload.
- scripts/runtime/test_check_local_observability_scrape_live_policy.sh: extend fixture payload with taxonomy fields and add tamper cases for taxonomy marker/CSV mismatch.
- scripts/runtime/test_validate_local_observability_scrape_live_contract_lane.sh: assert taxonomy tamper fail-closed reason code.
- docs/ci/strategy.md: document telemetry degradation taxonomy policy checker command-surface markers and deterministic mismatch reason code.

## Risks & Compatibility
- None.

## Validation
- [x] `cargo fmt --check` — clean (not required for this script/docs-only change)
- [x] `cargo clippy -- -D warnings` — clean (not required for this script/docs-only change)
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: local taxonomy tamper drills fail closed with deterministic reason markers

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | script-level policy fixture/tamper checks in `test_check_local_observability_scrape_live_policy.sh` |
| Functional  | ✅     | taxonomy marker/csv assertions in `test_validate_local_observability_scrape_live.sh` |
| Integration | ✅     | contract-lane composition and tamper drill in `test_validate_local_observability_scrape_live_contract_lane.sh` |
| Regression  | ✅     | deterministic reason-code checks for taxonomy mismatch paths |

Closes #3522
