### PR TITLE
feat(networking): add native backend mode for live libp2p transport

### DIFF
--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -348,9 +348,10 @@ pub use operator_dashboard_ui::{
 pub use p2p_transport::{
     build_libp2p_lifecycle_regression_corpus, build_p2p_swarm_deterministic_config,
     compose_kademlia_discovery_bootstrap, compose_libp2p_swarm_behavior_stack,
-    run_libp2p_lifecycle_regression_case, run_libp2p_lifecycle_regression_corpus,
-    InMemoryPeerLifecycleTransport, KademliaBootstrapSeedSet, KademliaDiscoveryBootstrapPlan,
-    Libp2pLivePeerLifecycleTransport, LiveTransportFaultClass, LiveTransportReconnectDecision,
+    resolve_libp2p_live_runtime_backend, run_libp2p_lifecycle_regression_case,
+    run_libp2p_lifecycle_regression_corpus, InMemoryPeerLifecycleTransport,
+    KademliaBootstrapSeedSet, KademliaDiscoveryBootstrapPlan, Libp2pLivePeerLifecycleTransport,
+    Libp2pLiveRuntimeBackend, LiveTransportFaultClass, LiveTransportReconnectDecision,
     LiveTransportReconnectPolicy, P2pSwarmBehaviorStack, P2pSwarmDeterministicConfig,
     P2pSwarmHarnessMode, P2pSwarmHarnessReport, P2pSwarmHarnessTask, P2pTransportError,
     PeerDiscoveryRecord, PeerGossipFrame, PeerLifecycleRegressionCase,

--- a/crates/kamn-core/src/p2p_transport.rs
+++ b/crates/kamn-core/src/p2p_transport.rs
@@ -526,11 +526,46 @@ impl<T: PeerLifecycleTransport> PeerLifecycleTransportCoordinator<T> {
     }
 }
 
+/// Runtime backend mode selected for live libp2p transport operations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Libp2pLiveRuntimeBackend {
+    /// Deterministic in-process data-plane fallback path.
+    ContractDataPlane,
+    /// Native socket-backed path used by feature-enabled runtime builds.
+    NativeSocket,
+}
+
+impl Libp2pLiveRuntimeBackend {
+    /// Returns deterministic backend marker for policy and docs contracts.
+    pub fn marker(self) -> &'static str {
+        match self {
+            Self::ContractDataPlane => "contract-data-plane",
+            Self::NativeSocket => "native-socket",
+        }
+    }
+}
+
+/// Resolves live libp2p runtime backend mode from compile-time feature gates.
+pub fn resolve_libp2p_live_runtime_backend() -> Libp2pLiveRuntimeBackend {
+    #[cfg(feature = "libp2p-live-transport")]
+    {
+        Libp2pLiveRuntimeBackend::NativeSocket
+    }
+    #[cfg(not(feature = "libp2p-live-transport"))]
+    {
+        Libp2pLiveRuntimeBackend::ContractDataPlane
+    }
+}
+
 /// Live libp2p transport adapter contract backed by deterministic swarm startup.
 #[derive(Debug, Clone)]
 pub struct Libp2pLivePeerLifecycleTransport {
     swarm_config: P2pSwarmDeterministicConfig,
     harness_report: P2pSwarmHarnessReport,
+    live_network_id: String,
+    #[cfg(feature = "libp2p-live-transport")]
+    native_socket_transport: UdpPeerLifecycleTransport,
+    #[cfg(not(feature = "libp2p-live-transport"))]
     live_data_plane: Libp2pLiveDataPlane,
 }
 
@@ -543,11 +578,21 @@ impl Libp2pLivePeerLifecycleTransport {
         let task = P2pSwarmHarnessTask::new(config.clone());
         let harness_report = task.start(harness_mode)?;
         let network_id = build_live_data_plane_network_id(&config);
+        #[cfg(feature = "libp2p-live-transport")]
+        validate_libp2p_native_runtime_config(&config)?;
+        #[cfg(feature = "libp2p-live-transport")]
+        let native_socket_transport =
+            UdpPeerLifecycleTransport::bind_ephemeral(network_id.as_str(), config.local_peer_id())?;
+        #[cfg(not(feature = "libp2p-live-transport"))]
         let state = resolve_live_data_plane_state(network_id.as_str())?;
         Ok(Self {
             swarm_config: config,
             harness_report,
-            live_data_plane: Libp2pLiveDataPlane { network_id, state },
+            live_network_id: network_id.clone(),
+            #[cfg(feature = "libp2p-live-transport")]
+            native_socket_transport,
+            #[cfg(not(feature = "libp2p-live-transport"))]
+            live_data_plane: Libp2pLiveDataPlane { state },
         })
     }
 
@@ -561,6 +606,11 @@ impl Libp2pLivePeerLifecycleTransport {
         &self.harness_report
     }
 
+    /// Returns compile-mode runtime backend selected for this adapter.
+    pub fn runtime_backend(&self) -> Libp2pLiveRuntimeBackend {
+        resolve_libp2p_live_runtime_backend()
+    }
+
     /// Returns configured listen address for this live adapter.
     pub fn listen_address(&self) -> &str {
         self.swarm_config.listen_address()
@@ -568,9 +618,10 @@ impl Libp2pLivePeerLifecycleTransport {
 
     /// Returns deterministic live data-plane network identifier.
     pub fn live_data_plane_network_id(&self) -> &str {
-        self.live_data_plane.network_id.as_str()
+        self.live_network_id.as_str()
     }
 
+    #[cfg(not(feature = "libp2p-live-transport"))]
     fn lock_live_data_plane_state(
         &self,
     ) -> Result<std::sync::MutexGuard<'_, Libp2pLiveDataPlaneState>, P2pTransportError> {
@@ -583,13 +634,21 @@ impl Libp2pLivePeerLifecycleTransport {
 
 impl PeerLifecycleTransport for Libp2pLivePeerLifecycleTransport {
     fn advertise(&self, record: PeerDiscoveryRecord) -> Result<(), P2pTransportError> {
+        #[cfg(feature = "libp2p-live-transport")]
+        {
+            self.native_socket_transport.advertise(record)
+        }
+        #[cfg(not(feature = "libp2p-live-transport"))]
         let mut state = self.lock_live_data_plane_state()?;
-        state
-            .inbox_by_peer
-            .entry(record.peer_id.clone())
-            .or_insert_with(VecDeque::new);
-        state.peers_by_id.insert(record.peer_id.clone(), record);
-        Ok(())
+        #[cfg(not(feature = "libp2p-live-transport"))]
+        {
+            state
+                .inbox_by_peer
+                .entry(record.peer_id.clone())
+                .or_insert_with(VecDeque::new);
+            state.peers_by_id.insert(record.peer_id.clone(), record);
+            Ok(())
+        }
     }
 
     fn discover(
@@ -597,63 +656,97 @@ impl PeerLifecycleTransport for Libp2pLivePeerLifecycleTransport {
         requester_peer_id: &str,
         topic: &str,
     ) -> Result<Vec<PeerDiscoveryRecord>, P2pTransportError> {
+        #[cfg(feature = "libp2p-live-transport")]
+        {
+            self.native_socket_transport
+                .discover(requester_peer_id, topic)
+        }
+        #[cfg(not(feature = "libp2p-live-transport"))]
         validate_peer_id(requester_peer_id)?;
+        #[cfg(not(feature = "libp2p-live-transport"))]
         validate_topic(topic)?;
+        #[cfg(not(feature = "libp2p-live-transport"))]
         let state = self.lock_live_data_plane_state()?;
-        Ok(state
-            .peers_by_id
-            .values()
-            .filter(|record| record.peer_id != requester_peer_id && record.supports_topic(topic))
-            .cloned()
-            .collect())
+        #[cfg(not(feature = "libp2p-live-transport"))]
+        {
+            Ok(state
+                .peers_by_id
+                .values()
+                .filter(|record| {
+                    record.peer_id != requester_peer_id && record.supports_topic(topic)
+                })
+                .cloned()
+                .collect())
+        }
     }
 
     fn send(&self, frame: PeerGossipFrame) -> Result<(), P2pTransportError> {
+        #[cfg(feature = "libp2p-live-transport")]
+        {
+            self.native_socket_transport.send(frame)
+        }
+        #[cfg(not(feature = "libp2p-live-transport"))]
         let mut state = self.lock_live_data_plane_state()?;
+        #[cfg(not(feature = "libp2p-live-transport"))]
         if !state.peers_by_id.contains_key(&frame.sender_peer_id) {
             return Err(P2pTransportError::UnknownSenderPeer(
                 frame.sender_peer_id.clone(),
             ));
         }
+        #[cfg(not(feature = "libp2p-live-transport"))]
         if !state.peers_by_id.contains_key(&frame.recipient_peer_id) {
             return Err(P2pTransportError::UnknownRecipientPeer(
                 frame.recipient_peer_id.clone(),
             ));
         }
-        state
-            .inbox_by_peer
-            .entry(frame.recipient_peer_id.clone())
-            .or_insert_with(VecDeque::new)
-            .push_back(frame);
-        Ok(())
+        #[cfg(not(feature = "libp2p-live-transport"))]
+        {
+            state
+                .inbox_by_peer
+                .entry(frame.recipient_peer_id.clone())
+                .or_insert_with(VecDeque::new)
+                .push_back(frame);
+            Ok(())
+        }
     }
 
     fn drain_inbox(
         &self,
         recipient_peer_id: &str,
     ) -> Result<Vec<PeerGossipFrame>, P2pTransportError> {
+        #[cfg(feature = "libp2p-live-transport")]
+        {
+            self.native_socket_transport.drain_inbox(recipient_peer_id)
+        }
+        #[cfg(not(feature = "libp2p-live-transport"))]
         validate_peer_id(recipient_peer_id)?;
+        #[cfg(not(feature = "libp2p-live-transport"))]
         let mut state = self.lock_live_data_plane_state()?;
-        let queue = state
-            .inbox_by_peer
-            .entry(recipient_peer_id.to_owned())
-            .or_insert_with(VecDeque::new);
-        Ok(queue.drain(..).collect())
+        #[cfg(not(feature = "libp2p-live-transport"))]
+        {
+            let queue = state
+                .inbox_by_peer
+                .entry(recipient_peer_id.to_owned())
+                .or_insert_with(VecDeque::new);
+            Ok(queue.drain(..).collect())
+        }
     }
 }
 
+#[cfg(not(feature = "libp2p-live-transport"))]
 #[derive(Debug, Default)]
 struct Libp2pLiveDataPlaneState {
     peers_by_id: BTreeMap<String, PeerDiscoveryRecord>,
     inbox_by_peer: BTreeMap<String, VecDeque<PeerGossipFrame>>,
 }
 
+#[cfg(not(feature = "libp2p-live-transport"))]
 #[derive(Debug, Clone)]
 struct Libp2pLiveDataPlane {
-    network_id: String,
     state: Arc<Mutex<Libp2pLiveDataPlaneState>>,
 }
 
+#[cfg(not(feature = "libp2p-live-transport"))]
 fn libp2p_live_data_plane_registry(
 ) -> &'static Mutex<BTreeMap<String, Arc<Mutex<Libp2pLiveDataPlaneState>>>> {
     static REGISTRY: OnceLock<Mutex<BTreeMap<String, Arc<Mutex<Libp2pLiveDataPlaneState>>>>> =
@@ -661,6 +754,7 @@ fn libp2p_live_data_plane_registry(
     REGISTRY.get_or_init(|| Mutex::new(BTreeMap::new()))
 }
 
+#[cfg(not(feature = "libp2p-live-transport"))]
 fn resolve_live_data_plane_state(
     network_id: &str,
 ) -> Result<Arc<Mutex<Libp2pLiveDataPlaneState>>, P2pTransportError> {
@@ -681,6 +775,21 @@ fn build_live_data_plane_network_id(config: &P2pSwarmDeterministicConfig) -> Str
     };
     let topic_segment = format!("topics={}", config.gossip_topics().join(","));
     format!("{bootstrap_segment}|{topic_segment}")
+}
+
+#[cfg(feature = "libp2p-live-transport")]
+fn validate_libp2p_native_runtime_config(
+    config: &P2pSwarmDeterministicConfig,
+) -> Result<(), P2pTransportError> {
+    use libp2p::Multiaddr;
+    config
+        .listen_address()
+        .parse::<Multiaddr>()
+        .map_err(|_| P2pTransportError::Libp2pRuntimeConfigInvalid)?;
+    for topic in config.gossip_topics() {
+        let _ = libp2p::gossipsub::IdentTopic::new(topic.clone());
+    }
+    Ok(())
 }
 
 /// Fault classes observed during live libp2p reconnect/discovery operations.
@@ -1393,6 +1502,8 @@ pub enum P2pTransportError {
     LiveSocketReceiveFailed,
     /// Live socket datagram payload is malformed.
     LiveSocketFrameMalformed,
+    /// Libp2p runtime config validation failed in native mode.
+    Libp2pRuntimeConfigInvalid,
     /// Transport state lock is unavailable.
     StateUnavailable,
     /// Lifecycle state does not permit transport I/O.
@@ -1435,6 +1546,7 @@ impl P2pTransportError {
             Self::LiveSocketSendFailed => "p2p_transport_live_socket_send_failed",
             Self::LiveSocketReceiveFailed => "p2p_transport_live_socket_receive_failed",
             Self::LiveSocketFrameMalformed => "p2p_transport_live_socket_frame_malformed",
+            Self::Libp2pRuntimeConfigInvalid => "p2p_transport_libp2p_runtime_config_invalid",
             Self::StateUnavailable => "p2p_transport_state_unavailable",
             Self::InactivePeerLifecycleState(_) => "p2p_transport_inactive_lifecycle_state",
             Self::Lifecycle(error) => error.reason_code(),
@@ -1493,6 +1605,9 @@ impl Display for P2pTransportError {
             Self::LiveSocketSendFailed => write!(f, "p2p live socket send failed"),
             Self::LiveSocketReceiveFailed => write!(f, "p2p live socket receive failed"),
             Self::LiveSocketFrameMalformed => write!(f, "p2p live socket frame is malformed"),
+            Self::Libp2pRuntimeConfigInvalid => {
+                write!(f, "p2p libp2p native runtime config is invalid")
+            }
             Self::StateUnavailable => write!(f, "p2p in-memory transport state is unavailable"),
             Self::InactivePeerLifecycleState(state) => {
                 write!(

--- a/crates/kamn-core/tests/p2p_libp2p_native_adapter_runtime.rs
+++ b/crates/kamn-core/tests/p2p_libp2p_native_adapter_runtime.rs
@@ -1,0 +1,234 @@
+#![cfg(feature = "libp2p-live-transport")]
+
+use kamn_core::{
+    build_p2p_swarm_deterministic_config, resolve_libp2p_live_runtime_backend,
+    Libp2pLivePeerLifecycleTransport, Libp2pLiveRuntimeBackend, NodeConfig, NodeRole,
+    P2pSwarmHarnessMode, PeerDiscoveryRecord, PeerGossipFrame, PeerLifecycleState,
+    PeerLifecycleTransport, PeerLifecycleTransportCoordinator, RuntimeTransportProfile, SyncMode,
+};
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
+
+fn config_for(role: NodeRole, gossip_enabled: bool) -> NodeConfig {
+    NodeConfig {
+        chain_id: "kamn-devnet".to_owned(),
+        chain_version: "v0.1.0".to_owned(),
+        role,
+        storage_dir: "/tmp/kamn".to_owned(),
+        enable_gossip: gossip_enabled,
+        sync_mode: SyncMode::Fast,
+    }
+}
+
+fn unique_bootstrap_seed(label: &str) -> String {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock should be monotonic")
+        .as_nanos();
+    format!("/ip4/127.0.0.1/tcp/99{nonce}/{label}")
+}
+
+fn live_swarm_config_for_peer(
+    peer_id: &str,
+    listen_address: &str,
+    bootstrap_seed: &str,
+) -> kamn_core::P2pSwarmDeterministicConfig {
+    build_p2p_swarm_deterministic_config(
+        &config_for(NodeRole::Processor, true),
+        peer_id,
+        listen_address,
+        vec![bootstrap_seed.to_owned()],
+        vec!["messages".to_owned()],
+        3,
+    )
+    .expect("swarm config should build")
+}
+
+#[test]
+fn unit_libp2p_native_adapter_rejects_invalid_listen_multiaddr() {
+    let config = build_p2p_swarm_deterministic_config(
+        &config_for(NodeRole::Processor, true),
+        "peer-native-invalid",
+        "/ip4/127.0.0.1/tcp/invalid-port",
+        vec!["/ip4/127.0.0.1/tcp/9201".to_owned()],
+        vec!["messages".to_owned()],
+        3,
+    )
+    .expect("base config should build");
+
+    let error = Libp2pLivePeerLifecycleTransport::new(config, P2pSwarmHarnessMode::DryRun)
+        .expect_err("invalid libp2p native listen multiaddr must fail");
+    assert_eq!(
+        error.reason_code(),
+        "p2p_transport_libp2p_runtime_config_invalid"
+    );
+}
+
+#[test]
+fn functional_libp2p_native_backend_selection_marker_is_stable() {
+    assert_eq!(
+        resolve_libp2p_live_runtime_backend(),
+        Libp2pLiveRuntimeBackend::NativeSocket
+    );
+}
+
+#[test]
+fn integration_libp2p_native_adapter_supports_discovery_and_gossip_over_sockets() {
+    let bootstrap_seed = unique_bootstrap_seed("native");
+    let processor_transport = Libp2pLivePeerLifecycleTransport::new(
+        live_swarm_config_for_peer(
+            "peer-native-processor",
+            "/ip4/127.0.0.1/tcp/9520",
+            bootstrap_seed.as_str(),
+        ),
+        P2pSwarmHarnessMode::DryRun,
+    )
+    .expect("processor transport should initialize");
+    let listener_transport = Libp2pLivePeerLifecycleTransport::new(
+        live_swarm_config_for_peer(
+            "peer-native-listener",
+            "/ip4/127.0.0.1/tcp/9521",
+            bootstrap_seed.as_str(),
+        ),
+        P2pSwarmHarnessMode::DryRun,
+    )
+    .expect("listener transport should initialize");
+
+    assert_eq!(
+        processor_transport.transport_profile(),
+        RuntimeTransportProfile::Libp2pLive
+    );
+    assert_eq!(
+        resolve_libp2p_live_runtime_backend().marker(),
+        "native-socket"
+    );
+
+    let mut processor = PeerLifecycleTransportCoordinator::new(
+        "peer-native-processor",
+        NodeRole::Processor,
+        processor_transport,
+    )
+    .expect("processor coordinator should initialize");
+    let mut listener = PeerLifecycleTransportCoordinator::new(
+        "peer-native-listener",
+        NodeRole::Listener,
+        listener_transport,
+    )
+    .expect("listener coordinator should initialize");
+
+    assert_eq!(
+        processor.connect_and_advertise(vec!["messages".to_owned()]),
+        Ok(PeerLifecycleState::Active)
+    );
+    assert_eq!(
+        listener.connect_and_advertise(vec!["messages".to_owned()]),
+        Ok(PeerLifecycleState::Active)
+    );
+
+    let discovered = processor
+        .discover("messages")
+        .expect("native discovery should succeed");
+    assert_eq!(discovered.len(), 1);
+    assert_eq!(discovered[0].peer_id, "peer-native-listener");
+
+    let delivered = processor
+        .broadcast("messages", "tx-native-001")
+        .expect("native broadcast should succeed");
+    assert_eq!(delivered, 1);
+
+    let listener_frames = listener
+        .drain_inbox()
+        .expect("listener inbox drain should succeed");
+    assert_eq!(listener_frames.len(), 1);
+    assert_eq!(listener_frames[0].sender_peer_id, "peer-native-processor");
+    assert_eq!(listener_frames[0].topic, "messages");
+    assert_eq!(listener_frames[0].payload, "tx-native-001");
+}
+
+#[test]
+fn regression_libp2p_native_runtime_config_error_reason_code_stays_stable() {
+    // Regression: #3633
+    let config = build_p2p_swarm_deterministic_config(
+        &config_for(NodeRole::Processor, true),
+        "peer-native-invalid-regression",
+        "/ip4/127.0.0.1/tcp/invalid-port",
+        vec!["/ip4/127.0.0.1/tcp/9201".to_owned()],
+        vec!["messages".to_owned()],
+        3,
+    )
+    .expect("base config should build");
+
+    let error = Libp2pLivePeerLifecycleTransport::new(config, P2pSwarmHarnessMode::DryRun)
+        .expect_err("invalid config should fail");
+    assert_eq!(
+        error.reason_code(),
+        "p2p_transport_libp2p_runtime_config_invalid"
+    );
+}
+
+#[test]
+fn performance_libp2p_native_adapter_stays_within_local_heavy_budget() {
+    let started = Instant::now();
+    let bootstrap_seed = unique_bootstrap_seed("native-performance");
+    let sender_transport = Libp2pLivePeerLifecycleTransport::new(
+        live_swarm_config_for_peer(
+            "peer-native-perf-sender",
+            "/ip4/127.0.0.1/tcp/9530",
+            bootstrap_seed.as_str(),
+        ),
+        P2pSwarmHarnessMode::DryRun,
+    )
+    .expect("sender transport should initialize");
+    let recipient_transport = Libp2pLivePeerLifecycleTransport::new(
+        live_swarm_config_for_peer(
+            "peer-native-perf-recipient",
+            "/ip4/127.0.0.1/tcp/9531",
+            bootstrap_seed.as_str(),
+        ),
+        P2pSwarmHarnessMode::DryRun,
+    )
+    .expect("recipient transport should initialize");
+
+    sender_transport
+        .advertise(
+            PeerDiscoveryRecord::new(
+                "peer-native-perf-sender",
+                NodeRole::Processor,
+                vec!["messages".to_owned()],
+            )
+            .expect("sender record should build"),
+        )
+        .expect("sender advertise should succeed");
+    recipient_transport
+        .advertise(
+            PeerDiscoveryRecord::new(
+                "peer-native-perf-recipient",
+                NodeRole::Listener,
+                vec!["messages".to_owned()],
+            )
+            .expect("recipient record should build"),
+        )
+        .expect("recipient advertise should succeed");
+
+    for nonce in 0..64 {
+        sender_transport
+            .send(
+                PeerGossipFrame::new(
+                    "messages",
+                    "peer-native-perf-sender",
+                    "peer-native-perf-recipient",
+                    &format!("tx-native-performance-{nonce}"),
+                )
+                .expect("frame should build"),
+            )
+            .expect("frame should send");
+    }
+
+    let frames = recipient_transport
+        .drain_inbox("peer-native-perf-recipient")
+        .expect("recipient inbox should drain");
+    assert_eq!(frames.len(), 64);
+    assert!(
+        started.elapsed() <= std::time::Duration::from_secs(2),
+        "libp2p native adapter exceeded local-heavy runtime budget"
+    );
+}

--- a/crates/kamn-core/tests/p2p_transport_docs.rs
+++ b/crates/kamn-core/tests/p2p_transport_docs.rs
@@ -21,6 +21,9 @@ fn architecture_doc_contains_p2p_transport_core_components() {
     assert!(DOC.contains("KademliaDiscoveryBootstrapPlan"));
     assert!(DOC.contains("PeerLifecycleRegressionCase"));
     assert!(DOC.contains("PeerLifecycleRegressionOutcome"));
+    assert!(DOC.contains("Libp2pLiveRuntimeBackend"));
+    assert!(DOC.contains("resolve_libp2p_live_runtime_backend()"));
+    assert!(DOC.contains("UdpPeerLifecycleTransport"));
 }
 
 #[test]
@@ -45,7 +48,10 @@ fn architecture_doc_contains_runtime_wiring_and_guardrails() {
     assert!(DOC.contains("P2pTransportError::InvalidReconnectRetryBudget"));
     assert!(DOC.contains("P2pTransportError::InvalidReconnectBackoffWindow"));
     assert!(DOC.contains("P2pTransportError::GossipTransportDisabled"));
+    assert!(DOC.contains("P2pTransportError::Libp2pRuntimeConfigInvalid"));
     assert!(DOC.contains("P2pTransportError::MissingKademliaBootstrapSeeds"));
+    assert!(DOC.contains("p2p-live-libp2p-provider:native"));
+    assert!(DOC.contains("p2p-live-libp2p-provider:contract-only"));
     assert!(DOC.contains("runtime_peer_transition_invalid"));
     assert!(DOC.contains("validate_p2p_transport_live.sh"));
     assert!(DOC.contains("test_validate_p2p_transport_live.sh"));
@@ -59,6 +65,9 @@ fn architecture_doc_contains_runtime_wiring_and_guardrails() {
     ));
     assert!(DOC.contains(
         "cargo test -p kamn-core --test p2p_live_transport_runtime regression_live_transport_invalid_transition_reason_code_stable -- --exact"
+    ));
+    assert!(DOC.contains(
+        "cargo test -p kamn-core --test p2p_libp2p_native_adapter_runtime --features libp2p-live-transport"
     ));
     assert!(DOC.contains("cargo test -p kamn-core --test p2p_reconnect_policy_runtime"));
     assert!(DOC.contains("p2p_live_reconnect_retry_dial_timeout"));

--- a/docs/architecture/p2p-transport.md
+++ b/docs/architecture/p2p-transport.md
@@ -48,8 +48,22 @@ libp2p I/O integration while preserving low-cost default CI behavior.
 - `Libp2pLivePeerLifecycleTransport`
   - deterministic live-adapter surface that boots swarm harness startup and
     provides a concrete transport profile for runtime wiring.
-  - executes advertise/discover/send/drain through a dedicated live data-plane
-    state channel (no `InMemoryPeerLifecycleTransport` delegate fallback path).
+  - compile-mode backend execution:
+    - contract mode executes advertise/discover/send/drain through a dedicated
+      live data-plane state channel (no `InMemoryPeerLifecycleTransport`
+      delegate fallback path).
+    - no `InMemoryPeerLifecycleTransport` delegate fallback path.
+    - `libp2p-live-transport` mode executes over native socket-backed
+      transport.
+- `Libp2pLiveRuntimeBackend`
+  - deterministic backend marker contract:
+    - `contract-data-plane`
+    - `native-socket`
+- `resolve_libp2p_live_runtime_backend()`
+  - compile-time resolver used by runtime/reporting contracts.
+- `UdpPeerLifecycleTransport`
+  - UDP socket-backed transport adapter for local live convergence drills and
+    feature-enabled native runtime delivery paths.
 - `PeerDiscoveryRecord`
   - normalized peer advertisement payload with role and gossip topic set.
 - `PeerGossipFrame`
@@ -115,6 +129,9 @@ provider marker contracts for local-heavy runtime rehearsal:
 - `RuntimeTransportProfile::Libp2pLive`
   - `p2p-transport-profile:libp2p-live`
   - `p2p-live-libp2p-provider`
+  - compile-mode provider marker:
+    - `p2p-live-libp2p-provider:contract-only` (feature disabled)
+    - `p2p-live-libp2p-provider:native` (`libp2p-live-transport` enabled)
 
 ## Live Data-Plane Execution
 
@@ -131,6 +148,14 @@ deterministic network identity.
 - `P2pTransportError::reason_code()`
   - exposes deterministic reason-code taxonomy for transport policy checks and
     repeated invalid-event idempotence guards.
+
+Task #3633 adds a feature-enabled native runtime path:
+
+- `resolve_libp2p_live_runtime_backend()`
+  - returns `Libp2pLiveRuntimeBackend::NativeSocket` when
+    `libp2p-live-transport` is enabled.
+- Feature-enabled live adapter construction validates native libp2p runtime
+  inputs and then routes send/receive/discovery over socket-backed transport.
 
 ## Reconnect Taxonomy
 
@@ -175,6 +200,8 @@ Deterministic reason-code markers:
   `P2pTransportError::InvalidReconnectBackoffWindow`.
 - Swarm config requests with `enable_gossip=false` fail closed with
   `P2pTransportError::GossipTransportDisabled`.
+- Feature-enabled native runtime config validation failures fail closed with
+  `P2pTransportError::Libp2pRuntimeConfigInvalid`.
 - Empty Kademlia seed sets fail closed with
   `P2pTransportError::MissingKademliaBootstrapSeeds`.
 - Invalid lifecycle transition replay remains fail closed with reason code
@@ -215,6 +242,7 @@ cargo test -p kamn-core --test p2p_kademlia_bootstrap
 cargo test -p kamn-core --test p2p_lifecycle_regression_corpus
 cargo test -p kamn-core --test p2p_transport_feature_gates
 cargo test -p kamn-core --test p2p_transport_feature_gates --features libp2p-live-transport
+cargo test -p kamn-core --test p2p_libp2p_native_adapter_runtime --features libp2p-live-transport
 cargo test -p kamn-core --test p2p_live_transport_runtime integration_live_transport_data_plane_supports_independent_adapter_exchange -- --exact
 cargo test -p kamn-core --test p2p_live_transport_runtime integration_live_transport_invalid_event_retries_are_idempotent -- --exact
 cargo test -p kamn-core --test p2p_live_transport_runtime regression_live_transport_invalid_transition_reason_code_stable -- --exact


### PR DESCRIPTION
Closes #3633
Refs #3627

## Summary
Implement a feature-enabled native runtime backend mode for `Libp2pLivePeerLifecycleTransport` that performs live discovery/gossip send/receive over sockets while preserving deterministic contract-mode behavior.
Add deterministic native runtime-config fail-closed mapping and dedicated unit/functional/integration/regression/performance coverage for the native path.

## Changes
- `crates/kamn-core/src/p2p_transport.rs`
  - Add `Libp2pLiveRuntimeBackend` and `resolve_libp2p_live_runtime_backend()`.
  - Wire `Libp2pLivePeerLifecycleTransport` to use `UdpPeerLifecycleTransport` when `libp2p-live-transport` is enabled; retain deterministic contract data-plane path otherwise.
  - Add native runtime-config validation hook and deterministic error code `p2p_transport_libp2p_runtime_config_invalid`.
- `crates/kamn-core/src/lib.rs`
  - Re-export native backend resolver/types.
- `crates/kamn-core/tests/p2p_libp2p_native_adapter_runtime.rs`
  - Add unit/functional/integration/regression/performance coverage for the feature-enabled native path.
- `docs/architecture/p2p-transport.md`
  - Document backend selection, native runtime behavior, fail-closed taxonomy, and validation commands.
- `crates/kamn-core/tests/p2p_transport_docs.rs`
  - Extend doc-contract assertions for native backend symbols/markers.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
`cargo test -p kamn-core --test p2p_libp2p_native_adapter_runtime --features libp2p-live-transport`

Failure excerpt:
- unresolved imports: `Libp2pLiveRuntimeBackend`, `resolve_libp2p_live_runtime_backend`

### 🟢 Green Phase
Commands:
- `cargo test -p kamn-core --test p2p_libp2p_native_adapter_runtime --features libp2p-live-transport`

Result:
- 5/5 native adapter tests passing.

### 🔁 Regression
Commands:
- `cargo test -p kamn-core --test p2p_libp2p_native_adapter_runtime --test p2p_live_transport_runtime --features libp2p-live-transport`
- `cargo test -p kamn-core --test p2p_transport_docs --test p2p_transport_feature_gates --test p2p_transport_runtime`
- `cargo clippy -p kamn-core --test p2p_transport_docs -- -D warnings`
- `cargo clippy -p kamn-core --test p2p_libp2p_native_adapter_runtime --features libp2p-live-transport -- -D warnings`
- `cargo fmt --check`

Result:
- All commands pass.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | `unit_libp2p_native_adapter_rejects_invalid_listen_multiaddr` | |
| Functional   | ✅ | `functional_libp2p_native_backend_selection_marker_is_stable` | |
| Integration  | ✅ | `integration_libp2p_native_adapter_supports_discovery_and_gossip_over_sockets` | |
| Regression   | ✅ | `regression_libp2p_native_runtime_config_error_reason_code_stays_stable` | |
| Performance  | ✅ | `performance_libp2p_native_adapter_stays_within_local_heavy_budget` | |

## Risks & Rollback
- Additive runtime backend mode; no API removal.
- Rollback plan: revert this PR commit to restore prior contract-only behavior.

## Documentation Updates
- `docs/architecture/p2p-transport.md` updated with native backend contracts and validation commands.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (default + feature-enabled changed targets)
- [x] TDD Red/Green evidence included above
