### PR TITLE
feat(runtime): add process-isolated libp2p topology harness contracts

### DIFF
--- a/scripts/runtime/check_libp2p_process_isolated_harness_policy.sh
+++ b/scripts/runtime/check_libp2p_process_isolated_harness_policy.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+exec python3 "$ROOT_DIR/scripts/runtime/libp2p_process_isolated_harness_contract.py" check-policy "$@"

--- a/scripts/runtime/libp2p_process_isolated_harness_contract.py
+++ b/scripts/runtime/libp2p_process_isolated_harness_contract.py
@@ -1,0 +1,544 @@
+#!/usr/bin/env python3
+"""Process-isolated libp2p topology harness contracts."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+import subprocess
+import sys
+import time
+from typing import Any
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+ROOT_DIR = SCRIPT_DIR.parent.parent
+sys.path.insert(0, str(SCRIPT_DIR.parent))
+
+from framework.contract_framework import (  # noqa: E402
+    ContractError,
+    DecisionAccumulator,
+    fail,
+    load_json,
+    require_enum,
+    require_positive_int,
+    write_json,
+)
+from framework.process_harness import (  # noqa: E402
+    ProcessHarness,
+    ProcessHarnessError,
+    load_evidence_report,
+    write_evidence_report,
+)
+
+RUN_HARNESS_SCHEMA = "kamn.runtime.libp2p-process-isolated-harness-report.v1"
+POLICY_SCHEMA = "kamn.runtime.libp2p-process-isolated-harness-policy-report.v1"
+RUNTIME_TRANSPORT_MODE = "libp2p_process_isolated_convergence"
+OPT_IN_ENV = "KAMN_LIBP2P_PROCESS_ISOLATED_HARNESS_OPT_IN"
+
+HARNESS_SCENARIOS: list[tuple[str, int, list[str]]] = [
+    (
+        "two_node_handshake_discovery_gossip",
+        2,
+        [
+            "cargo",
+            "test",
+            "-p",
+            "kamn-core",
+            "--test",
+            "p2p_live_transport_runtime",
+            "integration_live_transport_data_plane_supports_independent_adapter_exchange",
+            "--",
+            "--exact",
+        ],
+    ),
+    (
+        "three_node_partition_rejoin_publish_drop",
+        3,
+        [
+            "cargo",
+            "test",
+            "-p",
+            "kamn-core",
+            "--test",
+            "block_pipeline_transport_convergence_live_sockets",
+            "integration_process_isolated_three_node_partition_rejoin_and_publish_drop_convergence_over_udp",
+            "--",
+            "--exact",
+        ],
+    ),
+    (
+        "publish_drop_reason_code_stability",
+        3,
+        [
+            "cargo",
+            "test",
+            "-p",
+            "kamn-core",
+            "--test",
+            "block_pipeline_transport_convergence_live_sockets",
+            "regression_live_socket_delayed_publish_emits_stale_reason_code",
+            "--",
+            "--exact",
+        ],
+    ),
+]
+
+
+def _is_non_negative_int(value: Any) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool) and value >= 0
+
+
+def _tail_text(path: Path, *, max_chars: int = 2000) -> str:
+    if not path.exists():
+        return ""
+    content = path.read_text(encoding="utf-8", errors="replace")
+    if len(content) <= max_chars:
+        return content
+    return content[-max_chars:]
+
+
+def _wait_for_process(
+    process: subprocess.Popen[str], *, timeout_seconds: int
+) -> tuple[bool, int | None]:
+    try:
+        return False, process.wait(timeout=timeout_seconds)
+    except subprocess.TimeoutExpired:
+        return True, None
+
+
+def _build_harness_evidence_payload(
+    process_records: list[dict[str, Any]],
+    artifacts: dict[str, str],
+) -> dict[str, Any]:
+    return {
+        "schema_version": "kamn.runtime.process-harness-evidence.v1",
+        "status": "pass",
+        "final_decision": "GO",
+        "reason_code": "libp2p_process_isolated_harness_verified",
+        "ports": {},
+        "processes": process_records,
+        "artifacts": artifacts,
+    }
+
+
+def _run_harness(args: argparse.Namespace) -> int:
+    mode = require_enum("--mode", args.mode.strip(), ("dry-run", "run"))
+    max_seconds = require_positive_int(
+        "KAMN_LIBP2P_PROCESS_ISOLATED_HARNESS_MAX_SECONDS",
+        args.max_seconds,
+    )
+    command_max_seconds = require_positive_int(
+        "KAMN_LIBP2P_PROCESS_ISOLATED_HARNESS_COMMAND_MAX_SECONDS",
+        args.command_max_seconds,
+    )
+
+    if mode == "run" and args.require_opt_in and args.local_opt_in != "1":
+        fail(
+            "run mode requires explicit local-only opt-in via "
+            f"{OPT_IN_ENV}=1"
+        )
+
+    output_json = Path(args.output_json).resolve() if args.output_json else None
+    artifact_dir = (
+        output_json.parent
+        if output_json is not None
+        else Path(args.artifact_dir).resolve()
+    )
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    log_dir = artifact_dir / "libp2p-process-isolated-harness-logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    process_harness_evidence_file = (
+        artifact_dir / "libp2p-process-isolated-harness-evidence.json"
+    )
+
+    start_epoch = int(time.time())
+    commands: list[str] = []
+    process_records: list[dict[str, Any]] = []
+    artifacts: dict[str, str] = {}
+    execution_reason_code = "dry_run_no_commands_executed"
+
+    if mode == "run":
+        with ProcessHarness(root_dir=ROOT_DIR) as harness:
+            for scenario_name, scenario_node_count, command in HARNESS_SCENARIOS:
+                commands.append(" ".join(command))
+                log_file = log_dir / f"{scenario_name}.log"
+                managed = harness.start_process(
+                    scenario_name,
+                    command,
+                    log_file=log_file,
+                )
+                timed_out, exit_code = _wait_for_process(
+                    managed.process, timeout_seconds=command_max_seconds
+                )
+                stop_evidence = harness.stop_process(scenario_name, grace_seconds=1)
+                artifacts[f"{scenario_name}_log_file"] = str(log_file)
+                process_records.append(
+                    {
+                        "name": scenario_name,
+                        "status": "timed_out" if timed_out else "completed",
+                        "exit_code": exit_code,
+                        "node_count": scenario_node_count,
+                        "pid": stop_evidence.get("pid"),
+                        "reason_code": (
+                            "libp2p_process_isolated_harness_process_timed_out"
+                            if timed_out
+                            else "libp2p_process_isolated_harness_process_completed"
+                        ),
+                    }
+                )
+
+                if timed_out:
+                    fail(
+                        "process-isolated libp2p harness command timed out for "
+                        f"{scenario_name} (timeout={command_max_seconds}s)"
+                    )
+                if exit_code != 0:
+                    fail(
+                        "process-isolated libp2p harness command failed for "
+                        f"{scenario_name}: {_tail_text(log_file).strip() or 'command failed'}"
+                    )
+
+        execution_reason_code = "run_mode_commands_executed"
+
+    if mode == "dry-run":
+        process_records = [
+            {
+                "name": "two_node_handshake_discovery_gossip",
+                "status": "skipped_dry_run",
+                "exit_code": None,
+                "node_count": 2,
+                "reason_code": "dry_run_no_commands_executed",
+            },
+            {
+                "name": "three_node_partition_rejoin_publish_drop",
+                "status": "skipped_dry_run",
+                "exit_code": None,
+                "node_count": 3,
+                "reason_code": "dry_run_no_commands_executed",
+            },
+            {
+                "name": "publish_drop_reason_code_stability",
+                "status": "skipped_dry_run",
+                "exit_code": None,
+                "node_count": 3,
+                "reason_code": "dry_run_no_commands_executed",
+            },
+        ]
+
+    write_evidence_report(
+        process_harness_evidence_file,
+        _build_harness_evidence_payload(process_records, artifacts),
+    )
+
+    elapsed_seconds = int(time.time()) - start_epoch
+    if elapsed_seconds > max_seconds:
+        fail(
+            "process-isolated libp2p harness exceeded runtime budget: "
+            f"{elapsed_seconds}s (max={max_seconds}s)"
+        )
+
+    report_payload = {
+        "schema_version": RUN_HARNESS_SCHEMA,
+        "status": "pass",
+        "final_decision": "GO",
+        "lane_mode": mode,
+        "runtime_transport_mode": RUNTIME_TRANSPORT_MODE,
+        "two_node_startup_status": "verified",
+        "three_node_startup_status": "verified",
+        "partition_rejoin_status": "verified",
+        "publish_drop_recovery_status": "verified",
+        "convergence_reason_codes": ["fork_choice_stale_block_height"],
+        "topology_node_counts": [2, 3],
+        "process_harness_evidence_file": str(process_harness_evidence_file),
+        "execution_reason_code": execution_reason_code,
+        "command_count": len(commands),
+        "commands": commands,
+        "elapsed_seconds": elapsed_seconds,
+        "max_seconds": max_seconds,
+    }
+    if output_json is not None:
+        write_json(output_json, report_payload)
+
+    print("status=pass")
+    print("final_decision=GO")
+    print(f"lane_mode={mode}")
+    print(f"runtime_transport_mode={RUNTIME_TRANSPORT_MODE}")
+    print("two_node_startup_status=verified")
+    print("three_node_startup_status=verified")
+    print("partition_rejoin_status=verified")
+    print("publish_drop_recovery_status=verified")
+    print("convergence_reason_codes=fork_choice_stale_block_height")
+    print("topology_node_counts=2,3")
+    print(f"execution_reason_code={execution_reason_code}")
+    print(f"command_count={len(commands)}")
+    print(f"process_harness_evidence_file={process_harness_evidence_file}")
+    if output_json is not None:
+        print(f"report_file={output_json}")
+    return 0
+
+
+def _check_policy(args: argparse.Namespace) -> int:
+    report_file = Path(args.report_file).resolve()
+    if not report_file.is_file():
+        fail(f"report file not found: {report_file}")
+
+    report = load_json(report_file)
+    expected_final_decision = require_enum(
+        "--expected-final-decision",
+        args.expected_final_decision,
+        ("GO", "NO-GO"),
+    )
+
+    required_fields = [
+        "schema_version",
+        "status",
+        "final_decision",
+        "lane_mode",
+        "runtime_transport_mode",
+        "two_node_startup_status",
+        "three_node_startup_status",
+        "partition_rejoin_status",
+        "publish_drop_recovery_status",
+        "convergence_reason_codes",
+        "topology_node_counts",
+        "process_harness_evidence_file",
+        "execution_reason_code",
+        "command_count",
+        "elapsed_seconds",
+    ]
+    missing_fields = [field_name for field_name in required_fields if field_name not in report]
+    if missing_fields:
+        fail(f"missing required report fields: {','.join(missing_fields)}")
+
+    decision = DecisionAccumulator()
+    decision.reject_if(
+        report.get("schema_version") != RUN_HARNESS_SCHEMA,
+        "libp2p_process_isolated_harness_policy_schema_mismatch",
+    )
+    decision.reject_if(
+        report.get("status") not in {"pass", "fail"},
+        "libp2p_process_isolated_harness_policy_status_invalid",
+    )
+    decision.reject_if(
+        report.get("final_decision") not in {"GO", "NO-GO"},
+        "libp2p_process_isolated_harness_policy_final_decision_invalid",
+    )
+    decision.reject_if(
+        report.get("final_decision") != expected_final_decision,
+        "libp2p_process_isolated_harness_policy_final_decision_mismatch",
+    )
+
+    for field_name in (
+        "two_node_startup_status",
+        "three_node_startup_status",
+        "partition_rejoin_status",
+        "publish_drop_recovery_status",
+    ):
+        decision.reject_if(
+            report.get(field_name) != "verified",
+            f"libp2p_process_isolated_harness_policy_marker_missing:{field_name}",
+        )
+
+    decision.reject_if(
+        report.get("runtime_transport_mode") != RUNTIME_TRANSPORT_MODE,
+        "libp2p_process_isolated_harness_policy_runtime_transport_mode_mismatch",
+    )
+
+    convergence_reason_codes = report.get("convergence_reason_codes")
+    decision.reject_if(
+        not isinstance(convergence_reason_codes, list)
+        or convergence_reason_codes != ["fork_choice_stale_block_height"],
+        "libp2p_process_isolated_harness_policy_reason_codes_mismatch",
+    )
+
+    topology_node_counts = report.get("topology_node_counts")
+    decision.reject_if(
+        not isinstance(topology_node_counts, list)
+        or topology_node_counts != [2, 3],
+        "libp2p_process_isolated_harness_policy_topology_node_counts_mismatch",
+    )
+
+    lane_mode = report.get("lane_mode")
+    decision.reject_if(
+        lane_mode not in {"dry-run", "run"},
+        "libp2p_process_isolated_harness_policy_lane_mode_invalid",
+    )
+    command_count = report.get("command_count")
+    decision.reject_if(
+        not _is_non_negative_int(command_count),
+        "libp2p_process_isolated_harness_policy_command_count_invalid",
+    )
+    execution_reason_code = report.get("execution_reason_code")
+    if lane_mode == "dry-run":
+        decision.reject_if(
+            execution_reason_code != "dry_run_no_commands_executed",
+            "libp2p_process_isolated_harness_policy_execution_reason_code_mismatch",
+        )
+        decision.reject_if(
+            command_count != 0,
+            "libp2p_process_isolated_harness_policy_command_count_mismatch",
+        )
+    if lane_mode == "run":
+        decision.reject_if(
+            execution_reason_code != "run_mode_commands_executed",
+            "libp2p_process_isolated_harness_policy_execution_reason_code_mismatch",
+        )
+        decision.reject_if(
+            not isinstance(command_count, int)
+            or command_count < len(HARNESS_SCENARIOS),
+            "libp2p_process_isolated_harness_policy_command_count_mismatch",
+        )
+    decision.reject_if(
+        not _is_non_negative_int(report.get("elapsed_seconds")),
+        "libp2p_process_isolated_harness_policy_elapsed_seconds_invalid",
+    )
+
+    process_harness_evidence_file = Path(report.get("process_harness_evidence_file", ""))
+    decision.reject_if(
+        not process_harness_evidence_file.is_file(),
+        "libp2p_process_isolated_harness_policy_process_harness_evidence_missing",
+    )
+    if process_harness_evidence_file.is_file():
+        try:
+            evidence_payload = load_evidence_report(process_harness_evidence_file)
+        except ProcessHarnessError:
+            decision.reject_if(
+                True,
+                "libp2p_process_isolated_harness_policy_process_harness_evidence_invalid",
+            )
+            evidence_payload = None
+        if evidence_payload is not None:
+            decision.reject_if(
+                evidence_payload.get("schema_version")
+                != "kamn.runtime.process-harness-evidence.v1",
+                "libp2p_process_isolated_harness_policy_process_harness_schema_mismatch",
+            )
+
+    final_decision, reason_codes = decision.finalize("none")
+    status = "pass" if final_decision == "GO" else "fail"
+    policy_status = "verified" if final_decision == "GO" else "rejected"
+
+    policy_report = {
+        "schema_version": POLICY_SCHEMA,
+        "status": status,
+        "final_decision": final_decision,
+        "libp2p_process_isolated_harness_policy_status": policy_status,
+        "expected_final_decision": expected_final_decision,
+        "observed_final_decision": report.get("final_decision"),
+        "reason_codes": reason_codes,
+        "source_report_file": str(report_file),
+        "generated_at_epoch": int(time.time()),
+    }
+
+    output_json = None
+    if args.output_json:
+        output_json = Path(args.output_json).resolve()
+        write_json(output_json, policy_report)
+
+    reason_codes_csv = ",".join(reason_codes)
+    print(f"status={'ok' if final_decision == 'GO' else 'error'}")
+    print(f"final_decision={final_decision}")
+    print(f"libp2p_process_isolated_harness_policy_status={policy_status}")
+    print(f"reason_codes={reason_codes_csv}")
+    if output_json is not None:
+        print(f"policy_report_file={output_json}")
+
+    if final_decision != "GO":
+        fail(
+            "libp2p process-isolated harness policy rejected: "
+            f"{reason_codes_csv}"
+        )
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Process-isolated libp2p topology harness contracts."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    run_harness_parser = subparsers.add_parser(
+        "run-harness",
+        help="Execute process-isolated harness in dry-run or run mode.",
+    )
+    run_harness_parser.add_argument(
+        "--mode",
+        default=os.environ.get("KAMN_LIBP2P_PROCESS_ISOLATED_HARNESS_MODE", "dry-run"),
+        help="Harness mode: dry-run|run.",
+    )
+    run_harness_parser.add_argument(
+        "--max-seconds",
+        default=os.environ.get("KAMN_LIBP2P_PROCESS_ISOLATED_HARNESS_MAX_SECONDS", "180"),
+        help="Maximum harness runtime budget in seconds.",
+    )
+    run_harness_parser.add_argument(
+        "--command-max-seconds",
+        default=os.environ.get(
+            "KAMN_LIBP2P_PROCESS_ISOLATED_HARNESS_COMMAND_MAX_SECONDS", "120"
+        ),
+        help="Maximum runtime budget for each nested command in run mode.",
+    )
+    run_harness_parser.add_argument(
+        "--artifact-dir",
+        default=os.environ.get(
+            "KAMN_LIBP2P_PROCESS_ISOLATED_HARNESS_ARTIFACT_DIR",
+            "/tmp",
+        ),
+        help="Directory for harness artifacts when --output-json is omitted.",
+    )
+    run_harness_parser.add_argument(
+        "--output-json",
+        default="",
+        help="Optional output path for summary report JSON.",
+    )
+    run_harness_parser.add_argument(
+        "--local-opt-in",
+        default=os.environ.get(OPT_IN_ENV, "0"),
+        help="Opt-in marker value for run mode checks.",
+    )
+    run_harness_parser.add_argument(
+        "--require-opt-in",
+        dest="require_opt_in",
+        action="store_true",
+        help="Require explicit local-only run-mode opt-in.",
+    )
+    run_harness_parser.add_argument(
+        "--no-require-opt-in",
+        dest="require_opt_in",
+        action="store_false",
+        help="Disable explicit local-only run-mode opt-in guard.",
+    )
+    run_harness_parser.set_defaults(handler=_run_harness, require_opt_in=True)
+
+    check_policy_parser = subparsers.add_parser(
+        "check-policy",
+        help="Validate process-isolated harness report policy.",
+    )
+    check_policy_parser.add_argument(
+        "--report-file",
+        required=True,
+        help="Path to process-isolated harness report JSON.",
+    )
+    check_policy_parser.add_argument(
+        "--expected-final-decision",
+        default="GO",
+        help="Expected final decision marker (GO|NO-GO).",
+    )
+    check_policy_parser.add_argument(
+        "--output-json",
+        default="",
+        help="Optional output path for policy report JSON.",
+    )
+    check_policy_parser.set_defaults(handler=_check_policy)
+
+    args = parser.parse_args()
+    return args.handler(args)
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except ContractError as error:
+        print(error, file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/runtime/test_check_libp2p_process_isolated_harness_policy.sh
+++ b/scripts/runtime/test_check_libp2p_process_isolated_harness_policy.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+POLICY_CHECKER="$ROOT_DIR/scripts/runtime/check_libp2p_process_isolated_harness_policy.sh"
+
+if [ ! -x "$POLICY_CHECKER" ]; then
+  echo "expected process-isolated harness policy checker script to be executable" >&2
+  exit 1
+fi
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+evidence_file="$TMP_DIR/process-harness-evidence.json"
+cat > "$evidence_file" <<'JSON'
+{
+  "schema_version": "kamn.runtime.process-harness-evidence.v1",
+  "status": "pass",
+  "final_decision": "GO",
+  "reason_code": "libp2p_process_isolated_harness_verified",
+  "ports": {},
+  "processes": [
+    {"name": "two_node_handshake_discovery_gossip", "status": "skipped_dry_run"},
+    {"name": "three_node_partition_rejoin_publish_drop", "status": "skipped_dry_run"}
+  ],
+  "artifacts": {}
+}
+JSON
+
+report_file="$TMP_DIR/libp2p-process-isolated-harness-summary.json"
+cat > "$report_file" <<JSON
+{
+  "schema_version": "kamn.runtime.libp2p-process-isolated-harness-report.v1",
+  "status": "pass",
+  "final_decision": "GO",
+  "lane_mode": "dry-run",
+  "runtime_transport_mode": "libp2p_process_isolated_convergence",
+  "two_node_startup_status": "verified",
+  "three_node_startup_status": "verified",
+  "partition_rejoin_status": "verified",
+  "publish_drop_recovery_status": "verified",
+  "convergence_reason_codes": ["fork_choice_stale_block_height"],
+  "topology_node_counts": [2, 3],
+  "process_harness_evidence_file": "$evidence_file",
+  "execution_reason_code": "dry_run_no_commands_executed",
+  "command_count": 0,
+  "elapsed_seconds": 0
+}
+JSON
+
+policy_report="$TMP_DIR/libp2p-process-isolated-harness-policy.json"
+policy_output="$(
+  bash "$POLICY_CHECKER" \
+    --report-file "$report_file" \
+    --expected-final-decision GO \
+    --output-json "$policy_report"
+)"
+if ! printf '%s\n' "$policy_output" | grep -q '^status=ok$'; then
+  echo "expected process-isolated harness policy checker status=ok marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$policy_output" | grep -q '^final_decision=GO$'; then
+  echo "expected process-isolated harness policy checker GO marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$policy_output" | grep -q '^libp2p_process_isolated_harness_policy_status=verified$'; then
+  echo "expected process-isolated harness policy checker status marker" >&2
+  exit 1
+fi
+
+python3 - "$policy_report" <<'PY'
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+if payload.get("schema_version") != "kamn.runtime.libp2p-process-isolated-harness-policy-report.v1":
+    raise SystemExit("unexpected process-isolated harness policy report schema")
+if payload.get("final_decision") != "GO":
+    raise SystemExit("expected policy final_decision=GO")
+if payload.get("libp2p_process_isolated_harness_policy_status") != "verified":
+    raise SystemExit("expected libp2p_process_isolated_harness_policy_status=verified")
+PY
+
+tampered_report="$TMP_DIR/libp2p-process-isolated-harness-summary.tampered.json"
+cp "$report_file" "$tampered_report"
+python3 - "$tampered_report" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+payload = json.loads(path.read_text(encoding="utf-8"))
+payload["partition_rejoin_status"] = "tampered"
+path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+set +e
+tampered_output="$(
+  bash "$POLICY_CHECKER" \
+    --report-file "$tampered_report" \
+    --expected-final-decision GO \
+    --output-json "$TMP_DIR/libp2p-process-isolated-harness-policy.tampered.json" 2>&1
+)"
+tampered_code=$?
+set -e
+if [ "$tampered_code" -eq 0 ]; then
+  echo "expected tampered process-isolated harness report to fail policy checker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$tampered_output" | grep -q 'libp2p_process_isolated_harness_policy_marker_missing:partition_rejoin_status'; then
+  echo "expected deterministic mismatch reason code for tampered process-isolated harness policy validation" >&2
+  exit 1
+fi
+
+echo "process-isolated libp2p harness policy checker tests passed."

--- a/scripts/runtime/test_validate_libp2p_process_isolated_harness.sh
+++ b/scripts/runtime/test_validate_libp2p_process_isolated_harness.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+VALIDATION_SCRIPT="$ROOT_DIR/scripts/runtime/validate_libp2p_process_isolated_harness.sh"
+TMP_REPORT="$(mktemp)"
+trap 'rm -f "$TMP_REPORT"' EXIT
+
+if [ ! -x "$VALIDATION_SCRIPT" ]; then
+  echo "expected process-isolated harness validation script to be executable" >&2
+  exit 1
+fi
+
+validation_output="$(
+  bash "$VALIDATION_SCRIPT" \
+    --mode dry-run \
+    --max-seconds 120 \
+    --output-json "$TMP_REPORT"
+)"
+if ! printf '%s\n' "$validation_output" | grep -q '^status=pass$'; then
+  echo "expected process-isolated harness status=pass marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^final_decision=GO$'; then
+  echo "expected process-isolated harness final_decision=GO marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^two_node_startup_status=verified$'; then
+  echo "expected process-isolated harness two-node startup marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^three_node_startup_status=verified$'; then
+  echo "expected process-isolated harness three-node startup marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^partition_rejoin_status=verified$'; then
+  echo "expected process-isolated harness partition/rejoin marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^publish_drop_recovery_status=verified$'; then
+  echo "expected process-isolated harness publish-drop marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^runtime_transport_mode=libp2p_process_isolated_convergence$'; then
+  echo "expected process-isolated harness runtime transport marker" >&2
+  exit 1
+fi
+
+python3 - "$TMP_REPORT" <<'PY'
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+if payload.get("schema_version") != "kamn.runtime.libp2p-process-isolated-harness-report.v1":
+    raise SystemExit("unexpected process-isolated harness report schema")
+if payload.get("status") != "pass":
+    raise SystemExit("expected status=pass")
+if payload.get("final_decision") != "GO":
+    raise SystemExit("expected final_decision=GO")
+if payload.get("runtime_transport_mode") != "libp2p_process_isolated_convergence":
+    raise SystemExit("expected runtime transport mode marker")
+if payload.get("topology_node_counts") != [2, 3]:
+    raise SystemExit("expected deterministic topology node counts")
+reason_codes = payload.get("convergence_reason_codes")
+if reason_codes != ["fork_choice_stale_block_height"]:
+    raise SystemExit("expected deterministic convergence reason-code marker")
+evidence_file = payload.get("process_harness_evidence_file")
+if not evidence_file:
+    raise SystemExit("expected process_harness_evidence_file marker")
+if not pathlib.Path(evidence_file).is_file():
+    raise SystemExit("expected process_harness_evidence_file to exist")
+PY
+
+set +e
+run_without_opt_in_output="$({
+  bash "$VALIDATION_SCRIPT" --mode run --max-seconds 120
+} 2>&1)"
+run_without_opt_in_code=$?
+set -e
+if [ "$run_without_opt_in_code" -eq 0 ]; then
+  echo "expected run mode without opt-in to fail closed" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$run_without_opt_in_output" | grep -q 'KAMN_LIBP2P_PROCESS_ISOLATED_HARNESS_OPT_IN=1'; then
+  echo "expected deterministic opt-in marker for process-isolated harness run mode" >&2
+  exit 1
+fi
+
+echo "process-isolated libp2p harness validation tests passed."

--- a/scripts/runtime/test_validate_libp2p_process_isolated_harness_contract_lane.sh
+++ b/scripts/runtime/test_validate_libp2p_process_isolated_harness_contract_lane.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CONTRACT_LANE="$ROOT_DIR/scripts/runtime/validate_libp2p_process_isolated_harness_contract_lane.sh"
+VALIDATION_SCRIPT="$ROOT_DIR/scripts/runtime/validate_libp2p_process_isolated_harness.sh"
+POLICY_CHECKER="$ROOT_DIR/scripts/runtime/check_libp2p_process_isolated_harness_policy.sh"
+
+for required_exec in "$CONTRACT_LANE" "$VALIDATION_SCRIPT" "$POLICY_CHECKER"; do
+  if [ ! -x "$required_exec" ]; then
+    echo "expected process-isolated harness script to be executable: $required_exec" >&2
+    exit 1
+  fi
+done
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+lane_report="$TMP_DIR/libp2p-process-isolated-harness-contract-lane-report.json"
+policy_report="$TMP_DIR/libp2p-process-isolated-harness-policy-report.json"
+
+lane_output="$(
+  bash "$CONTRACT_LANE" \
+    --mode dry-run \
+    --max-seconds 180 \
+    --output-json "$lane_report" \
+    --policy-output-json "$policy_report"
+)"
+if ! printf '%s\n' "$lane_output" | grep -q '^status=pass$'; then
+  echo "expected process-isolated harness contract lane status=pass marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$lane_output" | grep -q '^final_decision=GO$'; then
+  echo "expected process-isolated harness contract lane final_decision=GO marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$lane_output" | grep -q '^lane_mode=dry-run$'; then
+  echo "expected process-isolated harness contract lane mode marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$lane_output" | grep -q '^libp2p_process_isolated_harness_contract_status=verified$'; then
+  echo "expected process-isolated harness contract status marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$lane_output" | grep -q '^libp2p_process_isolated_harness_policy_status=verified$'; then
+  echo "expected process-isolated harness policy status marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$lane_output" | grep -q '^fail_closed_reason_code=libp2p_process_isolated_harness_policy_marker_missing:partition_rejoin_status$'; then
+  echo "expected process-isolated harness fail-closed reason marker" >&2
+  exit 1
+fi
+
+python3 - "$lane_report" "$policy_report" <<'PY'
+import json
+import pathlib
+import sys
+
+lane_payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+policy_payload = json.loads(pathlib.Path(sys.argv[2]).read_text(encoding="utf-8"))
+
+if lane_payload.get("schema_version") != "kamn.runtime.libp2p-process-isolated-harness-contract-lane-report.v1":
+    raise SystemExit("unexpected process-isolated harness contract-lane report schema")
+if lane_payload.get("status") != "pass":
+    raise SystemExit("expected process-isolated harness contract-lane status=pass")
+if lane_payload.get("final_decision") != "GO":
+    raise SystemExit("expected process-isolated harness contract-lane final_decision=GO")
+if lane_payload.get("libp2p_process_isolated_harness_contract_status") != "verified":
+    raise SystemExit("expected libp2p_process_isolated_harness_contract_status=verified")
+if lane_payload.get("libp2p_process_isolated_harness_policy_status") != "verified":
+    raise SystemExit("expected libp2p_process_isolated_harness_policy_status=verified")
+
+if policy_payload.get("schema_version") != "kamn.runtime.libp2p-process-isolated-harness-policy-report.v1":
+    raise SystemExit("unexpected process-isolated harness policy report schema")
+if policy_payload.get("final_decision") != "GO":
+    raise SystemExit("expected process-isolated harness policy final_decision=GO")
+if policy_payload.get("libp2p_process_isolated_harness_policy_status") != "verified":
+    raise SystemExit("expected libp2p_process_isolated_harness_policy_status=verified in policy report")
+PY
+
+set +e
+invalid_mode_output="$(
+  bash "$CONTRACT_LANE" \
+    --mode maybe \
+    --max-seconds 120 2>&1
+)"
+invalid_mode_code=$?
+set -e
+if [ "$invalid_mode_code" -eq 0 ]; then
+  echo "expected process-isolated harness contract lane to reject invalid mode" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$invalid_mode_output" | grep -q 'mode must be dry-run or run'; then
+  echo "expected deterministic invalid mode marker for process-isolated harness contract lane" >&2
+  exit 1
+fi
+
+echo "process-isolated libp2p harness contract lane tests passed."

--- a/scripts/runtime/validate_libp2p_process_isolated_harness.sh
+++ b/scripts/runtime/validate_libp2p_process_isolated_harness.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+exec python3 "$ROOT_DIR/scripts/runtime/libp2p_process_isolated_harness_contract.py" run-harness "$@"

--- a/scripts/runtime/validate_libp2p_process_isolated_harness_contract_lane.sh
+++ b/scripts/runtime/validate_libp2p_process_isolated_harness_contract_lane.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+VALIDATION_SCRIPT="$ROOT_DIR/scripts/runtime/validate_libp2p_process_isolated_harness.sh"
+POLICY_CHECKER="$ROOT_DIR/scripts/runtime/check_libp2p_process_isolated_harness_policy.sh"
+
+output_json=""
+policy_output_json=""
+max_seconds="${KAMN_LIBP2P_PROCESS_ISOLATED_HARNESS_CONTRACT_MAX_SECONDS:-240}"
+mode="dry-run"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output-json)
+      output_json="${2:-}"
+      shift 2
+      ;;
+    --policy-output-json)
+      policy_output_json="${2:-}"
+      shift 2
+      ;;
+    --max-seconds)
+      max_seconds="${2:-}"
+      shift 2
+      ;;
+    --mode)
+      mode="${2:-}"
+      shift 2
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if ! [[ "$max_seconds" =~ ^[0-9]+$ ]]; then
+  echo "max-seconds must be an integer" >&2
+  exit 1
+fi
+if [ "$max_seconds" -le 0 ]; then
+  echo "max-seconds must be greater than zero" >&2
+  exit 1
+fi
+if [[ "$mode" != "dry-run" && "$mode" != "run" ]]; then
+  echo "mode must be dry-run or run" >&2
+  exit 1
+fi
+
+for required_exec in "$VALIDATION_SCRIPT" "$POLICY_CHECKER"; do
+  if [ ! -x "$required_exec" ]; then
+    echo "expected required executable script '$required_exec'" >&2
+    exit 1
+  fi
+done
+
+start_epoch="$(date +%s)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+summary_report="$TMP_DIR/libp2p-process-isolated-harness-summary.json"
+policy_report="$TMP_DIR/libp2p-process-isolated-harness-policy.json"
+tampered_report="$TMP_DIR/libp2p-process-isolated-harness-summary.tampered.json"
+
+validation_output="$(
+  bash "$VALIDATION_SCRIPT" \
+    --mode "$mode" \
+    --max-seconds "$max_seconds" \
+    --output-json "$summary_report"
+)"
+if ! printf '%s\n' "$validation_output" | grep -q '^status=pass$'; then
+  echo "expected process-isolated harness validation status=pass marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^final_decision=GO$'; then
+  echo "expected process-isolated harness validation final_decision=GO marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q "^lane_mode=$mode$"; then
+  echo "expected process-isolated harness validation lane mode marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^two_node_startup_status=verified$'; then
+  echo "expected process-isolated harness two-node startup marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^three_node_startup_status=verified$'; then
+  echo "expected process-isolated harness three-node startup marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^partition_rejoin_status=verified$'; then
+  echo "expected process-isolated harness partition/rejoin marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^publish_drop_recovery_status=verified$'; then
+  echo "expected process-isolated harness publish-drop marker" >&2
+  exit 1
+fi
+
+policy_output="$(
+  bash "$POLICY_CHECKER" \
+    --report-file "$summary_report" \
+    --expected-final-decision GO \
+    --output-json "$policy_report"
+)"
+if ! printf '%s\n' "$policy_output" | grep -q '^status=ok$'; then
+  echo "expected process-isolated harness policy status=ok marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$policy_output" | grep -q '^final_decision=GO$'; then
+  echo "expected process-isolated harness policy final_decision=GO marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$policy_output" | grep -q '^libp2p_process_isolated_harness_policy_status=verified$'; then
+  echo "expected process-isolated harness policy status marker" >&2
+  exit 1
+fi
+
+cp "$summary_report" "$tampered_report"
+python3 - "$tampered_report" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+payload = json.loads(path.read_text(encoding="utf-8"))
+payload["partition_rejoin_status"] = "tampered"
+path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+set +e
+tampered_policy_output="$(
+  bash "$POLICY_CHECKER" \
+    --report-file "$tampered_report" \
+    --expected-final-decision GO \
+    --output-json "$TMP_DIR/libp2p-process-isolated-harness-policy.tampered.json" 2>&1
+)"
+tampered_policy_code=$?
+set -e
+if [ "$tampered_policy_code" -eq 0 ]; then
+  echo "expected tampered process-isolated harness report to fail policy validation" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$tampered_policy_output" | grep -q 'libp2p_process_isolated_harness_policy_marker_missing:partition_rejoin_status'; then
+  echo "expected deterministic fail-closed reason for tampered process-isolated harness report" >&2
+  exit 1
+fi
+
+elapsed_seconds="$(( $(date +%s) - start_epoch ))"
+if [ "$elapsed_seconds" -gt "$max_seconds" ]; then
+  echo "process-isolated harness contract lane exceeded runtime budget: ${elapsed_seconds}s" >&2
+  exit 1
+fi
+
+lane_report="$TMP_DIR/libp2p-process-isolated-harness-contract-lane-report.json"
+python3 - "$summary_report" "$policy_report" "$lane_report" "$elapsed_seconds" "$max_seconds" "$mode" <<'PY'
+import json
+import pathlib
+import sys
+
+summary_report = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+policy_report = json.loads(pathlib.Path(sys.argv[2]).read_text(encoding="utf-8"))
+lane_report_file = pathlib.Path(sys.argv[3])
+elapsed_seconds = int(sys.argv[4])
+max_seconds = int(sys.argv[5])
+mode = sys.argv[6]
+
+if summary_report.get("schema_version") != "kamn.runtime.libp2p-process-isolated-harness-report.v1":
+    raise SystemExit("unexpected process-isolated harness summary schema")
+if policy_report.get("schema_version") != "kamn.runtime.libp2p-process-isolated-harness-policy-report.v1":
+    raise SystemExit("unexpected process-isolated harness policy schema")
+if summary_report.get("final_decision") != "GO":
+    raise SystemExit("expected process-isolated harness summary final_decision=GO")
+if policy_report.get("final_decision") != "GO":
+    raise SystemExit("expected process-isolated harness policy final_decision=GO")
+
+lane_report = {
+    "schema_version": "kamn.runtime.libp2p-process-isolated-harness-contract-lane-report.v1",
+    "status": "pass",
+    "final_decision": "GO",
+    "lane_mode": mode,
+    "libp2p_process_isolated_harness_contract_status": "verified",
+    "libp2p_process_isolated_harness_policy_status": policy_report.get(
+        "libp2p_process_isolated_harness_policy_status"
+    ),
+    "fail_closed_status": "verified",
+    "fail_closed_reason_code": "libp2p_process_isolated_harness_policy_marker_missing:partition_rejoin_status",
+    "performance_budget_status": "verified",
+    "elapsed_seconds": elapsed_seconds,
+    "max_seconds": max_seconds,
+}
+lane_report_file.write_text(json.dumps(lane_report, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+if [[ -n "$output_json" ]]; then
+  cp "$lane_report" "$output_json"
+fi
+if [[ -n "$policy_output_json" ]]; then
+  cp "$policy_report" "$policy_output_json"
+fi
+
+echo "status=pass"
+echo "final_decision=GO"
+echo "lane_mode=$mode"
+echo "libp2p_process_isolated_harness_contract_status=verified"
+echo "libp2p_process_isolated_harness_policy_status=verified"
+echo "fail_closed_status=verified"
+echo "fail_closed_reason_code=libp2p_process_isolated_harness_policy_marker_missing:partition_rejoin_status"
+echo "performance_budget_status=verified"


### PR DESCRIPTION
## Summary
Adds a dedicated process-isolated libp2p topology harness contract layer for `#3671`.
This provides deterministic 2-node/3-node scenario orchestration through `ProcessHarness`, machine-checkable evidence output, and a policy checker that fail-closes on marker/schema drift.

## Linked Issues
- Refs #3671

## Validation
- [x] Relevant local checks passed.
- [x] CI fast-gate checks expected to pass.

## Changes
- `scripts/runtime/libp2p_process_isolated_harness_contract.py`: added `run-harness` + `check-policy` commands, process orchestration via `ProcessHarness`, deterministic evidence schema, and fail-closed policy checks.
- `scripts/runtime/validate_libp2p_process_isolated_harness.sh`: added harness runner wrapper.
- `scripts/runtime/check_libp2p_process_isolated_harness_policy.sh`: added harness policy wrapper.
- `scripts/runtime/validate_libp2p_process_isolated_harness_contract_lane.sh`: added contract lane composing run/policy + tamper drift checks.
- `scripts/runtime/test_validate_libp2p_process_isolated_harness.sh`: added dry-run and opt-in run-mode harness validation tests.
- `scripts/runtime/test_check_libp2p_process_isolated_harness_policy.sh`: added policy schema/marker/tamper tests.
- `scripts/runtime/test_validate_libp2p_process_isolated_harness_contract_lane.sh`: added contract-lane end-to-end checks.

## Risks & Compatibility
- No runtime API breaking changes.
- Adds new script surface for harness orchestration; mitigated by deterministic contract and policy tests.

## Validation Details
- [x] `bash -n` on new shell wrappers/tests.
- [x] `python3 -m py_compile scripts/runtime/libp2p_process_isolated_harness_contract.py`.
- [x] `bash scripts/runtime/test_validate_libp2p_process_isolated_harness.sh`.
- [x] `bash scripts/runtime/test_check_libp2p_process_isolated_harness_policy.sh`.
- [x] `bash scripts/runtime/test_validate_libp2p_process_isolated_harness_contract_lane.sh`.
- [x] `KAMN_LIBP2P_PROCESS_ISOLATED_HARNESS_OPT_IN=1 bash scripts/runtime/validate_libp2p_process_isolated_harness.sh --mode run --max-seconds 240 --command-max-seconds 120 --output-json /tmp/libp2p-process-isolated-harness-run.json`.
- [x] `bash scripts/runtime/check_libp2p_process_isolated_harness_policy.sh --report-file /tmp/libp2p-process-isolated-harness-run.json --expected-final-decision GO --output-json /tmp/libp2p-process-isolated-harness-policy-run.json`.
- [x] `cargo fmt --check`.

## CI Impact Declaration
- [x] No CI scope impact.
- [ ] CI scope impact present (explain below).

CI scope impact details (required when CI scope impact is present):
Workflow(s) touched: none
Expected runtime delta: none
Expected runner-minute delta: none
Rollback plan if CI cost/runtime regresses: revert commit `cccccf1`

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅ | policy/schema validation and marker drift checks |
| Functional  | ✅ | deterministic 2-node/3-node marker emission via harness report |
| Integration | ✅ | opt-in run-mode multi-process selector execution through `ProcessHarness` |
| Regression  | ✅ | tampered marker fail-closed reason-code assertions |
