### PR TITLE
test(kamn-core): add deterministic proptest task and escrow invariants (#3532)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
 name = "axum"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -92,6 +98,21 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -251,6 +272,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "ff"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -265,6 +292,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "form_urlencoded"
@@ -507,6 +540,7 @@ version = "0.1.0"
 dependencies = [
  "k256",
  "kamn-kolme",
+ "proptest",
  "rusqlite",
  "rustls",
  "rustls-pemfile",
@@ -553,6 +587,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -585,6 +625,15 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -646,6 +695,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -699,6 +773,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
+
+[[package]]
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -734,6 +823,19 @@ dependencies = [
  "hashlink",
  "libsqlite3-sys",
  "smallvec",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -777,6 +879,18 @@ dependencies = [
  "ring",
  "rustls-pki-types",
  "untrusted",
+]
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
 ]
 
 [[package]]
@@ -969,6 +1083,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
+name = "tempfile"
+version = "3.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1099,6 +1226,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1127,6 +1260,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "wasi"

--- a/crates/kamn-core/Cargo.toml
+++ b/crates/kamn-core/Cargo.toml
@@ -21,6 +21,7 @@ webpki-roots = { version = "1.0.3", optional = true }
 
 [dev-dependencies]
 k256 = { version = "0.13.4", features = ["ecdsa"] }
+proptest = "1.6.0"
 
 [lints]
 workspace = true

--- a/crates/kamn-core/proptest-regressions/tests/task_escrow_proptest_invariants.txt
+++ b/crates/kamn-core/proptest-regressions/tests/task_escrow_proptest_invariants.txt
@@ -1,0 +1,6 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.

--- a/crates/kamn-core/tests/runtime_watchdog_attestation_docs.rs
+++ b/crates/kamn-core/tests/runtime_watchdog_attestation_docs.rs
@@ -71,6 +71,21 @@ fn doc_contains_parser_fuzz_surface_inventory_contracts() {
 }
 
 #[test]
+fn doc_contains_task_escrow_proptest_invariant_catalog_contracts() {
+    assert!(DOC.contains("## Task/Escrow Proptest Invariant Catalog"));
+    assert!(DOC.contains("cargo test -p kamn-core --test task_escrow_proptest_invariants"));
+    assert!(DOC.contains("TASK_SEED"));
+    assert!(DOC.contains("ESCROW_SEED"));
+    assert!(DOC.contains("FileFailurePersistence::SourceParallel(\"proptest-regressions\")"));
+    assert!(DOC.contains(
+        "crates/kamn-core/proptest-regressions/tests/task_escrow_proptest_invariants.txt"
+    ));
+    assert!(DOC.contains("accepted transitions must match the legal state graph."));
+    assert!(DOC.contains("released + refunded + remaining == total"));
+    assert!(DOC.contains("deterministic seed corpus is versioned in git"));
+}
+
+#[test]
 fn regression_requires_divergence_and_censorship_guard_rules() {
     // Regression: #383
     assert!(DOC

--- a/crates/kamn-core/tests/task_escrow_proptest_invariants.rs
+++ b/crates/kamn-core/tests/task_escrow_proptest_invariants.rs
@@ -1,0 +1,307 @@
+use kamn_core::{
+    EscrowLifecycle, EscrowLifecycleError, EscrowStatus, TaskLifecycle, TaskLifecycleError,
+    TaskState, TaskTransition,
+};
+use proptest::collection::vec;
+use proptest::prelude::*;
+use proptest::test_runner::{
+    Config as ProptestConfig, FileFailurePersistence, RngAlgorithm, RngSeed,
+};
+
+const TASK_CASES: u32 = 192;
+const ESCROW_CASES: u32 = 192;
+const MAX_SEQUENCE_LEN: usize = 32;
+const TASK_SEED: u64 = 0x3532_0000_0000_0001;
+const ESCROW_SEED: u64 = 0x3532_0000_0000_0002;
+const PROPTASK_SOURCE_PATH: &str = file!();
+
+#[derive(Debug, Clone, Copy)]
+enum EscrowAction {
+    ReleaseScaled(u8),
+    ReleaseRemaining,
+    Dispute,
+    ResolveHalfSplit,
+    RefundRemaining,
+}
+
+fn deterministic_config(cases: u32, seed: u64) -> ProptestConfig {
+    ProptestConfig {
+        cases,
+        failure_persistence: Some(Box::new(FileFailurePersistence::SourceParallel(
+            "proptest-regressions",
+        ))),
+        source_file: Some(PROPTASK_SOURCE_PATH),
+        rng_algorithm: RngAlgorithm::ChaCha,
+        rng_seed: RngSeed::Fixed(seed),
+        ..ProptestConfig::default()
+    }
+}
+
+fn task_transition_strategy() -> impl Strategy<Value = TaskTransition> {
+    prop_oneof![
+        Just(TaskTransition::Accept),
+        Just(TaskTransition::Delegate),
+        Just(TaskTransition::StartWork),
+        Just(TaskTransition::RequestInput),
+        Just(TaskTransition::Block),
+        Just(TaskTransition::Complete),
+        Just(TaskTransition::Fail),
+        Just(TaskTransition::Cancel),
+    ]
+}
+
+fn escrow_action_strategy() -> impl Strategy<Value = EscrowAction> {
+    prop_oneof![
+        (1_u8..=16_u8).prop_map(EscrowAction::ReleaseScaled),
+        Just(EscrowAction::ReleaseRemaining),
+        Just(EscrowAction::Dispute),
+        Just(EscrowAction::ResolveHalfSplit),
+        Just(EscrowAction::RefundRemaining),
+    ]
+}
+
+fn is_legal_task_state_step(from: TaskState, to: TaskState) -> bool {
+    matches!(
+        (from, to),
+        (TaskState::Submitted, TaskState::Accepted)
+            | (TaskState::Submitted, TaskState::Cancelled)
+            | (TaskState::Accepted, TaskState::Delegated)
+            | (TaskState::Accepted, TaskState::InProgress)
+            | (TaskState::Accepted, TaskState::Cancelled)
+            | (TaskState::Delegated, TaskState::InProgress)
+            | (TaskState::Delegated, TaskState::Cancelled)
+            | (TaskState::InProgress, TaskState::Blocked)
+            | (TaskState::InProgress, TaskState::InputRequired)
+            | (TaskState::InProgress, TaskState::Completed)
+            | (TaskState::InProgress, TaskState::Failed)
+            | (TaskState::InProgress, TaskState::Cancelled)
+            | (TaskState::InputRequired, TaskState::InProgress)
+            | (TaskState::InputRequired, TaskState::Failed)
+            | (TaskState::InputRequired, TaskState::Cancelled)
+            | (TaskState::Blocked, TaskState::InProgress)
+            | (TaskState::Blocked, TaskState::Failed)
+            | (TaskState::Blocked, TaskState::Cancelled)
+    )
+}
+
+fn apply_escrow_action(
+    escrow: &mut EscrowLifecycle,
+    action: EscrowAction,
+) -> Result<(), EscrowLifecycleError> {
+    let remaining = escrow.remaining_amount();
+    match action {
+        EscrowAction::ReleaseScaled(scale) => {
+            let amount = if remaining == 0 {
+                1
+            } else {
+                (remaining.saturating_mul(u128::from(scale)) + 15) / 16
+            }
+            .max(1);
+            escrow.release(amount)
+        }
+        EscrowAction::ReleaseRemaining => escrow.release(remaining.max(1)),
+        EscrowAction::Dispute => escrow.dispute(),
+        EscrowAction::ResolveHalfSplit => {
+            let release_to_payee = remaining / 2;
+            let refund_to_payer = remaining.saturating_sub(release_to_payee);
+            escrow.resolve(release_to_payee, refund_to_payer)
+        }
+        EscrowAction::RefundRemaining => escrow.refund_remaining(),
+    }
+}
+
+fn escrow_invariant_violation(escrow: &EscrowLifecycle, total: u128) -> Option<String> {
+    let released = escrow.released_amount();
+    let refunded = escrow.refunded_amount();
+    let remaining = escrow.remaining_amount();
+    let total_projection = released
+        .checked_add(refunded)
+        .and_then(|value| value.checked_add(remaining));
+    if total_projection != Some(total) {
+        return Some(format!(
+            "amount conservation failed: released={released}, refunded={refunded}, remaining={remaining}, total={total}"
+        ));
+    }
+
+    match escrow.status() {
+        EscrowStatus::Funded => {
+            if released != 0 || refunded != 0 || remaining != total {
+                return Some(format!(
+                    "funded projection mismatch: released={released}, refunded={refunded}, remaining={remaining}, total={total}"
+                ));
+            }
+        }
+        EscrowStatus::PartiallyReleased {
+            released: status_released,
+            remaining: status_remaining,
+        } => {
+            if status_released != released || status_remaining != remaining || remaining == 0 {
+                return Some(format!(
+                    "partial projection mismatch: status_released={status_released}, released={released}, status_remaining={status_remaining}, remaining={remaining}"
+                ));
+            }
+        }
+        EscrowStatus::Released => {
+            if released != total || refunded != 0 || remaining != 0 {
+                return Some(format!(
+                    "released projection mismatch: released={released}, refunded={refunded}, remaining={remaining}, total={total}"
+                ));
+            }
+        }
+        EscrowStatus::Refunded => {
+            if refunded == 0 || remaining != 0 {
+                return Some(format!(
+                    "refunded projection mismatch: released={released}, refunded={refunded}, remaining={remaining}, total={total}"
+                ));
+            }
+        }
+        EscrowStatus::Disputed => {
+            if remaining == 0 {
+                return Some("disputed projection must keep non-zero remaining balance".to_owned());
+            }
+        }
+        EscrowStatus::Resolved {
+            released_total,
+            refunded_total,
+        } => {
+            if released_total != released || refunded_total != refunded || remaining != 0 {
+                return Some(format!(
+                    "resolved projection mismatch: status_released={released_total}, released={released}, status_refunded={refunded_total}, refunded={refunded}, remaining={remaining}"
+                ));
+            }
+        }
+    }
+    None
+}
+
+#[test]
+fn unit_task_escrow_proptest_config_is_deterministic_and_persistent() {
+    let config = deterministic_config(TASK_CASES, TASK_SEED);
+    assert_eq!(config.cases, TASK_CASES);
+    assert_eq!(config.rng_algorithm, RngAlgorithm::ChaCha);
+    assert_eq!(config.rng_seed, RngSeed::Fixed(TASK_SEED));
+    assert_eq!(config.source_file, Some(PROPTASK_SOURCE_PATH));
+    assert!(config.failure_persistence.is_some());
+}
+
+#[test]
+fn regression_task_escrow_proptest_seed_corpus_is_tracked() {
+    let corpus = include_str!("../proptest-regressions/tests/task_escrow_proptest_invariants.txt");
+    assert!(corpus.contains("Seeds for failure cases"));
+}
+
+proptest! {
+    #![proptest_config(deterministic_config(TASK_CASES, TASK_SEED))]
+
+    #[test]
+    fn functional_task_lifecycle_proptest_sequence_invariants_hold(
+        transitions in vec(task_transition_strategy(), 0..(MAX_SEQUENCE_LEN + 1))
+    ) {
+        let mut lifecycle = TaskLifecycle::new("task-proptest-sequence").expect("task lifecycle must initialize");
+        for transition in transitions {
+            let before_state = lifecycle.state();
+            let before_history = lifecycle.history();
+
+            match lifecycle.transition(transition) {
+                Ok(()) => {
+                    let after_state = lifecycle.state();
+                    prop_assert!(
+                        is_legal_task_state_step(before_state, after_state),
+                        "illegal successful step: {before_state:?} -> {after_state:?} via {transition:?}"
+                    );
+                    prop_assert_eq!(lifecycle.history().len(), before_history.len() + 1);
+                }
+                Err(TaskLifecycleError::InvalidTransition { from, transition: rejected }) => {
+                    prop_assert_eq!(from, before_state);
+                    prop_assert_eq!(rejected, transition);
+                    prop_assert_eq!(lifecycle.state(), before_state);
+                    prop_assert_eq!(lifecycle.history(), before_history);
+                }
+                Err(TaskLifecycleError::TerminalState(state)) => {
+                    prop_assert_eq!(state, before_state);
+                    prop_assert_eq!(lifecycle.state(), before_state);
+                    prop_assert_eq!(lifecycle.history(), before_history);
+                }
+                Err(error) => {
+                    prop_assert!(false, "unexpected task lifecycle error: {error:?}");
+                }
+            }
+
+            let history = lifecycle.history();
+            prop_assert_eq!(history.first().copied(), Some(TaskState::Submitted));
+            prop_assert_eq!(history.last().copied(), Some(lifecycle.state()));
+        }
+    }
+}
+
+proptest! {
+    #![proptest_config(deterministic_config(TASK_CASES, TASK_SEED ^ 0x0f0f_0f0f))]
+
+    #[test]
+    fn integration_task_lifecycle_proptest_restore_roundtrip_is_stable(
+        transitions in vec(task_transition_strategy(), 0..(MAX_SEQUENCE_LEN + 1))
+    ) {
+        let mut lifecycle = TaskLifecycle::new("task-proptest-restore").expect("task lifecycle must initialize");
+        for transition in transitions {
+            let _ = lifecycle.transition(transition);
+        }
+
+        let history = lifecycle.history();
+        let restored = TaskLifecycle::restore("task-proptest-restore-copy", history.clone())
+            .expect("history generated by transition replay must restore");
+        prop_assert_eq!(restored.state(), lifecycle.state());
+        prop_assert_eq!(restored.history(), history);
+        prop_assert_eq!(restored.history().first().copied(), Some(TaskState::Submitted));
+    }
+}
+
+proptest! {
+    #![proptest_config(deterministic_config(ESCROW_CASES, ESCROW_SEED))]
+
+    #[test]
+    fn integration_escrow_proptest_conserves_amounts_and_status_projections(
+        total_amount in 1_u128..513_u128,
+        actions in vec(escrow_action_strategy(), 0..(MAX_SEQUENCE_LEN + 1))
+    ) {
+        let mut escrow = EscrowLifecycle::new(total_amount).expect("escrow lifecycle must initialize");
+        if let Some(violation) = escrow_invariant_violation(&escrow, total_amount) {
+            prop_assert!(false, "{violation}");
+        }
+
+        for action in actions {
+            let before_status = escrow.status();
+            let before_released = escrow.released_amount();
+            let before_refunded = escrow.refunded_amount();
+            let before_remaining = escrow.remaining_amount();
+
+            match apply_escrow_action(&mut escrow, action) {
+                Ok(()) => {
+                    if let Some(violation) = escrow_invariant_violation(&escrow, total_amount) {
+                        prop_assert!(false, "{violation}");
+                    }
+                }
+                Err(error) => {
+                    prop_assert_eq!(escrow.status(), before_status);
+                    prop_assert_eq!(escrow.released_amount(), before_released);
+                    prop_assert_eq!(escrow.refunded_amount(), before_refunded);
+                    prop_assert_eq!(escrow.remaining_amount(), before_remaining);
+                    prop_assert!(
+                        matches!(
+                            error.reason_code(),
+                            "escrow_amount_zero"
+                                | "escrow_amount_invalid"
+                                | "escrow_transition_invalid"
+                                | "escrow_resolution_mismatch"
+                                | "escrow_amount_overflow"
+                        ),
+                        "unexpected escrow rejection reason code: {}",
+                        error.reason_code()
+                    );
+                    if let Some(violation) = escrow_invariant_violation(&escrow, total_amount) {
+                        prop_assert!(false, "{violation}");
+                    }
+                }
+            }
+        }
+    }
+}

--- a/docs/foundation/runtime-watchdog-attestation.md
+++ b/docs/foundation/runtime-watchdog-attestation.md
@@ -97,6 +97,25 @@ It complements `docs/foundation/watchdog-node-prototype.md` with runtime-facing 
 - Cost boundary:
   - parser fuzz and concurrency deep paths remain local-only and excluded from `ci-fast-gate`; PR path uses deterministic contract-lane evidence.
 
+## Task/Escrow Proptest Invariant Catalog
+- Proptest target:
+  - `cargo test -p kamn-core --test task_escrow_proptest_invariants`
+- Deterministic runner contract:
+  - fixed runner seeds are used for task and escrow invariants (`TASK_SEED`, `ESCROW_SEED`).
+  - runner persistence is enabled with `FileFailurePersistence::SourceParallel("proptest-regressions")`.
+  - tracked seed corpus path: `crates/kamn-core/proptest-regressions/tests/task_escrow_proptest_invariants.txt`.
+- Task lifecycle invariants:
+  - accepted transitions must match the legal state graph.
+  - rejected transitions must preserve state and history.
+  - restore replay roundtrip must preserve state and history.
+- Escrow safety invariants:
+  - `released + refunded + remaining == total` for every step.
+  - terminal projections (`Released`, `Refunded`, `Resolved`) must keep remaining amount at zero.
+  - rejected escrow actions must preserve status and ledger counters.
+- Regression inventory:
+  - deterministic seed corpus is versioned in git and replayed before novel generated cases.
+  - rejection reason-code guardrail allows only expected escrow classes (`escrow_amount_invalid`, `escrow_transition_invalid`, `escrow_resolution_mismatch`, `escrow_amount_overflow`) inside this lane.
+
 ## Incident Response Mapping
 - Runtime watchdog output is triaged with `WatchdogSeverity` and `incident_fingerprint`.
 - Incident operators execute deterministic response workflow from `docs/foundation/upgrade-rollback-runbook.md`.
@@ -116,6 +135,10 @@ cargo test -p kamn-core runtime::tests::functional_runtime_backpressure_classifi
 bash scripts/runtime/test_generate_watchdog_proof_consensus_evidence_bundle.sh
 bash scripts/runtime/test_run_watchdog_proof_consensus_contract_lane.sh
 bash scripts/runtime/test_run_watchdog_proof_consensus_deep_lane.sh
+cargo test -p kamn-core --test task_escrow_proptest_invariants unit_task_escrow_proptest_config_is_deterministic_and_persistent -- --exact
+cargo test -p kamn-core --test task_escrow_proptest_invariants functional_task_lifecycle_proptest_sequence_invariants_hold -- --exact
+cargo test -p kamn-core --test task_escrow_proptest_invariants integration_task_lifecycle_proptest_restore_roundtrip_is_stable -- --exact
+cargo test -p kamn-core --test task_escrow_proptest_invariants integration_escrow_proptest_conserves_amounts_and_status_projections -- --exact
 cargo fmt --check
 cargo clippy -p kamn-core -- -D warnings
 ```


### PR DESCRIPTION
## Summary
Adds deterministic proptest-based invariant coverage for task lifecycle and escrow safety, including tracked seed-corpus persistence and watchdog attestation documentation updates.

## Changes
- crates/kamn-core/tests/task_escrow_proptest_invariants.rs: new proptest suite covering task transition legality/history stability, restore roundtrip stability, and escrow amount/status invariants
- crates/kamn-core/proptest-regressions/tests/task_escrow_proptest_invariants.txt: tracked deterministic seed-corpus file for replay
- crates/kamn-core/Cargo.toml: add proptest dev-dependency for invariant generators
- crates/kamn-core/tests/runtime_watchdog_attestation_docs.rs: enforce task/escrow proptest catalog doc markers
- docs/foundation/runtime-watchdog-attestation.md: add Task/Escrow Proptest Invariant Catalog and validation commands

## Risks & Compatibility
- Low: test-only and documentation changes; no runtime behavior changes

## Validation
- [x] cargo fmt --check — clean
- [x] cargo clippy -- -D warnings — clean (cargo clippy -p kamn-core -- -D warnings)
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: validated deterministic red to green path for new proptest target and docs contract lane

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | unit_task_escrow_proptest_config_is_deterministic_and_persistent |
| Functional  | ✅     | functional_task_lifecycle_proptest_sequence_invariants_hold |
| Integration | ✅     | integration_task_lifecycle_proptest_restore_roundtrip_is_stable; integration_escrow_proptest_conserves_amounts_and_status_projections; task_escrow_transition_contracts suite |
| Regression  | ✅     | tracked corpus contract plus deterministic runner seed and persistence wiring |

Closes #3532
