### PR TITLE
fix(deploy): fail closed promotion gate on missing runbook markers

### DIFF
--- a/docs/foundation/release-gonogo-checklist.md
+++ b/docs/foundation/release-gonogo-checklist.md
@@ -130,11 +130,15 @@ Milestone go/no-go review must aggregate linked preflight/live/gate artifacts in
   - `lineage_status=verified|fail-closed`
   - `milestone_review_go_no_go_gate_report_missing`
   - `milestone_review_live_node_validation_runtime_provider_mismatch`
+  - `milestone_review_operator_runbook_missing`
+  - `milestone_review_operator_runbook_markers_missing`
   - `contracts.linked_artifact_lineage_required=true`
+  - `contracts.operator_runbook_markers_required=true`
   - `contracts.live_bundle_runtime_provider_client_required=KolmeRuntimeCommitLiveProvider`
   - `contracts.go_no_go_gate_final_decision_required=GO`
 - Decision contract:
   - aggregate lineage drift or missing linked artifacts force `NO-GO` through deterministic milestone reason codes.
+  - missing operator runbook file/markers force `NO-GO` through milestone-review reason taxonomy.
   - policy checker fails closed on tampered milestone lineage payloads (`milestone review bundle lineage mismatch`).
 
 ## Staging Deploy + Rollback Rehearsal Contract (Issue #658)

--- a/docs/plans/2026-02-14-production-service-next-steps.md
+++ b/docs/plans/2026-02-14-production-service-next-steps.md
@@ -68,6 +68,8 @@ This refreshed version separates:
 ### Composed full-stack E2E against `kolme_fork`
 - Delivered chain: `#3333 -> #3419 -> #3420 -> (#3432, #3433, #3434)`.
 - Delivery includes composed local-heavy integration evidence bundle, release go/no-go linkage, and architecture/documentation lineage.
+- Promotion evidence gate lineage now fails closed when operator runbook markers drift or go missing (`milestone_review_operator_runbook_missing`, `milestone_review_operator_runbook_markers_missing`) in `scripts/deploy/gonogo_evidence_contract.py`.
+- Local validation drill override for runbook-marker regression uses `KAMN_GONOGO_RUNBOOK_DOC_FILE=<path>`.
 
 ### Runtime observability reason-code/checkpoint projection
 - Delivered chain: `#3333 -> #3471 -> #3472 -> #3473 -> #3474 -> #3490`.

--- a/scripts/deploy/gonogo_evidence_contract.py
+++ b/scripts/deploy/gonogo_evidence_contract.py
@@ -6,12 +6,14 @@ from __future__ import annotations
 import argparse
 from datetime import datetime, timezone
 import hashlib
+import os
 from pathlib import Path
 import sys
 from typing import Any
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR.parent))
+ROOT_DIR = SCRIPT_DIR.parent.parent
 
 from framework.contract_framework import (  # noqa: E402
     ContractError,
@@ -26,6 +28,15 @@ SCHEMA_VERSION = "kamn.release.gonogo.v1"
 MILESTONE_REVIEW_SCHEMA_VERSION = "kamn.release.milestone-review-bundle.v1"
 GO_DECISION = "GO"
 NO_GO_DECISION = "NO-GO"
+DEFAULT_OPERATOR_RUNBOOK_DOC = ROOT_DIR / "docs/foundation/upgrade-rollback-runbook.md"
+REQUIRED_OPERATOR_RUNBOOK_MARKERS = (
+    "## Deployment SLO Evidence and Rollback Automation Contract",
+    "run_deployment_slo_rollback_lane.sh",
+    "check_deployment_slo_rollback_policy.sh",
+    "run_deployment_slo_rollback_contract_lane.sh",
+    "kamn.deploy.slo-rollback-report.v1",
+    "Regression: #944",
+)
 REQUIRED_EVIDENCE_MARKERS = (
     "ci_fast_gate",
     "ci_deep_lane",
@@ -54,6 +65,26 @@ def _artifact_sha256(path: Path) -> str:
     if not path.is_file():
         return ""
     return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _resolve_operator_runbook_doc() -> Path:
+    override = os.getenv("KAMN_GONOGO_RUNBOOK_DOC_FILE", "").strip()
+    if override:
+        return Path(override).resolve()
+    return DEFAULT_OPERATOR_RUNBOOK_DOC.resolve()
+
+
+def _operator_runbook_marker_status(runbook_doc: Path) -> tuple[bool, list[str]]:
+    if not runbook_doc.is_file():
+        return False, list(REQUIRED_OPERATOR_RUNBOOK_MARKERS)
+
+    try:
+        runbook_text = runbook_doc.read_text(encoding="utf-8")
+    except OSError:
+        return False, list(REQUIRED_OPERATOR_RUNBOOK_MARKERS)
+
+    missing_markers = [marker for marker in REQUIRED_OPERATOR_RUNBOOK_MARKERS if marker not in runbook_text]
+    return len(missing_markers) == 0, missing_markers
 
 
 def _optional_milestone_artifact_paths(args: argparse.Namespace) -> dict[str, Path] | None:
@@ -100,6 +131,14 @@ def _load_milestone_artifact(
 
 def _build_milestone_review_bundle(artifact_paths: dict[str, Path]) -> dict[str, Any]:
     reason_codes: list[str] = []
+    operator_runbook_doc = _resolve_operator_runbook_doc()
+    operator_runbook_markers_present, operator_runbook_missing_markers = _operator_runbook_marker_status(
+        operator_runbook_doc
+    )
+    if not operator_runbook_doc.is_file():
+        reason_codes.append("milestone_review_operator_runbook_missing")
+    elif not operator_runbook_markers_present:
+        reason_codes.append("milestone_review_operator_runbook_markers_missing")
 
     preflight_summary = _load_milestone_artifact(
         artifact_paths["deployment_preflight_summary_file"],
@@ -229,6 +268,8 @@ def _build_milestone_review_bundle(artifact_paths: dict[str, Path]) -> dict[str,
     for field_name, path in artifact_paths.items():
         artifacts[field_name] = str(path)
         artifacts[f"{field_name[:-5]}sha256"] = _artifact_sha256(path)
+    artifacts["operator_runbook_doc_file"] = str(operator_runbook_doc)
+    artifacts["operator_runbook_doc_sha256"] = _artifact_sha256(operator_runbook_doc)
 
     return {
         "schema_version": MILESTONE_REVIEW_SCHEMA_VERSION,
@@ -249,9 +290,13 @@ def _build_milestone_review_bundle(artifact_paths: dict[str, Path]) -> dict[str,
             "live_node_validation_lineage_contract_present": live_rollback_recovery_lineage_required,
             "live_node_validation_rollback_lineage_present": live_rollback_evidence_present,
             "live_node_validation_recovery_lineage_present": live_recovery_evidence_present,
+            "operator_runbook_markers_present": operator_runbook_markers_present,
+            "operator_runbook_missing_markers": operator_runbook_missing_markers,
         },
         "contracts": {
             "linked_artifact_lineage_required": True,
+            "operator_runbook_markers_required": True,
+            "operator_runbook_required_markers": list(REQUIRED_OPERATOR_RUNBOOK_MARKERS),
             "deployment_preflight_scope_required": "ci-fast-gate",
             "live_bundle_scope_required": "local-only",
             "live_bundle_runtime_provider_client_required": "KolmeRuntimeCommitLiveProvider",

--- a/scripts/deploy/gonogo_evidence_contract_lane_contract.sh
+++ b/scripts/deploy/gonogo_evidence_contract_lane_contract.sh
@@ -125,4 +125,50 @@ if ! printf '%s\n' "$milestone_policy_output" | grep -q "^final_decision=GO$"; t
   exit 1
 fi
 
+runbook_marker_missing_doc="$TMP_DIR/runbook-marker-missing.md"
+cat >"$runbook_marker_missing_doc" <<'TXT'
+# Upgrade Rollback Runbook
+Marker intentionally incomplete for contract lane regression coverage.
+TXT
+
+milestone_missing_runbook_bundle_file="$TMP_DIR/gonogo-milestone-contract-missing-runbook.json"
+milestone_missing_runbook_output="$(
+  KAMN_GONOGO_RUNBOOK_DOC_FILE="$runbook_marker_missing_doc" \
+    bash "$GENERATOR" \
+      --output-file "$milestone_missing_runbook_bundle_file" \
+      --release-candidate "v1.0.0-contract-missing-runbook" \
+      --schema-target-version "1.0.0" \
+      --runtime-image-digest "sha256:contract-missing-runbook" \
+      --ci-fast-gate PASS \
+      --ci-deep-lane PASS \
+      --rollback-precheck PASS \
+      --rollback-trigger-status CLEAR \
+      --required-approvals 2 \
+      --received-approvals 2 \
+      --deployment-preflight-summary-file "$milestone_preflight_summary" \
+      --deployment-preflight-policy-file "$milestone_preflight_policy" \
+      --live-node-validation-summary-file "$milestone_live_bundle_summary" \
+      --live-node-validation-policy-file "$milestone_live_bundle_policy" \
+      --go-no-go-gate-report-file "$milestone_gate_report"
+)"
+
+if ! printf '%s\n' "$milestone_missing_runbook_output" | grep -q "^final_decision=NO-GO$"; then
+  echo "expected milestone aggregate generator decision to fail closed when runbook markers are missing" >&2
+  exit 1
+fi
+
+milestone_missing_runbook_policy_output="$(
+  KAMN_GONOGO_RUNBOOK_DOC_FILE="$runbook_marker_missing_doc" \
+    bash "$POLICY_CHECKER" \
+      --bundle-file "$milestone_missing_runbook_bundle_file"
+)"
+if ! printf '%s\n' "$milestone_missing_runbook_policy_output" | grep -q "^milestone_review_final_decision=NO-GO$"; then
+  echo "expected milestone aggregate policy decision marker to fail closed when runbook markers are missing" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$milestone_missing_runbook_policy_output" | grep -q "^final_decision=NO-GO$"; then
+  echo "expected milestone aggregate policy check decision to fail closed when runbook markers are missing" >&2
+  exit 1
+fi
+
 echo "go/no-go evidence contract lane tests passed."

--- a/scripts/deploy/test_generate_gonogo_evidence_bundle.sh
+++ b/scripts/deploy/test_generate_gonogo_evidence_bundle.sh
@@ -366,6 +366,60 @@ milestone_missing_artifact_policy_output="$(bash "$POLICY_CHECKER" --bundle-file
 assert_eq "$(extract_value "$milestone_missing_artifact_policy_output" "status")" "ok" "expected policy checker to preserve deterministic NO-GO for missing artifact bundle"
 assert_eq "$(extract_value "$milestone_missing_artifact_policy_output" "final_decision")" "NO-GO" "expected policy checker NO-GO decision for missing linked artifact bundle"
 
+milestone_missing_runbook_marker_doc="$TMP_DIR/milestone-runbook-marker-missing.md"
+cat >"$milestone_missing_runbook_marker_doc" <<'TXT'
+# Upgrade Rollback Runbook
+
+Marker intentionally incomplete for regression coverage.
+TXT
+
+milestone_missing_runbook_bundle="$TMP_DIR/gonogo-milestone-missing-runbook.json"
+milestone_missing_runbook_output="$(
+  KAMN_GONOGO_RUNBOOK_DOC_FILE="$milestone_missing_runbook_marker_doc" \
+    bash "$GENERATOR" \
+      --output-file "$milestone_missing_runbook_bundle" \
+      --release-candidate "v1.0.0-rc.6" \
+      --schema-target-version "1.0.0" \
+      --runtime-image-digest "sha256:milestone-missing-runbook" \
+      --ci-fast-gate PASS \
+      --ci-deep-lane PASS \
+      --rollback-precheck PASS \
+      --rollback-trigger-status CLEAR \
+      --required-approvals 2 \
+      --received-approvals 2 \
+      --deployment-preflight-summary-file "$milestone_preflight_summary" \
+      --deployment-preflight-policy-file "$milestone_preflight_policy" \
+      --live-node-validation-summary-file "$milestone_live_bundle_summary" \
+      --live-node-validation-policy-file "$milestone_live_bundle_policy" \
+      --go-no-go-gate-report-file "$milestone_gate_report"
+)"
+
+assert_eq "$(extract_value "$milestone_missing_runbook_output" "final_decision")" "NO-GO" "expected milestone bundle to fail closed when operator runbook markers are missing"
+
+python3 - "$milestone_missing_runbook_bundle" <<'PY'
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+milestone = payload.get("milestone_review_bundle", {})
+reason_codes = milestone.get("reason_codes")
+if not isinstance(reason_codes, list):
+    raise SystemExit("expected milestone reason_codes list for missing runbook marker case")
+if "milestone_review_operator_runbook_markers_missing" not in reason_codes:
+    raise SystemExit("expected missing operator runbook markers reason code in milestone review bundle")
+if milestone.get("lineage_status") != "fail-closed":
+    raise SystemExit("expected fail-closed lineage status for missing runbook marker case")
+PY
+
+milestone_missing_runbook_policy_output="$(
+  KAMN_GONOGO_RUNBOOK_DOC_FILE="$milestone_missing_runbook_marker_doc" \
+    bash "$POLICY_CHECKER" \
+      --bundle-file "$milestone_missing_runbook_bundle"
+)"
+assert_eq "$(extract_value "$milestone_missing_runbook_policy_output" "status")" "ok" "expected policy checker to preserve deterministic NO-GO for missing runbook marker bundle"
+assert_eq "$(extract_value "$milestone_missing_runbook_policy_output" "final_decision")" "NO-GO" "expected policy checker NO-GO decision for missing runbook marker bundle"
+
 milestone_lineage_tampered_bundle="$TMP_DIR/gonogo-milestone-lineage-tampered.json"
 cp "$milestone_bundle" "$milestone_lineage_tampered_bundle"
 python3 - "$milestone_lineage_tampered_bundle" <<'PY'


### PR DESCRIPTION
## Summary
Hardens promotion go/no-go milestone evidence validation so operator runbook lineage markers are enforced as deterministic fail-closed requirements. Missing runbook file/markers now force `NO-GO` with explicit reason codes and are covered by contract-lane and bundle regressions.

Closes #3543
Refs #3541

## Changes
- `scripts/deploy/gonogo_evidence_contract.py`: add operator runbook marker validation for milestone review bundles, with fail-closed reason codes:
  - `milestone_review_operator_runbook_missing`
  - `milestone_review_operator_runbook_markers_missing`
- `scripts/deploy/gonogo_evidence_contract.py`: include operator runbook lineage fields in milestone bundle artifacts/observed/contracts.
- `scripts/deploy/test_generate_gonogo_evidence_bundle.sh`: add regression drill proving deterministic `NO-GO` when runbook markers are missing.
- `scripts/deploy/gonogo_evidence_contract_lane_contract.sh`: extend lane contract with missing-runbook-marker `NO-GO` scenario.
- `docs/plans/2026-02-14-production-service-next-steps.md`: add promotion gate/runbook lineage references.
- `docs/foundation/release-gonogo-checklist.md`: document runbook-marker fail-closed milestone reason taxonomy.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
bash scripts/deploy/test_generate_gonogo_evidence_bundle.sh
```
Observed failing output (before implementation):
```text
expected milestone bundle to fail closed when operator runbook markers are missing: expected 'NO-GO', got 'GO'
```
Exit code: `1`

### 🟢 Green Phase
Command:
```bash
bash scripts/deploy/test_generate_gonogo_evidence_bundle.sh
```
Observed output:
```text
go/no-go evidence bundle tests passed.
```

### 🔁 Regression
Commands:
```bash
bash scripts/deploy/test_generate_gonogo_evidence_bundle.sh
bash scripts/deploy/test_run_gonogo_evidence_contract_lane.sh
bash scripts/ci/test_production_service_next_steps_contract.sh
bash scripts/ci/test_ci_strategy_contract.sh
cargo test -p kamn-core --test release_gonogo_checklist_docs
```
Result: all pass.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | N/A    | None                 | Subtask scope is deploy contract/policy and docs-contract behavior at lane level. |
| Functional   | ✅     | `scripts/deploy/test_generate_gonogo_evidence_bundle.sh` | |
| Integration  | ✅     | `scripts/deploy/test_run_gonogo_evidence_contract_lane.sh`, `cargo test -p kamn-core --test release_gonogo_checklist_docs` | |
| Regression   | ✅     | Missing-runbook-marker NO-GO drill in go/no-go bundle + lane contract | |
| Performance  | N/A    | None                 | No lane runtime budget threshold changes introduced. |

## Risks & Rollback
- Breaking changes: None.
- Risk: promotion milestone bundles now fail closed if operator runbook file/markers drift.
- Rollback plan: Revert this commit to restore prior milestone marker requirements.

## Documentation Updates
- Updated `docs/plans/2026-02-14-production-service-next-steps.md` with promotion gate/runbook lineage references.
- Updated `docs/foundation/release-gonogo-checklist.md` milestone marker taxonomy.

## Validation Checklist
- [x] `cargo fmt --check` — N/A (no Rust files changed)
- [x] `cargo clippy -- -D warnings` — N/A (no Rust files changed)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (scoped to changed deploy/doc surfaces)
- [x] Docs updated
