### PR TITLE
refactor(runtime): migrate service api tranche-1 wrappers to shared runner (#3525)

### DIFF
--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -706,6 +706,19 @@ Versioned thresholds are defined in `.ci/ci-budget.env`.
 - Deterministic fail-closed marker for policy tamper drills:
   - `service_api_prometheus_metrics_policy_marker_missing:metrics_contract_status`
 
+## Runtime Service API Tranche-1 Wrapper Migration Parity Matrix
+- service api tranche-1 runner migration parity guard stays on PR fast gate:
+  - `bash scripts/runtime/test_service_api_tranche1_wrapper_family_parity_matrix.sh`
+  - validates migrated wrappers are runner-backed via `scripts/runtime/service_api_contract_lane_runner.sh`:
+    - `scripts/runtime/validate_service_api_prometheus_metrics_live_contract_lane.sh`
+    - `scripts/runtime/validate_service_api_graceful_shutdown_drain_live_contract_lane.sh`
+    - `scripts/runtime/validate_service_api_shutdown_abrupt_close_regression_live_contract_lane.sh`
+    - `scripts/runtime/validate_service_api_validation_negative_matrix_live_contract_lane.sh`
+  - enforces tranche shell-wrapper budget:
+    - combined migrated wrapper shell LOC must remain `<= 260`
+  - deterministic fail-closed drift reason marker:
+    - `wrapper_policy_checker_marker_missing:scripts/runtime/validate_service_api_prometheus_metrics_live_contract_lane.sh`
+
 ## Kolme HTTPS Native Transport Contract
 - Runtime-commit HTTPS transport uses an in-process native TLS client path.
 - `openssl s_client` subprocess execution is prohibited in transport code paths (`Regression: #2671`).

--- a/fixtures/ci/service_api_tranche1_wrapper_family_matrix.json
+++ b/fixtures/ci/service_api_tranche1_wrapper_family_matrix.json
@@ -1,0 +1,38 @@
+{
+  "schema_version": "kamn.runtime.service-api-tranche1-wrapper-family-matrix.v1",
+  "max_shell_loc": 260,
+  "wrappers": [
+    {
+      "wrapper": "scripts/runtime/validate_service_api_prometheus_metrics_live_contract_lane.sh",
+      "validation_script": "scripts/runtime/validate_service_api_prometheus_metrics_live.sh",
+      "policy_checker": "scripts/runtime/check_service_api_prometheus_metrics_live_policy.sh",
+      "contract_status_key": "service_api_prometheus_metrics_contract_status",
+      "policy_status_key": "service_api_prometheus_metrics_policy_status",
+      "tamper_reason_code": "service_api_prometheus_metrics_policy_marker_missing:metrics_contract_status"
+    },
+    {
+      "wrapper": "scripts/runtime/validate_service_api_graceful_shutdown_drain_live_contract_lane.sh",
+      "validation_script": "scripts/runtime/validate_service_api_graceful_shutdown_drain_live.sh",
+      "policy_checker": "scripts/runtime/check_service_api_graceful_shutdown_drain_live_policy.sh",
+      "contract_status_key": "service_api_graceful_shutdown_drain_contract_status",
+      "policy_status_key": "service_api_graceful_shutdown_drain_policy_status",
+      "tamper_reason_code": "service_api_graceful_shutdown_drain_policy_marker_missing:websocket_drain_status"
+    },
+    {
+      "wrapper": "scripts/runtime/validate_service_api_shutdown_abrupt_close_regression_live_contract_lane.sh",
+      "validation_script": "scripts/runtime/validate_service_api_shutdown_abrupt_close_regression_live.sh",
+      "policy_checker": "scripts/runtime/check_service_api_shutdown_abrupt_close_regression_live_policy.sh",
+      "contract_status_key": "service_api_shutdown_abrupt_close_regression_contract_status",
+      "policy_status_key": "service_api_shutdown_abrupt_close_regression_policy_status",
+      "tamper_reason_code": "service_api_shutdown_abrupt_close_regression_policy_marker_missing:abrupt_close_guard_status"
+    },
+    {
+      "wrapper": "scripts/runtime/validate_service_api_validation_negative_matrix_live_contract_lane.sh",
+      "validation_script": "scripts/runtime/validate_service_api_validation_negative_matrix_live.sh",
+      "policy_checker": "scripts/runtime/check_service_api_validation_negative_matrix_live_policy.sh",
+      "contract_status_key": "service_api_validation_negative_matrix_contract_status",
+      "policy_status_key": "service_api_validation_negative_matrix_policy_status",
+      "tamper_reason_code": "service_api_validation_negative_matrix_policy_marker_missing:replay_guard_status"
+    }
+  ]
+}

--- a/scripts/ci/test_ci_tools.sh
+++ b/scripts/ci/test_ci_tools.sh
@@ -405,6 +405,7 @@ bash "$ROOT_DIR/scripts/runtime/test_check_service_api_shutdown_abrupt_close_reg
 bash "$ROOT_DIR/scripts/runtime/test_validate_service_api_shutdown_abrupt_close_regression_live_contract_lane.sh"
 bash "$ROOT_DIR/scripts/runtime/test_check_service_api_prometheus_metrics_live_policy.sh"
 bash "$ROOT_DIR/scripts/runtime/test_validate_service_api_prometheus_metrics_live_contract_lane.sh"
+bash "$ROOT_DIR/scripts/runtime/test_service_api_tranche1_wrapper_family_parity_matrix.sh"
 bash "$ROOT_DIR/scripts/runtime/test_select_failover_sync_drill_lane.sh"
 bash "$ROOT_DIR/scripts/runtime/test_run_failover_sync_drill_preflight_contract_lane.sh"
 bash "$ROOT_DIR/scripts/runtime/test_run_failover_sync_drill_deep_lane.sh"

--- a/scripts/ci/test_ci_tools_command_surface_contract.sh
+++ b/scripts/ci/test_ci_tools_command_surface_contract.sh
@@ -126,6 +126,7 @@ required_commands=(
   'bash "$ROOT_DIR/scripts/runtime/test_validate_service_api_shutdown_abrupt_close_regression_live_contract_lane.sh"'
   'bash "$ROOT_DIR/scripts/runtime/test_check_service_api_prometheus_metrics_live_policy.sh"'
   'bash "$ROOT_DIR/scripts/runtime/test_validate_service_api_prometheus_metrics_live_contract_lane.sh"'
+  'bash "$ROOT_DIR/scripts/runtime/test_service_api_tranche1_wrapper_family_parity_matrix.sh"'
   'bash "$ROOT_DIR/scripts/runtime/test_validate_libp2p_three_node_discovery_live.sh"'
   'bash "$ROOT_DIR/scripts/runtime/test_check_libp2p_three_node_discovery_live_policy.sh"'
   'bash "$ROOT_DIR/scripts/runtime/test_validate_libp2p_three_node_discovery_live_contract_lane.sh"'

--- a/scripts/runtime/service_api_tranche1_wrapper_family_parity_contract.py
+++ b/scripts/runtime/service_api_tranche1_wrapper_family_parity_contract.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Check service API tranche-1 wrapper family parity and migration invariants."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+MATRIX_SCHEMA = "kamn.runtime.service-api-tranche1-wrapper-family-matrix.v1"
+
+
+def _load_json(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise SystemExit(f"matrix_file_missing:{path}") from exc
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"matrix_file_invalid_json:{path}:{exc}") from exc
+
+
+def _read_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise SystemExit(f"wrapper_read_failed:{path}:{exc}") from exc
+
+
+def _is_executable(path: Path) -> bool:
+    return path.exists() and path.is_file() and os.access(path, os.X_OK)
+
+
+def _ensure_string(payload: dict[str, Any], key: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str) or not value:
+        raise SystemExit(f"matrix_field_invalid:{key}")
+    return value
+
+
+def _check_wrapper(root: Path, wrapper_cfg: dict[str, Any], reason_codes: list[str]) -> int:
+    wrapper = _ensure_string(wrapper_cfg, "wrapper")
+    validation_script = _ensure_string(wrapper_cfg, "validation_script")
+    policy_checker = _ensure_string(wrapper_cfg, "policy_checker")
+    contract_status_key = _ensure_string(wrapper_cfg, "contract_status_key")
+    policy_status_key = _ensure_string(wrapper_cfg, "policy_status_key")
+    tamper_reason_code = _ensure_string(wrapper_cfg, "tamper_reason_code")
+
+    wrapper_path = root / wrapper
+    if not wrapper_path.exists():
+        reason_codes.append(f"wrapper_missing:{wrapper}")
+        return 0
+    if not _is_executable(wrapper_path):
+        reason_codes.append(f"wrapper_not_executable:{wrapper}")
+        return 0
+
+    text = _read_text(wrapper_path)
+    if 'source "$ROOT_DIR/scripts/runtime/service_api_contract_lane_runner.sh"' not in text:
+        reason_codes.append(f"wrapper_runner_source_marker_missing:{wrapper}")
+    if 'service_api_contract_lane_run "$@"' not in text:
+        reason_codes.append(f"wrapper_runner_entry_marker_missing:{wrapper}")
+    if f'VALIDATION_SCRIPT="$ROOT_DIR/{validation_script}"' not in text:
+        reason_codes.append(f"wrapper_validation_script_marker_missing:{wrapper}")
+    if f'POLICY_CHECKER="$ROOT_DIR/{policy_checker}"' not in text:
+        reason_codes.append(f"wrapper_policy_checker_marker_missing:{wrapper}")
+    if f'CONTRACT_STATUS_KEY="{contract_status_key}"' not in text:
+        reason_codes.append(f"wrapper_contract_status_marker_missing:{wrapper}")
+    if f'POLICY_STATUS_KEY="{policy_status_key}"' not in text:
+        reason_codes.append(f"wrapper_policy_status_marker_missing:{wrapper}")
+    if f'TAMPER_REASON_CODE="{tamper_reason_code}"' not in text:
+        reason_codes.append(f"wrapper_tamper_reason_marker_missing:{wrapper}")
+
+    return sum(1 for _ in wrapper_path.read_text(encoding="utf-8").splitlines())
+
+
+def _run(args: argparse.Namespace) -> int:
+    root = Path(args.root_dir).resolve()
+    matrix_file = Path(args.matrix_file).resolve()
+    payload = _load_json(matrix_file)
+
+    if payload.get("schema_version") != MATRIX_SCHEMA:
+        raise SystemExit("matrix_schema_mismatch")
+
+    wrappers = payload.get("wrappers")
+    if not isinstance(wrappers, list) or not wrappers:
+        raise SystemExit("matrix_wrappers_missing")
+
+    max_shell_loc = payload.get("max_shell_loc")
+    if not isinstance(max_shell_loc, int) or max_shell_loc < 1:
+        raise SystemExit("matrix_max_shell_loc_invalid")
+
+    reason_codes: list[str] = []
+    total_shell_loc = 0
+    for entry in wrappers:
+        if not isinstance(entry, dict):
+            reason_codes.append("matrix_wrapper_entry_invalid")
+            continue
+        total_shell_loc += _check_wrapper(root, entry, reason_codes)
+
+    if total_shell_loc > max_shell_loc:
+        reason_codes.append("service_api_tranche1_shell_loc_budget_exceeded")
+
+    if reason_codes:
+        reason_codes_csv = ",".join(reason_codes)
+        print("status=fail")
+        print("service_api_tranche1_wrapper_family_status=rejected")
+        print(f"wrapper_count={len(wrappers)}")
+        print(f"total_shell_loc={total_shell_loc}")
+        print(f"max_shell_loc={max_shell_loc}")
+        print(f"reason_codes={reason_codes_csv}")
+        raise SystemExit(1)
+
+    print("status=pass")
+    print("service_api_tranche1_wrapper_family_status=verified")
+    print(f"wrapper_count={len(wrappers)}")
+    print(f"total_shell_loc={total_shell_loc}")
+    print(f"max_shell_loc={max_shell_loc}")
+    print("reason_codes=none")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate service API tranche-1 wrapper family parity contract.",
+    )
+    parser.add_argument("--root-dir", required=True, help="Repository root.")
+    parser.add_argument("--matrix-file", required=True, help="Wrapper family matrix JSON.")
+    args = parser.parse_args()
+    return _run(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/runtime/test_service_api_tranche1_wrapper_family_parity_matrix.sh
+++ b/scripts/runtime/test_service_api_tranche1_wrapper_family_parity_matrix.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CHECKER="$ROOT_DIR/scripts/runtime/service_api_tranche1_wrapper_family_parity_contract.py"
+MATRIX_FILE="$ROOT_DIR/fixtures/ci/service_api_tranche1_wrapper_family_matrix.json"
+STRATEGY_DOC="$ROOT_DIR/docs/ci/strategy.md"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+if [ ! -x "$CHECKER" ]; then
+  echo "expected service api tranche-1 wrapper parity checker to be executable" >&2
+  exit 1
+fi
+if [ ! -f "$MATRIX_FILE" ]; then
+  echo "expected service api tranche-1 wrapper family matrix file" >&2
+  exit 1
+fi
+
+parity_output="$(
+  python3 "$CHECKER" \
+    --root-dir "$ROOT_DIR" \
+    --matrix-file "$MATRIX_FILE"
+)"
+if ! printf '%s\n' "$parity_output" | grep -q '^status=pass$'; then
+  echo "expected service api tranche-1 parity checker status=pass" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$parity_output" | grep -q '^service_api_tranche1_wrapper_family_status=verified$'; then
+  echo "expected service api tranche-1 parity checker status marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$parity_output" | grep -q '^reason_codes=none$'; then
+  echo "expected service api tranche-1 parity checker reason code marker" >&2
+  exit 1
+fi
+
+while IFS=$'\t' read -r wrapper contract_key policy_key tamper_reason; do
+  lane_output="$(
+    bash "$ROOT_DIR/$wrapper" \
+      --mode dry-run \
+      --output-json "$TMP_DIR/$(basename "$wrapper" .sh)-report.json" \
+      --policy-output-json "$TMP_DIR/$(basename "$wrapper" .sh)-policy.json"
+  )"
+  if ! printf '%s\n' "$lane_output" | grep -q '^status=pass$'; then
+    echo "expected wrapper lane status marker for $wrapper" >&2
+    exit 1
+  fi
+  if ! printf '%s\n' "$lane_output" | grep -q '^final_decision=GO$'; then
+    echo "expected wrapper lane final decision marker for $wrapper" >&2
+    exit 1
+  fi
+  if ! printf '%s\n' "$lane_output" | grep -q '^lane_mode=dry-run$'; then
+    echo "expected wrapper lane mode marker for $wrapper" >&2
+    exit 1
+  fi
+  if ! printf '%s\n' "$lane_output" | grep -q "^${contract_key}=verified$"; then
+    echo "expected wrapper lane contract status marker for $wrapper" >&2
+    exit 1
+  fi
+  if ! printf '%s\n' "$lane_output" | grep -q "^${policy_key}=verified$"; then
+    echo "expected wrapper lane policy status marker for $wrapper" >&2
+    exit 1
+  fi
+  if ! printf '%s\n' "$lane_output" | grep -q "^fail_closed_reason_code=${tamper_reason}$"; then
+    echo "expected wrapper lane fail-closed reason marker for $wrapper" >&2
+    exit 1
+  fi
+done < <(
+  python3 - "$MATRIX_FILE" <<'PY'
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+for wrapper in payload["wrappers"]:
+    print(
+        "\t".join(
+            [
+                wrapper["wrapper"],
+                wrapper["contract_status_key"],
+                wrapper["policy_status_key"],
+                wrapper["tamper_reason_code"],
+            ]
+        )
+    )
+PY
+)
+
+if ! grep -q "test_service_api_tranche1_wrapper_family_parity_matrix.sh" "$STRATEGY_DOC"; then
+  echo "expected CI strategy docs to reference service api tranche-1 parity matrix command" >&2
+  exit 1
+fi
+if ! grep -q "service api tranche-1 runner migration parity guard" "$STRATEGY_DOC"; then
+  echo "expected CI strategy docs to include service api tranche-1 migration marker" >&2
+  exit 1
+fi
+
+tampered_matrix="$TMP_DIR/service-api-tranche1-wrapper-family-matrix.tampered.json"
+cp "$MATRIX_FILE" "$tampered_matrix"
+python3 - "$tampered_matrix" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+payload = json.loads(path.read_text(encoding="utf-8"))
+payload["wrappers"][0]["policy_checker"] = "scripts/runtime/check_service_api_prometheus_metrics_live_policy_drifted.sh"
+path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+set +e
+tampered_output="$(
+  python3 "$CHECKER" \
+    --root-dir "$ROOT_DIR" \
+    --matrix-file "$tampered_matrix" 2>&1
+)"
+tampered_code=$?
+set -e
+
+if [ "$tampered_code" -eq 0 ]; then
+  echo "expected tampered service api tranche-1 matrix to fail closed" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$tampered_output" | grep -q 'wrapper_policy_checker_marker_missing:scripts/runtime/validate_service_api_prometheus_metrics_live_contract_lane.sh'; then
+  echo "expected deterministic policy-checker drift reason code for tampered service api tranche-1 matrix" >&2
+  exit 1
+fi
+
+echo "service api tranche-1 wrapper family parity matrix tests passed."

--- a/scripts/runtime/validate_service_api_graceful_shutdown_drain_live_contract_lane.sh
+++ b/scripts/runtime/validate_service_api_graceful_shutdown_drain_live_contract_lane.sh
@@ -2,264 +2,60 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# Shared runner for service-api contract lanes.
+source "$ROOT_DIR/scripts/runtime/service_api_contract_lane_runner.sh"
+
 VALIDATION_SCRIPT="$ROOT_DIR/scripts/runtime/validate_service_api_graceful_shutdown_drain_live.sh"
 POLICY_CHECKER="$ROOT_DIR/scripts/runtime/check_service_api_graceful_shutdown_drain_live_policy.sh"
 STRATEGY_DOC="$ROOT_DIR/docs/ci/strategy.md"
 ROADMAP_DOC="$ROOT_DIR/docs/plans/2026-02-08-production-service-roadmap.md"
 
-output_json=""
-policy_output_json=""
-max_seconds="${KAMN_SERVICE_API_GRACEFUL_SHUTDOWN_DRAIN_CONTRACT_MAX_SECONDS:-240}"
-ci_fast_gate="PASS"
-mode="dry-run"
+LANE_LABEL="service api graceful-shutdown drain"
+LANE_SLUG="service-api-graceful-shutdown-drain-live"
+MAX_SECONDS_ENV="KAMN_SERVICE_API_GRACEFUL_SHUTDOWN_DRAIN_CONTRACT_MAX_SECONDS"
+MAX_SECONDS_DEFAULT="240"
+CONTRACT_STATUS_KEY="service_api_graceful_shutdown_drain_contract_status"
+POLICY_STATUS_KEY="service_api_graceful_shutdown_drain_policy_status"
+SUMMARY_SCHEMA="kamn.runtime.service-api-graceful-shutdown-drain-live-report.v1"
+POLICY_SCHEMA="kamn.runtime.service-api-graceful-shutdown-drain-live-policy-report.v1"
+LANE_REPORT_SCHEMA="kamn.runtime.service-api-graceful-shutdown-drain-live-contract-lane-report.v1"
+TAMPER_FIELD="websocket_drain_status"
+TAMPER_REASON_CODE="service_api_graceful_shutdown_drain_policy_marker_missing:websocket_drain_status"
+ROADMAP_TASK_MARKER="Task #3274"
+ROADMAP_CONTRACT_SCRIPT_REF="scripts/runtime/validate_service_api_graceful_shutdown_drain_live_contract_lane.sh"
+ROADMAP_POLICY_SCRIPT_REF="scripts/runtime/check_service_api_graceful_shutdown_drain_live_policy.sh"
+ALLOW_MODE="1"
 
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    --output-json)
-      output_json="${2:-}"
-      shift 2
-      ;;
-    --policy-output-json)
-      policy_output_json="${2:-}"
-      shift 2
-      ;;
-    --max-seconds)
-      max_seconds="${2:-}"
-      shift 2
-      ;;
-    --ci-fast-gate)
-      ci_fast_gate="${2:-}"
-      shift 2
-      ;;
-    --mode)
-      mode="${2:-}"
-      shift 2
-      ;;
-    *)
-      echo "unknown argument: $1" >&2
-      exit 1
-      ;;
-  esac
-done
+VALIDATION_REQUIRED_MARKERS=(
+  "status=pass"
+  "final_decision=GO"
+  "http_drain_status=verified"
+  "websocket_drain_status=verified"
+  "shutdown_signal_status=verified"
+  "shutdown_timeout_guard_status=verified"
+  "fail_closed_status=verified"
+)
+VALIDATION_REQUIRED_REGEX_MARKERS=()
+POLICY_REQUIRED_MARKERS=(
+  "status=ok"
+  "final_decision=GO"
+  "service_api_graceful_shutdown_drain_policy_status=verified"
+)
+STRATEGY_REQUIRED_REFS=(
+  "validate_service_api_graceful_shutdown_drain_live.sh"
+  "check_service_api_graceful_shutdown_drain_live_policy.sh"
+  "validate_service_api_graceful_shutdown_drain_live_contract_lane.sh"
+  "test_validate_service_api_graceful_shutdown_drain_live_contract_lane.sh"
+  "test_check_service_api_graceful_shutdown_drain_live_policy.sh"
+)
+STRATEGY_REQUIRED_MARKERS=(
+  "service api graceful-shutdown drain contract-lane commands remain excluded from ci-fast-gate and ci-tools fast mode."
+)
+LANE_REPORT_SUMMARY_FIELDS=(
+  lane_mode
+)
+OUTPUT_SUMMARY_FIELDS=(
+  lane_mode
+)
 
-if ! [[ "$max_seconds" =~ ^[0-9]+$ ]]; then
-  echo "max-seconds must be an integer" >&2
-  exit 1
-fi
-if [ "$max_seconds" -le 0 ]; then
-  echo "max-seconds must be greater than zero" >&2
-  exit 1
-fi
-if [[ "$ci_fast_gate" != "PASS" && "$ci_fast_gate" != "FAIL" ]]; then
-  echo "ci-fast-gate must be PASS or FAIL" >&2
-  exit 1
-fi
-if [[ "$mode" != "dry-run" && "$mode" != "run" ]]; then
-  echo "mode must be dry-run or run" >&2
-  exit 1
-fi
-
-for required_exec in "$VALIDATION_SCRIPT" "$POLICY_CHECKER"; do
-  if [ ! -x "$required_exec" ]; then
-    echo "expected required executable script '$required_exec'" >&2
-    exit 1
-  fi
-done
-for required_doc in "$STRATEGY_DOC" "$ROADMAP_DOC"; do
-  if [ ! -f "$required_doc" ]; then
-    echo "expected required documentation file '$required_doc'" >&2
-    exit 1
-  fi
-done
-
-start_epoch="$(date +%s)"
-TMP_DIR="$(mktemp -d)"
-trap 'rm -rf "$TMP_DIR"' EXIT
-
-summary_report="$TMP_DIR/service-api-graceful-shutdown-drain-live-summary.json"
-policy_report="$TMP_DIR/service-api-graceful-shutdown-drain-live-policy.json"
-tampered_report="$TMP_DIR/service-api-graceful-shutdown-drain-live-summary.tampered.json"
-
-validation_output="$(
-  bash "$VALIDATION_SCRIPT" \
-    --mode "$mode" \
-    --max-seconds "$max_seconds" \
-    --output-json "$summary_report"
-)"
-if ! printf '%s\n' "$validation_output" | grep -q '^status=pass$'; then
-  echo "expected service api graceful-shutdown drain validation status=pass marker" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$validation_output" | grep -q '^final_decision=GO$'; then
-  echo "expected service api graceful-shutdown drain validation final_decision=GO marker" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$validation_output" | grep -q "^lane_mode=$mode$"; then
-  echo "expected service api graceful-shutdown drain validation lane mode marker" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$validation_output" | grep -q '^http_drain_status=verified$'; then
-  echo "expected service api graceful-shutdown drain http drain marker" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$validation_output" | grep -q '^websocket_drain_status=verified$'; then
-  echo "expected service api graceful-shutdown drain websocket drain marker" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$validation_output" | grep -q '^shutdown_signal_status=verified$'; then
-  echo "expected service api graceful-shutdown drain signal marker" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$validation_output" | grep -q '^shutdown_timeout_guard_status=verified$'; then
-  echo "expected service api graceful-shutdown drain timeout guard marker" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$validation_output" | grep -q '^fail_closed_status=verified$'; then
-  echo "expected service api graceful-shutdown drain fail-closed marker" >&2
-  exit 1
-fi
-
-policy_output="$(
-  bash "$POLICY_CHECKER" \
-    --report-file "$summary_report" \
-    --expected-final-decision GO \
-    --ci-fast-gate "$ci_fast_gate" \
-    --output-json "$policy_report"
-)"
-if ! printf '%s\n' "$policy_output" | grep -q '^status=ok$'; then
-  echo "expected service api graceful-shutdown drain policy checker status=ok marker" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$policy_output" | grep -q '^final_decision=GO$'; then
-  echo "expected service api graceful-shutdown drain policy checker final_decision=GO marker" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$policy_output" | grep -q '^service_api_graceful_shutdown_drain_policy_status=verified$'; then
-  echo "expected service api graceful-shutdown drain policy checker status marker" >&2
-  exit 1
-fi
-
-cp "$summary_report" "$tampered_report"
-python3 - "$tampered_report" <<'PY'
-import json
-import pathlib
-import sys
-
-path = pathlib.Path(sys.argv[1])
-payload = json.loads(path.read_text(encoding="utf-8"))
-payload["websocket_drain_status"] = "missing"
-path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
-PY
-
-set +e
-tampered_policy_output="$(
-  bash "$POLICY_CHECKER" \
-    --report-file "$tampered_report" \
-    --expected-final-decision GO \
-    --ci-fast-gate "$ci_fast_gate" \
-    --output-json "$TMP_DIR/service-api-graceful-shutdown-drain-live-policy.tampered.json" 2>&1
-)"
-tampered_policy_code=$?
-set -e
-
-if [ "$tampered_policy_code" -eq 0 ]; then
-  echo "expected tampered service api graceful-shutdown drain report to fail policy validation" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$tampered_policy_output" | grep -q 'service_api_graceful_shutdown_drain_policy_marker_missing:websocket_drain_status'; then
-  echo "expected deterministic fail-closed reason for tampered service api graceful-shutdown drain report" >&2
-  exit 1
-fi
-
-for required_ref in \
-  "validate_service_api_graceful_shutdown_drain_live.sh" \
-  "check_service_api_graceful_shutdown_drain_live_policy.sh" \
-  "validate_service_api_graceful_shutdown_drain_live_contract_lane.sh" \
-  "test_validate_service_api_graceful_shutdown_drain_live_contract_lane.sh" \
-  "test_check_service_api_graceful_shutdown_drain_live_policy.sh"; do
-  if ! grep -q "$required_ref" "$STRATEGY_DOC"; then
-    echo "expected CI strategy docs to reference $required_ref" >&2
-    exit 1
-  fi
-done
-if ! grep -q "service api graceful-shutdown drain contract-lane commands remain excluded from ci-fast-gate and ci-tools fast mode." "$STRATEGY_DOC"; then
-  echo "expected CI strategy docs to include service api graceful-shutdown drain contract-lane exclusion marker" >&2
-  exit 1
-fi
-
-if ! grep -q "Task #3274" "$ROADMAP_DOC"; then
-  echo "expected roadmap marker for Task #3274" >&2
-  exit 1
-fi
-if ! grep -q "scripts/runtime/validate_service_api_graceful_shutdown_drain_live_contract_lane.sh" "$ROADMAP_DOC"; then
-  echo "expected roadmap to reference service api graceful-shutdown drain contract lane script" >&2
-  exit 1
-fi
-if ! grep -q "scripts/runtime/check_service_api_graceful_shutdown_drain_live_policy.sh" "$ROADMAP_DOC"; then
-  echo "expected roadmap to reference service api graceful-shutdown drain policy checker script" >&2
-  exit 1
-fi
-
-elapsed_seconds="$(( $(date +%s) - start_epoch ))"
-if [ "$elapsed_seconds" -gt "$max_seconds" ]; then
-  echo "service api graceful-shutdown drain contract lane exceeded runtime budget: ${elapsed_seconds}s" >&2
-  exit 1
-fi
-
-lane_report="$TMP_DIR/service-api-graceful-shutdown-drain-live-contract-lane-report.json"
-python3 - "$summary_report" "$policy_report" "$lane_report" "$elapsed_seconds" "$max_seconds" "$mode" <<'PY'
-import json
-import pathlib
-import sys
-
-summary_report = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
-policy_report = json.loads(pathlib.Path(sys.argv[2]).read_text(encoding="utf-8"))
-lane_report_file = pathlib.Path(sys.argv[3])
-elapsed_seconds = int(sys.argv[4])
-max_seconds = int(sys.argv[5])
-mode = sys.argv[6]
-
-if summary_report.get("schema_version") != "kamn.runtime.service-api-graceful-shutdown-drain-live-report.v1":
-    raise SystemExit("unexpected service api graceful-shutdown drain live summary schema")
-if policy_report.get("schema_version") != "kamn.runtime.service-api-graceful-shutdown-drain-live-policy-report.v1":
-    raise SystemExit("unexpected service api graceful-shutdown drain live policy schema")
-if summary_report.get("final_decision") != "GO":
-    raise SystemExit("expected service api graceful-shutdown drain summary final_decision=GO")
-if policy_report.get("final_decision") != "GO":
-    raise SystemExit("expected service api graceful-shutdown drain policy final_decision=GO")
-
-lane_report = {
-    "schema_version": "kamn.runtime.service-api-graceful-shutdown-drain-live-contract-lane-report.v1",
-    "status": "pass",
-    "final_decision": "GO",
-    "lane_mode": mode,
-    "service_api_graceful_shutdown_drain_contract_status": "verified",
-    "service_api_graceful_shutdown_drain_policy_status": policy_report.get(
-        "service_api_graceful_shutdown_drain_policy_status"
-    ),
-    "docs_contract_status": "verified",
-    "fail_closed_status": "verified",
-    "fail_closed_reason_code": "service_api_graceful_shutdown_drain_policy_marker_missing:websocket_drain_status",
-    "performance_budget_status": "verified",
-    "elapsed_seconds": elapsed_seconds,
-    "max_seconds": max_seconds,
-}
-lane_report_file.write_text(json.dumps(lane_report, sort_keys=True, indent=2) + "\n", encoding="utf-8")
-PY
-
-if [[ -n "$output_json" ]]; then
-  cp "$lane_report" "$output_json"
-fi
-if [[ -n "$policy_output_json" ]]; then
-  cp "$policy_report" "$policy_output_json"
-fi
-
-echo "status=pass"
-echo "final_decision=GO"
-echo "lane_mode=$mode"
-echo "service_api_graceful_shutdown_drain_contract_status=verified"
-echo "service_api_graceful_shutdown_drain_policy_status=verified"
-echo "docs_contract_status=verified"
-echo "fail_closed_status=verified"
-echo "fail_closed_reason_code=service_api_graceful_shutdown_drain_policy_marker_missing:websocket_drain_status"
-echo "performance_budget_status=verified"
+service_api_contract_lane_run "$@"

--- a/scripts/runtime/validate_service_api_prometheus_metrics_live_contract_lane.sh
+++ b/scripts/runtime/validate_service_api_prometheus_metrics_live_contract_lane.sh
@@ -2,266 +2,59 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# Shared runner for service-api contract lanes.
+source "$ROOT_DIR/scripts/runtime/service_api_contract_lane_runner.sh"
+
 VALIDATION_SCRIPT="$ROOT_DIR/scripts/runtime/validate_service_api_prometheus_metrics_live.sh"
 POLICY_CHECKER="$ROOT_DIR/scripts/runtime/check_service_api_prometheus_metrics_live_policy.sh"
 STRATEGY_DOC="$ROOT_DIR/docs/ci/strategy.md"
 ROADMAP_DOC="$ROOT_DIR/docs/plans/2026-02-08-production-service-roadmap.md"
 
-output_json=""
-policy_output_json=""
-max_seconds="${KAMN_SERVICE_API_PROMETHEUS_METRICS_CONTRACT_MAX_SECONDS:-240}"
-ci_fast_gate="PASS"
-mode="dry-run"
+LANE_LABEL="service api prometheus metrics"
+LANE_SLUG="service-api-prometheus-metrics-live"
+MAX_SECONDS_ENV="KAMN_SERVICE_API_PROMETHEUS_METRICS_CONTRACT_MAX_SECONDS"
+MAX_SECONDS_DEFAULT="240"
+CONTRACT_STATUS_KEY="service_api_prometheus_metrics_contract_status"
+POLICY_STATUS_KEY="service_api_prometheus_metrics_policy_status"
+SUMMARY_SCHEMA="kamn.runtime.service-api-prometheus-metrics-live-report.v1"
+POLICY_SCHEMA="kamn.runtime.service-api-prometheus-metrics-live-policy-report.v1"
+LANE_REPORT_SCHEMA="kamn.runtime.service-api-prometheus-metrics-live-contract-lane-report.v1"
+TAMPER_FIELD="metrics_contract_status"
+TAMPER_REASON_CODE="service_api_prometheus_metrics_policy_marker_missing:metrics_contract_status"
+ROADMAP_TASK_MARKER="Task #3270"
+ROADMAP_CONTRACT_SCRIPT_REF="scripts/runtime/validate_service_api_prometheus_metrics_live_contract_lane.sh"
+ROADMAP_POLICY_SCRIPT_REF="scripts/runtime/check_service_api_prometheus_metrics_live_policy.sh"
+ALLOW_MODE="1"
 
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    --output-json)
-      output_json="${2:-}"
-      shift 2
-      ;;
-    --policy-output-json)
-      policy_output_json="${2:-}"
-      shift 2
-      ;;
-    --max-seconds)
-      max_seconds="${2:-}"
-      shift 2
-      ;;
-    --ci-fast-gate)
-      ci_fast_gate="${2:-}"
-      shift 2
-      ;;
-    --mode)
-      mode="${2:-}"
-      shift 2
-      ;;
-    *)
-      echo "unknown argument: $1" >&2
-      exit 1
-      ;;
-  esac
-done
+VALIDATION_REQUIRED_MARKERS=(
+  "status=pass"
+  "final_decision=GO"
+  "metrics_contract_status=verified"
+  "health_contract_status=verified"
+  "prometheus_format_status=verified"
+  "fail_closed_status=verified"
+)
+VALIDATION_REQUIRED_REGEX_MARKERS=()
+POLICY_REQUIRED_MARKERS=(
+  "status=ok"
+  "final_decision=GO"
+  "service_api_prometheus_metrics_policy_status=verified"
+)
+STRATEGY_REQUIRED_REFS=(
+  "validate_service_api_prometheus_metrics_live.sh"
+  "check_service_api_prometheus_metrics_live_policy.sh"
+  "validate_service_api_prometheus_metrics_live_contract_lane.sh"
+  "test_validate_service_api_prometheus_metrics_live_contract_lane.sh"
+  "test_check_service_api_prometheus_metrics_live_policy.sh"
+)
+STRATEGY_REQUIRED_MARKERS=(
+  "service api prometheus metrics contract-lane commands remain excluded from ci-fast-gate and ci-tools fast mode."
+)
+LANE_REPORT_SUMMARY_FIELDS=(
+  lane_mode
+)
+OUTPUT_SUMMARY_FIELDS=(
+  lane_mode
+)
 
-if ! [[ "$max_seconds" =~ ^[0-9]+$ ]]; then
-  echo "max-seconds must be an integer" >&2
-  exit 1
-fi
-if [ "$max_seconds" -le 0 ]; then
-  echo "max-seconds must be greater than zero" >&2
-  exit 1
-fi
-if [[ "$ci_fast_gate" != "PASS" && "$ci_fast_gate" != "FAIL" ]]; then
-  echo "ci-fast-gate must be PASS or FAIL" >&2
-  exit 1
-fi
-if [[ "$mode" != "dry-run" && "$mode" != "run" ]]; then
-  echo "mode must be dry-run or run" >&2
-  exit 1
-fi
-
-for required_exec in "$VALIDATION_SCRIPT" "$POLICY_CHECKER"; do
-  if [ ! -x "$required_exec" ]; then
-    echo "expected required executable script '$required_exec'" >&2
-    exit 1
-  fi
-done
-for required_doc in "$STRATEGY_DOC" "$ROADMAP_DOC"; do
-  if [ ! -f "$required_doc" ]; then
-    echo "expected required documentation file '$required_doc'" >&2
-    exit 1
-  fi
-done
-
-start_epoch="$(date +%s)"
-TMP_DIR="$(mktemp -d)"
-trap 'rm -rf "$TMP_DIR"' EXIT
-
-summary_report="$TMP_DIR/service-api-prometheus-metrics-live-summary.json"
-policy_report="$TMP_DIR/service-api-prometheus-metrics-live-policy.json"
-tampered_report="$TMP_DIR/service-api-prometheus-metrics-live-summary.tampered.json"
-
-validation_output="$(
-  bash "$VALIDATION_SCRIPT" \
-    --mode "$mode" \
-    --max-seconds "$max_seconds" \
-    --output-json "$summary_report"
-)"
-if ! printf '%s\n' "$validation_output" | grep -q '^status=pass$'; then
-  echo "expected service api prometheus metrics validation status=pass marker" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$validation_output" | grep -q '^final_decision=GO$'; then
-  echo "expected service api prometheus metrics validation final_decision=GO marker" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$validation_output" | grep -q "^lane_mode=$mode$"; then
-  echo "expected service api prometheus metrics validation lane mode marker" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$validation_output" | grep -q '^metrics_contract_status=verified$'; then
-  echo "expected service api prometheus metrics validation metrics marker" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$validation_output" | grep -q '^health_contract_status=verified$'; then
-  echo "expected service api prometheus metrics validation health marker" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$validation_output" | grep -q '^prometheus_format_status=verified$'; then
-  echo "expected service api prometheus metrics validation prometheus-format marker" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$validation_output" | grep -q '^fail_closed_status=verified$'; then
-  echo "expected service api prometheus metrics validation fail-closed marker" >&2
-  exit 1
-fi
-
-policy_output="$(
-  bash "$POLICY_CHECKER" \
-    --report-file "$summary_report" \
-    --expected-final-decision GO \
-    --ci-fast-gate "$ci_fast_gate" \
-    --output-json "$policy_report"
-)"
-if ! printf '%s\n' "$policy_output" | grep -q '^status=ok$'; then
-  echo "expected service api prometheus metrics policy checker status=ok marker" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$policy_output" | grep -q '^final_decision=GO$'; then
-  echo "expected service api prometheus metrics policy checker final_decision=GO marker" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$policy_output" | grep -q '^service_api_prometheus_metrics_policy_status=verified$'; then
-  echo "expected service api prometheus metrics policy checker status marker" >&2
-  exit 1
-fi
-
-cp "$summary_report" "$tampered_report"
-python3 - "$tampered_report" <<'PY'
-import json
-import pathlib
-import sys
-
-path = pathlib.Path(sys.argv[1])
-payload = json.loads(path.read_text(encoding="utf-8"))
-payload["metrics_contract_status"] = "missing"
-path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
-PY
-
-set +e
-tampered_policy_output="$(
-  bash "$POLICY_CHECKER" \
-    --report-file "$tampered_report" \
-    --expected-final-decision GO \
-    --ci-fast-gate "$ci_fast_gate" \
-    --output-json "$TMP_DIR/service-api-prometheus-metrics-live-policy.tampered.json" 2>&1
-)"
-tampered_policy_code=$?
-set -e
-
-if [ "$tampered_policy_code" -eq 0 ]; then
-  echo "expected tampered service api prometheus metrics report to fail policy validation" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$tampered_policy_output" | grep -q 'service_api_prometheus_metrics_policy_marker_missing:metrics_contract_status'; then
-  echo "expected deterministic fail-closed reason for tampered service api prometheus metrics report" >&2
-  exit 1
-fi
-
-for required_ref in \
-  "validate_service_api_prometheus_metrics_live.sh" \
-  "check_service_api_prometheus_metrics_live_policy.sh" \
-  "validate_service_api_prometheus_metrics_live_contract_lane.sh" \
-  "test_validate_service_api_prometheus_metrics_live_contract_lane.sh" \
-  "test_check_service_api_prometheus_metrics_live_policy.sh"; do
-  if ! grep -q "$required_ref" "$STRATEGY_DOC"; then
-    echo "expected CI strategy docs to reference $required_ref" >&2
-    exit 1
-  fi
-done
-if ! grep -q "service api prometheus metrics contract-lane commands remain excluded from ci-fast-gate and ci-tools fast mode." "$STRATEGY_DOC"; then
-  echo "expected CI strategy docs to include service api prometheus metrics contract-lane exclusion marker" >&2
-  exit 1
-fi
-
-if ! grep -q "Task #3270" "$ROADMAP_DOC"; then
-  echo "expected roadmap marker for Task #3270" >&2
-  exit 1
-fi
-if ! grep -q "scripts/runtime/validate_service_api_prometheus_metrics_live_contract_lane.sh" "$ROADMAP_DOC"; then
-  echo "expected roadmap to reference service api prometheus metrics contract lane script" >&2
-  exit 1
-fi
-if ! grep -q "scripts/runtime/check_service_api_prometheus_metrics_live_policy.sh" "$ROADMAP_DOC"; then
-  echo "expected roadmap to reference service api prometheus metrics policy checker script" >&2
-  exit 1
-fi
-
-elapsed_seconds="$(( $(date +%s) - start_epoch ))"
-if [ "$elapsed_seconds" -gt "$max_seconds" ]; then
-  echo "service api prometheus metrics contract lane exceeded runtime budget: ${elapsed_seconds}s" >&2
-  exit 1
-fi
-
-lane_report="$TMP_DIR/service-api-prometheus-metrics-live-contract-lane-report.json"
-python3 - "$summary_report" "$policy_report" "$lane_report" "$elapsed_seconds" "$max_seconds" "$mode" <<'PY'
-import json
-import pathlib
-import sys
-
-summary_report = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
-policy_report = json.loads(pathlib.Path(sys.argv[2]).read_text(encoding="utf-8"))
-lane_report_file = pathlib.Path(sys.argv[3])
-elapsed_seconds = int(sys.argv[4])
-max_seconds = int(sys.argv[5])
-mode = sys.argv[6]
-
-if summary_report.get("schema_version") != "kamn.runtime.service-api-prometheus-metrics-live-report.v1":
-    raise SystemExit("unexpected service api prometheus metrics live summary schema")
-if policy_report.get("schema_version") != "kamn.runtime.service-api-prometheus-metrics-live-policy-report.v1":
-    raise SystemExit("unexpected service api prometheus metrics live policy schema")
-if summary_report.get("final_decision") != "GO":
-    raise SystemExit("expected service api prometheus metrics summary final_decision=GO")
-if policy_report.get("final_decision") != "GO":
-    raise SystemExit("expected service api prometheus metrics policy final_decision=GO")
-
-lane_report = {
-    "schema_version": "kamn.runtime.service-api-prometheus-metrics-live-contract-lane-report.v1",
-    "status": "pass",
-    "final_decision": "GO",
-    "lane_mode": mode,
-    "service_api_prometheus_metrics_contract_status": "verified",
-    "service_api_prometheus_metrics_policy_status": policy_report.get(
-        "service_api_prometheus_metrics_policy_status"
-    ),
-    "docs_contract_status": "verified",
-    "fail_closed_status": "verified",
-    "fail_closed_reason_code": "service_api_prometheus_metrics_policy_marker_missing:metrics_contract_status",
-    "performance_budget_status": "verified",
-    "elapsed_seconds": elapsed_seconds,
-    "max_seconds": max_seconds,
-}
-lane_report_file.write_text(json.dumps(lane_report, sort_keys=True, indent=2) + "\n", encoding="utf-8")
-PY
-
-if [[ -n "$output_json" ]]; then
-  cp "$lane_report" "$output_json"
-fi
-if [[ -n "$policy_output_json" ]]; then
-  cp "$policy_report" "$policy_output_json"
-fi
-
-echo "status=pass"
-echo "final_decision=GO"
-echo "lane_mode=$mode"
-echo "service_api_prometheus_metrics_contract_status=verified"
-echo "service_api_prometheus_metrics_policy_status=verified"
-echo "docs_contract_status=verified"
-echo "fail_closed_status=verified"
-echo "fail_closed_reason_code=service_api_prometheus_metrics_policy_marker_missing:metrics_contract_status"
-echo "performance_budget_status=verified"
-if [[ -n "$output_json" ]]; then
-  echo "contract_lane_report=$output_json"
-fi
-if [[ -n "$policy_output_json" ]]; then
-  echo "policy_report=$policy_output_json"
-fi
+service_api_contract_lane_run "$@"

--- a/scripts/runtime/validate_service_api_shutdown_abrupt_close_regression_live_contract_lane.sh
+++ b/scripts/runtime/validate_service_api_shutdown_abrupt_close_regression_live_contract_lane.sh
@@ -2,264 +2,60 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# Shared runner for service-api contract lanes.
+source "$ROOT_DIR/scripts/runtime/service_api_contract_lane_runner.sh"
+
 VALIDATION_SCRIPT="$ROOT_DIR/scripts/runtime/validate_service_api_shutdown_abrupt_close_regression_live.sh"
 POLICY_CHECKER="$ROOT_DIR/scripts/runtime/check_service_api_shutdown_abrupt_close_regression_live_policy.sh"
 STRATEGY_DOC="$ROOT_DIR/docs/ci/strategy.md"
 ROADMAP_DOC="$ROOT_DIR/docs/plans/2026-02-08-production-service-roadmap.md"
 
-output_json=""
-policy_output_json=""
-max_seconds="${KAMN_SERVICE_API_SHUTDOWN_ABRUPT_CLOSE_REGRESSION_CONTRACT_MAX_SECONDS:-240}"
-ci_fast_gate="PASS"
-mode="dry-run"
+LANE_LABEL="service api shutdown abrupt-close regression"
+LANE_SLUG="service-api-shutdown-abrupt-close-regression-live"
+MAX_SECONDS_ENV="KAMN_SERVICE_API_SHUTDOWN_ABRUPT_CLOSE_REGRESSION_CONTRACT_MAX_SECONDS"
+MAX_SECONDS_DEFAULT="240"
+CONTRACT_STATUS_KEY="service_api_shutdown_abrupt_close_regression_contract_status"
+POLICY_STATUS_KEY="service_api_shutdown_abrupt_close_regression_policy_status"
+SUMMARY_SCHEMA="kamn.runtime.service-api-shutdown-abrupt-close-regression-live-report.v1"
+POLICY_SCHEMA="kamn.runtime.service-api-shutdown-abrupt-close-regression-live-policy-report.v1"
+LANE_REPORT_SCHEMA="kamn.runtime.service-api-shutdown-abrupt-close-regression-live-contract-lane-report.v1"
+TAMPER_FIELD="abrupt_close_guard_status"
+TAMPER_REASON_CODE="service_api_shutdown_abrupt_close_regression_policy_marker_missing:abrupt_close_guard_status"
+ROADMAP_TASK_MARKER="Task #3275"
+ROADMAP_CONTRACT_SCRIPT_REF="scripts/runtime/validate_service_api_shutdown_abrupt_close_regression_live_contract_lane.sh"
+ROADMAP_POLICY_SCRIPT_REF="scripts/runtime/check_service_api_shutdown_abrupt_close_regression_live_policy.sh"
+ALLOW_MODE="1"
 
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    --output-json)
-      output_json="${2:-}"
-      shift 2
-      ;;
-    --policy-output-json)
-      policy_output_json="${2:-}"
-      shift 2
-      ;;
-    --max-seconds)
-      max_seconds="${2:-}"
-      shift 2
-      ;;
-    --ci-fast-gate)
-      ci_fast_gate="${2:-}"
-      shift 2
-      ;;
-    --mode)
-      mode="${2:-}"
-      shift 2
-      ;;
-    *)
-      echo "unknown argument: $1" >&2
-      exit 1
-      ;;
-  esac
-done
+VALIDATION_REQUIRED_MARKERS=(
+  "status=pass"
+  "final_decision=GO"
+  "abrupt_close_guard_status=verified"
+  "websocket_rejection_guard_status=verified"
+  "shutdown_timeout_guard_status=verified"
+  "replayed_signal_guard_status=verified"
+  "fail_closed_status=verified"
+)
+VALIDATION_REQUIRED_REGEX_MARKERS=()
+POLICY_REQUIRED_MARKERS=(
+  "status=ok"
+  "final_decision=GO"
+  "service_api_shutdown_abrupt_close_regression_policy_status=verified"
+)
+STRATEGY_REQUIRED_REFS=(
+  "validate_service_api_shutdown_abrupt_close_regression_live.sh"
+  "check_service_api_shutdown_abrupt_close_regression_live_policy.sh"
+  "validate_service_api_shutdown_abrupt_close_regression_live_contract_lane.sh"
+  "test_validate_service_api_shutdown_abrupt_close_regression_live_contract_lane.sh"
+  "test_check_service_api_shutdown_abrupt_close_regression_live_policy.sh"
+)
+STRATEGY_REQUIRED_MARKERS=(
+  "service api shutdown abrupt-close regression contract-lane commands remain excluded from ci-fast-gate and ci-tools fast mode."
+)
+LANE_REPORT_SUMMARY_FIELDS=(
+  lane_mode
+)
+OUTPUT_SUMMARY_FIELDS=(
+  lane_mode
+)
 
-if ! [[ "$max_seconds" =~ ^[0-9]+$ ]]; then
-  echo "max-seconds must be an integer" >&2
-  exit 1
-fi
-if [ "$max_seconds" -le 0 ]; then
-  echo "max-seconds must be greater than zero" >&2
-  exit 1
-fi
-if [[ "$ci_fast_gate" != "PASS" && "$ci_fast_gate" != "FAIL" ]]; then
-  echo "ci-fast-gate must be PASS or FAIL" >&2
-  exit 1
-fi
-if [[ "$mode" != "dry-run" && "$mode" != "run" ]]; then
-  echo "mode must be dry-run or run" >&2
-  exit 1
-fi
-
-for required_exec in "$VALIDATION_SCRIPT" "$POLICY_CHECKER"; do
-  if [ ! -x "$required_exec" ]; then
-    echo "expected required executable script '$required_exec'" >&2
-    exit 1
-  fi
-done
-for required_doc in "$STRATEGY_DOC" "$ROADMAP_DOC"; do
-  if [ ! -f "$required_doc" ]; then
-    echo "expected required documentation file '$required_doc'" >&2
-    exit 1
-  fi
-done
-
-start_epoch="$(date +%s)"
-TMP_DIR="$(mktemp -d)"
-trap 'rm -rf "$TMP_DIR"' EXIT
-
-summary_report="$TMP_DIR/service-api-shutdown-abrupt-close-regression-live-summary.json"
-policy_report="$TMP_DIR/service-api-shutdown-abrupt-close-regression-live-policy.json"
-tampered_report="$TMP_DIR/service-api-shutdown-abrupt-close-regression-live-summary.tampered.json"
-
-validation_output="$(
-  bash "$VALIDATION_SCRIPT" \
-    --mode "$mode" \
-    --max-seconds "$max_seconds" \
-    --output-json "$summary_report"
-)"
-if ! printf '%s\n' "$validation_output" | grep -q '^status=pass$'; then
-  echo "expected service api shutdown abrupt-close regression validation status=pass marker" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$validation_output" | grep -q '^final_decision=GO$'; then
-  echo "expected service api shutdown abrupt-close regression validation final_decision=GO marker" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$validation_output" | grep -q "^lane_mode=$mode$"; then
-  echo "expected service api shutdown abrupt-close regression validation lane mode marker" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$validation_output" | grep -q '^abrupt_close_guard_status=verified$'; then
-  echo "expected service api shutdown abrupt-close regression abrupt-close marker" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$validation_output" | grep -q '^websocket_rejection_guard_status=verified$'; then
-  echo "expected service api shutdown abrupt-close regression websocket marker" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$validation_output" | grep -q '^shutdown_timeout_guard_status=verified$'; then
-  echo "expected service api shutdown abrupt-close regression timeout marker" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$validation_output" | grep -q '^replayed_signal_guard_status=verified$'; then
-  echo "expected service api shutdown abrupt-close regression replayed-signal marker" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$validation_output" | grep -q '^fail_closed_status=verified$'; then
-  echo "expected service api shutdown abrupt-close regression fail-closed marker" >&2
-  exit 1
-fi
-
-policy_output="$(
-  bash "$POLICY_CHECKER" \
-    --report-file "$summary_report" \
-    --expected-final-decision GO \
-    --ci-fast-gate "$ci_fast_gate" \
-    --output-json "$policy_report"
-)"
-if ! printf '%s\n' "$policy_output" | grep -q '^status=ok$'; then
-  echo "expected service api shutdown abrupt-close regression policy checker status=ok marker" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$policy_output" | grep -q '^final_decision=GO$'; then
-  echo "expected service api shutdown abrupt-close regression policy checker final_decision=GO marker" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$policy_output" | grep -q '^service_api_shutdown_abrupt_close_regression_policy_status=verified$'; then
-  echo "expected service api shutdown abrupt-close regression policy checker status marker" >&2
-  exit 1
-fi
-
-cp "$summary_report" "$tampered_report"
-python3 - "$tampered_report" <<'PY'
-import json
-import pathlib
-import sys
-
-path = pathlib.Path(sys.argv[1])
-payload = json.loads(path.read_text(encoding="utf-8"))
-payload["abrupt_close_guard_status"] = "missing"
-path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
-PY
-
-set +e
-tampered_policy_output="$(
-  bash "$POLICY_CHECKER" \
-    --report-file "$tampered_report" \
-    --expected-final-decision GO \
-    --ci-fast-gate "$ci_fast_gate" \
-    --output-json "$TMP_DIR/service-api-shutdown-abrupt-close-regression-live-policy.tampered.json" 2>&1
-)"
-tampered_policy_code=$?
-set -e
-
-if [ "$tampered_policy_code" -eq 0 ]; then
-  echo "expected tampered service api shutdown abrupt-close regression report to fail policy validation" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$tampered_policy_output" | grep -q 'service_api_shutdown_abrupt_close_regression_policy_marker_missing:abrupt_close_guard_status'; then
-  echo "expected deterministic fail-closed reason for tampered service api shutdown abrupt-close regression report" >&2
-  exit 1
-fi
-
-for required_ref in \
-  "validate_service_api_shutdown_abrupt_close_regression_live.sh" \
-  "check_service_api_shutdown_abrupt_close_regression_live_policy.sh" \
-  "validate_service_api_shutdown_abrupt_close_regression_live_contract_lane.sh" \
-  "test_validate_service_api_shutdown_abrupt_close_regression_live_contract_lane.sh" \
-  "test_check_service_api_shutdown_abrupt_close_regression_live_policy.sh"; do
-  if ! grep -q "$required_ref" "$STRATEGY_DOC"; then
-    echo "expected CI strategy docs to reference $required_ref" >&2
-    exit 1
-  fi
-done
-if ! grep -q "service api shutdown abrupt-close regression contract-lane commands remain excluded from ci-fast-gate and ci-tools fast mode." "$STRATEGY_DOC"; then
-  echo "expected CI strategy docs to include service api shutdown abrupt-close regression contract-lane exclusion marker" >&2
-  exit 1
-fi
-
-if ! grep -q "Task #3275" "$ROADMAP_DOC"; then
-  echo "expected roadmap marker for Task #3275" >&2
-  exit 1
-fi
-if ! grep -q "scripts/runtime/validate_service_api_shutdown_abrupt_close_regression_live_contract_lane.sh" "$ROADMAP_DOC"; then
-  echo "expected roadmap to reference service api shutdown abrupt-close regression contract lane script" >&2
-  exit 1
-fi
-if ! grep -q "scripts/runtime/check_service_api_shutdown_abrupt_close_regression_live_policy.sh" "$ROADMAP_DOC"; then
-  echo "expected roadmap to reference service api shutdown abrupt-close regression policy checker script" >&2
-  exit 1
-fi
-
-elapsed_seconds="$(( $(date +%s) - start_epoch ))"
-if [ "$elapsed_seconds" -gt "$max_seconds" ]; then
-  echo "service api shutdown abrupt-close regression contract lane exceeded runtime budget: ${elapsed_seconds}s" >&2
-  exit 1
-fi
-
-lane_report="$TMP_DIR/service-api-shutdown-abrupt-close-regression-live-contract-lane-report.json"
-python3 - "$summary_report" "$policy_report" "$lane_report" "$elapsed_seconds" "$max_seconds" "$mode" <<'PY'
-import json
-import pathlib
-import sys
-
-summary_report = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
-policy_report = json.loads(pathlib.Path(sys.argv[2]).read_text(encoding="utf-8"))
-lane_report_file = pathlib.Path(sys.argv[3])
-elapsed_seconds = int(sys.argv[4])
-max_seconds = int(sys.argv[5])
-mode = sys.argv[6]
-
-if summary_report.get("schema_version") != "kamn.runtime.service-api-shutdown-abrupt-close-regression-live-report.v1":
-    raise SystemExit("unexpected service api shutdown abrupt-close regression live summary schema")
-if policy_report.get("schema_version") != "kamn.runtime.service-api-shutdown-abrupt-close-regression-live-policy-report.v1":
-    raise SystemExit("unexpected service api shutdown abrupt-close regression live policy schema")
-if summary_report.get("final_decision") != "GO":
-    raise SystemExit("expected service api shutdown abrupt-close regression summary final_decision=GO")
-if policy_report.get("final_decision") != "GO":
-    raise SystemExit("expected service api shutdown abrupt-close regression policy final_decision=GO")
-
-lane_report = {
-    "schema_version": "kamn.runtime.service-api-shutdown-abrupt-close-regression-live-contract-lane-report.v1",
-    "status": "pass",
-    "final_decision": "GO",
-    "lane_mode": mode,
-    "service_api_shutdown_abrupt_close_regression_contract_status": "verified",
-    "service_api_shutdown_abrupt_close_regression_policy_status": policy_report.get(
-        "service_api_shutdown_abrupt_close_regression_policy_status"
-    ),
-    "docs_contract_status": "verified",
-    "fail_closed_status": "verified",
-    "fail_closed_reason_code": "service_api_shutdown_abrupt_close_regression_policy_marker_missing:abrupt_close_guard_status",
-    "performance_budget_status": "verified",
-    "elapsed_seconds": elapsed_seconds,
-    "max_seconds": max_seconds,
-}
-lane_report_file.write_text(json.dumps(lane_report, sort_keys=True, indent=2) + "\n", encoding="utf-8")
-PY
-
-if [[ -n "$output_json" ]]; then
-  cp "$lane_report" "$output_json"
-fi
-if [[ -n "$policy_output_json" ]]; then
-  cp "$policy_report" "$policy_output_json"
-fi
-
-echo "status=pass"
-echo "final_decision=GO"
-echo "lane_mode=$mode"
-echo "service_api_shutdown_abrupt_close_regression_contract_status=verified"
-echo "service_api_shutdown_abrupt_close_regression_policy_status=verified"
-echo "docs_contract_status=verified"
-echo "fail_closed_status=verified"
-echo "fail_closed_reason_code=service_api_shutdown_abrupt_close_regression_policy_marker_missing:abrupt_close_guard_status"
-echo "performance_budget_status=verified"
+service_api_contract_lane_run "$@"

--- a/scripts/runtime/validate_service_api_validation_negative_matrix_live_contract_lane.sh
+++ b/scripts/runtime/validate_service_api_validation_negative_matrix_live_contract_lane.sh
@@ -2,264 +2,60 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# Shared runner for service-api contract lanes.
+source "$ROOT_DIR/scripts/runtime/service_api_contract_lane_runner.sh"
+
 VALIDATION_SCRIPT="$ROOT_DIR/scripts/runtime/validate_service_api_validation_negative_matrix_live.sh"
 POLICY_CHECKER="$ROOT_DIR/scripts/runtime/check_service_api_validation_negative_matrix_live_policy.sh"
 STRATEGY_DOC="$ROOT_DIR/docs/ci/strategy.md"
 ROADMAP_DOC="$ROOT_DIR/docs/plans/2026-02-08-production-service-roadmap.md"
 
-output_json=""
-policy_output_json=""
-max_seconds="${KAMN_SERVICE_API_VALIDATION_NEGATIVE_MATRIX_CONTRACT_MAX_SECONDS:-240}"
-ci_fast_gate="PASS"
-mode="dry-run"
+LANE_LABEL="service api validation negative-matrix"
+LANE_SLUG="service-api-validation-negative-matrix-live"
+MAX_SECONDS_ENV="KAMN_SERVICE_API_VALIDATION_NEGATIVE_MATRIX_CONTRACT_MAX_SECONDS"
+MAX_SECONDS_DEFAULT="240"
+CONTRACT_STATUS_KEY="service_api_validation_negative_matrix_contract_status"
+POLICY_STATUS_KEY="service_api_validation_negative_matrix_policy_status"
+SUMMARY_SCHEMA="kamn.runtime.service-api-validation-negative-matrix-live-report.v1"
+POLICY_SCHEMA="kamn.runtime.service-api-validation-negative-matrix-live-policy-report.v1"
+LANE_REPORT_SCHEMA="kamn.runtime.service-api-validation-negative-matrix-live-contract-lane-report.v1"
+TAMPER_FIELD="replay_guard_status"
+TAMPER_REASON_CODE="service_api_validation_negative_matrix_policy_marker_missing:replay_guard_status"
+ROADMAP_TASK_MARKER="Task #3279"
+ROADMAP_CONTRACT_SCRIPT_REF="scripts/runtime/validate_service_api_validation_negative_matrix_live_contract_lane.sh"
+ROADMAP_POLICY_SCRIPT_REF="scripts/runtime/check_service_api_validation_negative_matrix_live_policy.sh"
+ALLOW_MODE="1"
 
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    --output-json)
-      output_json="${2:-}"
-      shift 2
-      ;;
-    --policy-output-json)
-      policy_output_json="${2:-}"
-      shift 2
-      ;;
-    --max-seconds)
-      max_seconds="${2:-}"
-      shift 2
-      ;;
-    --ci-fast-gate)
-      ci_fast_gate="${2:-}"
-      shift 2
-      ;;
-    --mode)
-      mode="${2:-}"
-      shift 2
-      ;;
-    *)
-      echo "unknown argument: $1" >&2
-      exit 1
-      ;;
-  esac
-done
+VALIDATION_REQUIRED_MARKERS=(
+  "status=pass"
+  "final_decision=GO"
+  "malformed_payload_status=verified"
+  "missing_auth_status=verified"
+  "replay_guard_status=verified"
+  "websocket_upgrade_guard_status=verified"
+  "fail_closed_status=verified"
+)
+VALIDATION_REQUIRED_REGEX_MARKERS=()
+POLICY_REQUIRED_MARKERS=(
+  "status=ok"
+  "final_decision=GO"
+  "service_api_validation_negative_matrix_policy_status=verified"
+)
+STRATEGY_REQUIRED_REFS=(
+  "validate_service_api_validation_negative_matrix_live.sh"
+  "check_service_api_validation_negative_matrix_live_policy.sh"
+  "validate_service_api_validation_negative_matrix_live_contract_lane.sh"
+  "test_validate_service_api_validation_negative_matrix_live_contract_lane.sh"
+  "test_check_service_api_validation_negative_matrix_live_policy.sh"
+)
+STRATEGY_REQUIRED_MARKERS=(
+  "service api validation negative-matrix contract-lane commands remain excluded from ci-fast-gate and ci-tools fast mode."
+)
+LANE_REPORT_SUMMARY_FIELDS=(
+  lane_mode
+)
+OUTPUT_SUMMARY_FIELDS=(
+  lane_mode
+)
 
-if ! [[ "$max_seconds" =~ ^[0-9]+$ ]]; then
-  echo "max-seconds must be an integer" >&2
-  exit 1
-fi
-if [ "$max_seconds" -le 0 ]; then
-  echo "max-seconds must be greater than zero" >&2
-  exit 1
-fi
-if [[ "$ci_fast_gate" != "PASS" && "$ci_fast_gate" != "FAIL" ]]; then
-  echo "ci-fast-gate must be PASS or FAIL" >&2
-  exit 1
-fi
-if [[ "$mode" != "dry-run" && "$mode" != "run" ]]; then
-  echo "mode must be dry-run or run" >&2
-  exit 1
-fi
-
-for required_exec in "$VALIDATION_SCRIPT" "$POLICY_CHECKER"; do
-  if [ ! -x "$required_exec" ]; then
-    echo "expected required executable script '$required_exec'" >&2
-    exit 1
-  fi
-done
-for required_doc in "$STRATEGY_DOC" "$ROADMAP_DOC"; do
-  if [ ! -f "$required_doc" ]; then
-    echo "expected required documentation file '$required_doc'" >&2
-    exit 1
-  fi
-done
-
-start_epoch="$(date +%s)"
-TMP_DIR="$(mktemp -d)"
-trap 'rm -rf "$TMP_DIR"' EXIT
-
-summary_report="$TMP_DIR/service-api-validation-negative-matrix-live-summary.json"
-policy_report="$TMP_DIR/service-api-validation-negative-matrix-live-policy.json"
-tampered_report="$TMP_DIR/service-api-validation-negative-matrix-live-summary.tampered.json"
-
-validation_output="$(
-  bash "$VALIDATION_SCRIPT" \
-    --mode "$mode" \
-    --max-seconds "$max_seconds" \
-    --output-json "$summary_report"
-)"
-if ! printf '%s\n' "$validation_output" | grep -q '^status=pass$'; then
-  echo "expected service api validation negative-matrix live validation status=pass marker" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$validation_output" | grep -q '^final_decision=GO$'; then
-  echo "expected service api validation negative-matrix live validation final_decision=GO marker" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$validation_output" | grep -q "^lane_mode=$mode$"; then
-  echo "expected service api validation negative-matrix live validation lane mode marker" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$validation_output" | grep -q '^malformed_payload_status=verified$'; then
-  echo "expected service api validation negative-matrix malformed payload marker" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$validation_output" | grep -q '^missing_auth_status=verified$'; then
-  echo "expected service api validation negative-matrix missing auth marker" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$validation_output" | grep -q '^replay_guard_status=verified$'; then
-  echo "expected service api validation negative-matrix replay marker" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$validation_output" | grep -q '^websocket_upgrade_guard_status=verified$'; then
-  echo "expected service api validation negative-matrix websocket marker" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$validation_output" | grep -q '^fail_closed_status=verified$'; then
-  echo "expected service api validation negative-matrix fail-closed marker" >&2
-  exit 1
-fi
-
-policy_output="$(
-  bash "$POLICY_CHECKER" \
-    --report-file "$summary_report" \
-    --expected-final-decision GO \
-    --ci-fast-gate "$ci_fast_gate" \
-    --output-json "$policy_report"
-)"
-if ! printf '%s\n' "$policy_output" | grep -q '^status=ok$'; then
-  echo "expected service api validation negative-matrix policy checker status=ok marker" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$policy_output" | grep -q '^final_decision=GO$'; then
-  echo "expected service api validation negative-matrix policy checker final_decision=GO marker" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$policy_output" | grep -q '^service_api_validation_negative_matrix_policy_status=verified$'; then
-  echo "expected service api validation negative-matrix policy checker status marker" >&2
-  exit 1
-fi
-
-cp "$summary_report" "$tampered_report"
-python3 - "$tampered_report" <<'PY'
-import json
-import pathlib
-import sys
-
-path = pathlib.Path(sys.argv[1])
-payload = json.loads(path.read_text(encoding="utf-8"))
-payload["replay_guard_status"] = "missing"
-path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
-PY
-
-set +e
-tampered_policy_output="$(
-  bash "$POLICY_CHECKER" \
-    --report-file "$tampered_report" \
-    --expected-final-decision GO \
-    --ci-fast-gate "$ci_fast_gate" \
-    --output-json "$TMP_DIR/service-api-validation-negative-matrix-live-policy.tampered.json" 2>&1
-)"
-tampered_policy_code=$?
-set -e
-
-if [ "$tampered_policy_code" -eq 0 ]; then
-  echo "expected tampered service api validation negative-matrix report to fail policy validation" >&2
-  exit 1
-fi
-if ! printf '%s\n' "$tampered_policy_output" | grep -q 'service_api_validation_negative_matrix_policy_marker_missing:replay_guard_status'; then
-  echo "expected deterministic fail-closed reason for tampered service api validation negative-matrix report" >&2
-  exit 1
-fi
-
-for required_ref in \
-  "validate_service_api_validation_negative_matrix_live.sh" \
-  "check_service_api_validation_negative_matrix_live_policy.sh" \
-  "validate_service_api_validation_negative_matrix_live_contract_lane.sh" \
-  "test_validate_service_api_validation_negative_matrix_live_contract_lane.sh" \
-  "test_check_service_api_validation_negative_matrix_live_policy.sh"; do
-  if ! grep -q "$required_ref" "$STRATEGY_DOC"; then
-    echo "expected CI strategy docs to reference $required_ref" >&2
-    exit 1
-  fi
-done
-if ! grep -q "service api validation negative-matrix contract-lane commands remain excluded from ci-fast-gate and ci-tools fast mode." "$STRATEGY_DOC"; then
-  echo "expected CI strategy docs to include service api validation negative-matrix contract-lane exclusion marker" >&2
-  exit 1
-fi
-
-if ! grep -q "Task #3279" "$ROADMAP_DOC"; then
-  echo "expected roadmap marker for Task #3279" >&2
-  exit 1
-fi
-if ! grep -q "scripts/runtime/validate_service_api_validation_negative_matrix_live_contract_lane.sh" "$ROADMAP_DOC"; then
-  echo "expected roadmap to reference service api validation negative-matrix contract lane script" >&2
-  exit 1
-fi
-if ! grep -q "scripts/runtime/check_service_api_validation_negative_matrix_live_policy.sh" "$ROADMAP_DOC"; then
-  echo "expected roadmap to reference service api validation negative-matrix policy checker script" >&2
-  exit 1
-fi
-
-elapsed_seconds="$(( $(date +%s) - start_epoch ))"
-if [ "$elapsed_seconds" -gt "$max_seconds" ]; then
-  echo "service api validation negative-matrix contract lane exceeded runtime budget: ${elapsed_seconds}s" >&2
-  exit 1
-fi
-
-lane_report="$TMP_DIR/service-api-validation-negative-matrix-live-contract-lane-report.json"
-python3 - "$summary_report" "$policy_report" "$lane_report" "$elapsed_seconds" "$max_seconds" "$mode" <<'PY'
-import json
-import pathlib
-import sys
-
-summary_report = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
-policy_report = json.loads(pathlib.Path(sys.argv[2]).read_text(encoding="utf-8"))
-lane_report_file = pathlib.Path(sys.argv[3])
-elapsed_seconds = int(sys.argv[4])
-max_seconds = int(sys.argv[5])
-mode = sys.argv[6]
-
-if summary_report.get("schema_version") != "kamn.runtime.service-api-validation-negative-matrix-live-report.v1":
-    raise SystemExit("unexpected service api validation negative-matrix live summary schema")
-if policy_report.get("schema_version") != "kamn.runtime.service-api-validation-negative-matrix-live-policy-report.v1":
-    raise SystemExit("unexpected service api validation negative-matrix live policy schema")
-if summary_report.get("final_decision") != "GO":
-    raise SystemExit("expected service api validation negative-matrix summary final_decision=GO")
-if policy_report.get("final_decision") != "GO":
-    raise SystemExit("expected service api validation negative-matrix policy final_decision=GO")
-
-lane_report = {
-    "schema_version": "kamn.runtime.service-api-validation-negative-matrix-live-contract-lane-report.v1",
-    "status": "pass",
-    "final_decision": "GO",
-    "lane_mode": mode,
-    "service_api_validation_negative_matrix_contract_status": "verified",
-    "service_api_validation_negative_matrix_policy_status": policy_report.get(
-        "service_api_validation_negative_matrix_policy_status"
-    ),
-    "docs_contract_status": "verified",
-    "fail_closed_status": "verified",
-    "fail_closed_reason_code": "service_api_validation_negative_matrix_policy_marker_missing:replay_guard_status",
-    "performance_budget_status": "verified",
-    "elapsed_seconds": elapsed_seconds,
-    "max_seconds": max_seconds,
-}
-lane_report_file.write_text(json.dumps(lane_report, sort_keys=True, indent=2) + "\n", encoding="utf-8")
-PY
-
-if [[ -n "$output_json" ]]; then
-  cp "$lane_report" "$output_json"
-fi
-if [[ -n "$policy_output_json" ]]; then
-  cp "$policy_report" "$policy_output_json"
-fi
-
-echo "status=pass"
-echo "final_decision=GO"
-echo "lane_mode=$mode"
-echo "service_api_validation_negative_matrix_contract_status=verified"
-echo "service_api_validation_negative_matrix_policy_status=verified"
-echo "docs_contract_status=verified"
-echo "fail_closed_status=verified"
-echo "fail_closed_reason_code=service_api_validation_negative_matrix_policy_marker_missing:replay_guard_status"
-echo "performance_budget_status=verified"
+service_api_contract_lane_run "$@"


### PR DESCRIPTION
## Summary
Migrates the first service API contract-lane wrapper tranche to the shared `service_api_contract_lane_runner.sh` and adds a deterministic parity/drift matrix guard for the family.

## Changes
- scripts/runtime/validate_service_api_prometheus_metrics_live_contract_lane.sh: converted from monolithic shell lane to shared-runner configuration wrapper.
- scripts/runtime/validate_service_api_graceful_shutdown_drain_live_contract_lane.sh: converted to shared-runner configuration wrapper.
- scripts/runtime/validate_service_api_shutdown_abrupt_close_regression_live_contract_lane.sh: converted to shared-runner configuration wrapper.
- scripts/runtime/validate_service_api_validation_negative_matrix_live_contract_lane.sh: converted to shared-runner configuration wrapper.
- scripts/runtime/service_api_tranche1_wrapper_family_parity_contract.py: new checker enforcing runner-backed wrapper markers and shell LOC budget for tranche-1 family.
- scripts/runtime/test_service_api_tranche1_wrapper_family_parity_matrix.sh: new parity matrix + drift tamper test.
- fixtures/ci/service_api_tranche1_wrapper_family_matrix.json: deterministic wrapper family matrix for tranche-1 contract checks.
- scripts/ci/test_ci_tools.sh: includes tranche-1 parity matrix test in CI tools lane.
- scripts/ci/test_ci_tools_command_surface_contract.sh: enforces CI command-surface entry for new tranche parity command.
- docs/ci/strategy.md: added tranche-1 migration guard command, migrated wrapper inventory, shell LOC budget, and deterministic drift reason marker.

## Risks & Compatibility
- Low. Wrapper behavior is preserved but now delegated to shared runner config; drift guards were added to fail closed.

## Validation
- [x] `cargo fmt --check` — clean (not required for script/docs-only changes)
- [x] `cargo clippy -- -D warnings` — clean (not required for script/docs-only changes)
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: wrapper parity checker and drift tamper matrix fail closed with deterministic reason codes.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | wrapper marker and budget invariants validated in `service_api_tranche1_wrapper_family_parity_contract.py` |
| Functional  | ✅     | dry-run contract-lane marker parity verified for all four migrated wrappers |
| Integration | ✅     | each migrated wrapper executes full validation+policy contract composition |
| Regression  | ✅     | tampered matrix triggers deterministic `wrapper_policy_checker_marker_missing:*` fail-closed reason |

Closes #3525
