### PR TITLE
test(ci): enforce fast-gate budget governance command coverage

### DIFF
--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -2756,6 +2756,10 @@ Fast-mode CI tooling regression coverage includes:
     - `reason_codes=command_surface_shell_line_total_trend_fail_delta_exceeded`
     - `reason_codes=command_surface_budget_status_fail`
 - Fast-gate runtime/cost trend contract lane (`test_run_fast_gate_budget_delta_contract_lane.sh`)
+  - delta report generator test:
+    - `bash scripts/ci/test_generate_fast_gate_budget_delta_report.sh`
+  - delta threshold checker test:
+    - `bash scripts/ci/test_check_fast_gate_budget_delta_threshold.sh`
   - contract lane command:
     - `bash scripts/ci/run_fast_gate_budget_delta_contract_lane.sh --output-json /tmp/fast-gate-budget-delta-contract-report.json`
   - deterministic threshold-guard reason-code surface:

--- a/scripts/ci/test_ci_strategy_contract.sh
+++ b/scripts/ci/test_ci_strategy_contract.sh
@@ -49,6 +49,8 @@ required_snippets=(
   "delta_threshold_violation_unwaived"
   "run_fast_gate_budget_delta_contract_lane.sh --output-json /tmp/fast-gate-budget-delta-contract-report.json"
   "test_run_fast_gate_budget_delta_contract_lane.sh"
+  "test_generate_fast_gate_budget_delta_report.sh"
+  "test_check_fast_gate_budget_delta_threshold.sh"
   "reason_codes=fast_gate_delta_threshold_file_stale"
   "reason_codes=fast_gate_delta_threshold_file_corrupt"
   "refresh .ci/fast-gate-budget-delta.env baseline and threshold metadata"

--- a/scripts/ci/test_ci_tools_command_surface_contract.sh
+++ b/scripts/ci/test_ci_tools_command_surface_contract.sh
@@ -102,6 +102,8 @@ required_commands=(
   'bash "$ROOT_DIR/scripts/ci/test_service_api_prometheus_metrics_ci_exclusion_policy.sh"'
   'bash "$ROOT_DIR/scripts/ci/test_run_test_harness_loc_soft_budget_contract_lane.sh"'
   'bash "$ROOT_DIR/scripts/ci/test_run_kolme_test_harness_loc_soft_budget_contract_lane.sh"'
+  'bash "$ROOT_DIR/scripts/ci/test_generate_fast_gate_budget_delta_report.sh"'
+  'bash "$ROOT_DIR/scripts/ci/test_check_fast_gate_budget_delta_threshold.sh"'
   'bash "$ROOT_DIR/scripts/ci/test_run_fast_gate_budget_delta_contract_lane.sh"'
   'bash "$ROOT_DIR/scripts/runtime/test_validate_local_retry_diagnostics_live.sh"'
   'bash "$ROOT_DIR/scripts/runtime/test_check_local_retry_diagnostics_live_policy.sh"'


### PR DESCRIPTION
## Summary
Wires fast-gate budget governance checks fully into the CI command-surface and strategy contracts so omission of any fast-gate budget checker is fail-closed. This tightens low-cost dry-run governance enforcement without expanding lane runtime.

Closes #3529
Refs #3527

## Changes
- `scripts/ci/test_ci_tools_command_surface_contract.sh`: require all three fast-gate budget governance commands in `scripts/ci/test_ci_tools.sh`.
- `docs/ci/strategy.md`: explicitly document fast-gate delta report generator and threshold checker tests alongside the existing contract lane test.
- `scripts/ci/test_ci_strategy_contract.sh`: require strategy snippets for the two additional fast-gate budget tests.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
KAMN_CI_STRATEGY_DOC_FILE=/tmp/strategy-missing-fast-gate-snippet.md bash scripts/ci/test_ci_strategy_contract.sh
```
Observed output (excerpt):
```text
CI strategy contract failed: missing snippet 'test_generate_fast_gate_budget_delta_report.sh'.
```
Exit code: `1`

### 🟢 Green Phase
Command:
```bash
bash scripts/ci/test_ci_strategy_contract.sh
```
Observed output:
```text
CI strategy contract tests passed.
```

### 🔁 Regression
Commands:
```bash
bash scripts/ci/test_generate_fast_gate_budget_delta_report.sh
bash scripts/ci/test_check_fast_gate_budget_delta_threshold.sh
bash scripts/ci/test_run_fast_gate_budget_delta_contract_lane.sh
bash scripts/ci/test_ci_tools_command_surface_contract.sh
bash scripts/ci/test_ci_strategy_contract.sh
```
Result: all pass.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | N/A    | None                 | Subtask changes are command-surface/doc-contract wiring in shell/doc artifacts. |
| Functional   | ✅     | `scripts/ci/test_ci_tools_command_surface_contract.sh` | |
| Integration  | ✅     | `scripts/ci/test_ci_strategy_contract.sh`, `scripts/ci/test_run_fast_gate_budget_delta_contract_lane.sh` | |
| Regression   | ✅     | `scripts/ci/test_generate_fast_gate_budget_delta_report.sh`, `scripts/ci/test_check_fast_gate_budget_delta_threshold.sh` | |
| Performance  | N/A    | None                 | No runtime-threshold or lane-budget expansion in this change. |

## Risks & Rollback
- Breaking changes: None.
- Risk: CI contract checks now enforce two additional snippet markers; missing doc/command entries will hard-fail.
- Rollback plan: Revert this commit to restore previous command-surface contract strictness.

## Documentation Updates
- Updated `docs/ci/strategy.md` with fast-gate budget generator/checker test references.

## Validation Checklist
- [x] `cargo fmt --check` — N/A (no Rust files changed)
- [x] `cargo clippy -- -D warnings` — N/A (no Rust files changed)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (scoped to fast-gate budget governance contracts)
- [x] Docs updated
