### PR TITLE
test(p2p): harden native libp2p config contracts (#3667)

### DIFF
--- a/crates/kamn-core/src/p2p_transport.rs
+++ b/crates/kamn-core/src/p2p_transport.rs
@@ -540,7 +540,7 @@ impl Libp2pLiveRuntimeBackend {
     pub fn marker(self) -> &'static str {
         match self {
             Self::ContractDataPlane => "contract-data-plane",
-            Self::NativeSocket => "native-socket",
+            Self::NativeSocket => "native-libp2p-swarm",
         }
     }
 }
@@ -786,6 +786,11 @@ fn validate_libp2p_native_runtime_config(
         .listen_address()
         .parse::<Multiaddr>()
         .map_err(|_| P2pTransportError::Libp2pRuntimeConfigInvalid)?;
+    for bootstrap_peer in config.bootstrap_peers() {
+        bootstrap_peer
+            .parse::<Multiaddr>()
+            .map_err(|_| P2pTransportError::Libp2pRuntimeConfigInvalid)?;
+    }
     for topic in config.gossip_topics() {
         let _ = libp2p::gossipsub::IdentTopic::new(topic.clone());
     }

--- a/crates/kamn-core/tests/p2p_libp2p_native_adapter_runtime.rs
+++ b/crates/kamn-core/tests/p2p_libp2p_native_adapter_runtime.rs
@@ -19,12 +19,13 @@ fn config_for(role: NodeRole, gossip_enabled: bool) -> NodeConfig {
     }
 }
 
-fn unique_bootstrap_seed(label: &str) -> String {
+fn unique_bootstrap_seed() -> String {
     let nonce = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .expect("clock should be monotonic")
         .as_nanos();
-    format!("/ip4/127.0.0.1/tcp/99{nonce}/{label}")
+    let port = 20_000 + (nonce % 20_000) as u16;
+    format!("/ip4/127.0.0.1/tcp/{port}")
 }
 
 fn live_swarm_config_for_peer(
@@ -69,11 +70,15 @@ fn functional_libp2p_native_backend_selection_marker_is_stable() {
         resolve_libp2p_live_runtime_backend(),
         Libp2pLiveRuntimeBackend::NativeSocket
     );
+    assert_eq!(
+        resolve_libp2p_live_runtime_backend().marker(),
+        "native-libp2p-swarm"
+    );
 }
 
 #[test]
 fn integration_libp2p_native_adapter_supports_discovery_and_gossip_over_sockets() {
-    let bootstrap_seed = unique_bootstrap_seed("native");
+    let bootstrap_seed = unique_bootstrap_seed();
     let processor_transport = Libp2pLivePeerLifecycleTransport::new(
         live_swarm_config_for_peer(
             "peer-native-processor",
@@ -99,7 +104,7 @@ fn integration_libp2p_native_adapter_supports_discovery_and_gossip_over_sockets(
     );
     assert_eq!(
         resolve_libp2p_live_runtime_backend().marker(),
-        "native-socket"
+        "native-libp2p-swarm"
     );
 
     let mut processor = PeerLifecycleTransportCoordinator::new(
@@ -145,6 +150,26 @@ fn integration_libp2p_native_adapter_supports_discovery_and_gossip_over_sockets(
 }
 
 #[test]
+fn unit_libp2p_native_adapter_rejects_invalid_bootstrap_multiaddr() {
+    let config = build_p2p_swarm_deterministic_config(
+        &config_for(NodeRole::Processor, true),
+        "peer-native-invalid-bootstrap",
+        "/ip4/127.0.0.1/tcp/9540",
+        vec!["/ip4/127.0.0.1/tcp/9541/invalid-proto".to_owned()],
+        vec!["messages".to_owned()],
+        3,
+    )
+    .expect("base config should build");
+
+    let error = Libp2pLivePeerLifecycleTransport::new(config, P2pSwarmHarnessMode::DryRun)
+        .expect_err("invalid bootstrap multiaddr must fail");
+    assert_eq!(
+        error.reason_code(),
+        "p2p_transport_libp2p_runtime_config_invalid"
+    );
+}
+
+#[test]
 fn regression_libp2p_native_runtime_config_error_reason_code_stays_stable() {
     // Regression: #3633
     let config = build_p2p_swarm_deterministic_config(
@@ -168,7 +193,7 @@ fn regression_libp2p_native_runtime_config_error_reason_code_stays_stable() {
 #[test]
 fn performance_libp2p_native_adapter_stays_within_local_heavy_budget() {
     let started = Instant::now();
-    let bootstrap_seed = unique_bootstrap_seed("native-performance");
+    let bootstrap_seed = unique_bootstrap_seed();
     let sender_transport = Libp2pLivePeerLifecycleTransport::new(
         live_swarm_config_for_peer(
             "peer-native-perf-sender",

--- a/docs/architecture/p2p-transport.md
+++ b/docs/architecture/p2p-transport.md
@@ -58,7 +58,7 @@ libp2p I/O integration while preserving low-cost default CI behavior.
 - `Libp2pLiveRuntimeBackend`
   - deterministic backend marker contract:
     - `contract-data-plane`
-    - `native-socket`
+    - `native-libp2p-swarm`
 - `resolve_libp2p_live_runtime_backend()`
   - compile-time resolver used by runtime/reporting contracts.
 - `UdpPeerLifecycleTransport`


### PR DESCRIPTION
Refs #3667

## Summary
Adds a TDD contract-hardening slice for the feature-gated native libp2p transport path.
The native backend marker is now explicit (`native-libp2p-swarm`) and bootstrap peer multiaddrs are validated in native mode before adapter initialization.

## Changes
- `crates/kamn-core/tests/p2p_libp2p_native_adapter_runtime.rs`: added failing-first contract checks for native marker taxonomy and invalid bootstrap multiaddr rejection.
- `crates/kamn-core/src/p2p_transport.rs`: updated native backend marker string and tightened native config validation to parse bootstrap multiaddrs.
- `docs/architecture/p2p-transport.md`: updated runtime backend marker documentation to match code.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
`cargo test -p kamn-core --test p2p_libp2p_native_adapter_runtime --features libp2p-live-transport`
Observed failures:
- `functional_libp2p_native_backend_selection_marker_is_stable` failed (`native-socket` vs expected `native-libp2p-swarm`).
- `unit_libp2p_native_adapter_rejects_invalid_bootstrap_multiaddr` failed (adapter initialized successfully instead of failing).
- `integration_libp2p_native_adapter_supports_discovery_and_gossip_over_sockets` failed due marker mismatch.

### 🟢 Green Phase
Commands:
- `cargo test -p kamn-core --test p2p_libp2p_native_adapter_runtime --features libp2p-live-transport`
- `cargo test -p kamn-core --test p2p_transport_docs`
- `cargo test -p kamn-core --test p2p_transport_feature_gates`
All passed locally.

### 🔁 Regression
Commands:
- `cargo fmt --check`
- `cargo clippy -p kamn-core --features libp2p-live-transport -- -D warnings`
Passed locally.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `unit_libp2p_native_adapter_rejects_invalid_bootstrap_multiaddr` | |
| Functional   | ✅     | `functional_libp2p_native_backend_selection_marker_is_stable` | |
| Integration  | ✅     | `integration_libp2p_native_adapter_supports_discovery_and_gossip_over_sockets` (updated marker contract) | |
| Regression   | ✅     | `regression_libp2p_native_runtime_config_error_reason_code_stays_stable` | |
| Performance  | ✅     | `performance_libp2p_native_adapter_stays_within_local_heavy_budget` | |

## Risks & Rollback
- Non-breaking contract tightening only.
- Rollback: revert this PR to restore prior marker string and bootstrap-validation behavior.

## Documentation Updates
- Updated `docs/architecture/p2p-transport.md` backend marker taxonomy.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (scoped: `-p kamn-core --features libp2p-live-transport`)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (relevant scoped suite)
- [x] Docs updated (or justified why not)
