### PR TITLE
feat(node): emit deterministic shutdown flush markers (#3597)

### DIFF
--- a/crates/kamn-node/src/main.rs
+++ b/crates/kamn-node/src/main.rs
@@ -515,6 +515,16 @@ fn daemon_shutdown_drain_status(completion_reason: &str) -> &'static str {
     }
 }
 
+fn daemon_shutdown_snapshot_flush_status(completion_reason: &str) -> &'static str {
+    if completion_reason.starts_with("graceful-shutdown:signal@") {
+        "snapshot-flushed"
+    } else if completion_reason.starts_with("graceful-shutdown-timeout:signal@") {
+        "snapshot-flush-timeout"
+    } else {
+        "snapshot-not-requested"
+    }
+}
+
 fn daemon_shutdown_signal_tick(completion_reason: &str) -> Option<&str> {
     completion_reason
         .strip_prefix("graceful-shutdown:signal@")
@@ -561,6 +571,7 @@ fn validate_full_bootstrap_component_contract(components: &[&str]) -> Result<(),
 fn classify_full_supervisor_stop_contract_violation(
     completion_reason: &str,
     shutdown_drain_status: &str,
+    shutdown_snapshot_flush_status: &str,
 ) -> Option<&'static str> {
     if !matches!(
         shutdown_drain_status,
@@ -568,11 +579,20 @@ fn classify_full_supervisor_stop_contract_violation(
     ) {
         return Some("full_supervisor_stop_invalid_shutdown_drain_status");
     }
+    if !matches!(
+        shutdown_snapshot_flush_status,
+        "snapshot-flushed" | "snapshot-flush-timeout" | "snapshot-not-requested"
+    ) {
+        return Some("full_supervisor_stop_invalid_shutdown_snapshot_flush_status");
+    }
     if completion_reason == "tick-budget-exhausted"
         || completion_reason.starts_with("tick-budget-exhausted;ignored_signals=")
     {
         if shutdown_drain_status != "not-signaled" {
             return Some("full_supervisor_stop_not_signaled_status_mismatch");
+        }
+        if shutdown_snapshot_flush_status != "snapshot-not-requested" {
+            return Some("full_supervisor_stop_not_signaled_snapshot_flush_mismatch");
         }
         return None;
     }
@@ -592,6 +612,9 @@ fn classify_full_supervisor_stop_contract_violation(
         if shutdown_drain_status != "completed" {
             return Some("full_supervisor_stop_graceful_status_mismatch");
         }
+        if shutdown_snapshot_flush_status != "snapshot-flushed" {
+            return Some("full_supervisor_stop_graceful_snapshot_flush_status_mismatch");
+        }
         return None;
     }
     if completion_reason.starts_with("graceful-shutdown-timeout:signal@") {
@@ -610,6 +633,9 @@ fn classify_full_supervisor_stop_contract_violation(
         if shutdown_drain_status != "timeout" {
             return Some("full_supervisor_stop_graceful_timeout_status_mismatch");
         }
+        if shutdown_snapshot_flush_status != "snapshot-flush-timeout" {
+            return Some("full_supervisor_stop_graceful_timeout_snapshot_flush_status_mismatch");
+        }
         return None;
     }
     Some("full_supervisor_stop_unknown_completion_reason")
@@ -618,10 +644,13 @@ fn classify_full_supervisor_stop_contract_violation(
 fn validate_full_supervisor_stop_contract(
     completion_reason: &str,
     shutdown_drain_status: &str,
+    shutdown_snapshot_flush_status: &str,
 ) -> Result<(), ConfigError> {
-    if let Some(reason) =
-        classify_full_supervisor_stop_contract_violation(completion_reason, shutdown_drain_status)
-    {
+    if let Some(reason) = classify_full_supervisor_stop_contract_violation(
+        completion_reason,
+        shutdown_drain_status,
+        shutdown_snapshot_flush_status,
+    ) {
         return Err(ConfigError::RuntimeDaemonLifecycle(format!(
             "full_supervisor_invariant_violation:{reason}"
         )));
@@ -704,6 +733,8 @@ fn execute_daemon_runtime(
     .map_err(|error| ConfigError::RuntimeDaemonLifecycle(error.to_string()))?;
     let shutdown_drain_status =
         daemon_shutdown_drain_status(daemon_completion.completion_reason.as_str());
+    let shutdown_snapshot_flush_status =
+        daemon_shutdown_snapshot_flush_status(daemon_completion.completion_reason.as_str());
     let shutdown_signal_tick =
         daemon_shutdown_signal_tick(daemon_completion.completion_reason.as_str()).unwrap_or("none");
     let shutdown_drain_ticks =
@@ -730,6 +761,10 @@ fn execute_daemon_runtime(
                 daemon_completion.completion_reason.as_str(),
             ),
             ("shutdown_drain_status", shutdown_drain_status),
+            (
+                "shutdown_snapshot_flush_status",
+                shutdown_snapshot_flush_status,
+            ),
             ("shutdown_signal_tick", shutdown_signal_tick),
             ("shutdown_drain_ticks", shutdown_drain_ticks),
             ("shutdown_timeout_ticks", shutdown_timeout_ticks),
@@ -1149,12 +1184,22 @@ fn execute(cli: NodeCli) -> Result<NodeBootstrapReport, ConfigError> {
             let stop_reason = "daemon-execution-complete";
             let completion_reason = daemon_execution.completion_reason.as_str();
             let shutdown_drain_status = daemon_shutdown_drain_status(completion_reason);
-            validate_full_supervisor_stop_contract(completion_reason, shutdown_drain_status)?;
+            let shutdown_snapshot_flush_status =
+                daemon_shutdown_snapshot_flush_status(completion_reason);
+            validate_full_supervisor_stop_contract(
+                completion_reason,
+                shutdown_drain_status,
+                shutdown_snapshot_flush_status,
+            )?;
             log_info(
                 "node.runtime.full.supervisor.stop.requested",
                 &[
                     ("stop_reason", stop_reason),
                     ("daemon_completion_reason", completion_reason),
+                    (
+                        "shutdown_snapshot_flush_status",
+                        shutdown_snapshot_flush_status,
+                    ),
                     ("execution_id", execution_id.as_str()),
                 ],
             )?;
@@ -1164,6 +1209,10 @@ fn execute(cli: NodeCli) -> Result<NodeBootstrapReport, ConfigError> {
                     ("stop_reason", stop_reason),
                     ("daemon_completion_reason", completion_reason),
                     ("shutdown_drain_status", shutdown_drain_status),
+                    (
+                        "shutdown_snapshot_flush_status",
+                        shutdown_snapshot_flush_status,
+                    ),
                     ("execution_id", execution_id.as_str()),
                 ],
             )?;

--- a/crates/kamn-node/src/main_tests/core_behavior_tests.rs
+++ b/crates/kamn-node/src/main_tests/core_behavior_tests.rs
@@ -578,6 +578,10 @@ fn functional_runtime_daemon_emits_structured_transition_markers() {
         Some("not-signaled")
     );
     assert_eq!(
+        extract_json_string_field(complete_line, "shutdown_snapshot_flush_status").as_deref(),
+        Some("snapshot-not-requested")
+    );
+    assert_eq!(
         extract_json_string_field(complete_line, "shutdown_signal_tick").as_deref(),
         Some("none")
     );
@@ -801,6 +805,10 @@ fn functional_runtime_daemon_graceful_shutdown_emits_structured_drain_markers() 
         extract_json_string_field(complete_line, "shutdown_ignored_signals").as_deref(),
         Some("0")
     );
+    assert_eq!(
+        extract_json_string_field(complete_line, "shutdown_snapshot_flush_status").as_deref(),
+        Some("snapshot-flushed")
+    );
 }
 
 #[test]
@@ -860,6 +868,10 @@ fn regression_runtime_daemon_shutdown_timeout_emits_structured_timeout_drain_mar
     assert_eq!(
         extract_json_string_field(complete_line, "shutdown_ignored_signals").as_deref(),
         Some("0")
+    );
+    assert_eq!(
+        extract_json_string_field(complete_line, "shutdown_snapshot_flush_status").as_deref(),
+        Some("snapshot-flush-timeout")
     );
 }
 
@@ -1213,6 +1225,14 @@ fn regression_runtime_full_emits_supervisor_stop_markers_with_daemon_reason() {
         extract_json_string_field(stop_complete_line, "daemon_completion_reason").as_deref(),
         Some("tick-budget-exhausted")
     );
+    assert_eq!(
+        extract_json_string_field(stop_requested_line, "shutdown_snapshot_flush_status").as_deref(),
+        Some("snapshot-not-requested")
+    );
+    assert_eq!(
+        extract_json_string_field(stop_complete_line, "shutdown_snapshot_flush_status").as_deref(),
+        Some("snapshot-not-requested")
+    );
     let requested_execution_id = extract_json_string_field(stop_requested_line, "execution_id")
         .expect("stop-request marker should include execution id");
     let complete_execution_id = extract_json_string_field(stop_complete_line, "execution_id")
@@ -1237,8 +1257,12 @@ fn unit_full_supervisor_bootstrap_component_contract_rejects_order_drift() {
 #[test]
 fn regression_full_supervisor_stop_contract_rejects_unknown_completion_reason() {
     // Regression: #3283
-    let error = validate_full_supervisor_stop_contract("legacy-stop-reason", "not-signaled")
-        .expect_err("unknown supervisor stop completion reason must fail closed");
+    let error = validate_full_supervisor_stop_contract(
+        "legacy-stop-reason",
+        "not-signaled",
+        "snapshot-not-requested",
+    )
+    .expect_err("unknown supervisor stop completion reason must fail closed");
     assert!(
         matches!(error, ConfigError::RuntimeDaemonLifecycle(message) if message.contains("full_supervisor_invariant_violation:full_supervisor_stop_unknown_completion_reason")),
         "unknown supervisor stop completion reason must emit deterministic fail-closed reason code"
@@ -1250,10 +1274,25 @@ fn unit_full_supervisor_stop_contract_classifier_rejects_status_mismatch() {
     let reason = classify_full_supervisor_stop_contract_violation(
         "graceful-shutdown:signal@2;drain_ticks=1;timeout_ticks=3;ignored_signals=0",
         "not-signaled",
+        "snapshot-flushed",
     );
     assert_eq!(
         reason,
         Some("full_supervisor_stop_graceful_status_mismatch")
+    );
+}
+
+#[test]
+fn regression_full_supervisor_stop_contract_classifier_rejects_snapshot_flush_mismatch() {
+    // Regression: #3597
+    let reason = classify_full_supervisor_stop_contract_violation(
+        "graceful-shutdown-timeout:signal@2;drain_ticks=3;timeout_ticks=1;ignored_signals=0",
+        "timeout",
+        "snapshot-flushed",
+    );
+    assert_eq!(
+        reason,
+        Some("full_supervisor_stop_graceful_timeout_snapshot_flush_status_mismatch")
     );
 }
 
@@ -1294,6 +1333,10 @@ fn integration_runtime_full_emits_timeout_shutdown_supervisor_reason_codes() {
     assert_eq!(
         extract_json_string_field(stop_complete_line, "shutdown_drain_status").as_deref(),
         Some("timeout")
+    );
+    assert_eq!(
+        extract_json_string_field(stop_complete_line, "shutdown_snapshot_flush_status").as_deref(),
+        Some("snapshot-flush-timeout")
     );
     assert!(
         extract_json_string_field(stop_complete_line, "daemon_completion_reason")

--- a/docs/architecture/service-runtime.md
+++ b/docs/architecture/service-runtime.md
@@ -1,0 +1,42 @@
+# Service Runtime Shutdown Contracts
+
+This document defines deterministic shutdown marker semantics for daemon and
+full runtime execution paths.
+
+## Scope
+
+- Runtime mode: `daemon`, `full`
+- Trigger sources:
+- deterministic signal-tick controls (`--daemon-shutdown-signal-tick`)
+- OS signals (`--daemon-shutdown-os-signals`) on Unix
+
+## Drain Marker Contract
+
+`shutdown_drain_status` is emitted on daemon completion and full-supervisor stop
+markers with these values:
+
+- `completed`: shutdown drain target completed before timeout budget.
+- `timeout`: shutdown drain exceeded timeout budget and failed closed.
+- `not-signaled`: no shutdown signal triggered during runtime tick budget.
+
+## Snapshot Flush Marker Contract
+
+`shutdown_snapshot_flush_status` is emitted on daemon completion and full
+supervisor stop markers with these values:
+
+- `snapshot-flushed`: graceful shutdown path committed final snapshot flush.
+- `snapshot-flush-timeout`: timeout shutdown path emitted forced final flush
+  marker and failed closed.
+- `snapshot-not-requested`: no signal-triggered shutdown occurred.
+
+## Fail-Closed Validation
+
+The full-supervisor stop contract validator enforces deterministic consistency
+between completion reason, drain status, and snapshot flush status:
+
+- Unknown status values are rejected.
+- `tick-budget-exhausted` requires `not-signaled` + `snapshot-not-requested`.
+- `graceful-shutdown:*` requires `completed` + `snapshot-flushed`.
+- `graceful-shutdown-timeout:*` requires `timeout` + `snapshot-flush-timeout`.
+
+Invalid combinations emit deterministic reason codes and fail closed.


### PR DESCRIPTION
## Summary
Adds deterministic shutdown snapshot-flush markers to daemon and full-runtime supervisor stop paths, and enforces fail-closed contract validation for drain/flush status consistency.

Closes #3597
Refs #3590

## Changes
- `crates/kamn-node/src/main.rs`: added `daemon_shutdown_snapshot_flush_status` and propagated `shutdown_snapshot_flush_status` markers through daemon completion and full supervisor stop logs.
- `crates/kamn-node/src/main.rs`: extended full-supervisor contract validation to enforce completion reason + drain status + snapshot flush status consistency.
- `crates/kamn-node/src/main_tests/core_behavior_tests.rs`: added and updated functional/integration/regression tests for snapshot flush marker emission and contract mismatch rejection.
- `docs/architecture/service-runtime.md`: documented shutdown drain/flush marker contract and fail-closed validation rules.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
`cargo test -p kamn-node structured_drain_markers -- --nocapture`

Observed failure:
`assertion left == right failed; left: None right: Some("snapshot-flushed")`

### 🟢 Green Phase
Command:
`cargo test -p kamn-node structured_drain_markers -- --nocapture`

Observed result:
`functional_runtime_daemon_graceful_shutdown_emits_structured_drain_markers ... ok`

### 🔁 Regression
Commands:
- `cargo test -p kamn-node structured_transition_markers -- --nocapture`
- `cargo test -p kamn-node structured_timeout_drain_markers -- --nocapture`
- `cargo test -p kamn-node supervisor_stop_markers_with_daemon_reason -- --nocapture`
- `cargo test -p kamn-node timeout_shutdown_supervisor_reason_codes -- --nocapture`
- `cargo test -p kamn-node full_supervisor_stop_contract -- --nocapture`
- `cargo fmt --check`
- `cargo clippy -p kamn-node -- -D warnings`

Observed result:
- all targeted shutdown/supervisor tests pass
- fmt check: clean
- clippy: clean

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | full-supervisor contract classifier tests updated + new mismatch regression | |
| Functional   | ✅     | daemon structured transition/drain marker tests include snapshot flush markers | |
| Integration  | ✅     | full runtime timeout supervisor reason-code flow validated with snapshot marker | |
| Regression   | ✅     | snapshot flush mismatch regression added (`#3597`) | |
| Performance  | N/A    | no throughput behavior changes; marker/contract semantics only | scoped to separate soak lanes |

## Risks & Rollback
- Risk: low-medium; isolated to shutdown marker emission and contract validation.
- Rollback: revert this PR to restore prior drain-only marker contract.

## Documentation Updates
- `docs/architecture/service-runtime.md`: new shutdown contract documentation.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-node -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Relevant tests pass locally
