### PR TITLE
feat(core): replace live transport delegate with data-plane registry (#3574)

### DIFF
--- a/crates/kamn-core/src/p2p_transport.rs
+++ b/crates/kamn-core/src/p2p_transport.rs
@@ -8,7 +8,7 @@ use crate::runtime::{
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::error::Error;
 use std::fmt::{Display, Formatter};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 
 const LIBP2P_SWARM_BEHAVIOR_COMPONENTS: [&str; 6] =
     ["tcp", "noise", "yamux", "identify", "kad", "gossipsub"];
@@ -327,7 +327,7 @@ impl<T: PeerLifecycleTransport> PeerLifecycleTransportCoordinator<T> {
 pub struct Libp2pLivePeerLifecycleTransport {
     swarm_config: P2pSwarmDeterministicConfig,
     harness_report: P2pSwarmHarnessReport,
-    delegate: InMemoryPeerLifecycleTransport,
+    live_data_plane: Libp2pLiveDataPlane,
 }
 
 impl Libp2pLivePeerLifecycleTransport {
@@ -338,10 +338,12 @@ impl Libp2pLivePeerLifecycleTransport {
     ) -> Result<Self, P2pTransportError> {
         let task = P2pSwarmHarnessTask::new(config.clone());
         let harness_report = task.start(harness_mode)?;
+        let network_id = build_live_data_plane_network_id(&config);
+        let state = resolve_live_data_plane_state(network_id.as_str())?;
         Ok(Self {
             swarm_config: config,
             harness_report,
-            delegate: InMemoryPeerLifecycleTransport::default(),
+            live_data_plane: Libp2pLiveDataPlane { network_id, state },
         })
     }
 
@@ -359,11 +361,31 @@ impl Libp2pLivePeerLifecycleTransport {
     pub fn listen_address(&self) -> &str {
         self.swarm_config.listen_address()
     }
+
+    /// Returns deterministic live data-plane network identifier.
+    pub fn live_data_plane_network_id(&self) -> &str {
+        self.live_data_plane.network_id.as_str()
+    }
+
+    fn lock_live_data_plane_state(
+        &self,
+    ) -> Result<std::sync::MutexGuard<'_, Libp2pLiveDataPlaneState>, P2pTransportError> {
+        self.live_data_plane
+            .state
+            .lock()
+            .map_err(|_| P2pTransportError::StateUnavailable)
+    }
 }
 
 impl PeerLifecycleTransport for Libp2pLivePeerLifecycleTransport {
     fn advertise(&self, record: PeerDiscoveryRecord) -> Result<(), P2pTransportError> {
-        self.delegate.advertise(record)
+        let mut state = self.lock_live_data_plane_state()?;
+        state
+            .inbox_by_peer
+            .entry(record.peer_id.clone())
+            .or_insert_with(VecDeque::new);
+        state.peers_by_id.insert(record.peer_id.clone(), record);
+        Ok(())
     }
 
     fn discover(
@@ -371,19 +393,90 @@ impl PeerLifecycleTransport for Libp2pLivePeerLifecycleTransport {
         requester_peer_id: &str,
         topic: &str,
     ) -> Result<Vec<PeerDiscoveryRecord>, P2pTransportError> {
-        self.delegate.discover(requester_peer_id, topic)
+        validate_peer_id(requester_peer_id)?;
+        validate_topic(topic)?;
+        let state = self.lock_live_data_plane_state()?;
+        Ok(state
+            .peers_by_id
+            .values()
+            .filter(|record| record.peer_id != requester_peer_id && record.supports_topic(topic))
+            .cloned()
+            .collect())
     }
 
     fn send(&self, frame: PeerGossipFrame) -> Result<(), P2pTransportError> {
-        self.delegate.send(frame)
+        let mut state = self.lock_live_data_plane_state()?;
+        if !state.peers_by_id.contains_key(&frame.sender_peer_id) {
+            return Err(P2pTransportError::UnknownSenderPeer(
+                frame.sender_peer_id.clone(),
+            ));
+        }
+        if !state.peers_by_id.contains_key(&frame.recipient_peer_id) {
+            return Err(P2pTransportError::UnknownRecipientPeer(
+                frame.recipient_peer_id.clone(),
+            ));
+        }
+        state
+            .inbox_by_peer
+            .entry(frame.recipient_peer_id.clone())
+            .or_insert_with(VecDeque::new)
+            .push_back(frame);
+        Ok(())
     }
 
     fn drain_inbox(
         &self,
         recipient_peer_id: &str,
     ) -> Result<Vec<PeerGossipFrame>, P2pTransportError> {
-        self.delegate.drain_inbox(recipient_peer_id)
+        validate_peer_id(recipient_peer_id)?;
+        let mut state = self.lock_live_data_plane_state()?;
+        let queue = state
+            .inbox_by_peer
+            .entry(recipient_peer_id.to_owned())
+            .or_insert_with(VecDeque::new);
+        Ok(queue.drain(..).collect())
     }
+}
+
+#[derive(Debug, Default)]
+struct Libp2pLiveDataPlaneState {
+    peers_by_id: BTreeMap<String, PeerDiscoveryRecord>,
+    inbox_by_peer: BTreeMap<String, VecDeque<PeerGossipFrame>>,
+}
+
+#[derive(Debug, Clone)]
+struct Libp2pLiveDataPlane {
+    network_id: String,
+    state: Arc<Mutex<Libp2pLiveDataPlaneState>>,
+}
+
+fn libp2p_live_data_plane_registry(
+) -> &'static Mutex<BTreeMap<String, Arc<Mutex<Libp2pLiveDataPlaneState>>>> {
+    static REGISTRY: OnceLock<Mutex<BTreeMap<String, Arc<Mutex<Libp2pLiveDataPlaneState>>>>> =
+        OnceLock::new();
+    REGISTRY.get_or_init(|| Mutex::new(BTreeMap::new()))
+}
+
+fn resolve_live_data_plane_state(
+    network_id: &str,
+) -> Result<Arc<Mutex<Libp2pLiveDataPlaneState>>, P2pTransportError> {
+    let mut registry = libp2p_live_data_plane_registry()
+        .lock()
+        .map_err(|_| P2pTransportError::StateUnavailable)?;
+    Ok(registry
+        .entry(network_id.to_owned())
+        .or_insert_with(|| Arc::new(Mutex::new(Libp2pLiveDataPlaneState::default())))
+        .clone())
+}
+
+fn build_live_data_plane_network_id(config: &P2pSwarmDeterministicConfig) -> String {
+    let bootstrap_segment = if config.bootstrap_peers().is_empty() {
+        format!("listen={}", config.listen_address())
+    } else {
+        format!("bootstrap={}", config.bootstrap_peers().join(","))
+    };
+    let topic_segment = format!("topics={}", config.gossip_topics().join(","));
+    format!("{bootstrap_segment}|{topic_segment}")
 }
 
 /// Deterministic config used to compose a libp2p swarm behavior stack.

--- a/crates/kamn-core/tests/p2p_live_transport_runtime.rs
+++ b/crates/kamn-core/tests/p2p_live_transport_runtime.rs
@@ -1,9 +1,11 @@
 use kamn_core::{
     build_p2p_swarm_deterministic_config, build_runtime_wiring,
     build_runtime_wiring_with_transport_profile, Libp2pLivePeerLifecycleTransport, NodeConfig,
-    NodeRole, P2pSwarmHarnessMode, P2pTransportError, PeerLifecycleEvent, PeerLifecycleState,
+    NodeRole, P2pSwarmHarnessMode, P2pTransportError, PeerDiscoveryRecord, PeerGossipFrame,
+    PeerLifecycleEvent, PeerLifecycleState, PeerLifecycleTransport,
     PeerLifecycleTransportCoordinator, RuntimeLifecycleError, RuntimeTransportProfile, SyncMode,
 };
+use std::time::{SystemTime, UNIX_EPOCH};
 
 fn config_for(role: NodeRole, gossip_enabled: bool) -> NodeConfig {
     NodeConfig {
@@ -26,6 +28,30 @@ fn live_swarm_config() -> kamn_core::P2pSwarmDeterministicConfig {
         3,
     )
     .expect("swarm config should build")
+}
+
+fn live_swarm_config_for_peer(
+    peer_id: &str,
+    listen_address: &str,
+    bootstrap_seed: &str,
+) -> kamn_core::P2pSwarmDeterministicConfig {
+    build_p2p_swarm_deterministic_config(
+        &config_for(NodeRole::Processor, true),
+        peer_id,
+        listen_address,
+        vec![bootstrap_seed.to_owned()],
+        vec!["messages".to_owned()],
+        3,
+    )
+    .expect("swarm config should build")
+}
+
+fn unique_bootstrap_seed(label: &str) -> String {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock should be monotonic")
+        .as_nanos();
+    format!("/ip4/127.0.0.1/tcp/99{nonce}/p2p/{label}")
 }
 
 #[test]
@@ -94,6 +120,111 @@ fn integration_runtime_wiring_can_enable_live_transport_profile_markers() {
     assert!(default_wiring
         .all_components()
         .contains(&"p2p-in-memory-transport-fallback"));
+}
+
+#[test]
+fn integration_live_transport_data_plane_supports_independent_adapter_exchange() {
+    let bootstrap_seed = unique_bootstrap_seed("live-data-plane");
+    let processor_transport = Libp2pLivePeerLifecycleTransport::new(
+        live_swarm_config_for_peer(
+            "peer-processor-live",
+            "/ip4/127.0.0.1/tcp/9220",
+            bootstrap_seed.as_str(),
+        ),
+        P2pSwarmHarnessMode::DryRun,
+    )
+    .expect("processor live transport should initialize");
+    let listener_transport = Libp2pLivePeerLifecycleTransport::new(
+        live_swarm_config_for_peer(
+            "peer-listener-live",
+            "/ip4/127.0.0.1/tcp/9221",
+            bootstrap_seed.as_str(),
+        ),
+        P2pSwarmHarnessMode::DryRun,
+    )
+    .expect("listener live transport should initialize");
+
+    let mut processor = PeerLifecycleTransportCoordinator::new(
+        "peer-processor-live",
+        NodeRole::Processor,
+        processor_transport,
+    )
+    .expect("processor coordinator should initialize");
+    let mut listener = PeerLifecycleTransportCoordinator::new(
+        "peer-listener-live",
+        NodeRole::Listener,
+        listener_transport,
+    )
+    .expect("listener coordinator should initialize");
+
+    assert_eq!(
+        processor.connect_and_advertise(vec!["messages".to_owned()]),
+        Ok(PeerLifecycleState::Active)
+    );
+    assert_eq!(
+        listener.connect_and_advertise(vec!["messages".to_owned()]),
+        Ok(PeerLifecycleState::Active)
+    );
+
+    let discovered = processor
+        .discover("messages")
+        .expect("live discovery should succeed");
+    assert_eq!(discovered.len(), 1);
+    assert_eq!(discovered[0].peer_id, "peer-listener-live");
+
+    let delivered = processor
+        .broadcast("messages", "tx-live-001")
+        .expect("live broadcast should succeed");
+    assert_eq!(delivered, 1);
+
+    let listener_frames = listener
+        .drain_inbox()
+        .expect("listener live inbox drain should succeed");
+    assert_eq!(listener_frames.len(), 1);
+    assert_eq!(listener_frames[0].sender_peer_id, "peer-processor-live");
+    assert_eq!(listener_frames[0].topic, "messages");
+    assert_eq!(listener_frames[0].payload, "tx-live-001");
+}
+
+#[test]
+fn regression_live_transport_data_plane_unknown_recipient_fails_closed() {
+    // Regression: #3574
+    let bootstrap_seed = unique_bootstrap_seed("live-fail-closed");
+    let transport = Libp2pLivePeerLifecycleTransport::new(
+        live_swarm_config_for_peer(
+            "peer-processor-live-fail-closed",
+            "/ip4/127.0.0.1/tcp/9222",
+            bootstrap_seed.as_str(),
+        ),
+        P2pSwarmHarnessMode::DryRun,
+    )
+    .expect("live transport should initialize");
+
+    transport
+        .advertise(
+            PeerDiscoveryRecord::new(
+                "peer-processor-live-fail-closed",
+                NodeRole::Processor,
+                vec!["messages".to_owned()],
+            )
+            .expect("discovery record should build"),
+        )
+        .expect("local peer should advertise");
+
+    let frame = PeerGossipFrame::new(
+        "messages",
+        "peer-processor-live-fail-closed",
+        "peer-missing-live",
+        "tx-live-fail-closed",
+    )
+    .expect("frame should build");
+    let result = transport.send(frame);
+    assert_eq!(
+        result,
+        Err(P2pTransportError::UnknownRecipientPeer(
+            "peer-missing-live".to_owned()
+        ))
+    );
 }
 
 #[test]

--- a/crates/kamn-core/tests/p2p_transport_docs.rs
+++ b/crates/kamn-core/tests/p2p_transport_docs.rs
@@ -10,6 +10,7 @@ fn architecture_doc_contains_p2p_transport_core_components() {
     assert!(DOC.contains("PeerGossipFrame"));
     assert!(DOC.contains("PeerLifecycleTransportCoordinator"));
     assert!(DOC.contains("apply_live_transport_signal"));
+    assert!(DOC.contains("live_data_plane_network_id()"));
     assert!(DOC.contains("P2pSwarmDeterministicConfig"));
     assert!(DOC.contains("P2pSwarmBehaviorStack"));
     assert!(DOC.contains("P2pSwarmHarnessTask"));
@@ -29,6 +30,7 @@ fn architecture_doc_contains_runtime_wiring_and_guardrails() {
     assert!(DOC.contains("p2p-in-memory-transport-fallback"));
     assert!(DOC.contains("p2p-transport-profile:libp2p-live"));
     assert!(DOC.contains("p2p-live-libp2p-provider"));
+    assert!(DOC.contains("no `InMemoryPeerLifecycleTransport` delegate fallback path"));
     assert!(DOC.contains("gossip-transport-disabled"));
     assert!(DOC.contains("P2pTransportError::InvalidPeerId"));
     assert!(DOC.contains("P2pTransportError::InvalidTopic"));
@@ -43,6 +45,9 @@ fn architecture_doc_contains_runtime_wiring_and_guardrails() {
     assert!(DOC.contains("test_validate_p2p_transport_live.sh"));
     assert!(DOC.contains("cargo test -p kamn-core --test p2p_kademlia_bootstrap"));
     assert!(DOC.contains("cargo test -p kamn-core --test p2p_lifecycle_regression_corpus"));
+    assert!(DOC.contains(
+        "cargo test -p kamn-core --test p2p_live_transport_runtime integration_live_transport_data_plane_supports_independent_adapter_exchange -- --exact"
+    ));
 }
 
 #[test]

--- a/docs/architecture/p2p-transport.md
+++ b/docs/architecture/p2p-transport.md
@@ -30,6 +30,8 @@ the default fast test lane.
 - `Libp2pLivePeerLifecycleTransport`
   - deterministic live-adapter surface that boots swarm harness startup and
     provides a concrete transport profile for runtime wiring.
+  - executes advertise/discover/send/drain through a dedicated live data-plane
+    state channel (no `InMemoryPeerLifecycleTransport` delegate fallback path).
 - `PeerDiscoveryRecord`
   - normalized peer advertisement payload with role and gossip topic set.
 - `PeerGossipFrame`
@@ -90,6 +92,19 @@ provider marker contracts for local-heavy runtime rehearsal:
   - `p2p-transport-profile:libp2p-live`
   - `p2p-live-libp2p-provider`
 
+## Live Data-Plane Execution
+
+Subtask #3574 moves the live adapter execution path off the in-memory delegate
+wrapper and onto a dedicated live data-plane state registry keyed by
+deterministic network identity.
+
+- `Libp2pLivePeerLifecycleTransport::live_data_plane_network_id()`
+  - exposes the deterministic network identifier used for adapter mesh routing.
+- Independent live adapter instances with matching deterministic network inputs
+  can discover and exchange gossip frames without cloning one shared adapter.
+- Unsupported lifecycle transitions still fail closed through
+  `P2pTransportError::Lifecycle(RuntimeLifecycleError::InvalidTransition { ... })`.
+
 ## Deterministic Guardrails
 
 - Empty peer IDs fail closed with `P2pTransportError::InvalidPeerId`.
@@ -141,6 +156,7 @@ cargo test -p kamn-core --test p2p_transport_runtime
 cargo test -p kamn-core --test p2p_swarm_stack_runtime
 cargo test -p kamn-core --test p2p_kademlia_bootstrap
 cargo test -p kamn-core --test p2p_lifecycle_regression_corpus
+cargo test -p kamn-core --test p2p_live_transport_runtime integration_live_transport_data_plane_supports_independent_adapter_exchange -- --exact
 cargo test -p kamn-core --test peer_lifecycle_proptest_invariants unit_peer_lifecycle_proptest_config_is_deterministic_and_persistent -- --exact
 cargo test -p kamn-core --test peer_lifecycle_proptest_invariants functional_peer_lifecycle_proptest_enforces_legal_transition_graph -- --exact
 cargo test -p kamn-core --test peer_lifecycle_proptest_invariants integration_peer_lifecycle_proptest_invalid_event_replays_are_idempotent -- --exact


### PR DESCRIPTION
## Summary
Replaced `Libp2pLivePeerLifecycleTransport` delegate-backed behavior with a dedicated live data-plane state registry so independently created live adapters can advertise/discover/send/drain against the same deterministic network identity. Added live data-plane integration/regression coverage and updated architecture docs to reflect the no-delegate execution path.

## Changes
- `crates/kamn-core/src/p2p_transport.rs`: replaced `InMemoryPeerLifecycleTransport` delegate field with a dedicated live data-plane state/registry (`OnceLock` + `Arc<Mutex<...>>`), added `live_data_plane_network_id()`, and wired advertise/discover/send/drain directly to live data-plane state.
- `crates/kamn-core/tests/p2p_live_transport_runtime.rs`: added independent-adapter live exchange integration test and fail-closed regression for unknown recipients (`Regression: #3574`).
- `crates/kamn-core/tests/p2p_transport_docs.rs`: extended docs contract assertions for live data-plane network-id and no-delegate path markers.
- `docs/architecture/p2p-transport.md`: documented the live data-plane execution model and validation command for independent-adapter exchange.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
`cargo test -p kamn-core --test p2p_live_transport_runtime integration_live_transport_data_plane_supports_independent_adapter_exchange`

Observed failure before implementation:
- assertion failed in `integration_live_transport_data_plane_supports_independent_adapter_exchange`
- `left: 0`, `right: 1` (independent live adapters could not discover each other)

### 🟢 Green Phase
Command:
`cargo test -p kamn-core --test p2p_live_transport_runtime integration_live_transport_data_plane_supports_independent_adapter_exchange`

Observed result after implementation:
- test passes (`ok`)

### 🔁 Regression
Commands:
- `cargo test -p kamn-core --test p2p_live_transport_runtime`
- `cargo test -p kamn-core --test p2p_transport_runtime`
- `cargo test -p kamn-core --test p2p_transport_docs`
- `cargo fmt --check`
- `cargo clippy -p kamn-core -- -D warnings`

Observed result:
- all commands pass

## Test Matrix (Mandatory)
For each category, provide status and specifics. If N/A, state why.

| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | Existing `unit_live_transport_adapter_reports_harness_startup_profile`; transport unit behavior retained through direct live-path implementation | |
| Functional   | ✅ | Existing `functional_live_transport_signal_bridge_maps_deterministic_lifecycle_states`; new live-path direct execution exercised by the runtime test suite | |
| Integration  | ✅ | Added `integration_live_transport_data_plane_supports_independent_adapter_exchange` | |
| Regression   | ✅ | Added `regression_live_transport_data_plane_unknown_recipient_fails_closed` (`Regression: #3574`) | |
| Performance  | N/A | No new throughput/latency path or lane budget changes introduced | Deterministic in-memory state registry only; no performance contract altered |

## Risks & Rollback
- Breaking changes: None.
- Risk: global live data-plane registry state is keyed by deterministic transport identity; incorrect identity inputs could cause unintended mesh sharing in tests.
- Rollback: revert this PR to restore previous delegate-backed live adapter behavior.

## Documentation Updates
- `docs/architecture/p2p-transport.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (`cargo clippy -p kamn-core -- -D warnings`)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (relevant suite for touched area)
- [x] Docs updated (or justified why not)

Closes #3574
