### PR TITLE
docs(ci): restore local observability scrape marker parity (#3601)

### DIFF
--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -577,6 +577,7 @@ Versioned thresholds are defined in `.ci/ci-budget.env`.
   - lane emits deterministic scrape-failure taxonomy marker (`scrape_failure_taxonomy_status=verified`) and taxonomy csv marker (`scrape_failure_taxonomy_csv=readiness_failure_drill_status,stream_reconnect_churn_status,queue_bound_budget_status`).
   - telemetry degradation taxonomy policy checker markers remain command-surface contract-governed.
 - Deterministic fail-closed marker for policy tamper drills:
+  - `local_observability_scrape_policy_marker_missing:scrape_probe_status`
   - `local_observability_scrape_policy_marker_missing:readiness_failure_drill_status`
   - `local_observability_scrape_policy_degradation_reason_codes_csv_mismatch`
 


### PR DESCRIPTION
Closes #3601

## Summary
Restores CI strategy docs parity for the local observability scrape lane by reintroducing the expected fail-closed marker entry required by docs-contract tests.

## Changes
- `docs/ci/strategy.md`: add `local_observability_scrape_policy_marker_missing:scrape_probe_status` under local observability scrape policy tamper-drill markers.

## Risks & Compatibility
- None.

## Validation
- [ ] `cargo fmt --check` — clean (N/A: docs-only change)
- [ ] `cargo clippy -- -D warnings` — clean (N/A: docs-only change)
- [ ] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: confirmed docs-contract parity and lane/policy tests pass.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | N/A    | Docs-only change |
| Functional  | ✅     | `bash scripts/runtime/test_check_local_observability_scrape_live_policy.sh` |
| Integration | ✅     | `bash scripts/runtime/test_validate_local_observability_scrape_live_contract_lane.sh` |
| Regression  | ✅     | `cargo test -p kamn-core --test ci_strategy_docs doc_contains_runtime_local_observability_scrape_contract_lane_ci_mode_markers -- --exact` |
