### PR TITLE
docs(observability): add streaming contract guardrails (#3602)

### DIFF
--- a/crates/kamn-core/tests/ci_strategy_docs.rs
+++ b/crates/kamn-core/tests/ci_strategy_docs.rs
@@ -586,6 +586,7 @@ fn doc_contains_runtime_local_observability_scrape_contract_lane_ci_mode_markers
     assert!(DOC.contains("ci-fast-gate mode: fast"));
     assert!(DOC.contains("local-dev mode: local"));
     assert!(DOC.contains("manual-hardened mode: manual"));
+    assert!(DOC.contains("docs/observability/streaming.md"));
     assert!(DOC.contains(
         "local observability scrape run-mode commands remain excluded from ci-fast-gate and ci-tools fast mode."
     ));

--- a/crates/kamn-node/tests/observability_streaming_docs.rs
+++ b/crates/kamn-node/tests/observability_streaming_docs.rs
@@ -1,0 +1,26 @@
+const DOC: &str = include_str!("../../../docs/observability/streaming.md");
+
+#[test]
+fn doc_contains_stream_payload_schema_contract() {
+    assert!(DOC.contains("GET /metrics.stream"));
+    assert!(DOC.contains("application/x-ndjson"));
+    assert!(DOC.contains("schema_version=\"kamn.runtime.observability.stream.v1\""));
+    assert!(DOC.contains("readiness_reason_code"));
+}
+
+#[test]
+fn doc_contains_backpressure_and_reconnect_contract_markers() {
+    assert!(DOC.contains("stream_reconnect_churn_status=verified"));
+    assert!(DOC.contains("queue_bound_budget_status=verified"));
+    assert!(DOC.contains("scrape_failure_taxonomy_status=verified"));
+    assert!(DOC.contains(
+        "scrape_failure_taxonomy_csv=readiness_failure_drill_status,stream_reconnect_churn_status,queue_bound_budget_status"
+    ));
+}
+
+#[test]
+fn doc_contains_low_cost_validation_lane_commands() {
+    assert!(DOC.contains("validate_local_observability_scrape_live.sh --mode dry-run"));
+    assert!(DOC.contains("check_local_observability_scrape_live_policy.sh"));
+    assert!(DOC.contains("validate_local_observability_scrape_live_contract_lane.sh"));
+}

--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -570,6 +570,7 @@ Versioned thresholds are defined in `.ci/ci-budget.env`.
   - local observability scrape run-mode commands remain excluded from ci-fast-gate and ci-tools fast mode.
   - local observability soak run-mode commands remain excluded from ci-fast-gate and ci-tools fast mode.
 - Readiness/failure-drill contracts:
+  - streaming contract reference: `docs/observability/streaming.md`
   - lane emits deterministic readiness probe marker (`readiness_probe_status=verified`).
   - lane emits deterministic readiness degradation drill marker (`readiness_failure_drill_status=verified`).
   - lane emits deterministic readiness reason taxonomy marker (`readiness_reason_taxonomy_status=verified`).

--- a/docs/observability/streaming.md
+++ b/docs/observability/streaming.md
@@ -1,0 +1,56 @@
+# Streaming Observability Contracts
+
+## Scope
+
+This document defines the deterministic stream telemetry contract for `kamn-node`
+runtime observability and the bounded local validation policy used in CI.
+
+## Stream Payload Contract
+
+- Endpoint: `GET /metrics.stream`
+- Content type: `application/x-ndjson`
+- Schema marker: `schema_version="kamn.runtime.observability.stream.v1"`
+- Deterministic fields:
+  - `source`
+  - `runtime_mode`
+  - `health`
+  - `reason_code`
+  - `ready`
+  - `readiness_reason_code`
+  - `transport_dependency_status`
+  - `signer_dependency_status`
+  - `commit_dependency_status`
+  - `transport_checkpoint_failures`
+  - `signer_checkpoint_failures`
+  - `commit_checkpoint_failures`
+  - `latency_p50_ms`
+  - `latency_p99_ms`
+  - `throughput_tps`
+  - `error_rate_bps`
+  - `availability_bps`
+
+## Backpressure and Reconnect Contracts
+
+- Queue/backpressure behavior remains bounded by request-budget controls:
+  - `--observability-endpoint-max-requests`
+  - `--observability-endpoint-idle-timeout-ms`
+- Local validation lane emits deterministic contract markers:
+  - `stream_reconnect_churn_status=verified`
+  - `queue_bound_budget_status=verified`
+  - `readiness_failure_drill_status=verified`
+  - `scrape_failure_taxonomy_status=verified`
+  - `scrape_failure_taxonomy_csv=readiness_failure_drill_status,stream_reconnect_churn_status,queue_bound_budget_status`
+- Readiness reason taxonomy is deterministic:
+  - `none`
+  - `readiness_transport_dependency_unhealthy`
+  - `readiness_signer_dependency_unhealthy`
+  - `readiness_commit_dependency_unhealthy`
+  - `readiness_runtime_health_degraded`
+
+## Low-Cost Validation Lane
+
+- `bash scripts/runtime/validate_local_observability_scrape_live.sh --mode dry-run --output-json /tmp/local-observability-scrape-live-summary.json`
+- `bash scripts/runtime/check_local_observability_scrape_live_policy.sh --report-file /tmp/local-observability-scrape-live-summary.json --expected-final-decision GO --ci-fast-gate PASS --output-json /tmp/local-observability-scrape-live-policy.json`
+- `bash scripts/runtime/validate_local_observability_scrape_live_contract_lane.sh --output-json /tmp/local-observability-scrape-live-contract-lane-report.json --policy-output-json /tmp/local-observability-scrape-live-policy.json`
+
+Regression: #3602


### PR DESCRIPTION
Closes #3602

## Summary
Adds explicit streaming observability contract documentation and fail-closed docs guardrails for stream backpressure and reconnect taxonomy, aligning CI strategy references and docs-contract tests.

## Changes
- `docs/observability/streaming.md`: new stream backpressure/reconnect contract spec and low-cost validation lane commands.
- `crates/kamn-node/tests/observability_streaming_docs.rs`: fail-closed docs contract tests for stream schema, queue/reconnect markers, and lane commands.
- `docs/ci/strategy.md`: add streaming contract reference in local observability scrape readiness/failure section.
- `crates/kamn-core/tests/ci_strategy_docs.rs`: assert streaming contract doc reference remains present in CI strategy docs.

## Risks & Compatibility
- None.

## Validation
- [ ] `cargo fmt --check` — clean (N/A: docs/tests only, no source formatting drift remains)
- [x] `cargo clippy -p kamn-node -- -D warnings` — clean
- [x] `cargo clippy -p kamn-core -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: validated queue-budget and reconnect churn scenario tests plus local scrape lane/policy script contracts.

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | `cargo test -p kamn-node --test observability_streaming_docs` |
| Functional  | ✅     | `bash scripts/runtime/test_check_local_observability_scrape_live_policy.sh` |
| Integration | ✅     | `cargo test -p kamn-node main_tests::observability_endpoint_tests::integration_runtime_observability_endpoint_supports_stream_reconnect_churn_sequence -- --exact` and queue-budget integration pair |
| Regression  | ✅     | `cargo test -p kamn-core --test ci_strategy_docs doc_contains_runtime_local_observability_scrape_contract_lane_ci_mode_markers -- --exact` |
