### PR TITLE
feat(p2p): validate native swarm runtime composition in harness mode (#3668)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1495,6 +1495,7 @@ dependencies = [
  "rusqlite",
  "rustls",
  "rustls-pemfile",
+ "tokio",
  "webpki-roots",
 ]
 

--- a/crates/kamn-core/Cargo.toml
+++ b/crates/kamn-core/Cargo.toml
@@ -10,12 +10,13 @@ path = "src/lib.rs"
 [features]
 default = ["live-https"]
 live-https = ["dep:rustls", "dep:rustls-pemfile", "dep:webpki-roots"]
-libp2p-live-transport = ["dep:libp2p"]
+libp2p-live-transport = ["dep:libp2p", "dep:tokio"]
 
 [dependencies]
 kamn-kolme = { path = "../kamn-kolme" }
 rusqlite = { version = "0.31.0", features = ["bundled"] }
 libp2p = { version = "0.56.0", default-features = false, features = ["dns", "gossipsub", "identify", "kad", "macros", "noise", "ping", "tcp", "tokio", "yamux"], optional = true }
+tokio = { version = "1.48.0", features = ["rt", "time", "net"], optional = true }
 # Live HTTPS runtime-commit transport uses rustls directly (no subprocess curl path).
 rustls = { version = "0.23.36", default-features = false, features = ["ring", "std", "tls12"], optional = true }
 rustls-pemfile = { version = "2.2.0", optional = true }

--- a/crates/kamn-core/src/p2p_transport.rs
+++ b/crates/kamn-core/src/p2p_transport.rs
@@ -5,6 +5,8 @@ use crate::runtime::{
     PeerLifecycle, PeerLifecycleEvent, PeerLifecycleState, RuntimeLifecycleError,
     RuntimeTransportProfile,
 };
+#[cfg(feature = "libp2p-live-transport")]
+use libp2p::{gossipsub, identify, noise, swarm::Swarm, tcp, yamux, Multiaddr, SwarmBuilder};
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::error::Error;
 use std::fmt::{Display, Formatter};
@@ -14,6 +16,13 @@ use std::sync::{Arc, Mutex, OnceLock};
 
 const LIBP2P_SWARM_BEHAVIOR_COMPONENTS: [&str; 6] =
     ["tcp", "noise", "yamux", "identify", "kad", "gossipsub"];
+
+#[cfg(feature = "libp2p-live-transport")]
+#[derive(libp2p::swarm::NetworkBehaviour)]
+struct Libp2pDeterministicRuntimeBehaviour {
+    gossipsub: gossipsub::Behaviour,
+    identify: identify::Behaviour,
+}
 
 /// Transport-level discovery metadata advertised by each active peer.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1454,14 +1463,86 @@ impl P2pSwarmHarnessTask {
         } else {
             0
         };
+        let behavior_components = self.stack.behavior_components();
+        #[cfg(feature = "libp2p-live-transport")]
+        let mut behavior_components = behavior_components;
+        #[cfg(feature = "libp2p-live-transport")]
+        if started {
+            validate_libp2p_runtime_stack_composition(&self.config)?;
+            behavior_components.push("libp2p-runtime-swarm");
+        }
         Ok(P2pSwarmHarnessReport {
             mode,
             started,
             executed_ticks,
             bootstrap_peer_count: self.config.bootstrap_peers().len(),
-            behavior_components: self.stack.behavior_components(),
+            behavior_components,
         })
     }
+}
+
+#[cfg(feature = "libp2p-live-transport")]
+fn validate_libp2p_runtime_stack_composition(
+    config: &P2pSwarmDeterministicConfig,
+) -> Result<(), P2pTransportError> {
+    let config = config.clone();
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_io()
+        .enable_time()
+        .build()
+        .map_err(|_| P2pTransportError::Libp2pRuntimeConfigInvalid)?;
+
+    runtime.block_on(async move {
+        let mut swarm = SwarmBuilder::with_new_identity()
+            .with_tokio()
+            .with_tcp(
+                tcp::Config::default(),
+                noise::Config::new,
+                yamux::Config::default,
+            )
+            .map_err(|_| P2pTransportError::Libp2pRuntimeConfigInvalid)?
+            .with_behaviour(|key| {
+                let gossipsub_config = gossipsub::ConfigBuilder::default()
+                    .validation_mode(gossipsub::ValidationMode::Permissive)
+                    .build()
+                    .map_err(|_| P2pTransportError::Libp2pRuntimeConfigInvalid)?;
+                let mut gossipsub_behavior = gossipsub::Behaviour::new(
+                    gossipsub::MessageAuthenticity::Signed(key.clone()),
+                    gossipsub_config,
+                )
+                .map_err(|_| P2pTransportError::Libp2pRuntimeConfigInvalid)?;
+                for topic in config.gossip_topics() {
+                    gossipsub_behavior
+                        .subscribe(&gossipsub::IdentTopic::new(topic.clone()))
+                        .map_err(|_| P2pTransportError::Libp2pRuntimeConfigInvalid)?;
+                }
+                Ok(Libp2pDeterministicRuntimeBehaviour {
+                    gossipsub: gossipsub_behavior,
+                    identify: identify::Behaviour::new(identify::Config::new(
+                        "/kamn/libp2p-live/1.0.0".to_owned(),
+                        key.public(),
+                    )),
+                })
+            })
+            .map_err(|_| P2pTransportError::Libp2pRuntimeConfigInvalid)?
+            .build();
+
+        let listen_multiaddr = config
+            .listen_address()
+            .parse::<Multiaddr>()
+            .map_err(|_| P2pTransportError::Libp2pRuntimeConfigInvalid)?;
+        Swarm::listen_on(&mut swarm, listen_multiaddr)
+            .map_err(|_| P2pTransportError::Libp2pRuntimeConfigInvalid)?;
+
+        for bootstrap_peer in config.bootstrap_peers() {
+            let bootstrap_multiaddr = bootstrap_peer
+                .parse::<Multiaddr>()
+                .map_err(|_| P2pTransportError::Libp2pRuntimeConfigInvalid)?;
+            let _ = Swarm::dial(&mut swarm, bootstrap_multiaddr);
+        }
+
+        Ok(())
+    })
 }
 
 /// Deterministic p2p discovery and gossip transport error variants.

--- a/crates/kamn-core/tests/p2p_kademlia_bootstrap.rs
+++ b/crates/kamn-core/tests/p2p_kademlia_bootstrap.rs
@@ -59,9 +59,9 @@ fn functional_kademlia_bootstrap_plan_normalizes_seed_order() {
         "peer-processor",
         "/ip4/127.0.0.1/tcp/9100",
         vec![
-            "/ip4/127.0.0.1/tcp/9102/p2p/peer-c".to_owned(),
-            "/ip4/127.0.0.1/tcp/9101/p2p/peer-b".to_owned(),
-            "/ip4/127.0.0.1/tcp/9101/p2p/peer-b".to_owned(),
+            "/ip4/127.0.0.1/tcp/9102".to_owned(),
+            "/ip4/127.0.0.1/tcp/9101".to_owned(),
+            "/ip4/127.0.0.1/tcp/9101".to_owned(),
         ],
         vec!["messages".to_owned(), "blocks".to_owned()],
         3,
@@ -74,8 +74,8 @@ fn functional_kademlia_bootstrap_plan_normalizes_seed_order() {
     assert_eq!(
         plan.seed_peers(),
         vec![
-            "/ip4/127.0.0.1/tcp/9101/p2p/peer-b".to_owned(),
-            "/ip4/127.0.0.1/tcp/9102/p2p/peer-c".to_owned(),
+            "/ip4/127.0.0.1/tcp/9101".to_owned(),
+            "/ip4/127.0.0.1/tcp/9102".to_owned(),
         ]
     );
 }
@@ -87,8 +87,8 @@ fn integration_kademlia_bootstrap_plan_composes_with_swarm_harness_startup() {
         "peer-processor",
         "/ip4/127.0.0.1/tcp/9100",
         vec![
-            "/ip4/127.0.0.1/tcp/9101/p2p/peer-listener".to_owned(),
-            "/ip4/127.0.0.1/tcp/9102/p2p/peer-approver".to_owned(),
+            "/ip4/127.0.0.1/tcp/9101".to_owned(),
+            "/ip4/127.0.0.1/tcp/9102".to_owned(),
         ],
         vec!["messages".to_owned(), "blocks".to_owned()],
         3,

--- a/crates/kamn-core/tests/p2p_swarm_stack_runtime.rs
+++ b/crates/kamn-core/tests/p2p_swarm_stack_runtime.rs
@@ -59,8 +59,8 @@ fn integration_runtime_can_start_swarm_harness_task() {
         "peer-processor",
         "/ip4/127.0.0.1/tcp/9000",
         vec![
-            "/ip4/127.0.0.1/tcp/9001/p2p/peer-listener".to_owned(),
-            "/ip4/127.0.0.1/tcp/9002/p2p/peer-approver".to_owned(),
+            "/ip4/127.0.0.1/tcp/9001".to_owned(),
+            "/ip4/127.0.0.1/tcp/9002".to_owned(),
         ],
         vec![
             "messages".to_owned(),
@@ -78,6 +78,32 @@ fn integration_runtime_can_start_swarm_harness_task() {
     assert!(report.started());
     assert_eq!(report.executed_ticks(), 4);
     assert_eq!(report.bootstrap_peer_count(), 2);
+}
+
+#[cfg(feature = "libp2p-live-transport")]
+#[test]
+fn integration_swarm_harness_report_includes_native_runtime_marker_when_feature_enabled() {
+    let config = build_p2p_swarm_deterministic_config(
+        &config_for(NodeRole::Processor, true),
+        "peer-native-marker",
+        "/ip4/127.0.0.1/tcp/9050",
+        vec!["/ip4/127.0.0.1/tcp/9051".to_owned()],
+        vec!["messages".to_owned()],
+        2,
+    )
+    .expect("deterministic config should build");
+
+    let task = P2pSwarmHarnessTask::new(config);
+    let report = task
+        .start(P2pSwarmHarnessMode::Run)
+        .expect("runtime harness start should pass");
+    assert!(report.started());
+    assert!(
+        report
+            .behavior_components()
+            .contains(&"libp2p-runtime-swarm"),
+        "feature-enabled run mode must report native libp2p runtime stack marker"
+    );
 }
 
 #[test]

--- a/crates/kamn-core/tests/p2p_transport_docs.rs
+++ b/crates/kamn-core/tests/p2p_transport_docs.rs
@@ -3,6 +3,7 @@ const ROADMAP: &str = include_str!("../../../docs/plans/2026-02-08-production-se
 
 #[test]
 fn architecture_doc_contains_p2p_transport_core_components() {
+    assert!(DOC.contains("`tokio`"));
     assert!(DOC.contains("PeerLifecycleTransport"));
     assert!(DOC.contains("InMemoryPeerLifecycleTransport"));
     assert!(DOC.contains("Libp2pLivePeerLifecycleTransport"));
@@ -14,6 +15,7 @@ fn architecture_doc_contains_p2p_transport_core_components() {
     assert!(DOC.contains("P2pSwarmDeterministicConfig"));
     assert!(DOC.contains("P2pSwarmBehaviorStack"));
     assert!(DOC.contains("P2pSwarmHarnessTask"));
+    assert!(DOC.contains("libp2p-runtime-swarm"));
     assert!(DOC.contains("LiveTransportReconnectPolicy"));
     assert!(DOC.contains("LiveTransportReconnectDecision"));
     assert!(DOC.contains("LiveTransportFaultClass"));
@@ -52,6 +54,7 @@ fn architecture_doc_contains_runtime_wiring_and_guardrails() {
     assert!(DOC.contains("P2pTransportError::MissingKademliaBootstrapSeeds"));
     assert!(DOC.contains("p2p-live-libp2p-provider:native"));
     assert!(DOC.contains("p2p-live-libp2p-provider:contract-only"));
+    assert!(DOC.contains("bootstrap peer multiaddrs"));
     assert!(DOC.contains("runtime_peer_transition_invalid"));
     assert!(DOC.contains("validate_p2p_transport_live.sh"));
     assert!(DOC.contains("test_validate_p2p_transport_live.sh"));

--- a/docs/architecture/p2p-transport.md
+++ b/docs/architecture/p2p-transport.md
@@ -28,8 +28,9 @@ libp2p I/O integration while preserving low-cost default CI behavior.
 
 - `kamn-core` optional dependency:
   - `libp2p` (disabled by default)
+  - `tokio` (enabled only with native live transport feature)
 - Cargo feature gate:
-  - `libp2p-live-transport` enables `dep:libp2p`
+  - `libp2p-live-transport` enables `dep:libp2p` + `dep:tokio`
 - Compile-mode hooks:
   - `libp2p_feature_gate_name()` returns `libp2p-live-transport`
   - `resolve_libp2p_compile_mode()` returns:
@@ -91,6 +92,8 @@ libp2p I/O integration while preserving low-cost default CI behavior.
 - `P2pSwarmHarnessTask`
   - controlled runtime-harness startup surface for deterministic `DryRun` / `Run`
     execution modes used by local integration tests.
+  - feature-enabled `Run` mode validates native libp2p stack composition and
+    appends `libp2p-runtime-swarm` to harness behavior markers.
 - `LiveTransportReconnectPolicy`
   - deterministic reconnect/backoff evaluator for live transport faults.
 - `LiveTransportReconnectDecision`
@@ -156,6 +159,10 @@ Task #3633 adds a feature-enabled native runtime path:
     `libp2p-live-transport` is enabled.
 - Feature-enabled live adapter construction validates native libp2p runtime
   inputs and then routes send/receive/discovery over socket-backed transport.
+- Feature-enabled harness startup validates:
+  - live listen multiaddr
+  - bootstrap peer multiaddrs
+  - gossipsub topic subscription composition
 
 ## Reconnect Taxonomy
 


### PR DESCRIPTION
Refs #3668

## Summary
Implements a feature-gated native swarm runtime composition check in `P2pSwarmHarnessTask::start` for `Run` mode.
This adds deterministic native-stack marker evidence and validates libp2p/tokio stack composition (listen + bootstrap + topic subscription) during harness startup.

## Changes
- `crates/kamn-core/src/p2p_transport.rs`
  - Added feature-gated libp2p runtime behavior composition helper using `SwarmBuilder` + `tokio` runtime.
  - `P2pSwarmHarnessTask::start` now appends `libp2p-runtime-swarm` marker in feature-enabled run mode after successful native composition validation.
- `crates/kamn-core/Cargo.toml`
  - `libp2p-live-transport` now also enables optional `tokio` dependency.
- `crates/kamn-core/tests/p2p_swarm_stack_runtime.rs`
  - Added feature-gated integration test asserting native runtime marker emission.
  - Updated bootstrap fixture addresses to valid multiaddrs in run-mode startup tests.
- `crates/kamn-core/tests/p2p_kademlia_bootstrap.rs`
  - Updated integration/functional bootstrap fixtures to valid multiaddrs under feature-enabled harness validation.
- `crates/kamn-core/tests/p2p_transport_docs.rs`, `docs/architecture/p2p-transport.md`
  - Added documentation contracts for `tokio` feature wiring and `libp2p-runtime-swarm` marker semantics.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
`cargo test -p kamn-core --test p2p_swarm_stack_runtime --features libp2p-live-transport integration_swarm_harness_report_includes_native_runtime_marker_when_feature_enabled -- --exact`
Observed failure:
- New marker assertion failed because `P2pSwarmHarnessTask::start` did not emit `libp2p-runtime-swarm`.

### 🟢 Green Phase
Commands:
- `cargo test -p kamn-core --test p2p_swarm_stack_runtime --features libp2p-live-transport`
- `cargo test -p kamn-core --test p2p_kademlia_bootstrap --features libp2p-live-transport`
- `cargo test -p kamn-core --test p2p_libp2p_native_adapter_runtime --features libp2p-live-transport`
- `cargo test -p kamn-core --test p2p_transport_docs`
All passed locally.

### 🔁 Regression
Commands:
- `cargo fmt --check`
- `cargo clippy -p kamn-core --features libp2p-live-transport -- -D warnings`
Passed locally.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | Existing swarm config and bootstrap validation tests remained green | |
| Functional   | ✅     | `functional_swarm_behavior_stack_contains_required_protocols` (feature lane) | |
| Integration  | ✅     | New `integration_swarm_harness_report_includes_native_runtime_marker_when_feature_enabled`; updated run-mode bootstrap integration tests | |
| Regression   | ✅     | Existing deterministic fallback/seeded-plan regression tests remained green | |
| Performance  | N/A    | No performance-sensitive runtime-path changes in this slice | Covered in #3670/#3672 |

## Risks & Rollback
- Risk: feature-enabled harness startup is stricter and now rejects malformed bootstrap multiaddrs in integration fixtures.
- Rollback: revert this PR to restore prior feature-lane harness behavior.

## Documentation Updates
- Updated `docs/architecture/p2p-transport.md` for feature-gated `tokio` dependency and `libp2p-runtime-swarm` marker contract.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (scoped: `-p kamn-core --features libp2p-live-transport`)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (relevant scoped suite)
- [x] Docs updated (or justified why not)
