### PR TITLE
test(runtime): enforce observability churn matrix contracts (#3603)

### DIFF
--- a/docs/ci/ci-cost-and-lane-framework.md
+++ b/docs/ci/ci-cost-and-lane-framework.md
@@ -122,6 +122,27 @@ Fast-gate threshold metadata contract:
 - contract lane command: `bash scripts/ci/run_fast_gate_budget_delta_contract_lane.sh --output-json /tmp/fast-gate-budget-delta-contract-report.json`
 - refresh .ci/fast-gate-budget-delta.env baseline and threshold metadata
 
+## Observability Churn Matrix Cost Boundary
+Local-heavy observability churn validation remains bounded and outside merge-critical fast-gate execution:
+
+- validation lane: `scripts/runtime/validate_local_observability_scrape_live.sh`
+- policy checker: `scripts/runtime/check_local_observability_scrape_live_policy.sh`
+- contract lane: `scripts/runtime/validate_local_observability_scrape_live_contract_lane.sh`
+- policy checker regression suite: `scripts/runtime/test_check_local_observability_scrape_live_policy.sh`
+
+Deterministic churn scenario markers required by policy:
+
+- `stream_reconnect_churn_status=verified`
+- `queue_bound_budget_status=verified`
+- `readiness_failure_drill_status=verified`
+- `scrape_failure_taxonomy_csv=readiness_failure_drill_status,stream_reconnect_churn_status,queue_bound_budget_status`
+
+Cost boundary:
+
+- fast-gate executes docs/contract drift checks only.
+- run mode requires explicit local opt-in (`KAMN_LOCAL_OBSERVABILITY_SCRAPE_OPT_IN=1`).
+- soak profile (`--lane-profile soak`) is local-only and bounded by configured iteration and timeout controls.
+
 ## Staging Soak Telemetry Policy
 Staging soak/rehearsal evidence for rollout readiness is generated and checked with:
 

--- a/scripts/runtime/test_check_local_observability_scrape_live_policy.sh
+++ b/scripts/runtime/test_check_local_observability_scrape_live_policy.sh
@@ -148,6 +148,39 @@ if ! printf '%s\n' "$tampered_queue_bound_output" | grep -q 'local_observability
   exit 1
 fi
 
+tampered_reconnect_report="$TMP_DIR/local-observability-scrape-live-summary.reconnect-churn.tampered.json"
+cp "$report_file" "$tampered_reconnect_report"
+python3 - "$tampered_reconnect_report" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+payload = json.loads(path.read_text(encoding="utf-8"))
+payload["stream_reconnect_churn_status"] = "missing"
+path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+set +e
+tampered_reconnect_output="$(
+  bash "$POLICY_CHECKER" \
+    --report-file "$tampered_reconnect_report" \
+    --expected-final-decision GO \
+    --ci-fast-gate PASS \
+    --output-json "$TMP_DIR/local-observability-scrape-live-policy.reconnect-churn.tampered.json" 2>&1
+)"
+tampered_reconnect_code=$?
+set -e
+
+if [ "$tampered_reconnect_code" -eq 0 ]; then
+  echo "expected tampered local observability reconnect churn marker report to fail policy checker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$tampered_reconnect_output" | grep -q 'local_observability_scrape_policy_marker_missing:stream_reconnect_churn_status'; then
+  echo "expected deterministic reconnect churn marker mismatch reason code for tampered local observability policy validation" >&2
+  exit 1
+fi
+
 tampered_degradation_taxonomy_report="$TMP_DIR/local-observability-scrape-live-summary.degradation-taxonomy.tampered.json"
 cp "$report_file" "$tampered_degradation_taxonomy_report"
 python3 - "$tampered_degradation_taxonomy_report" <<'PY'


### PR DESCRIPTION
Closes #3603

## Summary
Add explicit fail-closed reconnect-churn omission coverage to local observability scrape policy tests and document the local cost boundary for churn-matrix validation lanes.

## Changes
- `scripts/runtime/test_check_local_observability_scrape_live_policy.sh`: add reconnect-churn tamper drill and reason-code assertion.
- `docs/ci/ci-cost-and-lane-framework.md`: add Observability Churn Matrix Cost Boundary section with deterministic marker and cost controls.

## Risks & Compatibility
- None

## Validation
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual verification: ran local observability policy and contract lane scripts with tamper drills

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅     | Policy test harness validates deterministic marker failure semantics |
| Functional  | ✅     | Contract lane remains green with bounded local profile |
| Integration | ✅     | Local policy + lane scripts exercised together |
| Regression  | ✅     | New tamper case for missing `stream_reconnect_churn_status` |

## Commands Run
- `bash scripts/runtime/test_check_local_observability_scrape_live_policy.sh`
- `bash scripts/runtime/test_validate_local_observability_scrape_live_contract_lane.sh`
