### PR TITLE
feat(node): version health and readiness observability payloads (#3600)

### DIFF
--- a/crates/kamn-node/src/main_tests/observability_endpoint_tests.rs
+++ b/crates/kamn-node/src/main_tests/observability_endpoint_tests.rs
@@ -264,11 +264,17 @@ fn functional_observability_endpoint_renders_metrics_and_health_payloads() {
     let health = render_observability_endpoint_response(&snapshot, "/healthz");
     assert_eq!(health.status_code, 200);
     assert_eq!(health.content_type, "application/json");
+    assert!(health
+        .body
+        .contains("\"schema_version\":\"kamn.runtime.observability.health.v1\""));
     assert!(health.body.contains("\"health\":\"healthy\""));
     assert!(health.body.contains("\"runtime_mode\":\"daemon\""));
     assert!(health.body.contains("\"reason_code\":\"none\""));
     assert!(health.body.contains("\"ready\":true"));
     assert!(health.body.contains("\"readiness_reason_code\":\"none\""));
+    assert!(health.body.contains(
+        "\"readiness_reason_taxonomy_version\":\"kamn.runtime.observability.readiness.reason-taxonomy.v1\""
+    ));
     assert!(health
         .body
         .contains("\"transport_dependency_status\":\"ready\""));
@@ -285,10 +291,16 @@ fn functional_observability_endpoint_renders_metrics_and_health_payloads() {
     let readiness = render_observability_endpoint_response(&snapshot, "/readyz");
     assert_eq!(readiness.status_code, 200);
     assert_eq!(readiness.content_type, "application/json");
+    assert!(readiness
+        .body
+        .contains("\"schema_version\":\"kamn.runtime.observability.readiness.v1\""));
     assert!(readiness.body.contains("\"ready\":true"));
     assert!(readiness
         .body
         .contains("\"readiness_reason_code\":\"none\""));
+    assert!(readiness.body.contains(
+        "\"readiness_reason_taxonomy_version\":\"kamn.runtime.observability.readiness.reason-taxonomy.v1\""
+    ));
     assert!(readiness
         .body
         .contains("\"transport_dependency_status\":\"ready\""));
@@ -568,13 +580,22 @@ fn integration_runtime_observability_endpoint_serves_metrics_and_health_paths() 
         health_response.contains("HTTP/1.1 200 OK"),
         "health endpoint should return 200 response"
     );
+    assert!(health_response.contains("\"schema_version\":\"kamn.runtime.observability.health.v1\""));
     assert!(health_response.contains("\"health\":\"healthy\""));
     assert!(health_response.contains("\"reason_code\":\"none\""));
     assert!(health_response.contains("\"ready\":true"));
     assert!(health_response.contains("\"readiness_reason_code\":\"none\""));
+    assert!(health_response.contains(
+        "\"readiness_reason_taxonomy_version\":\"kamn.runtime.observability.readiness.reason-taxonomy.v1\""
+    ));
     assert!(readiness_response.contains("HTTP/1.1 200 OK"));
+    assert!(readiness_response
+        .contains("\"schema_version\":\"kamn.runtime.observability.readiness.v1\""));
     assert!(readiness_response.contains("\"ready\":true"));
     assert!(readiness_response.contains("\"readiness_reason_code\":\"none\""));
+    assert!(readiness_response.contains(
+        "\"readiness_reason_taxonomy_version\":\"kamn.runtime.observability.readiness.reason-taxonomy.v1\""
+    ));
 
     let server_result = server.join().expect("endpoint thread should complete");
     assert!(

--- a/crates/kamn-node/src/observability_endpoint.rs
+++ b/crates/kamn-node/src/observability_endpoint.rs
@@ -10,6 +10,11 @@ pub(crate) const DEFAULT_OBSERVABILITY_ENDPOINT_READINESS_PATH: &str = "/readyz"
 pub(crate) const DEFAULT_OBSERVABILITY_ENDPOINT_STREAM_PATH: &str = "/metrics.stream";
 pub(crate) const DEFAULT_OBSERVABILITY_ENDPOINT_MAX_REQUESTS: u64 = 1;
 pub(crate) const DEFAULT_OBSERVABILITY_ENDPOINT_IDLE_TIMEOUT_MS: u64 = 5_000;
+const OBSERVABILITY_HEALTH_SCHEMA_VERSION: &str = "kamn.runtime.observability.health.v1";
+const OBSERVABILITY_READINESS_SCHEMA_VERSION: &str = "kamn.runtime.observability.readiness.v1";
+const OBSERVABILITY_STREAM_SCHEMA_VERSION: &str = "kamn.runtime.observability.stream.v1";
+const OBSERVABILITY_READINESS_REASON_TAXONOMY_VERSION: &str =
+    "kamn.runtime.observability.readiness.reason-taxonomy.v1";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ObservabilityEndpointConfig {
@@ -370,7 +375,8 @@ fn render_metrics_body(snapshot: &RuntimeObservabilitySnapshot) -> String {
 fn render_health_body(snapshot: &RuntimeObservabilitySnapshot) -> String {
     let readiness_reason_code = readiness_reason_code(snapshot);
     format!(
-        "{{\"source\":\"{}\",\"runtime_mode\":\"{}\",\"health\":\"{}\",\"alert_count\":{},\"reason_code\":\"{}\",\"ready\":{},\"readiness_reason_code\":\"{}\",\"transport_dependency_status\":\"{}\",\"signer_dependency_status\":\"{}\",\"commit_dependency_status\":\"{}\",\"transport_checkpoint_failures\":{},\"signer_checkpoint_failures\":{},\"commit_checkpoint_failures\":{},\"latency_p50_ms\":{},\"latency_p99_ms\":{},\"throughput_tps\":{},\"error_rate_bps\":{},\"availability_bps\":{}}}",
+        "{{\"schema_version\":\"{}\",\"source\":\"{}\",\"runtime_mode\":\"{}\",\"health\":\"{}\",\"alert_count\":{},\"reason_code\":\"{}\",\"ready\":{},\"readiness_reason_code\":\"{}\",\"readiness_reason_taxonomy_version\":\"{}\",\"transport_dependency_status\":\"{}\",\"signer_dependency_status\":\"{}\",\"commit_dependency_status\":\"{}\",\"transport_checkpoint_failures\":{},\"signer_checkpoint_failures\":{},\"commit_checkpoint_failures\":{},\"latency_p50_ms\":{},\"latency_p99_ms\":{},\"throughput_tps\":{},\"error_rate_bps\":{},\"availability_bps\":{}}}",
+        OBSERVABILITY_HEALTH_SCHEMA_VERSION,
         escape_json_string(snapshot.source.as_str()),
         escape_json_string(snapshot.runtime_mode.as_str()),
         escape_json_string(snapshot.health.as_str()),
@@ -378,6 +384,7 @@ fn render_health_body(snapshot: &RuntimeObservabilitySnapshot) -> String {
         escape_json_string(snapshot.reason_code.as_str()),
         is_runtime_ready(snapshot),
         escape_json_string(readiness_reason_code),
+        OBSERVABILITY_READINESS_REASON_TAXONOMY_VERSION,
         transport_dependency_status(snapshot),
         signer_dependency_status(snapshot),
         commit_dependency_status(snapshot),
@@ -395,7 +402,8 @@ fn render_health_body(snapshot: &RuntimeObservabilitySnapshot) -> String {
 fn render_stream_body(snapshot: &RuntimeObservabilitySnapshot) -> String {
     let readiness_reason_code = readiness_reason_code(snapshot);
     format!(
-        "{{\"schema_version\":\"kamn.runtime.observability.stream.v1\",\"source\":\"{}\",\"runtime_mode\":\"{}\",\"health\":\"{}\",\"alert_count\":{},\"reason_code\":\"{}\",\"ready\":{},\"readiness_reason_code\":\"{}\",\"transport_dependency_status\":\"{}\",\"signer_dependency_status\":\"{}\",\"commit_dependency_status\":\"{}\",\"transport_checkpoint_failures\":{},\"signer_checkpoint_failures\":{},\"commit_checkpoint_failures\":{},\"latency_p50_ms\":{},\"latency_p99_ms\":{},\"throughput_tps\":{},\"error_rate_bps\":{},\"availability_bps\":{}}}\n",
+        "{{\"schema_version\":\"{}\",\"source\":\"{}\",\"runtime_mode\":\"{}\",\"health\":\"{}\",\"alert_count\":{},\"reason_code\":\"{}\",\"ready\":{},\"readiness_reason_code\":\"{}\",\"transport_dependency_status\":\"{}\",\"signer_dependency_status\":\"{}\",\"commit_dependency_status\":\"{}\",\"transport_checkpoint_failures\":{},\"signer_checkpoint_failures\":{},\"commit_checkpoint_failures\":{},\"latency_p50_ms\":{},\"latency_p99_ms\":{},\"throughput_tps\":{},\"error_rate_bps\":{},\"availability_bps\":{}}}\n",
+        OBSERVABILITY_STREAM_SCHEMA_VERSION,
         escape_json_string(snapshot.source.as_str()),
         escape_json_string(snapshot.runtime_mode.as_str()),
         escape_json_string(snapshot.health.as_str()),
@@ -420,13 +428,15 @@ fn render_stream_body(snapshot: &RuntimeObservabilitySnapshot) -> String {
 fn render_readiness_body(snapshot: &RuntimeObservabilitySnapshot) -> String {
     let readiness_reason_code = readiness_reason_code(snapshot);
     format!(
-        "{{\"source\":\"{}\",\"runtime_mode\":\"{}\",\"ready\":{},\"health\":\"{}\",\"reason_code\":\"{}\",\"readiness_reason_code\":\"{}\",\"transport_dependency_status\":\"{}\",\"signer_dependency_status\":\"{}\",\"commit_dependency_status\":\"{}\",\"transport_checkpoint_failures\":{},\"signer_checkpoint_failures\":{},\"commit_checkpoint_failures\":{}}}",
+        "{{\"schema_version\":\"{}\",\"source\":\"{}\",\"runtime_mode\":\"{}\",\"ready\":{},\"health\":\"{}\",\"reason_code\":\"{}\",\"readiness_reason_code\":\"{}\",\"readiness_reason_taxonomy_version\":\"{}\",\"transport_dependency_status\":\"{}\",\"signer_dependency_status\":\"{}\",\"commit_dependency_status\":\"{}\",\"transport_checkpoint_failures\":{},\"signer_checkpoint_failures\":{},\"commit_checkpoint_failures\":{}}}",
+        OBSERVABILITY_READINESS_SCHEMA_VERSION,
         escape_json_string(snapshot.source.as_str()),
         escape_json_string(snapshot.runtime_mode.as_str()),
         is_runtime_ready(snapshot),
         escape_json_string(snapshot.health.as_str()),
         escape_json_string(snapshot.reason_code.as_str()),
         escape_json_string(readiness_reason_code),
+        OBSERVABILITY_READINESS_REASON_TAXONOMY_VERSION,
         transport_dependency_status(snapshot),
         signer_dependency_status(snapshot),
         commit_dependency_status(snapshot),

--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -487,7 +487,8 @@ Versioned thresholds are defined in `.ci/ci-budget.env`.
   - deterministic fail-closed policy tamper drill executed in-process
 - Deterministic fail-closed marker for drift tamper drills:
   - `observability_source_marker_missing:async_dispatch`
-  - telemetry schema docs-contract marker set remains fail-closed for stream schema_version and readiness_reason_code taxonomy.
+  - `observability_source_marker_missing:legacy_tcp_listener_import`
+  - telemetry schema docs-contract marker set remains fail-closed for health/readiness/stream schema_version markers and readiness_reason_code taxonomy.
 
 ## Runtime Local Retry/Diagnostics Contract Lane
 - Entry commands:

--- a/docs/foundation/observability-slo-dashboards.md
+++ b/docs/foundation/observability-slo-dashboards.md
@@ -28,6 +28,8 @@ This document captures the first implementation slice for deterministic observab
   - metrics: `/metrics` (Prometheus text format)
   - health: `/healthz` (JSON payload)
   - readiness: `/readyz` (JSON payload)
+- Contract reference:
+  - `docs/observability/contracts.md`
 - Metrics payload keys:
   - `kamn_observability_latency_p50_ms`
   - `kamn_observability_latency_p99_ms`
@@ -41,22 +43,28 @@ This document captures the first implementation slice for deterministic observab
   - `kamn_observability_reason_code{reason_code="<reason>"}` with deterministic label values.
   - `kamn_observability_health{health="<healthy|degraded|critical>"}`
 - Health payload fields:
+  - `schema_version` (`kamn.runtime.observability.health.v1`)
   - `source`
   - `runtime_mode`
   - `health`
   - `alert_count`
   - `reason_code`
+  - `ready`
+  - `readiness_reason_code`
+  - `readiness_reason_taxonomy_version` (`kamn.runtime.observability.readiness.reason-taxonomy.v1`)
   - `transport_checkpoint_failures`
   - `signer_checkpoint_failures`
   - `commit_checkpoint_failures`
   - latency/throughput/error/availability numeric fields
 - Readiness payload fields:
+  - `schema_version` (`kamn.runtime.observability.readiness.v1`)
   - `source`
   - `runtime_mode`
   - `ready` (boolean)
   - `health`
   - `reason_code` (runtime telemetry reason)
   - `readiness_reason_code` (dependency-derived readiness taxonomy)
+  - `readiness_reason_taxonomy_version` (`kamn.runtime.observability.readiness.reason-taxonomy.v1`)
   - `transport_dependency_status`
   - `signer_dependency_status`
   - `commit_dependency_status`

--- a/docs/observability/contracts.md
+++ b/docs/observability/contracts.md
@@ -1,0 +1,65 @@
+# Observability Contracts
+
+## Runtime Endpoint Schemas
+
+This document defines deterministic payload contracts for the runtime observability endpoint.
+
+- `GET /metrics` emits Prometheus text with readiness and reason-code labels.
+- `GET /healthz` emits JSON with `schema_version="kamn.runtime.observability.health.v1"`.
+- `GET /readyz` emits JSON with `schema_version="kamn.runtime.observability.readiness.v1"`.
+- `GET /metrics.stream` emits NDJSON with `schema_version="kamn.runtime.observability.stream.v1"`.
+
+## Health Payload Contract
+
+`/healthz` includes:
+
+- `schema_version`
+- `source`
+- `runtime_mode`
+- `health`
+- `alert_count`
+- `reason_code`
+- `ready`
+- `readiness_reason_code`
+- `readiness_reason_taxonomy_version`
+- `transport_dependency_status`
+- `signer_dependency_status`
+- `commit_dependency_status`
+- `transport_checkpoint_failures`
+- `signer_checkpoint_failures`
+- `commit_checkpoint_failures`
+- `latency_p50_ms`
+- `latency_p99_ms`
+- `throughput_tps`
+- `error_rate_bps`
+- `availability_bps`
+
+## Readiness Payload Contract
+
+`/readyz` includes:
+
+- `schema_version`
+- `source`
+- `runtime_mode`
+- `ready`
+- `health`
+- `reason_code`
+- `readiness_reason_code`
+- `readiness_reason_taxonomy_version`
+- `transport_dependency_status`
+- `signer_dependency_status`
+- `commit_dependency_status`
+- `transport_checkpoint_failures`
+- `signer_checkpoint_failures`
+- `commit_checkpoint_failures`
+
+## Readiness Taxonomy Contract
+
+- `readiness_reason_taxonomy_version="kamn.runtime.observability.readiness.reason-taxonomy.v1"`
+- `none`
+- `readiness_transport_dependency_unhealthy`
+- `readiness_signer_dependency_unhealthy`
+- `readiness_commit_dependency_unhealthy`
+- `readiness_runtime_health_degraded`
+
+Regression: #3600

--- a/scripts/ci/check_observability_endpoint_drift_contract.py
+++ b/scripts/ci/check_observability_endpoint_drift_contract.py
@@ -37,13 +37,19 @@ SOURCE_MARKERS: dict[str, str] = {
 }
 
 TELEMETRY_SOURCE_MARKERS: dict[str, str] = {
-    "stream_schema_marker": "{\\\"schema_version\\\":\\\"kamn.runtime.observability.stream.v1\\\"",
+    "stream_schema_marker": "const OBSERVABILITY_STREAM_SCHEMA_VERSION: &str = \"kamn.runtime.observability.stream.v1\";",
+    "health_schema_marker": "const OBSERVABILITY_HEALTH_SCHEMA_VERSION: &str = \"kamn.runtime.observability.health.v1\";",
+    "readiness_schema_marker": "const OBSERVABILITY_READINESS_SCHEMA_VERSION: &str = \"kamn.runtime.observability.readiness.v1\";",
+    "readiness_reason_taxonomy_version_marker": "const OBSERVABILITY_READINESS_REASON_TAXONOMY_VERSION: &str =",
     "metrics_readiness_reason_code_marker": "kamn_observability_readiness_reason_code{{readiness_reason_code=\\\"{}\\\"}} 1",
     "readiness_reason_projection_fn": "fn readiness_reason_code(snapshot: &RuntimeObservabilitySnapshot) -> &'static str {",
 }
 
 TELEMETRY_DOC_MARKERS: dict[str, str] = {
     "stream_schema_marker": "schema_version=\"kamn.runtime.observability.stream.v1\"",
+    "health_schema_marker": "`schema_version` (`kamn.runtime.observability.health.v1`)",
+    "readiness_schema_marker": "`schema_version` (`kamn.runtime.observability.readiness.v1`)",
+    "readiness_reason_taxonomy_version_marker": "`readiness_reason_taxonomy_version` (`kamn.runtime.observability.readiness.reason-taxonomy.v1`)",
     "readiness_reason_taxonomy_marker": "`readiness_reason_code` (dependency-derived readiness taxonomy)",
     "readiness_transport_marker": "`readiness_transport_dependency_unhealthy`",
     "readiness_signer_marker": "`readiness_signer_dependency_unhealthy`",
@@ -51,9 +57,16 @@ TELEMETRY_DOC_MARKERS: dict[str, str] = {
     "readiness_runtime_health_marker": "`readiness_runtime_health_degraded`",
 }
 
+OBSERVABILITY_CONTRACT_DOC_MARKERS: dict[str, str] = {
+    "health_schema_marker": "schema_version=\"kamn.runtime.observability.health.v1\"",
+    "readiness_schema_marker": "schema_version=\"kamn.runtime.observability.readiness.v1\"",
+    "stream_schema_marker": "schema_version=\"kamn.runtime.observability.stream.v1\"",
+    "readiness_reason_taxonomy_version_marker": "readiness_reason_taxonomy_version=\"kamn.runtime.observability.readiness.reason-taxonomy.v1\"",
+}
+
 TELEMETRY_STRATEGY_MARKER = (
-    "telemetry schema docs-contract marker set remains fail-closed for stream "
-    "schema_version and readiness_reason_code taxonomy."
+    "telemetry schema docs-contract marker set remains fail-closed for "
+    "health/readiness/stream schema_version markers and readiness_reason_code taxonomy."
 )
 
 MAIN_WIRING_MARKER = "serve_observability_endpoint(&endpoint_config, &snapshot)"
@@ -72,6 +85,7 @@ def _run(args: argparse.Namespace) -> int:
     framework_file = Path(args.framework_file).resolve()
     docs_file = Path(args.docs_file).resolve()
     observability_doc_file = Path(args.observability_doc_file).resolve()
+    observability_contract_doc_file = Path(args.observability_contract_doc_file).resolve()
     strategy_doc_file = Path(args.strategy_doc_file).resolve()
 
     source_text = _read_text(
@@ -94,6 +108,10 @@ def _run(args: argparse.Namespace) -> int:
     observability_docs_text = _read_text(
         observability_doc_file,
         reason_code="observability_schema_docs_file_missing",
+    )
+    observability_contract_docs_text = _read_text(
+        observability_contract_doc_file,
+        reason_code="observability_contract_docs_file_missing",
     )
     strategy_doc_text = _read_text(
         strategy_doc_file,
@@ -127,6 +145,15 @@ def _run(args: argparse.Namespace) -> int:
             decision.reject_if(
                 True,
                 f"observability_schema_docs_marker_missing:{marker_key}",
+            )
+
+    missing_contract_doc_markers: list[str] = []
+    for marker_key, marker_value in OBSERVABILITY_CONTRACT_DOC_MARKERS.items():
+        if marker_value not in observability_contract_docs_text:
+            missing_contract_doc_markers.append(marker_key)
+            decision.reject_if(
+                True,
+                f"observability_contract_docs_marker_missing:{marker_key}",
             )
 
     decision.reject_if(
@@ -169,6 +196,7 @@ def _run(args: argparse.Namespace) -> int:
             if (
                 not missing_telemetry_source_markers
                 and not missing_telemetry_doc_markers
+                and not missing_contract_doc_markers
                 and TELEMETRY_STRATEGY_MARKER in strategy_doc_text
             )
             else "rejected"
@@ -183,12 +211,17 @@ def _run(args: argparse.Namespace) -> int:
             len(TELEMETRY_DOC_MARKERS) - len(missing_telemetry_doc_markers)
         ),
         "expected_telemetry_doc_marker_count": len(TELEMETRY_DOC_MARKERS),
+        "contract_doc_marker_count": (
+            len(OBSERVABILITY_CONTRACT_DOC_MARKERS) - len(missing_contract_doc_markers)
+        ),
+        "expected_contract_doc_marker_count": len(OBSERVABILITY_CONTRACT_DOC_MARKERS),
         "reason_codes": reason_codes,
         "source_file": str(source_file),
         "main_file": str(main_file),
         "framework_file": str(framework_file),
         "docs_file": str(docs_file),
         "observability_doc_file": str(observability_doc_file),
+        "observability_contract_doc_file": str(observability_contract_doc_file),
         "strategy_doc_file": str(strategy_doc_file),
         "generated_at_epoch": int(time.time()),
     }
@@ -249,6 +282,11 @@ def main() -> int:
         "--observability-doc-file",
         default=str(ROOT_DIR / "docs/foundation/observability-slo-dashboards.md"),
         help="Observability telemetry schema documentation path.",
+    )
+    parser.add_argument(
+        "--observability-contract-doc-file",
+        default=str(ROOT_DIR / "docs/observability/contracts.md"),
+        help="Observability runtime contracts documentation path.",
     )
     parser.add_argument(
         "--strategy-doc-file",

--- a/scripts/ci/test_check_observability_endpoint_drift_contract.sh
+++ b/scripts/ci/test_check_observability_endpoint_drift_contract.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 CHECK_SCRIPT="$ROOT_DIR/scripts/ci/check_observability_endpoint_drift_contract.sh"
 OBSERVABILITY_DOC="$ROOT_DIR/docs/foundation/observability-slo-dashboards.md"
+CONTRACT_DOC="$ROOT_DIR/docs/observability/contracts.md"
 STRATEGY_DOC="$ROOT_DIR/docs/ci/strategy.md"
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
@@ -135,8 +136,8 @@ import sys
 path = pathlib.Path(sys.argv[1])
 text = path.read_text(encoding="utf-8")
 text = text.replace(
-    "{\\\"schema_version\\\":\\\"kamn.runtime.observability.stream.v1\\\"",
-    "{\\\"schema_version\\\":\\\"kamn.runtime.observability.stream.vX\\\"",
+    'const OBSERVABILITY_STREAM_SCHEMA_VERSION: &str = "kamn.runtime.observability.stream.v1";',
+    'const OBSERVABILITY_STREAM_SCHEMA_VERSION: &str = "kamn.runtime.observability.stream.vX";',
     1,
 )
 path.write_text(text, encoding="utf-8")
@@ -186,6 +187,35 @@ if ! printf '%s\n' "$tampered_observability_docs_output" | grep -q 'observabilit
   exit 1
 fi
 
+tampered_contract_docs="$TMP_DIR/observability-contracts.md"
+cp "$CONTRACT_DOC" "$tampered_contract_docs"
+python3 - "$tampered_contract_docs" <<'PY'
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+needle = 'schema_version="kamn.runtime.observability.readiness.v1"'
+if needle not in text:
+    raise SystemExit("expected observability contracts docs marker not found in baseline copy")
+path.write_text(text.replace(needle, "", 1), encoding="utf-8")
+PY
+
+set +e
+tampered_contract_docs_output="$(
+  bash "$CHECK_SCRIPT" --observability-contract-doc-file "$tampered_contract_docs" --output-json "$TMP_DIR/observability-endpoint-drift-report.tampered-contract-docs.json" 2>&1
+)"
+tampered_contract_docs_code=$?
+set -e
+if [ "$tampered_contract_docs_code" -eq 0 ]; then
+  echo "expected observability endpoint drift checker to fail on contracts docs marker drift" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$tampered_contract_docs_output" | grep -q 'observability_contract_docs_marker_missing:readiness_schema_marker'; then
+  echo "expected deterministic observability contracts docs-marker drift reason code" >&2
+  exit 1
+fi
+
 tampered_strategy_docs="$TMP_DIR/ci-strategy.md"
 cp "$STRATEGY_DOC" "$tampered_strategy_docs"
 python3 - "$tampered_strategy_docs" <<'PY'
@@ -194,7 +224,7 @@ import sys
 
 path = pathlib.Path(sys.argv[1])
 text = path.read_text(encoding="utf-8")
-needle = "telemetry schema docs-contract marker set remains fail-closed for stream schema_version and readiness_reason_code taxonomy."
+needle = "telemetry schema docs-contract marker set remains fail-closed for health/readiness/stream schema_version markers and readiness_reason_code taxonomy."
 if needle not in text:
     raise SystemExit("expected telemetry strategy marker not found in baseline copy")
 path.write_text(text.replace(needle, "", 1), encoding="utf-8")


### PR DESCRIPTION
Closes #3600

## Summary
Adds deterministic schema-version markers to `/healthz` and `/readyz`, plus readiness taxonomy-version markers, and extends fail-closed observability drift contracts/documentation to guard these payloads.

## Changes
- `crates/kamn-node/src/observability_endpoint.rs`: versioned health/readiness payload schemas and readiness taxonomy-version marker constants.
- `crates/kamn-node/src/main_tests/observability_endpoint_tests.rs`: red-green coverage for schema/taxonomy markers across functional and integration endpoint responses.
- `scripts/ci/check_observability_endpoint_drift_contract.py`: extend telemetry source/docs contract markers to include health/readiness schemas and contracts-doc markers.
- `scripts/ci/test_check_observability_endpoint_drift_contract.sh`: add fail-closed tamper drill for contracts-doc marker drift and updated strategy marker expectations.
- `docs/observability/contracts.md`: new deterministic runtime endpoint schema contract document.
- `docs/foundation/observability-slo-dashboards.md`: health/readiness schema and taxonomy-version field definitions + link to contract doc.
- `docs/ci/strategy.md`: update runtime observability lane drift-marker language for health/readiness/stream schema contracts.

## Risks & Compatibility
- None.

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p kamn-node -- -D warnings` — clean
- [x] `cargo clippy -p kamn-core -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: red-phase failure reproduced for missing health schema marker before implementation; payloads now include deterministic schema/taxonomy markers and drift tamper checks fail closed.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `cargo test -p kamn-node observability_endpoint -- --nocapture` (unit cases included in slice) |
| Functional  | ✅     | `functional_observability_endpoint_renders_metrics_and_health_payloads` validates new health/readiness schema/taxonomy markers |
| Integration | ✅     | `integration_runtime_observability_endpoint_serves_metrics_and_health_paths` validates network-served payload markers |
| Regression  | ✅     | `bash scripts/ci/test_check_observability_endpoint_drift_contract.sh` covers source/docs drift fail-closed reasons |
