### PR TITLE
feat(core): add live lifecycle idempotence reason-code guards (#3575)

### DIFF
--- a/crates/kamn-core/src/p2p_transport.rs
+++ b/crates/kamn-core/src/p2p_transport.rs
@@ -1075,6 +1075,30 @@ impl From<RuntimeLifecycleError> for P2pTransportError {
     }
 }
 
+impl P2pTransportError {
+    /// Returns deterministic reason code for policy and regression guard checks.
+    pub fn reason_code(&self) -> &'static str {
+        match self {
+            Self::InvalidPeerId => "p2p_transport_invalid_peer_id",
+            Self::InvalidTopic => "p2p_transport_invalid_topic",
+            Self::MissingGossipTopics => "p2p_transport_missing_gossip_topics",
+            Self::EmptyPayload => "p2p_transport_empty_payload",
+            Self::UnknownSenderPeer(_) => "p2p_transport_unknown_sender_peer",
+            Self::UnknownRecipientPeer(_) => "p2p_transport_unknown_recipient_peer",
+            Self::MissingKademliaBootstrapSeeds => "p2p_transport_missing_kademlia_seeds",
+            Self::InvalidSwarmListenAddress => "p2p_transport_invalid_swarm_listen_address",
+            Self::InvalidSwarmBootstrapPeerAddress(_) => {
+                "p2p_transport_invalid_swarm_bootstrap_peer_address"
+            }
+            Self::InvalidSwarmHarnessTickBudget => "p2p_transport_invalid_harness_tick_budget",
+            Self::GossipTransportDisabled => "p2p_transport_gossip_disabled",
+            Self::StateUnavailable => "p2p_transport_state_unavailable",
+            Self::InactivePeerLifecycleState(_) => "p2p_transport_inactive_lifecycle_state",
+            Self::Lifecycle(error) => error.reason_code(),
+        }
+    }
+}
+
 impl Display for P2pTransportError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -1178,7 +1202,7 @@ mod tests {
     };
     use crate::config::NodeRole;
     use crate::p2p_transport::{PeerDiscoveryRecord, PeerLifecycleTransportCoordinator};
-    use crate::runtime::PeerLifecycleState;
+    use crate::runtime::{PeerLifecycleEvent, PeerLifecycleState, RuntimeLifecycleError};
 
     #[test]
     fn transport_discovery_filters_by_topic_and_excludes_requester() {
@@ -1270,6 +1294,22 @@ mod tests {
             Err(P2pTransportError::InactivePeerLifecycleState(
                 PeerLifecycleState::Disconnected
             ))
+        );
+    }
+
+    #[test]
+    fn transport_error_reason_code_remains_deterministic() {
+        assert_eq!(
+            P2pTransportError::UnknownRecipientPeer("peer-z".to_owned()).reason_code(),
+            "p2p_transport_unknown_recipient_peer"
+        );
+        assert_eq!(
+            P2pTransportError::Lifecycle(RuntimeLifecycleError::InvalidTransition {
+                from: PeerLifecycleState::Disconnected,
+                event: PeerLifecycleEvent::HeartbeatRestored,
+            })
+            .reason_code(),
+            "runtime_peer_transition_invalid"
         );
     }
 }

--- a/crates/kamn-core/tests/p2p_live_transport_runtime.rs
+++ b/crates/kamn-core/tests/p2p_live_transport_runtime.rs
@@ -94,6 +94,14 @@ fn functional_live_transport_signal_bridge_maps_deterministic_lifecycle_states()
         coordinator.apply_live_transport_signal(PeerLifecycleEvent::Disconnect),
         Ok(PeerLifecycleState::Disconnected)
     );
+    assert_eq!(
+        coordinator.apply_live_transport_signal(PeerLifecycleEvent::Rejoin),
+        Ok(PeerLifecycleState::Connecting)
+    );
+    assert_eq!(
+        coordinator.apply_live_transport_signal(PeerLifecycleEvent::HandshakeSucceeded),
+        Ok(PeerLifecycleState::Active)
+    );
 }
 
 #[test]
@@ -187,6 +195,27 @@ fn integration_live_transport_data_plane_supports_independent_adapter_exchange()
 }
 
 #[test]
+fn integration_live_transport_invalid_event_retries_are_idempotent() {
+    let transport =
+        Libp2pLivePeerLifecycleTransport::new(live_swarm_config(), P2pSwarmHarnessMode::DryRun)
+            .expect("live transport should initialize");
+    let mut coordinator =
+        PeerLifecycleTransportCoordinator::new("peer-processor", NodeRole::Processor, transport)
+            .expect("coordinator should initialize");
+
+    for _ in 0..3 {
+        let error = coordinator
+            .apply_live_transport_signal(PeerLifecycleEvent::HeartbeatRestored)
+            .expect_err("heartbeat restore from disconnected must fail");
+        assert_eq!(error.reason_code(), "runtime_peer_transition_invalid");
+        assert_eq!(
+            coordinator.lifecycle_state(),
+            PeerLifecycleState::Disconnected
+        );
+    }
+}
+
+#[test]
 fn regression_live_transport_data_plane_unknown_recipient_fails_closed() {
     // Regression: #3574
     let bootstrap_seed = unique_bootstrap_seed("live-fail-closed");
@@ -225,6 +254,22 @@ fn regression_live_transport_data_plane_unknown_recipient_fails_closed() {
             "peer-missing-live".to_owned()
         ))
     );
+}
+
+#[test]
+fn regression_live_transport_invalid_transition_reason_code_stable() {
+    // Regression: #3575
+    let transport =
+        Libp2pLivePeerLifecycleTransport::new(live_swarm_config(), P2pSwarmHarnessMode::DryRun)
+            .expect("live transport should initialize");
+    let mut coordinator =
+        PeerLifecycleTransportCoordinator::new("peer-processor", NodeRole::Processor, transport)
+            .expect("coordinator should initialize");
+
+    let error = coordinator
+        .apply_live_transport_signal(PeerLifecycleEvent::HeartbeatRestored)
+        .expect_err("heartbeat restore from disconnected must fail");
+    assert_eq!(error.reason_code(), "runtime_peer_transition_invalid");
 }
 
 #[test]

--- a/crates/kamn-core/tests/p2p_transport_docs.rs
+++ b/crates/kamn-core/tests/p2p_transport_docs.rs
@@ -31,6 +31,7 @@ fn architecture_doc_contains_runtime_wiring_and_guardrails() {
     assert!(DOC.contains("p2p-transport-profile:libp2p-live"));
     assert!(DOC.contains("p2p-live-libp2p-provider"));
     assert!(DOC.contains("no `InMemoryPeerLifecycleTransport` delegate fallback path"));
+    assert!(DOC.contains("P2pTransportError::reason_code()"));
     assert!(DOC.contains("gossip-transport-disabled"));
     assert!(DOC.contains("P2pTransportError::InvalidPeerId"));
     assert!(DOC.contains("P2pTransportError::InvalidTopic"));
@@ -48,6 +49,12 @@ fn architecture_doc_contains_runtime_wiring_and_guardrails() {
     assert!(DOC.contains(
         "cargo test -p kamn-core --test p2p_live_transport_runtime integration_live_transport_data_plane_supports_independent_adapter_exchange -- --exact"
     ));
+    assert!(DOC.contains(
+        "cargo test -p kamn-core --test p2p_live_transport_runtime integration_live_transport_invalid_event_retries_are_idempotent -- --exact"
+    ));
+    assert!(DOC.contains(
+        "cargo test -p kamn-core --test p2p_live_transport_runtime regression_live_transport_invalid_transition_reason_code_stable -- --exact"
+    ));
 }
 
 #[test]
@@ -63,6 +70,7 @@ fn architecture_doc_contains_peer_lifecycle_proptest_invariant_catalog() {
     ));
     assert!(DOC.contains("invalid transition retries must remain idempotent"));
     assert!(DOC.contains("runtime_peer_transition_invalid"));
+    assert!(DOC.contains("lifecycle state remains unchanged across retries"));
 }
 
 #[test]

--- a/docs/architecture/p2p-transport.md
+++ b/docs/architecture/p2p-transport.md
@@ -104,6 +104,9 @@ deterministic network identity.
   can discover and exchange gossip frames without cloning one shared adapter.
 - Unsupported lifecycle transitions still fail closed through
   `P2pTransportError::Lifecycle(RuntimeLifecycleError::InvalidTransition { ... })`.
+- `P2pTransportError::reason_code()`
+  - exposes deterministic reason-code taxonomy for transport policy checks and
+    repeated invalid-event idempotence guards.
 
 ## Deterministic Guardrails
 
@@ -126,6 +129,10 @@ deterministic network identity.
   `P2pTransportError::MissingKademliaBootstrapSeeds`.
 - Invalid lifecycle transition replay remains fail closed with reason code
   `runtime_peer_transition_invalid`.
+- Repeated invalid lifecycle events under live transport must remain idempotent:
+  - lifecycle state remains unchanged across retries.
+  - `P2pTransportError::reason_code()` remains stable at
+    `runtime_peer_transition_invalid` for invalid transition retries.
 
 ## Peer Lifecycle Proptest Invariants
 
@@ -157,6 +164,8 @@ cargo test -p kamn-core --test p2p_swarm_stack_runtime
 cargo test -p kamn-core --test p2p_kademlia_bootstrap
 cargo test -p kamn-core --test p2p_lifecycle_regression_corpus
 cargo test -p kamn-core --test p2p_live_transport_runtime integration_live_transport_data_plane_supports_independent_adapter_exchange -- --exact
+cargo test -p kamn-core --test p2p_live_transport_runtime integration_live_transport_invalid_event_retries_are_idempotent -- --exact
+cargo test -p kamn-core --test p2p_live_transport_runtime regression_live_transport_invalid_transition_reason_code_stable -- --exact
 cargo test -p kamn-core --test peer_lifecycle_proptest_invariants unit_peer_lifecycle_proptest_config_is_deterministic_and_persistent -- --exact
 cargo test -p kamn-core --test peer_lifecycle_proptest_invariants functional_peer_lifecycle_proptest_enforces_legal_transition_graph -- --exact
 cargo test -p kamn-core --test peer_lifecycle_proptest_invariants integration_peer_lifecycle_proptest_invalid_event_replays_are_idempotent -- --exact


### PR DESCRIPTION
## Summary
Added live-transport lifecycle legality/idempotence coverage and deterministic transport reason-code taxonomy so repeated invalid lifecycle events remain fail-closed and reason-code stable under live adapter execution timing.

## Changes
- `crates/kamn-core/src/p2p_transport.rs`: added `P2pTransportError::reason_code()` with deterministic taxonomy and lifecycle error passthrough (`runtime_peer_transition_invalid`).
- `crates/kamn-core/tests/p2p_live_transport_runtime.rs`: expanded legality transition coverage (disconnect/rejoin/handshake), added integration idempotence test for repeated invalid events, and added regression reason-code stability test (`Regression: #3575`).
- `docs/architecture/p2p-transport.md`: documented `P2pTransportError::reason_code()` and repeated invalid-event idempotence reason-code/state invariants.
- `crates/kamn-core/tests/p2p_transport_docs.rs`: added docs-contract assertions for the new reason-code and validation command markers.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
`cargo test -p kamn-core --test p2p_live_transport_runtime integration_live_transport_invalid_event_retries_are_idempotent`

Observed failure before implementation:
- compile error: `no method named reason_code found for enum P2pTransportError`

### 🟢 Green Phase
Command:
`cargo test -p kamn-core --test p2p_live_transport_runtime integration_live_transport_invalid_event_retries_are_idempotent`

Observed result after implementation:
- test passes (`ok`)

### 🔁 Regression
Commands:
- `cargo test -p kamn-core --test p2p_live_transport_runtime`
- `cargo test -p kamn-core --test p2p_transport_runtime`
- `cargo test -p kamn-core --test p2p_transport_docs`
- `cargo test -p kamn-core p2p_transport::tests::transport_error_reason_code_remains_deterministic`
- `cargo fmt --check`
- `cargo clippy -p kamn-core -- -D warnings`

Observed result:
- all commands pass

## Test Matrix (Mandatory)
For each category, provide status and specifics. If N/A, state why.

| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | Added `transport_error_reason_code_remains_deterministic` in `p2p_transport` unit tests | |
| Functional   | ✅ | Extended `functional_live_transport_signal_bridge_maps_deterministic_lifecycle_states` with legal disconnect/rejoin/handshake cycle | |
| Integration  | ✅ | Added `integration_live_transport_invalid_event_retries_are_idempotent` | |
| Regression   | ✅ | Added `regression_live_transport_invalid_transition_reason_code_stable` (`Regression: #3575`) | |
| Performance  | N/A | No runtime budget changes or throughput path modifications | This change is correctness/taxonomy and coverage only |

## Risks & Rollback
- Breaking changes: None.
- Risk: downstream checks that begin using `P2pTransportError::reason_code()` must align to the published taxonomy values.
- Rollback: revert this PR to restore prior transport-error API surface.

## Documentation Updates
- `docs/architecture/p2p-transport.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (`cargo clippy -p kamn-core -- -D warnings`)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (relevant suite for touched area)
- [x] Docs updated (or justified why not)

Closes #3575
