### PR TITLE
test(kamn-core): add proptest peer lifecycle legality invariants (#3533)

### DIFF
--- a/crates/kamn-core/proptest-regressions/tests/peer_lifecycle_proptest_invariants.txt
+++ b/crates/kamn-core/proptest-regressions/tests/peer_lifecycle_proptest_invariants.txt
@@ -1,0 +1,6 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.

--- a/crates/kamn-core/tests/p2p_transport_docs.rs
+++ b/crates/kamn-core/tests/p2p_transport_docs.rs
@@ -46,6 +46,21 @@ fn architecture_doc_contains_runtime_wiring_and_guardrails() {
 }
 
 #[test]
+fn architecture_doc_contains_peer_lifecycle_proptest_invariant_catalog() {
+    assert!(DOC.contains("## Peer Lifecycle Proptest Invariants"));
+    assert!(DOC.contains("cargo test -p kamn-core --test peer_lifecycle_proptest_invariants"));
+    assert!(DOC.contains("LEGALITY_SEED"));
+    assert!(DOC.contains("IDEMPOTENCE_SEED"));
+    assert!(DOC.contains("REPLAY_SEED"));
+    assert!(DOC.contains("FileFailurePersistence::SourceParallel(\"proptest-regressions\")"));
+    assert!(DOC.contains(
+        "crates/kamn-core/proptest-regressions/tests/peer_lifecycle_proptest_invariants.txt"
+    ));
+    assert!(DOC.contains("invalid transition retries must remain idempotent"));
+    assert!(DOC.contains("runtime_peer_transition_invalid"));
+}
+
+#[test]
 fn roadmap_references_phase_31_initial_p2p_slice() {
     assert!(ROADMAP.contains("Phase 3.1 initial slice delivered"));
     assert!(ROADMAP.contains("Task #2921, Subtask #2922"));

--- a/crates/kamn-core/tests/peer_lifecycle_proptest_invariants.rs
+++ b/crates/kamn-core/tests/peer_lifecycle_proptest_invariants.rs
@@ -1,0 +1,181 @@
+use kamn_core::{PeerLifecycle, PeerLifecycleEvent, PeerLifecycleState, RuntimeLifecycleError};
+use proptest::collection::vec;
+use proptest::prelude::*;
+use proptest::test_runner::{
+    Config as ProptestConfig, FileFailurePersistence, RngAlgorithm, RngSeed,
+};
+
+const CASES: u32 = 192;
+const MAX_SEQUENCE_LEN: usize = 40;
+const LEGALITY_SEED: u64 = 0x3533_0000_0000_0001;
+const IDEMPOTENCE_SEED: u64 = 0x3533_0000_0000_0002;
+const REPLAY_SEED: u64 = 0x3533_0000_0000_0003;
+const PROPTEST_SOURCE_PATH: &str = file!();
+
+fn deterministic_config(cases: u32, seed: u64) -> ProptestConfig {
+    ProptestConfig {
+        cases,
+        failure_persistence: Some(Box::new(FileFailurePersistence::SourceParallel(
+            "proptest-regressions",
+        ))),
+        source_file: Some(PROPTEST_SOURCE_PATH),
+        rng_algorithm: RngAlgorithm::ChaCha,
+        rng_seed: RngSeed::Fixed(seed),
+        ..ProptestConfig::default()
+    }
+}
+
+fn peer_event_strategy() -> impl Strategy<Value = PeerLifecycleEvent> {
+    prop_oneof![
+        Just(PeerLifecycleEvent::StartConnect),
+        Just(PeerLifecycleEvent::HandshakeSucceeded),
+        Just(PeerLifecycleEvent::HeartbeatMissed),
+        Just(PeerLifecycleEvent::HeartbeatRestored),
+        Just(PeerLifecycleEvent::Disconnect),
+        Just(PeerLifecycleEvent::Rejoin),
+    ]
+}
+
+fn expected_next_state(
+    from: PeerLifecycleState,
+    event: PeerLifecycleEvent,
+) -> Option<PeerLifecycleState> {
+    match (from, event) {
+        (PeerLifecycleState::Disconnected, PeerLifecycleEvent::StartConnect)
+        | (PeerLifecycleState::Disconnected, PeerLifecycleEvent::Rejoin) => {
+            Some(PeerLifecycleState::Connecting)
+        }
+        (PeerLifecycleState::Connecting, PeerLifecycleEvent::HandshakeSucceeded) => {
+            Some(PeerLifecycleState::Active)
+        }
+        (PeerLifecycleState::Connecting, PeerLifecycleEvent::Disconnect)
+        | (PeerLifecycleState::Active, PeerLifecycleEvent::Disconnect)
+        | (PeerLifecycleState::Degraded, PeerLifecycleEvent::Disconnect) => {
+            Some(PeerLifecycleState::Disconnected)
+        }
+        (PeerLifecycleState::Active, PeerLifecycleEvent::HeartbeatMissed) => {
+            Some(PeerLifecycleState::Degraded)
+        }
+        (PeerLifecycleState::Degraded, PeerLifecycleEvent::HeartbeatRestored) => {
+            Some(PeerLifecycleState::Active)
+        }
+        _ => None,
+    }
+}
+
+fn replay_sequence(
+    sequence: &[PeerLifecycleEvent],
+) -> (
+    PeerLifecycleState,
+    Vec<Result<PeerLifecycleState, RuntimeLifecycleError>>,
+) {
+    let mut lifecycle = PeerLifecycle::new("peer-proptest-replay").expect("peer should initialize");
+    let mut outcomes = Vec::with_capacity(sequence.len());
+    for event in sequence {
+        outcomes.push(lifecycle.transition(*event));
+    }
+    (lifecycle.state(), outcomes)
+}
+
+#[test]
+fn unit_peer_lifecycle_proptest_config_is_deterministic_and_persistent() {
+    let config = deterministic_config(CASES, LEGALITY_SEED);
+    assert_eq!(config.cases, CASES);
+    assert_eq!(config.rng_algorithm, RngAlgorithm::ChaCha);
+    assert_eq!(config.rng_seed, RngSeed::Fixed(LEGALITY_SEED));
+    assert_eq!(config.source_file, Some(PROPTEST_SOURCE_PATH));
+    assert!(config.failure_persistence.is_some());
+}
+
+#[test]
+fn regression_peer_lifecycle_seed_corpus_is_tracked() {
+    let corpus =
+        include_str!("../proptest-regressions/tests/peer_lifecycle_proptest_invariants.txt");
+    assert!(corpus.contains("Seeds for failure cases"));
+}
+
+proptest! {
+    #![proptest_config(deterministic_config(CASES, LEGALITY_SEED))]
+
+    #[test]
+    fn functional_peer_lifecycle_proptest_enforces_legal_transition_graph(
+        sequence in vec(peer_event_strategy(), 0..(MAX_SEQUENCE_LEN + 1))
+    ) {
+        let mut lifecycle = PeerLifecycle::new("peer-proptest-legality").expect("peer should initialize");
+        for event in sequence {
+            let before_state = lifecycle.state();
+            let expected = expected_next_state(before_state, event);
+
+            match (expected, lifecycle.transition(event)) {
+                (Some(next_state), Ok(applied_state)) => {
+                    prop_assert_eq!(applied_state, next_state);
+                    prop_assert_eq!(lifecycle.state(), next_state);
+                }
+                (None, Err(RuntimeLifecycleError::InvalidTransition { from, event: rejected })) => {
+                    prop_assert_eq!(from, before_state);
+                    prop_assert_eq!(rejected, event);
+                    prop_assert_eq!(lifecycle.state(), before_state);
+                }
+                (Some(next_state), Err(error)) => {
+                    prop_assert!(
+                        false,
+                        "expected legal transition to {next_state:?} from {before_state:?} via {event:?}, got error {error:?}"
+                    );
+                }
+                (None, Ok(applied_state)) => {
+                    prop_assert!(
+                        false,
+                        "expected illegal transition rejection from {before_state:?} via {event:?}, got state {applied_state:?}"
+                    );
+                }
+                (None, Err(RuntimeLifecycleError::InvalidPeerId)) => {
+                    prop_assert!(false, "peer id remains valid for the full property lane");
+                }
+            }
+        }
+    }
+}
+
+proptest! {
+    #![proptest_config(deterministic_config(CASES, IDEMPOTENCE_SEED))]
+
+    #[test]
+    fn integration_peer_lifecycle_proptest_invalid_event_replays_are_idempotent(
+        prefix in vec(peer_event_strategy(), 0..(MAX_SEQUENCE_LEN + 1)),
+        repeated_event in peer_event_strategy(),
+        repeats in 1_u8..=8_u8
+    ) {
+        let mut lifecycle = PeerLifecycle::new("peer-proptest-idempotence").expect("peer should initialize");
+        for event in prefix {
+            let _ = lifecycle.transition(event);
+        }
+
+        let baseline_state = lifecycle.state();
+        prop_assume!(expected_next_state(baseline_state, repeated_event).is_none());
+
+        for _ in 0..usize::from(repeats) {
+            prop_assert_eq!(
+                lifecycle.transition(repeated_event),
+                Err(RuntimeLifecycleError::InvalidTransition {
+                    from: baseline_state,
+                    event: repeated_event,
+                })
+            );
+            prop_assert_eq!(lifecycle.state(), baseline_state);
+        }
+    }
+}
+
+proptest! {
+    #![proptest_config(deterministic_config(CASES, REPLAY_SEED))]
+
+    #[test]
+    fn integration_peer_lifecycle_proptest_sequence_replay_is_deterministic(
+        sequence in vec(peer_event_strategy(), 0..(MAX_SEQUENCE_LEN + 1))
+    ) {
+        let (state_a, outcomes_a) = replay_sequence(&sequence);
+        let (state_b, outcomes_b) = replay_sequence(&sequence);
+        prop_assert_eq!(state_a, state_b);
+        prop_assert_eq!(outcomes_a, outcomes_b);
+    }
+}

--- a/docs/architecture/p2p-transport.md
+++ b/docs/architecture/p2p-transport.md
@@ -112,6 +112,25 @@ provider marker contracts for local-heavy runtime rehearsal:
 - Invalid lifecycle transition replay remains fail closed with reason code
   `runtime_peer_transition_invalid`.
 
+## Peer Lifecycle Proptest Invariants
+
+- Proptest target:
+  - `cargo test -p kamn-core --test peer_lifecycle_proptest_invariants`
+- Deterministic runner contract:
+  - fixed runner seeds are used for legality/idempotence/replay checks
+    (`LEGALITY_SEED`, `IDEMPOTENCE_SEED`, `REPLAY_SEED`).
+  - runner persistence is enabled with
+    `FileFailurePersistence::SourceParallel("proptest-regressions")`.
+  - tracked seed corpus path:
+    `crates/kamn-core/proptest-regressions/tests/peer_lifecycle_proptest_invariants.txt`.
+- Invariant inventory:
+  - legal transitions must match the peer lifecycle state graph.
+  - invalid transition retries must remain idempotent and preserve lifecycle state.
+  - replaying an identical event sequence must produce identical outcomes.
+- Rejection guardrail:
+  - invalid transition retries must continue returning reason code
+    `runtime_peer_transition_invalid`.
+
 Regression marker:
 - `Regression: #2922` ensures disconnected peers cannot broadcast gossip frames.
 
@@ -122,6 +141,10 @@ cargo test -p kamn-core --test p2p_transport_runtime
 cargo test -p kamn-core --test p2p_swarm_stack_runtime
 cargo test -p kamn-core --test p2p_kademlia_bootstrap
 cargo test -p kamn-core --test p2p_lifecycle_regression_corpus
+cargo test -p kamn-core --test peer_lifecycle_proptest_invariants unit_peer_lifecycle_proptest_config_is_deterministic_and_persistent -- --exact
+cargo test -p kamn-core --test peer_lifecycle_proptest_invariants functional_peer_lifecycle_proptest_enforces_legal_transition_graph -- --exact
+cargo test -p kamn-core --test peer_lifecycle_proptest_invariants integration_peer_lifecycle_proptest_invalid_event_replays_are_idempotent -- --exact
+cargo test -p kamn-core --test peer_lifecycle_proptest_invariants integration_peer_lifecycle_proptest_sequence_replay_is_deterministic -- --exact
 cargo test -p kamn-core p2p_transport
 cargo clippy -p kamn-core -- -D warnings
 cargo fmt --check


### PR DESCRIPTION
## Summary
Adds deterministic proptest invariant coverage for peer lifecycle legality and idempotence, with tracked seed-corpus persistence and p2p architecture documentation updates.

## Changes
- crates/kamn-core/tests/peer_lifecycle_proptest_invariants.rs: new proptest suite for peer lifecycle legality graph checks, invalid-event replay idempotence, and deterministic sequence replay
- crates/kamn-core/proptest-regressions/tests/peer_lifecycle_proptest_invariants.txt: tracked deterministic seed corpus
- docs/architecture/p2p-transport.md: added peer lifecycle proptest invariant catalog and validation commands
- crates/kamn-core/tests/p2p_transport_docs.rs: enforced new doc markers in docs-contract tests

## Risks & Compatibility
- Low: test and documentation only; no runtime behavior changes

## Validation
- [x] cargo fmt --check — clean
- [x] cargo clippy -- -D warnings — clean (cargo clippy -p kamn-core -- -D warnings)
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: validated red-to-green path for seed corpus tracking and deterministic proptest execution

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | unit_peer_lifecycle_proptest_config_is_deterministic_and_persistent |
| Functional  | ✅     | functional_peer_lifecycle_proptest_enforces_legal_transition_graph |
| Integration | ✅     | integration_peer_lifecycle_proptest_invalid_event_replays_are_idempotent; integration_peer_lifecycle_proptest_sequence_replay_is_deterministic; runtime_peer_lifecycle suite |
| Regression  | ✅     | regression_peer_lifecycle_seed_corpus_is_tracked plus docs marker contracts |

Closes #3533
