### PR TITLE
feat(block-pipeline): sqlite canonical commit store with strict schema guards

### DIFF
--- a/crates/kamn-core/src/block_pipeline.rs
+++ b/crates/kamn-core/src/block_pipeline.rs
@@ -8,6 +8,7 @@ use crate::runtime::{
     ListenerQuorumEvaluator, ListenerQuorumInput,
 };
 use crate::smoke::{ProducedBlock, RoleSmokeNetwork, SmokeError};
+use crate::sqlite_store_backend::{SqliteStoreBackend, SqliteStoreBackendError};
 use crate::transaction::BaselineTransaction;
 use std::collections::{BTreeMap, BTreeSet};
 use std::error::Error;
@@ -791,6 +792,208 @@ impl CanonicalCommitStore for FileCanonicalCommitStore {
             records.push(record);
         }
         Ok(records)
+    }
+}
+
+const CANONICAL_COMMIT_SQLITE_META_NAMESPACE: &str = "canonical_commit_store_meta";
+const CANONICAL_COMMIT_SQLITE_ENTRIES_NAMESPACE: &str = "canonical_commit_store_entries";
+const CANONICAL_COMMIT_SQLITE_SCHEMA_KEY: &str = "schema_version";
+const CANONICAL_COMMIT_SQLITE_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug)]
+/// Sqlite-backed canonical commit store with strict schema/version guards.
+pub struct SqliteCanonicalCommitStore {
+    backend: SqliteStoreBackend,
+}
+
+impl SqliteCanonicalCommitStore {
+    /// Creates sqlite-backed canonical commit store from path.
+    pub fn new(path: PathBuf) -> Result<Self, BlockPipelineError> {
+        let backend =
+            SqliteStoreBackend::open(path.as_path()).map_err(map_sqlite_commit_store_error)?;
+        let mut store = Self { backend };
+        store.bootstrap_and_validate_schema_version()?;
+        Ok(store)
+    }
+
+    fn bootstrap_and_validate_schema_version(&mut self) -> Result<(), BlockPipelineError> {
+        let current = self
+            .backend
+            .get(
+                CANONICAL_COMMIT_SQLITE_META_NAMESPACE,
+                CANONICAL_COMMIT_SQLITE_SCHEMA_KEY,
+            )
+            .map_err(map_sqlite_commit_store_error)?;
+
+        if let Some(bytes) = current {
+            let schema_raw = String::from_utf8(bytes).map_err(|_| {
+                BlockPipelineError::CommitStore(
+                    "canonical commit sqlite schema value is not utf-8 (canonical_commit_store_sqlite_schema_invalid)"
+                        .to_owned(),
+                )
+            })?;
+            let found = schema_raw.parse::<u32>().map_err(|_| {
+                BlockPipelineError::CommitStore(format!(
+                    "canonical commit sqlite schema value is invalid: {schema_raw} (canonical_commit_store_sqlite_schema_invalid)"
+                ))
+            })?;
+            if found != CANONICAL_COMMIT_SQLITE_SCHEMA_VERSION {
+                return Err(BlockPipelineError::CommitStore(format!(
+                    "canonical commit sqlite schema mismatch: expected {}, found {} (canonical_commit_store_sqlite_schema_mismatch)",
+                    CANONICAL_COMMIT_SQLITE_SCHEMA_VERSION, found
+                )));
+            }
+            return Ok(());
+        }
+
+        let existing_keys = self
+            .backend
+            .list_keys(CANONICAL_COMMIT_SQLITE_ENTRIES_NAMESPACE)
+            .map_err(map_sqlite_commit_store_error)?;
+        if !existing_keys.is_empty() {
+            return Err(BlockPipelineError::CommitStore(
+                "canonical commit sqlite schema row missing with existing commit entries (canonical_commit_store_sqlite_schema_missing)"
+                    .to_owned(),
+            ));
+        }
+
+        self.backend
+            .put(
+                CANONICAL_COMMIT_SQLITE_META_NAMESPACE,
+                CANONICAL_COMMIT_SQLITE_SCHEMA_KEY,
+                CANONICAL_COMMIT_SQLITE_SCHEMA_VERSION
+                    .to_string()
+                    .as_bytes(),
+            )
+            .map_err(map_sqlite_commit_store_error)
+    }
+}
+
+impl CanonicalCommitStore for SqliteCanonicalCommitStore {
+    fn persist_canonical_commit(
+        &mut self,
+        record: CanonicalCommitRecord,
+    ) -> Result<(), BlockPipelineError> {
+        let existing = self.list_canonical_commits()?;
+        if let Some(last) = existing.last() {
+            if record.block_height <= last.block_height {
+                return Err(BlockPipelineError::CommitStore(format!(
+                    "canonical commit block height regression: previous {}, found {} (canonical_commit_store_block_height_regression)",
+                    last.block_height, record.block_height
+                )));
+            }
+        }
+
+        let key = sqlite_canonical_commit_store_key(record.block_height);
+        let payload = serialize_canonical_commit_record(&record)?;
+        self.backend
+            .put(
+                CANONICAL_COMMIT_SQLITE_ENTRIES_NAMESPACE,
+                key.as_str(),
+                payload.as_bytes(),
+            )
+            .map_err(map_sqlite_commit_store_error)?;
+        Ok(())
+    }
+
+    fn list_canonical_commits(&self) -> Result<Vec<CanonicalCommitRecord>, BlockPipelineError> {
+        let mut records: Vec<CanonicalCommitRecord> = Vec::new();
+        let keys = self
+            .backend
+            .list_keys(CANONICAL_COMMIT_SQLITE_ENTRIES_NAMESPACE)
+            .map_err(map_sqlite_commit_store_error)?;
+
+        for key in keys {
+            let key_height = parse_sqlite_canonical_commit_store_key(&key)?;
+            let payload_bytes = self
+                .backend
+                .get(CANONICAL_COMMIT_SQLITE_ENTRIES_NAMESPACE, key.as_str())
+                .map_err(map_sqlite_commit_store_error)?
+                .ok_or_else(|| {
+                    BlockPipelineError::CommitStore(format!(
+                        "canonical commit sqlite row missing for key {key} (canonical_commit_store_sqlite_missing_entry)"
+                    ))
+                })?;
+            let payload = String::from_utf8(payload_bytes).map_err(|_| {
+                BlockPipelineError::CommitStore(format!(
+                    "canonical commit sqlite payload is not utf-8 for key {key} (canonical_commit_store_sqlite_payload_not_utf8)"
+                ))
+            })?;
+            if payload.trim().is_empty() {
+                return Err(BlockPipelineError::CommitStore(format!(
+                    "canonical commit sqlite payload is empty for key {key} (canonical_commit_store_sqlite_payload_empty)"
+                )));
+            }
+            let record = parse_canonical_commit_record(&payload)?;
+            if record.block_height != key_height {
+                return Err(BlockPipelineError::CommitStore(format!(
+                    "canonical commit sqlite key height mismatch: key {}, payload {} (canonical_commit_store_sqlite_key_height_mismatch)",
+                    key_height, record.block_height
+                )));
+            }
+            if let Some(previous) = records.last() {
+                if record.block_height <= previous.block_height {
+                    return Err(BlockPipelineError::CommitStore(format!(
+                        "canonical commit block height regression in persisted lineage: previous {}, found {} (canonical_commit_store_block_height_regression)",
+                        previous.block_height, record.block_height
+                    )));
+                }
+            }
+            records.push(record);
+        }
+        Ok(records)
+    }
+}
+
+fn sqlite_canonical_commit_store_key(block_height: u64) -> String {
+    format!("height:{block_height:020}")
+}
+
+fn parse_sqlite_canonical_commit_store_key(key: &str) -> Result<u64, BlockPipelineError> {
+    let Some(height_raw) = key.strip_prefix("height:") else {
+        return Err(BlockPipelineError::CommitStore(format!(
+            "canonical commit sqlite key is malformed: {key} (canonical_commit_store_sqlite_key_malformed)"
+        )));
+    };
+    if height_raw.len() != 20
+        || !height_raw
+            .chars()
+            .all(|character| character.is_ascii_digit())
+    {
+        return Err(BlockPipelineError::CommitStore(format!(
+            "canonical commit sqlite key is malformed: {key} (canonical_commit_store_sqlite_key_malformed)"
+        )));
+    }
+    height_raw.parse::<u64>().map_err(|_| {
+        BlockPipelineError::CommitStore(format!(
+            "canonical commit sqlite key is malformed: {key} (canonical_commit_store_sqlite_key_malformed)"
+        ))
+    })
+}
+
+fn map_sqlite_commit_store_error(error: SqliteStoreBackendError) -> BlockPipelineError {
+    match error {
+        SqliteStoreBackendError::SchemaVersionMissing => BlockPipelineError::CommitStore(
+            "canonical commit sqlite backend schema missing (canonical_commit_store_sqlite_backend_schema_missing)"
+                .to_owned(),
+        ),
+        SqliteStoreBackendError::SchemaVersionInvalid(value) => BlockPipelineError::CommitStore(
+            format!(
+                "canonical commit sqlite backend schema invalid: {value} (canonical_commit_store_sqlite_backend_schema_invalid)"
+            ),
+        ),
+        SqliteStoreBackendError::SchemaVersionMismatch { expected, found } => {
+            BlockPipelineError::CommitStore(format!(
+                "canonical commit sqlite backend schema mismatch: expected {expected}, found {found} (canonical_commit_store_sqlite_backend_schema_mismatch)"
+            ))
+        }
+        SqliteStoreBackendError::InvalidPath => BlockPipelineError::CommitStore(
+            "canonical commit sqlite path is invalid (canonical_commit_store_path_invalid)"
+                .to_owned(),
+        ),
+        other => BlockPipelineError::CommitStore(format!(
+            "canonical commit sqlite backend operation failed: {other} (canonical_commit_store_io)"
+        )),
     }
 }
 

--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -161,8 +161,9 @@ pub use block_pipeline::{
     DeterministicCompetingBranchForkChoiceHook, FileCanonicalCommitStore, ForkChoiceDecision,
     ForkChoiceHook, GossipFrameTransportMempoolFeed, GossipIngressAdapter, GossipIngressBatch,
     GossipIngressError, GossipIngressRecord, InMemoryCanonicalCommitStore,
-    InMemoryTransportMempoolFeed, MempoolBlockPipeline, TransportCanonicalCandidateFeed,
-    TransportEventMempoolFeed, TransportFedBlockPipeline, TransportMempoolFeed,
+    InMemoryTransportMempoolFeed, MempoolBlockPipeline, SqliteCanonicalCommitStore,
+    TransportCanonicalCandidateFeed, TransportEventMempoolFeed, TransportFedBlockPipeline,
+    TransportMempoolFeed,
 };
 pub use bootstrap::{bootstrap, bootstrap_from_state_version, BootstrapPlan};
 pub use bridge_adapter::{

--- a/crates/kamn-core/tests/block_pipeline_docs.rs
+++ b/crates/kamn-core/tests/block_pipeline_docs.rs
@@ -7,6 +7,7 @@ fn architecture_doc_contains_block_pipeline_core_components() {
     assert!(DOC.contains("BlockConsensusRoundInput"));
     assert!(DOC.contains("BlockPipelineCommitReport"));
     assert!(DOC.contains("BlockPipelineError"));
+    assert!(DOC.contains("SqliteCanonicalCommitStore"));
 }
 
 #[test]
@@ -45,4 +46,12 @@ fn regression_doc_tracks_digest_mismatch_fail_closed_guard() {
     // Regression: #2927
     assert!(DOC.contains("Regression: #2927"));
     assert!(DOC.contains("fail_closed_reason_code=block_pipeline_payload_digest_mismatch"));
+}
+
+#[test]
+fn regression_doc_tracks_sqlite_canonical_commit_store_fail_closed_markers() {
+    // Regression: #3580
+    assert!(DOC.contains("canonical_commit_store_sqlite_schema_mismatch"));
+    assert!(DOC.contains("canonical_commit_store_sqlite_payload_not_utf8"));
+    assert!(DOC.contains("canonical_commit_store_sqlite_key_height_mismatch"));
 }

--- a/crates/kamn-core/tests/block_pipeline_sqlite_commit_store.rs
+++ b/crates/kamn-core/tests/block_pipeline_sqlite_commit_store.rs
@@ -1,0 +1,175 @@
+use kamn_core::{
+    build_canonical_replay_evidence_bundle, BlockPipelineError, CanonicalCommitRecord,
+    CanonicalCommitStore, FileCanonicalCommitStore, NodeRole, SqliteCanonicalCommitStore,
+};
+use rusqlite::Connection;
+use std::fs;
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn sample_canonical_record(height: u64, digest: &str, tx_id: &str) -> CanonicalCommitRecord {
+    CanonicalCommitRecord {
+        block_height: height,
+        producer_role: NodeRole::Processor,
+        payload_digest: digest.to_owned(),
+        transaction_ids: vec![tx_id.to_owned()],
+    }
+}
+
+fn temp_sqlite_path(tag: &str) -> PathBuf {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock should be monotonic")
+        .as_nanos();
+    std::env::temp_dir().join(format!("kamn-canonical-commit-{tag}-{nonce}.sqlite"))
+}
+
+#[test]
+fn unit_sqlite_canonical_commit_store_rejects_schema_version_mismatch() {
+    let path = temp_sqlite_path("schema-mismatch");
+    let _ = fs::remove_file(&path);
+
+    let store = SqliteCanonicalCommitStore::new(path.clone()).expect("store should bootstrap");
+    drop(store);
+
+    let connection = Connection::open(&path).expect("sqlite file should open");
+    connection
+        .execute(
+            "UPDATE kamn_store_entries SET entry_value = ?1 WHERE namespace = ?2 AND entry_key = ?3",
+            (
+                b"2".as_slice(),
+                "canonical_commit_store_meta",
+                "schema_version",
+            ),
+        )
+        .expect("schema version row should be mutable in test");
+    drop(connection);
+
+    let result = SqliteCanonicalCommitStore::new(path.clone());
+    assert!(
+        matches!(result, Err(BlockPipelineError::CommitStore(message)) if message.contains("canonical_commit_store_sqlite_schema_mismatch")),
+        "schema mismatch must fail closed with deterministic reason marker"
+    );
+
+    let _ = fs::remove_file(path);
+}
+
+#[test]
+fn functional_sqlite_canonical_commit_store_persists_and_reloads_lineage() {
+    let path = temp_sqlite_path("roundtrip");
+    let _ = fs::remove_file(&path);
+    let mut store = SqliteCanonicalCommitStore::new(path.clone()).expect("store should bootstrap");
+    let first = sample_canonical_record(17, "digest-17", "tx-17");
+    let second = sample_canonical_record(18, "digest-18", "tx-18");
+
+    store
+        .persist_canonical_commit(first.clone())
+        .expect("first record should persist");
+    store
+        .persist_canonical_commit(second.clone())
+        .expect("second record should persist");
+    assert_eq!(
+        store
+            .list_canonical_commits()
+            .expect("lineage should list after writes"),
+        vec![first.clone(), second.clone()]
+    );
+
+    let restarted = SqliteCanonicalCommitStore::new(path.clone()).expect("store should reopen");
+    assert_eq!(
+        restarted
+            .list_canonical_commits()
+            .expect("lineage should list after restart"),
+        vec![first, second]
+    );
+
+    let _ = fs::remove_file(path);
+}
+
+#[test]
+fn integration_sqlite_canonical_commit_store_supports_restart_replay_evidence_validation() {
+    let path = temp_sqlite_path("replay");
+    let _ = fs::remove_file(&path);
+
+    let mut first_store =
+        SqliteCanonicalCommitStore::new(path.clone()).expect("store should bootstrap");
+    first_store
+        .persist_canonical_commit(sample_canonical_record(71, "digest-71", "tx-71"))
+        .expect("first record should persist");
+    first_store
+        .persist_canonical_commit(sample_canonical_record(72, "digest-72", "tx-72"))
+        .expect("second record should persist");
+    let pre_restart = first_store
+        .list_canonical_commits()
+        .expect("pre-restart lineage should load");
+
+    let restarted = SqliteCanonicalCommitStore::new(path.clone()).expect("store should reopen");
+    let post_restart = restarted
+        .list_canonical_commits()
+        .expect("post-restart lineage should load");
+    let evidence = build_canonical_replay_evidence_bundle(&pre_restart, &post_restart)
+        .expect("restart replay lineage should validate");
+    assert_eq!(evidence.continuity_status, "verified");
+    assert_eq!(evidence.restart_boundary_block_height, 72);
+    assert_eq!(evidence.replay_checkpoint_block_height, 72);
+
+    let _ = fs::remove_file(path);
+}
+
+#[test]
+fn regression_sqlite_canonical_commit_store_rejects_non_utf8_payload_bytes() {
+    // Regression: #3580
+    let path = temp_sqlite_path("corrupt-payload");
+    let _ = fs::remove_file(&path);
+
+    let mut store = SqliteCanonicalCommitStore::new(path.clone()).expect("store should bootstrap");
+    store
+        .persist_canonical_commit(sample_canonical_record(201, "digest-201", "tx-201"))
+        .expect("record should persist");
+
+    let connection = Connection::open(&path).expect("sqlite file should open");
+    connection
+        .execute(
+            "UPDATE kamn_store_entries SET entry_value = ?1 WHERE namespace = ?2 AND entry_key = ?3",
+            (
+                vec![0xff, 0xfe, 0xfd],
+                "canonical_commit_store_entries",
+                "height:00000000000000000201",
+            ),
+        )
+        .expect("test should tamper persisted payload");
+    drop(connection);
+
+    let restarted = SqliteCanonicalCommitStore::new(path.clone()).expect("store should reopen");
+    let result = restarted.list_canonical_commits();
+    assert!(
+        matches!(result, Err(BlockPipelineError::CommitStore(message)) if message.contains("canonical_commit_store_sqlite_payload_not_utf8")),
+        "non-utf8 payload bytes must fail closed with deterministic reason marker"
+    );
+
+    let _ = fs::remove_file(path);
+}
+
+#[test]
+fn regression_file_store_reference_keeps_parity_with_sqlite_lineage_shape() {
+    // Regression: #3580
+    let path = temp_sqlite_path("file-store-parity").with_extension("log");
+    let _ = fs::remove_file(&path);
+    let mut store = FileCanonicalCommitStore::new(path.clone()).expect("file store should build");
+
+    store
+        .persist_canonical_commit(sample_canonical_record(1, "digest-1", "tx-1"))
+        .expect("first file-backed record should persist");
+    store
+        .persist_canonical_commit(sample_canonical_record(2, "digest-2", "tx-2"))
+        .expect("second file-backed record should persist");
+
+    let records = store
+        .list_canonical_commits()
+        .expect("file-backed records should list");
+    assert_eq!(records.len(), 2);
+    assert_eq!(records[0].block_height, 1);
+    assert_eq!(records[1].block_height, 2);
+
+    let _ = fs::remove_file(path);
+}

--- a/docs/architecture/block-pipeline.md
+++ b/docs/architecture/block-pipeline.md
@@ -27,6 +27,9 @@ production and consensus validation (Task #2926, Subtask #2927).
     candidates and persists accepted records before transaction consensus.
 - `FileCanonicalCommitStore`
   - persists canonical commit lineage across process restart boundaries.
+- `SqliteCanonicalCommitStore`
+  - persists canonical commit lineage in sqlite with strict schema/version
+    validation for restart/replay flows.
 - `build_canonical_replay_evidence_bundle(...)`
   - validates restart/replay lineage continuity and emits deterministic
     checkpoint evidence (`kamn.runtime.canonical-replay-evidence.v1`).
@@ -85,6 +88,11 @@ Processor role runtime wiring now includes:
   `canonical_commit_store_record_malformed`,
   `canonical_commit_store_block_height_regression`,
   `canonical_commit_store_transaction_ids_invalid`.
+- Sqlite-backed canonical persistence fails closed on schema/version and payload
+  corruption with deterministic reason markers such as:
+  `canonical_commit_store_sqlite_schema_mismatch`,
+  `canonical_commit_store_sqlite_payload_not_utf8`,
+  `canonical_commit_store_sqlite_key_height_mismatch`.
 
 Regression marker:
 - `Regression: #2927` keeps digest mismatch fail-closed before commit.
@@ -99,6 +107,7 @@ cargo test -p kamn-core --test block_pipeline
 cargo test -p kamn-core --test block_pipeline_gossip_ingest
 cargo test -p kamn-core --test block_pipeline_canonical_reconciliation
 cargo test -p kamn-core --test block_pipeline_transport_fed
+cargo test -p kamn-core --test block_pipeline_sqlite_commit_store
 cargo test -p kamn-core block_pipeline
 cargo clippy -p kamn-core -- -D warnings
 cargo fmt --check


### PR DESCRIPTION
## Summary
Added a sqlite-backed canonical commit store for block-pipeline transport-fed convergence with strict schema/version guards and deterministic fail-closed reason codes. This closes the durability gap for sqlite commit replay and adds corruption/schema mismatch coverage.

## Changes
- `crates/kamn-core/src/block_pipeline.rs`: added `SqliteCanonicalCommitStore`, schema bootstrap/validation, sqlite key parsing, and deterministic error mapping.
- `crates/kamn-core/src/lib.rs`: exported `SqliteCanonicalCommitStore`.
- `crates/kamn-core/tests/block_pipeline_sqlite_commit_store.rs`: added unit/functional/integration/regression coverage for sqlite canonical commit storage.
- `docs/architecture/block-pipeline.md`: documented sqlite canonical commit persistence contract and fail-closed markers.
- `crates/kamn-core/tests/block_pipeline_docs.rs`: added docs contract assertions for sqlite markers.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
`cargo test -p kamn-core --test block_pipeline_sqlite_commit_store`

Failure:
`error[E0432]: unresolved import kamn_core::SqliteCanonicalCommitStore`

### 🟢 Green Phase
Command:
`cargo test -p kamn-core --test block_pipeline_sqlite_commit_store`

Result:
`5 passed; 0 failed`

### 🔁 Regression
Commands:
- `cargo test -p kamn-core --test block_pipeline_transport_fed`
- `cargo test -p kamn-core --test block_pipeline_docs`
- `cargo test -p kamn-core block_pipeline`
- `cargo fmt --check`
- `cargo clippy -p kamn-core -- -D warnings`

Result:
All commands passed locally.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `unit_sqlite_canonical_commit_store_rejects_schema_version_mismatch` | |
| Functional   | ✅     | `functional_sqlite_canonical_commit_store_persists_and_reloads_lineage` | |
| Integration  | ✅     | `integration_sqlite_canonical_commit_store_supports_restart_replay_evidence_validation` | |
| Regression   | ✅     | `regression_sqlite_canonical_commit_store_rejects_non_utf8_payload_bytes`, docs regression markers | |
| Performance  | N/A    |                      | Existing block-pipeline performance coverage unchanged; sqlite subtask scope is correctness/durability guards. |

## Risks & Rollback
- None.
- Rollback plan: revert this PR commit to return to pre-sqlite canonical store behavior.

## Documentation Updates
- `docs/architecture/block-pipeline.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (`-p kamn-core`)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (relevant block-pipeline regression set)
- [x] Docs updated (or justified why not)

Closes #3580
