### PR TITLE
test(node): add startup negative-matrix corpus contracts (#3599)

### DIFF
--- a/crates/kamn-core/tests/ci_strategy_docs.rs
+++ b/crates/kamn-core/tests/ci_strategy_docs.rs
@@ -383,6 +383,19 @@ fn doc_contains_make_and_demo_scope_contract_rules() {
 }
 
 #[test]
+fn doc_contains_node_runtime_startup_negative_matrix_fast_lane_contract_markers() {
+    assert!(DOC.contains("## Node Runtime Startup Negative-Matrix Fast Lane"));
+    assert!(DOC.contains(
+        "cargo test -p kamn-node main_tests::cli_contract_tests::regression_3599_startup_signer_mode_negative_matrix_corpus -- --exact"
+    ));
+    assert!(DOC.contains(
+        "cargo test -p kamn-node cli_tests::regression_3598_startup_paths_have_no_panic_control_flow -- --exact"
+    ));
+    assert!(DOC.contains("startup_negative_matrix_policy_marker_missing"));
+    assert!(DOC.contains("must fail before network dispatch"));
+}
+
+#[test]
 fn regression_requires_make_and_selector_demo_contract_marker() {
     // Regression: #900
     assert!(DOC.contains("Regression: #900"));

--- a/crates/kamn-node/src/main_tests/cli_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/cli_contract_tests.rs
@@ -725,6 +725,215 @@ fn integration_runtime_kolme_live_strict_signer_contracts_fail_closed_before_net
 }
 
 #[test]
+fn regression_3599_startup_signer_mode_negative_matrix_corpus() {
+    // Regression: #3599
+    let _lock = signer_env_lock()
+        .lock()
+        .expect("signer env lock should guard test mutation");
+    let mut covered_cases: Vec<&'static str> = Vec::new();
+    let expected_cases = vec![
+        "strict-missing-signer-profile",
+        "strict-missing-signer-key-source",
+        "daemon-shutdown-controls-missing-signal",
+        "strict-selector-env-mismatch-preflight",
+        "fallback-secret-preflight",
+    ];
+
+    {
+        let args = vec![
+            "kamn-node".to_owned(),
+            "--role".to_owned(),
+            "processor".to_owned(),
+            "--runtime-mode".to_owned(),
+            "kolme-live".to_owned(),
+            "--kolme-live-base-url".to_owned(),
+            "http://127.0.0.1:3000".to_owned(),
+            "--kolme-live-provider-hint".to_owned(),
+            "kolme-fork-local".to_owned(),
+            "--kolme-live-signing-profile".to_owned(),
+            "kolme-fork-secp256k1-v1".to_owned(),
+            "--kolme-live-strict-signer-contracts".to_owned(),
+            "--kolme-live-signer-key-source".to_owned(),
+            "env-local".to_owned(),
+        ];
+        assert!(
+            matches!(
+                parse_args(args),
+                Err(ConfigError::MissingArgumentValue(
+                    "--kolme-live-signer-profile"
+                ))
+            ),
+            "matrix case strict-missing-signer-profile must fail closed"
+        );
+        covered_cases.push("strict-missing-signer-profile");
+    }
+
+    {
+        let args = vec![
+            "kamn-node".to_owned(),
+            "--role".to_owned(),
+            "processor".to_owned(),
+            "--runtime-mode".to_owned(),
+            "kolme-live".to_owned(),
+            "--kolme-live-base-url".to_owned(),
+            "http://127.0.0.1:3000".to_owned(),
+            "--kolme-live-provider-hint".to_owned(),
+            "kolme-fork-local".to_owned(),
+            "--kolme-live-signing-profile".to_owned(),
+            "kolme-fork-secp256k1-v1".to_owned(),
+            "--kolme-live-strict-signer-contracts".to_owned(),
+            "--kolme-live-signer-profile".to_owned(),
+            "ops-primary".to_owned(),
+        ];
+        assert!(
+            matches!(
+                parse_args(args),
+                Err(ConfigError::MissingArgumentValue(
+                    "--kolme-live-signer-key-source"
+                ))
+            ),
+            "matrix case strict-missing-signer-key-source must fail closed"
+        );
+        covered_cases.push("strict-missing-signer-key-source");
+    }
+
+    {
+        let args = vec![
+            "kamn-node".to_owned(),
+            "--role".to_owned(),
+            "processor".to_owned(),
+            "--runtime-mode".to_owned(),
+            "daemon".to_owned(),
+            "--daemon-max-ticks".to_owned(),
+            "12".to_owned(),
+            "--daemon-tick-interval-ms".to_owned(),
+            "5".to_owned(),
+            "--daemon-shutdown-drain-ticks".to_owned(),
+            "2".to_owned(),
+            "--daemon-shutdown-timeout-ticks".to_owned(),
+            "4".to_owned(),
+        ];
+        assert!(
+            matches!(
+                parse_args(args),
+                Err(ConfigError::MissingArgumentValue(
+                    "--daemon-shutdown-signal-tick"
+                ))
+            ),
+            "matrix case daemon-shutdown-controls-missing-signal must fail closed"
+        );
+        covered_cases.push("daemon-shutdown-controls-missing-signal");
+    }
+
+    {
+        let _profile_env_guard =
+            EnvVarGuard::set("KAMN_KOLME_LIVE_SIGNER_PROFILE", Some("ops-secondary"));
+        let _primary_key_guard = EnvVarGuard::set(
+            "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX",
+            Some(TEST_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX),
+        );
+        let _fallback_key_guard =
+            EnvVarGuard::set("KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK", None);
+        let _override_guard = EnvVarGuard::set("KAMN_KOLME_LIVE_ALLOW_LOCAL_SIGNER_TESTING", None);
+        let (base_url, requests) = spawn_kolme_live_mock_server(vec![
+            MockHttpReply::ok(r#"{"next_nonce":17,"account_id":"acct-live-processor"}"#),
+            MockHttpReply::ok(
+                r#"{"status":"submitted","provider":"kolme-fork-local","commit_id":"kolme-commit:ab12cd34","finality":"pending"}"#,
+            ),
+        ]);
+        let args = vec![
+            "kamn-node".to_owned(),
+            "--role".to_owned(),
+            "processor".to_owned(),
+            "--runtime-mode".to_owned(),
+            "kolme-live".to_owned(),
+            "--kolme-live-base-url".to_owned(),
+            base_url,
+            "--kolme-live-provider-hint".to_owned(),
+            "kolme-fork-local".to_owned(),
+            "--kolme-live-signing-profile".to_owned(),
+            "kolme-fork-secp256k1-v1".to_owned(),
+            "--kolme-live-strict-signer-contracts".to_owned(),
+            "--kolme-live-signer-profile".to_owned(),
+            "ops-primary".to_owned(),
+            "--kolme-live-signer-key-source".to_owned(),
+            "env-local".to_owned(),
+        ];
+        let parsed = parse_args(args).expect("strict mismatch args should parse");
+        assert!(
+            matches!(
+                execute(parsed),
+                Err(ConfigError::RuntimeKolmeLive(message))
+                if message.contains("strict signer profile mismatch")
+            ),
+            "matrix case strict-selector-env-mismatch-preflight must fail closed before network"
+        );
+        let recorded_requests = requests.lock().expect("request mutex should lock");
+        assert_eq!(
+            recorded_requests.len(),
+            0,
+            "strict selector/env mismatch must fail before network"
+        );
+        covered_cases.push("strict-selector-env-mismatch-preflight");
+    }
+
+    {
+        let _profile_env_guard =
+            EnvVarGuard::set("KAMN_KOLME_LIVE_SIGNER_PROFILE", Some("ops-primary"));
+        let _primary_key_guard = EnvVarGuard::set(
+            "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX",
+            Some(TEST_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX),
+        );
+        let _fallback_key_guard = EnvVarGuard::set(
+            "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_FALLBACK",
+            Some(TEST_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX_SECONDARY),
+        );
+        let (base_url, requests) = spawn_kolme_live_mock_server(vec![MockHttpReply::ok(
+            r#"{"next_nonce":17,"account_id":"acct-live-processor"}"#,
+        )]);
+        let args = vec![
+            "kamn-node".to_owned(),
+            "--role".to_owned(),
+            "processor".to_owned(),
+            "--runtime-mode".to_owned(),
+            "kolme-live".to_owned(),
+            "--kolme-live-base-url".to_owned(),
+            base_url,
+            "--kolme-live-provider-hint".to_owned(),
+            "kolme-fork-local".to_owned(),
+            "--kolme-live-signing-profile".to_owned(),
+            "kolme-fork-secp256k1-v1".to_owned(),
+            "--kolme-live-strict-signer-contracts".to_owned(),
+            "--kolme-live-signer-profile".to_owned(),
+            "ops-primary".to_owned(),
+            "--kolme-live-signer-key-source".to_owned(),
+            "env-local".to_owned(),
+        ];
+        let parsed = parse_args(args).expect("fallback-secret args should parse");
+        assert!(
+            matches!(
+                execute(parsed),
+                Err(ConfigError::RuntimeKolmeLive(message))
+                if message.contains("fallback_signer_secret_present_violation")
+            ),
+            "matrix case fallback-secret-preflight must fail closed with deterministic reason code"
+        );
+        let recorded_requests = requests.lock().expect("request mutex should lock");
+        assert_eq!(
+            recorded_requests.len(),
+            0,
+            "fallback secret path must fail before network dispatch"
+        );
+        covered_cases.push("fallback-secret-preflight");
+    }
+
+    assert_eq!(
+        covered_cases, expected_cases,
+        "startup_negative_matrix_policy_marker_missing"
+    );
+}
+
+#[test]
 fn rejects_kolme_live_with_invalid_signing_profile() {
     let args = vec![
         "kamn-node".to_owned(),

--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -153,6 +153,17 @@ Versioned thresholds are defined in `.ci/ci-budget.env`.
   - harness accept windows are bounded to 2 seconds to avoid hanging PR runners
 - Heavy local Kolme node tests stay outside `ci-fast-gate` in local/manual lanes.
 
+## Node Runtime Startup Negative-Matrix Fast Lane
+- For `kamn-node` startup signer/profile/mode preflight contract changes, keep PR validation on deterministic local matrix tests:
+  - `cargo test -p kamn-node main_tests::cli_contract_tests::regression_3599_startup_signer_mode_negative_matrix_corpus -- --exact`
+  - `cargo test -p kamn-node cli_tests::regression_3598_startup_paths_have_no_panic_control_flow -- --exact`
+- Deterministic fail-closed startup matrix contracts:
+  - coverage corpus must preserve all required case IDs and fail closed with `startup_negative_matrix_policy_marker_missing` when coverage drifts.
+  - strict signer selector/profile mismatch and fallback-secret violations must fail before network dispatch.
+- This lane is intentionally bounded and cost-effective:
+  - all checks run in-process with deterministic env guards and localhost mock transport only.
+  - no external Kolme node process is required for PR fast-gate validation.
+
 ## Node Runtime Daemon Shutdown Fast Lane
 - For `kamn-node` daemon-shutdown contract changes, keep PR validation on bounded deterministic tests:
   - `cargo test -p kamn-node graceful_shutdown`


### PR DESCRIPTION
Closes #3599

## Summary
Adds a deterministic startup negative-matrix regression corpus for signer/profile/mode preflight fail-closed behavior, and documents the bounded fast-lane validation scope in CI strategy docs.

## Changes
- `crates/kamn-node/src/main_tests/cli_contract_tests.rs`: add `regression_3599_startup_signer_mode_negative_matrix_corpus` with deterministic case-ID coverage marker enforcement and fail-before-network assertions.
- `docs/ci/strategy.md`: add `Node Runtime Startup Negative-Matrix Fast Lane` section with fully-qualified commands and cost/scope constraints.
- `crates/kamn-core/tests/ci_strategy_docs.rs`: add docs-contract test to fail closed if startup lane scope markers drift.

## Risks & Compatibility
- None.

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-node -- -D warnings` — clean
- [x] `cargo clippy -p kamn-core -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: verified strict signer mismatch and fallback-secret startup paths fail before any network dispatch in the #3599 matrix corpus.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `cargo test -p kamn-node cli_tests::regression_3598_startup_paths_have_no_panic_control_flow -- --exact` |
| Functional  | ✅     | `cargo test -p kamn-node main_tests::cli_contract_tests::regression_3599_startup_signer_mode_negative_matrix_corpus -- --exact` |
| Integration | ✅     | `cargo test -p kamn-core --test ci_strategy_docs doc_contains_node_runtime_startup_negative_matrix_fast_lane_contract_markers -- --exact` |
| Regression  | ✅     | `startup_negative_matrix_policy_marker_missing` coverage contract enforced in #3599 corpus |
