### PR TITLE
fix(node): count replayed OS shutdown signals in daemon runtime (#3596)

### DIFF
--- a/crates/kamn-node/src/daemon_shutdown.rs
+++ b/crates/kamn-node/src/daemon_shutdown.rs
@@ -6,6 +6,35 @@ pub(super) struct DaemonCompletion {
     pub(super) completion_reason: String,
 }
 
+fn evaluate_daemon_completion_from_signal(
+    max_ticks: u64,
+    signal_tick: u64,
+    ignored_signals: usize,
+    drain_ticks: Option<u64>,
+    timeout_ticks: Option<u64>,
+) -> DaemonCompletion {
+    let drain_ticks = drain_ticks.unwrap_or(1);
+    let timeout_ticks = timeout_ticks.unwrap_or(1);
+    let target_drain_tick = signal_tick.saturating_add(drain_ticks);
+    let timeout_deadline_tick = signal_tick.saturating_add(timeout_ticks).min(max_ticks);
+
+    if target_drain_tick <= timeout_deadline_tick && target_drain_tick <= max_ticks {
+        return DaemonCompletion {
+            executed_ticks: target_drain_tick,
+            completion_reason: format!(
+                "graceful-shutdown:signal@{signal_tick};drain_ticks={drain_ticks};timeout_ticks={timeout_ticks};ignored_signals={ignored_signals}"
+            ),
+        };
+    }
+
+    DaemonCompletion {
+        executed_ticks: timeout_deadline_tick,
+        completion_reason: format!(
+            "graceful-shutdown-timeout:signal@{signal_tick};drain_ticks={drain_ticks};timeout_ticks={timeout_ticks};ignored_signals={ignored_signals}"
+        ),
+    }
+}
+
 pub(super) fn evaluate_daemon_completion(
     max_ticks: u64,
     shutdown_signal_ticks: &[u64],
@@ -36,26 +65,13 @@ pub(super) fn evaluate_daemon_completion(
         };
     };
 
-    let drain_ticks = drain_ticks.unwrap_or(1);
-    let timeout_ticks = timeout_ticks.unwrap_or(1);
-    let target_drain_tick = signal_tick.saturating_add(drain_ticks);
-    let timeout_deadline_tick = signal_tick.saturating_add(timeout_ticks).min(max_ticks);
-
-    if target_drain_tick <= timeout_deadline_tick && target_drain_tick <= max_ticks {
-        return DaemonCompletion {
-            executed_ticks: target_drain_tick,
-            completion_reason: format!(
-                "graceful-shutdown:signal@{signal_tick};drain_ticks={drain_ticks};timeout_ticks={timeout_ticks};ignored_signals={ignored_signals}"
-            ),
-        };
-    }
-
-    DaemonCompletion {
-        executed_ticks: timeout_deadline_tick,
-        completion_reason: format!(
-            "graceful-shutdown-timeout:signal@{signal_tick};drain_ticks={drain_ticks};timeout_ticks={timeout_ticks};ignored_signals={ignored_signals}"
-        ),
-    }
+    evaluate_daemon_completion_from_signal(
+        max_ticks,
+        signal_tick,
+        ignored_signals,
+        drain_ticks,
+        timeout_ticks,
+    )
 }
 
 pub(super) fn evaluate_daemon_completion_with_os_signals(
@@ -83,6 +99,7 @@ pub(super) fn evaluate_daemon_completion_with_os_signals(
 
             let tick_duration = Duration::from_millis(tick_interval_ms);
             let mut first_signal_tick: Option<u64> = None;
+            let mut ignored_signals = 0usize;
             for tick in 1..=max_ticks {
                 if first_signal_tick.is_none() {
                     if tick < max_ticks {
@@ -107,13 +124,32 @@ pub(super) fn evaluate_daemon_completion_with_os_signals(
                         }
                     }
                 } else if tick < max_ticks {
-                    tokio::time::sleep(tick_duration).await;
+                    tokio::select! {
+                        _ = sigint_stream.recv() => {
+                            ignored_signals = ignored_signals.saturating_add(1);
+                        }
+                        _ = sigterm_stream.recv() => {
+                            ignored_signals = ignored_signals.saturating_add(1);
+                        }
+                        _ = tokio::time::sleep(tick_duration) => {}
+                    }
+                } else {
+                    tokio::select! {
+                        _ = sigint_stream.recv() => {
+                            ignored_signals = ignored_signals.saturating_add(1);
+                        }
+                        _ = sigterm_stream.recv() => {
+                            ignored_signals = ignored_signals.saturating_add(1);
+                        }
+                        else => {}
+                    }
                 }
 
                 if let Some(signal_tick) = first_signal_tick {
-                    let completion = evaluate_daemon_completion(
+                    let completion = evaluate_daemon_completion_from_signal(
                         max_ticks,
-                        &[signal_tick],
+                        signal_tick,
+                        ignored_signals,
                         drain_ticks,
                         timeout_ticks,
                     );
@@ -124,9 +160,10 @@ pub(super) fn evaluate_daemon_completion_with_os_signals(
             }
 
             if let Some(signal_tick) = first_signal_tick {
-                return Ok(evaluate_daemon_completion(
+                return Ok(evaluate_daemon_completion_from_signal(
                     max_ticks,
-                    &[signal_tick],
+                    signal_tick,
+                    ignored_signals,
                     drain_ticks,
                     timeout_ticks,
                 ));
@@ -154,11 +191,23 @@ mod tests {
     use std::time::Duration;
 
     #[cfg(unix)]
+    const SIGINT: i32 = 2;
+    #[cfg(unix)]
     const SIGTERM: i32 = 15;
 
     #[cfg(unix)]
     unsafe extern "C" {
         fn raise(sig: i32) -> i32;
+    }
+
+    #[cfg(unix)]
+    fn raise_sigint_for_test() -> Result<(), String> {
+        let result = unsafe { raise(SIGINT) };
+        if result == 0 {
+            Ok(())
+        } else {
+            Err("failed to raise SIGINT".to_owned())
+        }
     }
 
     #[cfg(unix)]
@@ -241,6 +290,28 @@ mod tests {
         assert!(
             completion.executed_ticks <= 40,
             "signal-driven shutdown should remain bounded by max ticks"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn regression_daemon_completion_with_os_signals_counts_replayed_signals() {
+        // Regression: #3596
+        let trigger = thread::spawn(|| {
+            thread::sleep(Duration::from_millis(5));
+            raise_sigterm_for_test().expect("SIGTERM test signal should be raised");
+            thread::sleep(Duration::from_millis(1));
+            raise_sigint_for_test().expect("SIGINT test signal should be raised");
+        });
+        let completion = evaluate_daemon_completion_with_os_signals(60, 1, Some(5), Some(12))
+            .expect("daemon completion with OS signal handling should succeed");
+        trigger
+            .join()
+            .expect("signal trigger thread should complete");
+        assert!(
+            completion.completion_reason.contains("ignored_signals=1"),
+            "expected repeated signal count to be recorded, got {}",
+            completion.completion_reason
         );
     }
 

--- a/docs/ops/runbooks/shutdown.md
+++ b/docs/ops/runbooks/shutdown.md
@@ -1,0 +1,43 @@
+# Runtime Shutdown Runbook
+
+This runbook documents daemon shutdown behavior when the runtime is configured
+to consume OS shutdown signals.
+
+## Scope
+
+- Runtime mode: `daemon` and `full` daemon execution path.
+- Signal source: local process signals on Unix (`SIGINT`, `SIGTERM`).
+- Trigger mode: `--daemon-shutdown-os-signals` enabled and no
+  `--daemon-shutdown-signal-tick` overrides provided.
+
+## Signal Handling Contract
+
+1. The first received `SIGINT` or `SIGTERM` opens graceful shutdown.
+2. Drain and timeout budgets are resolved from:
+- `--daemon-shutdown-drain-ticks`
+- `--daemon-shutdown-timeout-ticks`
+3. Additional shutdown signals received after the first signal are counted as
+   ignored signals and reported in completion telemetry.
+
+## Completion Reason Semantics
+
+- Graceful completion:
+- `graceful-shutdown:signal@<tick>;drain_ticks=<n>;timeout_ticks=<n>;ignored_signals=<n>`
+- Timeout completion:
+- `graceful-shutdown-timeout:signal@<tick>;drain_ticks=<n>;timeout_ticks=<n>;ignored_signals=<n>`
+- No signal received:
+- `tick-budget-exhausted`
+
+## Operator Validation
+
+Use local tests to validate signal handling contracts:
+
+```bash
+cargo test -p kamn-node daemon_shutdown::tests::
+```
+
+The test suite covers:
+- first-signal graceful shutdown behavior,
+- timeout behavior when drain exceeds budget,
+- repeated signal accounting (`ignored_signals`),
+- fail-closed path verification for the tokio signal runtime path.


### PR DESCRIPTION
## Summary
Implements deterministic repeated-signal handling for daemon OS shutdown flow. The runtime now records shutdown signals received after the first SIGINT/SIGTERM as `ignored_signals` and emits them in completion telemetry.

Closes #3596
Refs #3590

## Changes
- `crates/kamn-node/src/daemon_shutdown.rs`: extracted first-signal completion helper, counted post-first OS signals in tokio signal loop, and wired the count into graceful/timeout completion reasons.
- `crates/kamn-node/src/daemon_shutdown.rs`: added regression test for repeated OS signals (`SIGTERM` then `SIGINT`) to enforce deterministic ignored-signal accounting.
- `docs/ops/runbooks/shutdown.md`: added operator runbook for OS signal shutdown semantics and validation command.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
`cargo test -p kamn-node replayed_signals -- --nocapture`

Observed failure:
`expected repeated signal count to be recorded, got graceful-shutdown:signal@3;drain_ticks=5;timeout_ticks=12;ignored_signals=0`

### 🟢 Green Phase
Command:
`cargo test -p kamn-node replayed_signals -- --nocapture`

Observed result:
`test daemon_shutdown::tests::regression_daemon_completion_with_os_signals_counts_replayed_signals ... ok`

### 🔁 Regression
Commands:
- `cargo test -p kamn-node daemon_shutdown::tests::`
- `cargo fmt --check`
- `cargo clippy -p kamn-node -- -D warnings`

Observed result:
- daemon shutdown test set: 8 passed, 0 failed
- fmt check: clean
- clippy: clean

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `unit_daemon_completion_*` path remains green under helper extraction | |
| Functional   | ✅     | graceful/timeout completion reason formatting verified via daemon shutdown tests | |
| Integration  | ✅     | `integration_daemon_completion_with_os_signals_applies_graceful_shutdown` | |
| Regression   | ✅     | `regression_daemon_completion_with_os_signals_counts_replayed_signals` | |
| Performance  | N/A    | no throughput/latency behavior changes in this subtask | scoped to later lane work |

## Risks & Rollback
- Risk: low-medium; signal-loop changes are isolated to daemon OS-signal path.
- Rollback: revert this PR to restore prior first-signal-only behavior.

## Documentation Updates
- `docs/ops/runbooks/shutdown.md`: added new runtime shutdown contract documentation.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-node -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Relevant tests pass locally
