### PR TITLE
feat(networking): add live UDP convergence drill harness

### DIFF
--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -356,6 +356,7 @@ pub use p2p_transport::{
     PeerDiscoveryRecord, PeerGossipFrame, PeerLifecycleRegressionCase,
     PeerLifecycleRegressionError, PeerLifecycleRegressionExpectedOutcome,
     PeerLifecycleRegressionOutcome, PeerLifecycleTransport, PeerLifecycleTransportCoordinator,
+    UdpPeerLifecycleTransport,
 };
 pub use performance_targets::{
     evaluate_performance_from_observability, evaluate_performance_run, PerformanceAggregate,

--- a/crates/kamn-core/src/p2p_transport.rs
+++ b/crates/kamn-core/src/p2p_transport.rs
@@ -8,6 +8,8 @@ use crate::runtime::{
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::error::Error;
 use std::fmt::{Display, Formatter};
+use std::io::ErrorKind;
+use std::net::UdpSocket;
 use std::sync::{Arc, Mutex, OnceLock};
 
 const LIBP2P_SWARM_BEHAVIOR_COMPONENTS: [&str; 6] =
@@ -201,6 +203,208 @@ impl InMemoryPeerLifecycleTransport {
             .lock()
             .map_err(|_| P2pTransportError::StateUnavailable)
     }
+}
+
+#[derive(Debug, Default)]
+struct UdpPeerLifecycleTransportState {
+    peers_by_id: BTreeMap<String, PeerDiscoveryRecord>,
+    socket_addr_by_peer: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone)]
+/// UDP socket-backed transport adapter for live local convergence drill execution.
+pub struct UdpPeerLifecycleTransport {
+    network_id: String,
+    local_peer_id: String,
+    socket: Arc<UdpSocket>,
+    state: Arc<Mutex<UdpPeerLifecycleTransportState>>,
+}
+
+impl UdpPeerLifecycleTransport {
+    /// Binds a UDP socket-backed transport adapter to one local peer id.
+    pub fn bind(
+        network_id: &str,
+        local_peer_id: &str,
+        bind_address: &str,
+    ) -> Result<Self, P2pTransportError> {
+        if network_id.trim().is_empty() {
+            return Err(P2pTransportError::InvalidLiveSocketNetworkId);
+        }
+        validate_peer_id(local_peer_id)?;
+        if bind_address.trim().is_empty() {
+            return Err(P2pTransportError::InvalidSocketBindAddress);
+        }
+
+        let socket =
+            UdpSocket::bind(bind_address).map_err(|_| P2pTransportError::LiveSocketBindFailed)?;
+        socket
+            .set_nonblocking(true)
+            .map_err(|_| P2pTransportError::LiveSocketBindFailed)?;
+        let state = resolve_udp_live_transport_state(network_id)?;
+
+        Ok(Self {
+            network_id: network_id.to_owned(),
+            local_peer_id: local_peer_id.to_owned(),
+            socket: Arc::new(socket),
+            state,
+        })
+    }
+
+    /// Binds a UDP socket-backed transport adapter to an ephemeral local port.
+    pub fn bind_ephemeral(
+        network_id: &str,
+        local_peer_id: &str,
+    ) -> Result<Self, P2pTransportError> {
+        Self::bind(network_id, local_peer_id, "127.0.0.1:0")
+    }
+
+    /// Returns the deterministic network identifier for this live socket transport.
+    pub fn network_id(&self) -> &str {
+        &self.network_id
+    }
+
+    fn lock_state(
+        &self,
+    ) -> Result<std::sync::MutexGuard<'_, UdpPeerLifecycleTransportState>, P2pTransportError> {
+        self.state
+            .lock()
+            .map_err(|_| P2pTransportError::StateUnavailable)
+    }
+
+    fn encode_frame(frame: &PeerGossipFrame) -> Vec<u8> {
+        format!(
+            "{}\n{}\n{}\n{}",
+            frame.topic, frame.sender_peer_id, frame.recipient_peer_id, frame.payload
+        )
+        .into_bytes()
+    }
+
+    fn decode_frame(payload: &[u8]) -> Result<PeerGossipFrame, P2pTransportError> {
+        let raw = std::str::from_utf8(payload)
+            .map_err(|_| P2pTransportError::LiveSocketFrameMalformed)?;
+        let mut parts = raw.splitn(4, '\n');
+        let topic = parts
+            .next()
+            .ok_or(P2pTransportError::LiveSocketFrameMalformed)?;
+        let sender_peer_id = parts
+            .next()
+            .ok_or(P2pTransportError::LiveSocketFrameMalformed)?;
+        let recipient_peer_id = parts
+            .next()
+            .ok_or(P2pTransportError::LiveSocketFrameMalformed)?;
+        let frame_payload = parts
+            .next()
+            .ok_or(P2pTransportError::LiveSocketFrameMalformed)?;
+        PeerGossipFrame::new(topic, sender_peer_id, recipient_peer_id, frame_payload)
+    }
+}
+
+impl PeerLifecycleTransport for UdpPeerLifecycleTransport {
+    fn advertise(&self, record: PeerDiscoveryRecord) -> Result<(), P2pTransportError> {
+        let socket_address = self
+            .socket
+            .local_addr()
+            .map_err(|_| P2pTransportError::LiveSocketLocalAddressUnavailable)?
+            .to_string();
+        let mut state = self.lock_state()?;
+        state
+            .socket_addr_by_peer
+            .insert(record.peer_id.clone(), socket_address);
+        state.peers_by_id.insert(record.peer_id.clone(), record);
+        Ok(())
+    }
+
+    fn discover(
+        &self,
+        requester_peer_id: &str,
+        topic: &str,
+    ) -> Result<Vec<PeerDiscoveryRecord>, P2pTransportError> {
+        validate_peer_id(requester_peer_id)?;
+        validate_topic(topic)?;
+        let state = self.lock_state()?;
+        Ok(state
+            .peers_by_id
+            .values()
+            .filter(|record| record.peer_id != requester_peer_id && record.supports_topic(topic))
+            .cloned()
+            .collect())
+    }
+
+    fn send(&self, frame: PeerGossipFrame) -> Result<(), P2pTransportError> {
+        let recipient_socket_address = {
+            let state = self.lock_state()?;
+            if !state.peers_by_id.contains_key(&frame.sender_peer_id) {
+                return Err(P2pTransportError::UnknownSenderPeer(
+                    frame.sender_peer_id.clone(),
+                ));
+            }
+            if !state.peers_by_id.contains_key(&frame.recipient_peer_id) {
+                return Err(P2pTransportError::UnknownRecipientPeer(
+                    frame.recipient_peer_id.clone(),
+                ));
+            }
+            state
+                .socket_addr_by_peer
+                .get(&frame.recipient_peer_id)
+                .cloned()
+                .ok_or_else(|| {
+                    P2pTransportError::UnknownRecipientPeer(frame.recipient_peer_id.clone())
+                })?
+        };
+
+        let encoded = Self::encode_frame(&frame);
+        self.socket
+            .send_to(encoded.as_slice(), recipient_socket_address.as_str())
+            .map_err(|_| P2pTransportError::LiveSocketSendFailed)?;
+        Ok(())
+    }
+
+    fn drain_inbox(
+        &self,
+        recipient_peer_id: &str,
+    ) -> Result<Vec<PeerGossipFrame>, P2pTransportError> {
+        validate_peer_id(recipient_peer_id)?;
+        if recipient_peer_id != self.local_peer_id {
+            return Err(P2pTransportError::UnknownRecipientPeer(
+                recipient_peer_id.to_owned(),
+            ));
+        }
+
+        let mut frames = Vec::new();
+        let mut buffer = [0u8; 32 * 1024];
+        loop {
+            match self.socket.recv_from(&mut buffer) {
+                Ok((payload_size, _source)) => {
+                    let frame = Self::decode_frame(&buffer[..payload_size])?;
+                    if frame.recipient_peer_id == recipient_peer_id {
+                        frames.push(frame);
+                    }
+                }
+                Err(error) if error.kind() == ErrorKind::WouldBlock => break,
+                Err(_) => return Err(P2pTransportError::LiveSocketReceiveFailed),
+            }
+        }
+        Ok(frames)
+    }
+}
+
+fn udp_live_transport_registry(
+) -> &'static Mutex<BTreeMap<String, Arc<Mutex<UdpPeerLifecycleTransportState>>>> {
+    static REGISTRY: OnceLock<Mutex<BTreeMap<String, Arc<Mutex<UdpPeerLifecycleTransportState>>>>> =
+        OnceLock::new();
+    REGISTRY.get_or_init(|| Mutex::new(BTreeMap::new()))
+}
+
+fn resolve_udp_live_transport_state(
+    network_id: &str,
+) -> Result<Arc<Mutex<UdpPeerLifecycleTransportState>>, P2pTransportError> {
+    let mut registry = udp_live_transport_registry()
+        .lock()
+        .map_err(|_| P2pTransportError::StateUnavailable)?;
+    Ok(registry
+        .entry(network_id.to_owned())
+        .or_insert_with(|| Arc::new(Mutex::new(UdpPeerLifecycleTransportState::default())))
+        .clone())
 }
 
 /// Coordinator that wires lifecycle transitions to transport discovery and gossip operations.
@@ -1175,6 +1379,20 @@ pub enum P2pTransportError {
     InvalidReconnectBackoffWindow,
     /// Swarm composition requested while gossip transport is disabled.
     GossipTransportDisabled,
+    /// Live socket network id is empty.
+    InvalidLiveSocketNetworkId,
+    /// Live socket bind address is empty or malformed.
+    InvalidSocketBindAddress,
+    /// Live socket bind operation failed.
+    LiveSocketBindFailed,
+    /// Live socket local address lookup failed.
+    LiveSocketLocalAddressUnavailable,
+    /// Live socket datagram send operation failed.
+    LiveSocketSendFailed,
+    /// Live socket datagram receive operation failed.
+    LiveSocketReceiveFailed,
+    /// Live socket datagram payload is malformed.
+    LiveSocketFrameMalformed,
     /// Transport state lock is unavailable.
     StateUnavailable,
     /// Lifecycle state does not permit transport I/O.
@@ -1208,6 +1426,15 @@ impl P2pTransportError {
             Self::InvalidReconnectRetryBudget => "p2p_transport_invalid_reconnect_retry_budget",
             Self::InvalidReconnectBackoffWindow => "p2p_transport_invalid_reconnect_backoff_window",
             Self::GossipTransportDisabled => "p2p_transport_gossip_disabled",
+            Self::InvalidLiveSocketNetworkId => "p2p_transport_live_socket_network_id_invalid",
+            Self::InvalidSocketBindAddress => "p2p_transport_live_socket_bind_address_invalid",
+            Self::LiveSocketBindFailed => "p2p_transport_live_socket_bind_failed",
+            Self::LiveSocketLocalAddressUnavailable => {
+                "p2p_transport_live_socket_local_address_unavailable"
+            }
+            Self::LiveSocketSendFailed => "p2p_transport_live_socket_send_failed",
+            Self::LiveSocketReceiveFailed => "p2p_transport_live_socket_receive_failed",
+            Self::LiveSocketFrameMalformed => "p2p_transport_live_socket_frame_malformed",
             Self::StateUnavailable => "p2p_transport_state_unavailable",
             Self::InactivePeerLifecycleState(_) => "p2p_transport_inactive_lifecycle_state",
             Self::Lifecycle(error) => error.reason_code(),
@@ -1253,6 +1480,19 @@ impl Display for P2pTransportError {
                     "p2p swarm composition requires gossip transport to be enabled"
                 )
             }
+            Self::InvalidLiveSocketNetworkId => {
+                write!(f, "p2p live socket network id cannot be empty")
+            }
+            Self::InvalidSocketBindAddress => {
+                write!(f, "p2p live socket bind address is invalid")
+            }
+            Self::LiveSocketBindFailed => write!(f, "p2p live socket bind failed"),
+            Self::LiveSocketLocalAddressUnavailable => {
+                write!(f, "p2p live socket local address lookup failed")
+            }
+            Self::LiveSocketSendFailed => write!(f, "p2p live socket send failed"),
+            Self::LiveSocketReceiveFailed => write!(f, "p2p live socket receive failed"),
+            Self::LiveSocketFrameMalformed => write!(f, "p2p live socket frame is malformed"),
             Self::StateUnavailable => write!(f, "p2p in-memory transport state is unavailable"),
             Self::InactivePeerLifecycleState(state) => {
                 write!(

--- a/crates/kamn-core/tests/block_pipeline_docs.rs
+++ b/crates/kamn-core/tests/block_pipeline_docs.rs
@@ -9,6 +9,7 @@ fn architecture_doc_contains_block_pipeline_core_components() {
     assert!(DOC.contains("BlockPipelineError"));
     assert!(DOC.contains("SqliteCanonicalCommitStore"));
     assert!(DOC.contains("build_transport_convergence_evidence_bundle(...)"));
+    assert!(DOC.contains("UdpPeerLifecycleTransport"));
 }
 
 #[test]
@@ -63,4 +64,7 @@ fn regression_doc_tracks_transport_convergence_fault_matrix_markers() {
     assert!(DOC.contains("transport_convergence_case_id_missing"));
     assert!(DOC.contains("transport_convergence_commit_height_regression"));
     assert!(DOC.contains("block_pipeline_transport_convergence_faults"));
+    assert!(DOC.contains("block_pipeline_transport_convergence_live_sockets"));
+    assert!(DOC.contains("Regression: #3652"));
+    assert!(DOC.contains("p2p_transport_live_socket_send_failed"));
 }

--- a/crates/kamn-core/tests/block_pipeline_transport_convergence_live_sockets.rs
+++ b/crates/kamn-core/tests/block_pipeline_transport_convergence_live_sockets.rs
@@ -1,0 +1,317 @@
+use kamn_core::{
+    build_transport_convergence_evidence_bundle, CanonicalCandidateDecision,
+    DeterministicCompetingBranchForkChoiceHook, InMemoryCanonicalCommitStore, NodeRole,
+    PeerDiscoveryRecord, PeerGossipFrame, PeerLifecycleTransport,
+    TransportConvergenceEvidenceBundle, TransportEventMempoolFeed, TransportFedBlockPipeline,
+    UdpPeerLifecycleTransport,
+};
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
+
+fn unique_network_id(tag: &str) -> String {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock should be monotonic")
+        .as_nanos();
+    format!("kamn-live-socket-{tag}-{nonce}")
+}
+
+fn block_frame_payload(
+    block_height: u64,
+    producer_role: &str,
+    payload_digest: &str,
+    transaction_ids: &str,
+) -> String {
+    format!(
+        "block_height={block_height}\nproducer_role={producer_role}\npayload_digest={payload_digest}\ntransaction_ids={transaction_ids}"
+    )
+}
+
+fn send_candidate_frame<TTransport: PeerLifecycleTransport>(
+    transport: &TTransport,
+    sender: &str,
+    recipient: &str,
+    payload: &str,
+) {
+    transport
+        .send(
+            PeerGossipFrame::new("kamn/blocks/v1", sender, recipient, payload)
+                .expect("candidate frame should build"),
+        )
+        .expect("candidate frame should send");
+}
+
+fn build_pipeline<TTransport: PeerLifecycleTransport + Clone>(
+    transport: TTransport,
+    recipient: &str,
+) -> TransportFedBlockPipeline<
+    TransportEventMempoolFeed<TTransport>,
+    InMemoryCanonicalCommitStore,
+    DeterministicCompetingBranchForkChoiceHook,
+> {
+    let feed = TransportEventMempoolFeed::new(
+        transport,
+        recipient,
+        Some(vec!["kamn/blocks/v1".to_owned()]),
+    )
+    .expect("transport event feed should build");
+    let store = InMemoryCanonicalCommitStore::default();
+    let hook = DeterministicCompetingBranchForkChoiceHook::new();
+    TransportFedBlockPipeline::new(true, 1, 1, feed, store, hook).expect("pipeline should build")
+}
+
+#[test]
+fn unit_live_socket_transport_rejects_empty_network_id() {
+    assert!(UdpPeerLifecycleTransport::bind_ephemeral("", "peer-processor").is_err());
+}
+
+#[test]
+fn functional_live_socket_partition_rejoin_evidence_marks_verified_status() {
+    let network_id = unique_network_id("partition-rejoin");
+    let sender = "peer-live-sender";
+    let recipient = "peer-live-recipient";
+    let sender_transport = UdpPeerLifecycleTransport::bind_ephemeral(&network_id, sender)
+        .expect("sender transport should build");
+    let recipient_transport = UdpPeerLifecycleTransport::bind_ephemeral(&network_id, recipient)
+        .expect("recipient transport should build");
+
+    sender_transport
+        .advertise(
+            PeerDiscoveryRecord::new(
+                sender,
+                NodeRole::Processor,
+                vec!["kamn/blocks/v1".to_owned()],
+            )
+            .expect("sender record should build"),
+        )
+        .expect("sender should advertise");
+    recipient_transport
+        .advertise(
+            PeerDiscoveryRecord::new(
+                recipient,
+                NodeRole::Processor,
+                vec!["kamn/blocks/v1".to_owned()],
+            )
+            .expect("recipient record should build"),
+        )
+        .expect("recipient should advertise");
+
+    let mut pipeline = build_pipeline(recipient_transport.clone(), recipient);
+    let empty_round = pipeline
+        .reconcile_transport_candidates()
+        .expect("empty partitioned round should reconcile");
+    let empty_commits = pipeline
+        .list_canonical_commits()
+        .expect("commit list should load");
+    let evidence: TransportConvergenceEvidenceBundle = build_transport_convergence_evidence_bundle(
+        "live-socket-partition-round-empty",
+        &empty_round,
+        &empty_commits,
+    )
+    .expect("empty evidence should build");
+    assert_eq!(
+        evidence.schema_version,
+        "kamn.runtime.transport-convergence-evidence.v1"
+    );
+    assert_eq!(evidence.continuity_status, "verified");
+}
+
+#[test]
+fn integration_live_socket_partition_rejoin_and_publish_drop_drill_executes_over_udp() {
+    let network_id = unique_network_id("integration");
+    let sender = "peer-live-sender-int";
+    let recipient = "peer-live-recipient-int";
+    let sender_transport = UdpPeerLifecycleTransport::bind_ephemeral(&network_id, sender)
+        .expect("sender transport should build");
+    let recipient_transport = UdpPeerLifecycleTransport::bind_ephemeral(&network_id, recipient)
+        .expect("recipient transport should build");
+
+    sender_transport
+        .advertise(
+            PeerDiscoveryRecord::new(
+                sender,
+                NodeRole::Processor,
+                vec!["kamn/blocks/v1".to_owned()],
+            )
+            .expect("sender record should build"),
+        )
+        .expect("sender should advertise");
+    recipient_transport
+        .advertise(
+            PeerDiscoveryRecord::new(
+                recipient,
+                NodeRole::Processor,
+                vec!["kamn/blocks/v1".to_owned()],
+            )
+            .expect("recipient record should build"),
+        )
+        .expect("recipient should advertise");
+
+    let mut pipeline = build_pipeline(recipient_transport.clone(), recipient);
+    let round_one = pipeline
+        .reconcile_transport_candidates()
+        .expect("partitioned round should reconcile");
+    assert_eq!(round_one.len(), 0);
+
+    send_candidate_frame(
+        &sender_transport,
+        sender,
+        recipient,
+        &block_frame_payload(700, "processor", "digest-700", "tx-700"),
+    );
+    let round_two = pipeline
+        .reconcile_transport_candidates()
+        .expect("rejoin round should reconcile");
+    assert!(matches!(
+        round_two[0].decision,
+        CanonicalCandidateDecision::Accepted
+    ));
+
+    send_candidate_frame(
+        &sender_transport,
+        sender,
+        recipient,
+        &block_frame_payload(702, "processor", "digest-702", "tx-702"),
+    );
+    let round_three = pipeline
+        .reconcile_transport_candidates()
+        .expect("post-drop round should reconcile");
+    assert!(matches!(
+        round_three[0].decision,
+        CanonicalCandidateDecision::Accepted
+    ));
+}
+
+#[test]
+fn regression_live_socket_delayed_publish_emits_stale_reason_code() {
+    // Regression: #3652
+    let network_id = unique_network_id("regression");
+    let sender = "peer-live-sender-reg";
+    let recipient = "peer-live-recipient-reg";
+    let sender_transport = UdpPeerLifecycleTransport::bind_ephemeral(&network_id, sender)
+        .expect("sender transport should build");
+    let recipient_transport = UdpPeerLifecycleTransport::bind_ephemeral(&network_id, recipient)
+        .expect("recipient transport should build");
+
+    sender_transport
+        .advertise(
+            PeerDiscoveryRecord::new(
+                sender,
+                NodeRole::Processor,
+                vec!["kamn/blocks/v1".to_owned()],
+            )
+            .expect("sender record should build"),
+        )
+        .expect("sender should advertise");
+    recipient_transport
+        .advertise(
+            PeerDiscoveryRecord::new(
+                recipient,
+                NodeRole::Processor,
+                vec!["kamn/blocks/v1".to_owned()],
+            )
+            .expect("recipient record should build"),
+        )
+        .expect("recipient should advertise");
+
+    let mut pipeline = build_pipeline(recipient_transport, recipient);
+
+    send_candidate_frame(
+        &sender_transport,
+        sender,
+        recipient,
+        &block_frame_payload(800, "processor", "digest-800", "tx-800"),
+    );
+    pipeline
+        .reconcile_transport_candidates()
+        .expect("baseline publish should reconcile");
+
+    send_candidate_frame(
+        &sender_transport,
+        sender,
+        recipient,
+        &block_frame_payload(802, "processor", "digest-802", "tx-802"),
+    );
+    pipeline
+        .reconcile_transport_candidates()
+        .expect("post-drop publish should reconcile");
+
+    send_candidate_frame(
+        &sender_transport,
+        sender,
+        recipient,
+        &block_frame_payload(801, "processor", "digest-801", "tx-801"),
+    );
+    let delayed = pipeline
+        .reconcile_transport_candidates()
+        .expect("delayed publish should reconcile");
+
+    assert!(matches!(
+        delayed[0].decision,
+        CanonicalCandidateDecision::Rejected { ref reason_code }
+            if reason_code == "fork_choice_stale_block_height"
+    ));
+}
+
+#[test]
+fn performance_live_socket_convergence_drill_stays_within_local_budget() {
+    let started = Instant::now();
+    let network_id = unique_network_id("performance");
+    let sender = "peer-live-sender-perf";
+    let recipient = "peer-live-recipient-perf";
+    let sender_transport = UdpPeerLifecycleTransport::bind_ephemeral(&network_id, sender)
+        .expect("sender transport should build");
+    let recipient_transport = UdpPeerLifecycleTransport::bind_ephemeral(&network_id, recipient)
+        .expect("recipient transport should build");
+
+    sender_transport
+        .advertise(
+            PeerDiscoveryRecord::new(
+                sender,
+                NodeRole::Processor,
+                vec!["kamn/blocks/v1".to_owned()],
+            )
+            .expect("sender record should build"),
+        )
+        .expect("sender should advertise");
+    recipient_transport
+        .advertise(
+            PeerDiscoveryRecord::new(
+                recipient,
+                NodeRole::Processor,
+                vec!["kamn/blocks/v1".to_owned()],
+            )
+            .expect("recipient record should build"),
+        )
+        .expect("recipient should advertise");
+
+    let mut pipeline = build_pipeline(recipient_transport, recipient);
+    for height in 1..=48 {
+        send_candidate_frame(
+            &sender_transport,
+            sender,
+            recipient,
+            &block_frame_payload(
+                height,
+                "processor",
+                &format!("digest-{height}"),
+                &format!("tx-{height}"),
+            ),
+        );
+        let outcomes = pipeline
+            .reconcile_transport_candidates()
+            .expect("performance publish should reconcile");
+        assert!(matches!(
+            outcomes[0].decision,
+            CanonicalCandidateDecision::Accepted
+        ));
+    }
+
+    let commits = pipeline
+        .list_canonical_commits()
+        .expect("commits should load");
+    assert_eq!(commits.len(), 48);
+    assert!(
+        started.elapsed() <= std::time::Duration::from_secs(2),
+        "live socket convergence drill exceeded local runtime budget"
+    );
+}

--- a/docs/architecture/block-pipeline.md
+++ b/docs/architecture/block-pipeline.md
@@ -36,6 +36,9 @@ production and consensus validation (Task #2926, Subtask #2927).
 - `build_transport_convergence_evidence_bundle(...)`
   - emits deterministic partition/rejoin and publish-drop convergence drill
     evidence (`kamn.runtime.transport-convergence-evidence.v1`).
+- `UdpPeerLifecycleTransport`
+  - local UDP socket-backed transport adapter used by live convergence drill
+    harness tests.
 - `BlockConsensusRoundInput`
   - listener and approver attestation input envelope for a round.
 - `BlockPipelineCommitReport`
@@ -90,6 +93,15 @@ Processor role runtime wiring now includes:
   reason codes:
   `transport_convergence_case_id_missing`,
   `transport_convergence_commit_height_regression`.
+- Live socket convergence drill transport fails closed with deterministic reason
+  codes:
+  `p2p_transport_live_socket_network_id_invalid`,
+  `p2p_transport_live_socket_bind_address_invalid`,
+  `p2p_transport_live_socket_bind_failed`,
+  `p2p_transport_live_socket_local_address_unavailable`,
+  `p2p_transport_live_socket_send_failed`,
+  `p2p_transport_live_socket_receive_failed`,
+  `p2p_transport_live_socket_frame_malformed`.
 - File-backed canonical persistence rejects malformed or regressive records with
   deterministic reason markers such as:
   `canonical_commit_store_record_malformed`,
@@ -108,6 +120,8 @@ Regression marker:
   reorg reason-code outcomes deterministic.
 - `Regression: #3579` keeps partition/rejoin and publish-drop convergence
   reason-code outcomes deterministic.
+- `Regression: #3652` keeps live socket delayed-delivery stale-height reject
+  reason code deterministic.
 
 ## Validation Commands
 
@@ -118,6 +132,7 @@ cargo test -p kamn-core --test block_pipeline_canonical_reconciliation
 cargo test -p kamn-core --test block_pipeline_transport_fed
 cargo test -p kamn-core --test block_pipeline_sqlite_commit_store
 cargo test -p kamn-core --test block_pipeline_transport_convergence_faults
+cargo test -p kamn-core --test block_pipeline_transport_convergence_live_sockets
 cargo test -p kamn-core block_pipeline
 cargo clippy -p kamn-core -- -D warnings
 cargo fmt --check


### PR DESCRIPTION
Closes #3652
Refs #3635
Refs #3633
Refs #3634

## Summary
Implement live local-socket convergence drill coverage by adding a UDP-backed `PeerLifecycleTransport` adapter and a deterministic partition/rejoin + publish-drop drill test harness.
This closes the gap between in-memory-only convergence checks and real socket I/O while preserving deterministic fail-closed reason-code contracts.

## Changes
- `crates/kamn-core/src/p2p_transport.rs`
  - Add `UdpPeerLifecycleTransport` implementing `PeerLifecycleTransport` over UDP sockets.
  - Add deterministic live-socket error taxonomy and reason codes.
- `crates/kamn-core/src/lib.rs`
  - Re-export `UdpPeerLifecycleTransport`.
- `crates/kamn-core/tests/block_pipeline_transport_convergence_live_sockets.rs`
  - Add unit/functional/integration/regression/performance tests for live socket convergence drills.
- `docs/architecture/block-pipeline.md`
  - Add live-socket convergence harness documentation and reason-code markers.
- `crates/kamn-core/tests/block_pipeline_docs.rs`
  - Extend doc-contract assertions for live-socket convergence markers.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
`cargo test -p kamn-core --test block_pipeline_transport_convergence_live_sockets`

Failure excerpt:
- unresolved import `kamn_core::UdpPeerLifecycleTransport`

### 🟢 Green Phase
Commands:
- `cargo test -p kamn-core --test block_pipeline_transport_convergence_live_sockets`

Result:
- 5/5 tests passing.

### 🔁 Regression
Commands:
- `cargo test -p kamn-core --test block_pipeline_transport_convergence_faults --test block_pipeline_docs --test p2p_transport_runtime --test p2p_live_transport_runtime`
- `cargo clippy -p kamn-core --test block_pipeline_transport_convergence_live_sockets -- -D warnings`
- `cargo fmt --check`

Result:
- All commands pass.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | `unit_live_socket_transport_rejects_empty_network_id` | |
| Functional   | ✅ | `functional_live_socket_partition_rejoin_evidence_marks_verified_status` | |
| Integration  | ✅ | `integration_live_socket_partition_rejoin_and_publish_drop_drill_executes_over_udp` | |
| Regression   | ✅ | `regression_live_socket_delayed_publish_emits_stale_reason_code` | |
| Performance  | ✅ | `performance_live_socket_convergence_drill_stays_within_local_budget` | |

## Risks & Rollback
- Additive transport adapter; no existing API removed.
- Rollback plan: revert this PR commit to remove UDP transport path and tests.

## Documentation Updates
- `docs/architecture/block-pipeline.md` updated with live-socket convergence drill markers and commands.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (scoped to changed target)
- [x] TDD Red/Green evidence included above
