### PR TITLE
feat(networking): add deterministic libp2p runtime event normalization

### DIFF
--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -349,11 +349,13 @@ pub use operator_dashboard_ui::{
 };
 pub use p2p_transport::{
     build_libp2p_lifecycle_regression_corpus, build_p2p_swarm_deterministic_config,
+    canonical_libp2p_identify_protocol_id, canonical_libp2p_topic_id,
     compose_kademlia_discovery_bootstrap, compose_libp2p_swarm_behavior_stack,
     resolve_libp2p_live_runtime_backend, run_libp2p_lifecycle_regression_case,
     run_libp2p_lifecycle_regression_corpus, InMemoryPeerLifecycleTransport,
-    KademliaBootstrapSeedSet, KademliaDiscoveryBootstrapPlan, Libp2pLivePeerLifecycleTransport,
-    Libp2pLiveRuntimeBackend, LiveTransportFaultClass, LiveTransportReconnectDecision,
+    KademliaBootstrapSeedSet, KademliaDiscoveryBootstrapPlan, Libp2pBehaviorFailureClass,
+    Libp2pLivePeerLifecycleTransport, Libp2pLiveRuntimeBackend, Libp2pRuntimeEvent,
+    Libp2pRuntimeEventKind, LiveTransportFaultClass, LiveTransportReconnectDecision,
     LiveTransportReconnectPolicy, P2pSwarmBehaviorStack, P2pSwarmDeterministicConfig,
     P2pSwarmHarnessMode, P2pSwarmHarnessReport, P2pSwarmHarnessTask, P2pTransportError,
     PeerDiscoveryRecord, PeerGossipFrame, PeerLifecycleRegressionCase,

--- a/crates/kamn-core/src/p2p_transport.rs
+++ b/crates/kamn-core/src/p2p_transport.rs
@@ -16,12 +16,212 @@ use std::sync::{Arc, Mutex, OnceLock};
 
 const LIBP2P_SWARM_BEHAVIOR_COMPONENTS: [&str; 6] =
     ["tcp", "noise", "yamux", "identify", "kad", "gossipsub"];
+const LIBP2P_IDENTIFY_PROTOCOL_ID: &str = "/kamn/libp2p-live/1.0.0";
+const LIBP2P_TOPIC_NAMESPACE: &str = "kamn/v1/";
+const LIBP2P_RUNTIME_EVENT_SCHEMA_MARKER: &str = "kamn.libp2p.runtime-event.v1";
 
 #[cfg(feature = "libp2p-live-transport")]
 #[derive(libp2p::swarm::NetworkBehaviour)]
 struct Libp2pDeterministicRuntimeBehaviour {
     gossipsub: gossipsub::Behaviour,
     identify: identify::Behaviour,
+}
+
+/// Failure classes produced while normalizing deterministic libp2p runtime events.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Libp2pBehaviorFailureClass {
+    /// Runtime publish call was rejected by behavior-level policy.
+    PublishRejected,
+    /// Runtime observed malformed or disallowed topic metadata.
+    InvalidTopic,
+    /// Runtime observed malformed peer metadata.
+    InvalidPeerEvent,
+    /// Runtime adapter control channel closed unexpectedly.
+    RuntimeChannelClosed,
+    /// Runtime frame send failed because sender peer was unknown.
+    UnknownSenderPeer,
+    /// Runtime frame send failed because recipient peer was unknown.
+    UnknownRecipientPeer,
+}
+
+impl Libp2pBehaviorFailureClass {
+    /// Returns deterministic reason code used by runtime policy checks.
+    pub fn reason_code(self) -> &'static str {
+        match self {
+            Self::PublishRejected => "p2p_libp2p_publish_rejected",
+            Self::InvalidTopic => "p2p_transport_invalid_topic",
+            Self::InvalidPeerEvent => "p2p_libp2p_event_invalid_peer_event",
+            Self::RuntimeChannelClosed => "p2p_libp2p_runtime_channel_closed",
+            Self::UnknownSenderPeer => "p2p_transport_unknown_sender_peer",
+            Self::UnknownRecipientPeer => "p2p_transport_unknown_recipient_peer",
+        }
+    }
+}
+
+/// Runtime event kinds emitted by deterministic libp2p adapter normalization.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Libp2pRuntimeEventKind {
+    /// Local peer advertised discovery metadata.
+    PeerAdvertised,
+    /// Discovery lookup returned one peer for requested topic.
+    PeerDiscovered,
+    /// Gossip payload published to one recipient.
+    GossipPublished,
+    /// Gossip payload accepted for one recipient inbox.
+    GossipReceived,
+    /// Behavior-level failure was emitted.
+    BehaviorFailure,
+}
+
+/// Deterministic libp2p runtime event schema consumed by runtime adapter policy checks.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Libp2pRuntimeEvent {
+    schema_marker: &'static str,
+    kind: Libp2pRuntimeEventKind,
+    peer_id: Option<String>,
+    topic_id: Option<String>,
+    payload: Option<String>,
+    reason_code: &'static str,
+}
+
+impl Libp2pRuntimeEvent {
+    fn new(
+        kind: Libp2pRuntimeEventKind,
+        peer_id: Option<String>,
+        topic_id: Option<String>,
+        payload: Option<String>,
+        reason_code: &'static str,
+    ) -> Self {
+        Self {
+            schema_marker: LIBP2P_RUNTIME_EVENT_SCHEMA_MARKER,
+            kind,
+            peer_id,
+            topic_id,
+            payload,
+            reason_code,
+        }
+    }
+
+    /// Builds normalized event for one successful peer advertisement.
+    pub fn peer_advertised(peer_id: &str) -> Result<Self, P2pTransportError> {
+        validate_peer_id(peer_id)?;
+        Ok(Self::new(
+            Libp2pRuntimeEventKind::PeerAdvertised,
+            Some(peer_id.to_owned()),
+            None,
+            None,
+            "p2p_libp2p_event_peer_advertised",
+        ))
+    }
+
+    /// Builds normalized event for one discovered peer and topic.
+    pub fn peer_discovered(peer_id: &str, topic: &str) -> Result<Self, P2pTransportError> {
+        validate_peer_id(peer_id)?;
+        let topic_id = canonical_libp2p_topic_id(topic)?;
+        Ok(Self::new(
+            Libp2pRuntimeEventKind::PeerDiscovered,
+            Some(peer_id.to_owned()),
+            Some(topic_id),
+            None,
+            "p2p_libp2p_event_peer_discovered",
+        ))
+    }
+
+    /// Builds normalized event for one successful gossip publish operation.
+    pub fn gossip_published(
+        peer_id: &str,
+        topic: &str,
+        payload: &str,
+    ) -> Result<Self, P2pTransportError> {
+        validate_peer_id(peer_id)?;
+        let topic_id = canonical_libp2p_topic_id(topic)?;
+        if payload.trim().is_empty() {
+            return Err(P2pTransportError::EmptyPayload);
+        }
+        Ok(Self::new(
+            Libp2pRuntimeEventKind::GossipPublished,
+            Some(peer_id.to_owned()),
+            Some(topic_id),
+            Some(payload.to_owned()),
+            "p2p_libp2p_event_gossip_published",
+        ))
+    }
+
+    /// Builds normalized event for one accepted gossip message delivery.
+    pub fn gossip_received(
+        peer_id: &str,
+        topic: &str,
+        payload: &str,
+    ) -> Result<Self, P2pTransportError> {
+        validate_peer_id(peer_id)?;
+        let topic_id = canonical_libp2p_topic_id(topic)?;
+        if payload.trim().is_empty() {
+            return Err(P2pTransportError::EmptyPayload);
+        }
+        Ok(Self::new(
+            Libp2pRuntimeEventKind::GossipReceived,
+            Some(peer_id.to_owned()),
+            Some(topic_id),
+            Some(payload.to_owned()),
+            "p2p_libp2p_event_gossip_received",
+        ))
+    }
+
+    /// Builds normalized event for one behavior-level failure.
+    pub fn behavior_failure(
+        class: Libp2pBehaviorFailureClass,
+        peer_id: Option<&str>,
+        topic: Option<&str>,
+    ) -> Result<Self, P2pTransportError> {
+        let peer_id = match peer_id {
+            Some(value) => {
+                validate_peer_id(value)?;
+                Some(value.to_owned())
+            }
+            None => None,
+        };
+        let topic_id = match topic {
+            Some(value) => Some(canonical_libp2p_topic_id(value)?),
+            None => None,
+        };
+        Ok(Self::new(
+            Libp2pRuntimeEventKind::BehaviorFailure,
+            peer_id,
+            topic_id,
+            None,
+            class.reason_code(),
+        ))
+    }
+
+    /// Returns deterministic schema marker for this event payload.
+    pub fn schema_marker(&self) -> &'static str {
+        self.schema_marker
+    }
+
+    /// Returns event kind.
+    pub fn kind(&self) -> Libp2pRuntimeEventKind {
+        self.kind
+    }
+
+    /// Returns optional peer identifier.
+    pub fn peer_id(&self) -> Option<&str> {
+        self.peer_id.as_deref()
+    }
+
+    /// Returns optional canonical topic identifier.
+    pub fn topic_id(&self) -> Option<&str> {
+        self.topic_id.as_deref()
+    }
+
+    /// Returns optional payload body.
+    pub fn payload(&self) -> Option<&str> {
+        self.payload.as_deref()
+    }
+
+    /// Returns deterministic reason code.
+    pub fn reason_code(&self) -> &'static str {
+        self.reason_code
+    }
 }
 
 /// Transport-level discovery metadata advertised by each active peer.
@@ -629,6 +829,19 @@ impl Libp2pLivePeerLifecycleTransport {
         self.live_network_id.as_str()
     }
 
+    /// Drains normalized runtime events emitted by this transport adapter.
+    pub fn drain_runtime_events(&self) -> Result<Vec<Libp2pRuntimeEvent>, P2pTransportError> {
+        #[cfg(feature = "libp2p-live-transport")]
+        {
+            self.native_runtime_loop.drain_runtime_events()
+        }
+        #[cfg(not(feature = "libp2p-live-transport"))]
+        {
+            let mut state = self.lock_live_data_plane_state()?;
+            Ok(state.runtime_events.drain(..).collect())
+        }
+    }
+
     #[cfg(feature = "libp2p-live-transport")]
     /// Returns deterministic native runtime loop marker for feature-enabled adapter wiring.
     pub fn native_runtime_loop_marker(&self) -> &'static str {
@@ -656,11 +869,13 @@ impl PeerLifecycleTransport for Libp2pLivePeerLifecycleTransport {
         let mut state = self.lock_live_data_plane_state()?;
         #[cfg(not(feature = "libp2p-live-transport"))]
         {
+            let event = Libp2pRuntimeEvent::peer_advertised(record.peer_id.as_str())?;
             state
                 .inbox_by_peer
                 .entry(record.peer_id.clone())
                 .or_insert_with(VecDeque::new);
             state.peers_by_id.insert(record.peer_id.clone(), record);
+            state.runtime_events.push_back(event);
             Ok(())
         }
     }
@@ -679,17 +894,26 @@ impl PeerLifecycleTransport for Libp2pLivePeerLifecycleTransport {
         #[cfg(not(feature = "libp2p-live-transport"))]
         validate_topic(topic)?;
         #[cfg(not(feature = "libp2p-live-transport"))]
-        let state = self.lock_live_data_plane_state()?;
+        let mut state = self.lock_live_data_plane_state()?;
         #[cfg(not(feature = "libp2p-live-transport"))]
         {
-            Ok(state
+            let discovered = state
                 .peers_by_id
                 .values()
                 .filter(|record| {
                     record.peer_id != requester_peer_id && record.supports_topic(topic)
                 })
                 .cloned()
-                .collect())
+                .collect::<Vec<PeerDiscoveryRecord>>();
+            for record in &discovered {
+                state
+                    .runtime_events
+                    .push_back(Libp2pRuntimeEvent::peer_discovered(
+                        record.peer_id.as_str(),
+                        topic,
+                    )?);
+            }
+            Ok(discovered)
         }
     }
 
@@ -702,23 +926,49 @@ impl PeerLifecycleTransport for Libp2pLivePeerLifecycleTransport {
         let mut state = self.lock_live_data_plane_state()?;
         #[cfg(not(feature = "libp2p-live-transport"))]
         if !state.peers_by_id.contains_key(&frame.sender_peer_id) {
+            state
+                .runtime_events
+                .push_back(Libp2pRuntimeEvent::behavior_failure(
+                    Libp2pBehaviorFailureClass::UnknownSenderPeer,
+                    Some(frame.sender_peer_id.as_str()),
+                    Some(frame.topic.as_str()),
+                )?);
             return Err(P2pTransportError::UnknownSenderPeer(
                 frame.sender_peer_id.clone(),
             ));
         }
         #[cfg(not(feature = "libp2p-live-transport"))]
         if !state.peers_by_id.contains_key(&frame.recipient_peer_id) {
+            state
+                .runtime_events
+                .push_back(Libp2pRuntimeEvent::behavior_failure(
+                    Libp2pBehaviorFailureClass::UnknownRecipientPeer,
+                    Some(frame.recipient_peer_id.as_str()),
+                    Some(frame.topic.as_str()),
+                )?);
             return Err(P2pTransportError::UnknownRecipientPeer(
                 frame.recipient_peer_id.clone(),
             ));
         }
         #[cfg(not(feature = "libp2p-live-transport"))]
         {
+            let published = Libp2pRuntimeEvent::gossip_published(
+                frame.sender_peer_id.as_str(),
+                frame.topic.as_str(),
+                frame.payload.as_str(),
+            )?;
+            let received = Libp2pRuntimeEvent::gossip_received(
+                frame.recipient_peer_id.as_str(),
+                frame.topic.as_str(),
+                frame.payload.as_str(),
+            )?;
             state
                 .inbox_by_peer
                 .entry(frame.recipient_peer_id.clone())
                 .or_insert_with(VecDeque::new)
                 .push_back(frame);
+            state.runtime_events.push_back(published);
+            state.runtime_events.push_back(received);
             Ok(())
         }
     }
@@ -750,6 +1000,7 @@ impl PeerLifecycleTransport for Libp2pLivePeerLifecycleTransport {
 struct Libp2pLiveDataPlaneState {
     peers_by_id: BTreeMap<String, PeerDiscoveryRecord>,
     inbox_by_peer: BTreeMap<String, VecDeque<PeerGossipFrame>>,
+    runtime_events: VecDeque<Libp2pRuntimeEvent>,
 }
 
 #[cfg(not(feature = "libp2p-live-transport"))]
@@ -799,6 +1050,9 @@ enum Libp2pNativeRuntimeAdapterLoopCommand {
     DrainInbox {
         recipient_peer_id: String,
         response: std::sync::mpsc::Sender<Result<Vec<PeerGossipFrame>, P2pTransportError>>,
+    },
+    DrainRuntimeEvents {
+        response: std::sync::mpsc::Sender<Result<Vec<Libp2pRuntimeEvent>, P2pTransportError>>,
     },
 }
 
@@ -889,6 +1143,18 @@ impl Libp2pNativeRuntimeAdapterLoop {
             .recv()
             .map_err(|_| P2pTransportError::StateUnavailable)?
     }
+
+    fn drain_runtime_events(&self) -> Result<Vec<Libp2pRuntimeEvent>, P2pTransportError> {
+        let (response_tx, response_rx) = std::sync::mpsc::channel();
+        self.command_tx
+            .send(Libp2pNativeRuntimeAdapterLoopCommand::DrainRuntimeEvents {
+                response: response_tx,
+            })
+            .map_err(|_| P2pTransportError::StateUnavailable)?;
+        response_rx
+            .recv()
+            .map_err(|_| P2pTransportError::StateUnavailable)?
+    }
 }
 
 #[cfg(feature = "libp2p-live-transport")]
@@ -902,7 +1168,8 @@ fn run_libp2p_native_runtime_adapter_loop(
                 let result = state
                     .lock()
                     .map_err(|_| P2pTransportError::StateUnavailable)
-                    .map(|mut locked_state| {
+                    .and_then(|mut locked_state| {
+                        let event = Libp2pRuntimeEvent::peer_advertised(record.peer_id.as_str())?;
                         locked_state
                             .inbox_by_peer
                             .entry(record.peer_id.clone())
@@ -910,8 +1177,10 @@ fn run_libp2p_native_runtime_adapter_loop(
                         locked_state
                             .peers_by_id
                             .insert(record.peer_id.clone(), record);
+                        locked_state.runtime_events.push_back(event);
+                        Ok(())
                     });
-                let _ = response.send(result.map(|_| ()));
+                let _ = response.send(result);
             }
             Libp2pNativeRuntimeAdapterLoopCommand::Discover {
                 requester_peer_id,
@@ -924,8 +1193,8 @@ fn run_libp2p_native_runtime_adapter_loop(
                         state
                             .lock()
                             .map_err(|_| P2pTransportError::StateUnavailable)
-                            .map(|locked_state| {
-                                locked_state
+                            .and_then(|mut locked_state| {
+                                let discovered = locked_state
                                     .peers_by_id
                                     .values()
                                     .filter(|record| {
@@ -933,34 +1202,76 @@ fn run_libp2p_native_runtime_adapter_loop(
                                             && record.supports_topic(topic.as_str())
                                     })
                                     .cloned()
-                                    .collect::<Vec<PeerDiscoveryRecord>>()
+                                    .collect::<Vec<PeerDiscoveryRecord>>();
+                                for record in &discovered {
+                                    locked_state.runtime_events.push_back(
+                                        Libp2pRuntimeEvent::peer_discovered(
+                                            record.peer_id.as_str(),
+                                            topic.as_str(),
+                                        )?,
+                                    );
+                                }
+                                Ok(discovered)
                             })
                     });
                 let _ = response.send(result);
             }
             Libp2pNativeRuntimeAdapterLoopCommand::Send { frame, response } => {
+                let sender_peer_id = frame.sender_peer_id.clone();
+                let recipient_peer_id = frame.recipient_peer_id.clone();
+                let topic = frame.topic.clone();
+                let payload = frame.payload.clone();
                 let result = state
                     .lock()
                     .map_err(|_| P2pTransportError::StateUnavailable)
                     .and_then(|mut locked_state| {
-                        if !locked_state.peers_by_id.contains_key(&frame.sender_peer_id) {
+                        if !locked_state
+                            .peers_by_id
+                            .contains_key(sender_peer_id.as_str())
+                        {
+                            locked_state.runtime_events.push_back(
+                                Libp2pRuntimeEvent::behavior_failure(
+                                    Libp2pBehaviorFailureClass::UnknownSenderPeer,
+                                    Some(sender_peer_id.as_str()),
+                                    Some(topic.as_str()),
+                                )?,
+                            );
                             return Err(P2pTransportError::UnknownSenderPeer(
-                                frame.sender_peer_id.clone(),
+                                sender_peer_id.clone(),
                             ));
                         }
                         if !locked_state
                             .peers_by_id
-                            .contains_key(&frame.recipient_peer_id)
+                            .contains_key(recipient_peer_id.as_str())
                         {
+                            locked_state.runtime_events.push_back(
+                                Libp2pRuntimeEvent::behavior_failure(
+                                    Libp2pBehaviorFailureClass::UnknownRecipientPeer,
+                                    Some(recipient_peer_id.as_str()),
+                                    Some(topic.as_str()),
+                                )?,
+                            );
                             return Err(P2pTransportError::UnknownRecipientPeer(
-                                frame.recipient_peer_id.clone(),
+                                recipient_peer_id.clone(),
                             ));
                         }
+                        let published = Libp2pRuntimeEvent::gossip_published(
+                            sender_peer_id.as_str(),
+                            topic.as_str(),
+                            payload.as_str(),
+                        )?;
+                        let received = Libp2pRuntimeEvent::gossip_received(
+                            recipient_peer_id.as_str(),
+                            topic.as_str(),
+                            payload.as_str(),
+                        )?;
                         locked_state
                             .inbox_by_peer
-                            .entry(frame.recipient_peer_id.clone())
+                            .entry(recipient_peer_id.clone())
                             .or_insert_with(VecDeque::new)
                             .push_back(frame);
+                        locked_state.runtime_events.push_back(published);
+                        locked_state.runtime_events.push_back(received);
                         Ok(())
                     });
                 let _ = response.send(result);
@@ -983,8 +1294,26 @@ fn run_libp2p_native_runtime_adapter_loop(
                 });
                 let _ = response.send(result);
             }
+            Libp2pNativeRuntimeAdapterLoopCommand::DrainRuntimeEvents { response } => {
+                let result = state
+                    .lock()
+                    .map_err(|_| P2pTransportError::StateUnavailable)
+                    .map(|mut locked_state| locked_state.runtime_events.drain(..).collect());
+                let _ = response.send(result);
+            }
         }
     }
+}
+
+/// Returns canonical identify protocol id for deterministic libp2p runtime composition.
+pub fn canonical_libp2p_identify_protocol_id() -> &'static str {
+    LIBP2P_IDENTIFY_PROTOCOL_ID
+}
+
+/// Returns canonical gossipsub topic id for deterministic runtime policy checks.
+pub fn canonical_libp2p_topic_id(topic: &str) -> Result<String, P2pTransportError> {
+    validate_topic(topic)?;
+    Ok(format!("{LIBP2P_TOPIC_NAMESPACE}{}", topic.trim()))
 }
 
 fn build_live_data_plane_network_id(config: &P2pSwarmDeterministicConfig) -> String {
@@ -1012,7 +1341,9 @@ fn validate_libp2p_native_runtime_config(
             .map_err(|_| P2pTransportError::Libp2pRuntimeConfigInvalid)?;
     }
     for topic in config.gossip_topics() {
-        let _ = libp2p::gossipsub::IdentTopic::new(topic.clone());
+        let topic_id = canonical_libp2p_topic_id(topic.as_str())
+            .map_err(|_| P2pTransportError::Libp2pRuntimeConfigInvalid)?;
+        let _ = libp2p::gossipsub::IdentTopic::new(topic_id);
     }
     Ok(())
 }
@@ -1230,6 +1561,8 @@ pub struct P2pSwarmBehaviorStack {
     bootstrap_peers: Vec<String>,
     gossip_topics: Vec<String>,
     behavior_components: Vec<&'static str>,
+    identify_protocol_id: &'static str,
+    gossip_topic_namespace: &'static str,
 }
 
 impl P2pSwarmBehaviorStack {
@@ -1252,6 +1585,16 @@ impl P2pSwarmBehaviorStack {
     pub fn listen_address(&self) -> &str {
         &self.listen_address
     }
+
+    /// Returns canonical identify protocol id.
+    pub fn identify_protocol_id(&self) -> &'static str {
+        self.identify_protocol_id
+    }
+
+    /// Returns canonical topic namespace prefix used during topic normalization.
+    pub fn gossip_topic_namespace(&self) -> &'static str {
+        self.gossip_topic_namespace
+    }
 }
 
 /// Composes deterministic libp2p behavior stack metadata.
@@ -1263,6 +1606,8 @@ pub fn compose_libp2p_swarm_behavior_stack(
         bootstrap_peers: config.bootstrap_peers().to_vec(),
         gossip_topics: config.gossip_topics().to_vec(),
         behavior_components: LIBP2P_SWARM_BEHAVIOR_COMPONENTS.to_vec(),
+        identify_protocol_id: canonical_libp2p_identify_protocol_id(),
+        gossip_topic_namespace: LIBP2P_TOPIC_NAMESPACE,
     }
 }
 
@@ -1723,14 +2068,16 @@ fn validate_libp2p_runtime_stack_composition(
                 )
                 .map_err(|_| P2pTransportError::Libp2pRuntimeConfigInvalid)?;
                 for topic in config.gossip_topics() {
+                    let topic_id = canonical_libp2p_topic_id(topic.as_str())
+                        .map_err(|_| P2pTransportError::Libp2pRuntimeConfigInvalid)?;
                     gossipsub_behavior
-                        .subscribe(&gossipsub::IdentTopic::new(topic.clone()))
+                        .subscribe(&gossipsub::IdentTopic::new(topic_id))
                         .map_err(|_| P2pTransportError::Libp2pRuntimeConfigInvalid)?;
                 }
                 Ok(Libp2pDeterministicRuntimeBehaviour {
                     gossipsub: gossipsub_behavior,
                     identify: identify::Behaviour::new(identify::Config::new(
-                        "/kamn/libp2p-live/1.0.0".to_owned(),
+                        canonical_libp2p_identify_protocol_id().to_owned(),
                         key.public(),
                     )),
                 })

--- a/crates/kamn-core/tests/p2p_live_transport_runtime.rs
+++ b/crates/kamn-core/tests/p2p_live_transport_runtime.rs
@@ -1,8 +1,9 @@
 use kamn_core::{
     build_p2p_swarm_deterministic_config, build_runtime_wiring,
-    build_runtime_wiring_with_transport_profile, Libp2pLivePeerLifecycleTransport, NodeConfig,
-    NodeRole, P2pSwarmHarnessMode, P2pTransportError, PeerDiscoveryRecord, PeerGossipFrame,
-    PeerLifecycleEvent, PeerLifecycleState, PeerLifecycleTransport,
+    build_runtime_wiring_with_transport_profile, canonical_libp2p_identify_protocol_id,
+    canonical_libp2p_topic_id, Libp2pLivePeerLifecycleTransport, Libp2pRuntimeEventKind,
+    NodeConfig, NodeRole, P2pSwarmHarnessMode, P2pTransportError, PeerDiscoveryRecord,
+    PeerGossipFrame, PeerLifecycleEvent, PeerLifecycleState, PeerLifecycleTransport,
     PeerLifecycleTransportCoordinator, RuntimeLifecycleError, RuntimeTransportProfile, SyncMode,
 };
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -67,6 +68,18 @@ fn unit_live_transport_adapter_reports_harness_startup_profile() {
     assert!(transport.harness_report().started());
     assert_eq!(transport.harness_report().executed_ticks(), 3);
     assert_eq!(transport.listen_address(), "/ip4/127.0.0.1/tcp/9200");
+}
+
+#[test]
+fn unit_libp2p_runtime_protocol_and_topic_ids_are_deterministic() {
+    assert_eq!(
+        canonical_libp2p_identify_protocol_id(),
+        "/kamn/libp2p-live/1.0.0"
+    );
+    assert_eq!(
+        canonical_libp2p_topic_id("messages").expect("topic id should normalize"),
+        "kamn/v1/messages"
+    );
 }
 
 #[test]
@@ -195,6 +208,89 @@ fn integration_live_transport_data_plane_supports_independent_adapter_exchange()
 }
 
 #[test]
+fn functional_live_transport_emits_normalized_runtime_events() {
+    let bootstrap_seed = unique_bootstrap_seed("live-normalized-events");
+    let processor_transport = Libp2pLivePeerLifecycleTransport::new(
+        live_swarm_config_for_peer(
+            "peer-processor-live-events",
+            "/ip4/127.0.0.1/tcp/9230",
+            bootstrap_seed.as_str(),
+        ),
+        P2pSwarmHarnessMode::DryRun,
+    )
+    .expect("processor live transport should initialize");
+    let listener_transport = Libp2pLivePeerLifecycleTransport::new(
+        live_swarm_config_for_peer(
+            "peer-listener-live-events",
+            "/ip4/127.0.0.1/tcp/9231",
+            bootstrap_seed.as_str(),
+        ),
+        P2pSwarmHarnessMode::DryRun,
+    )
+    .expect("listener live transport should initialize");
+
+    processor_transport
+        .advertise(
+            PeerDiscoveryRecord::new(
+                "peer-processor-live-events",
+                NodeRole::Processor,
+                vec!["messages".to_owned()],
+            )
+            .expect("processor record should build"),
+        )
+        .expect("processor advertise should pass");
+    listener_transport
+        .advertise(
+            PeerDiscoveryRecord::new(
+                "peer-listener-live-events",
+                NodeRole::Listener,
+                vec!["messages".to_owned()],
+            )
+            .expect("listener record should build"),
+        )
+        .expect("listener advertise should pass");
+
+    let discovered = processor_transport
+        .discover("peer-processor-live-events", "messages")
+        .expect("discovery should pass");
+    assert_eq!(discovered.len(), 1);
+    assert_eq!(discovered[0].peer_id, "peer-listener-live-events");
+
+    processor_transport
+        .send(
+            PeerGossipFrame::new(
+                "messages",
+                "peer-processor-live-events",
+                "peer-listener-live-events",
+                "tx-live-events-001",
+            )
+            .expect("gossip frame should build"),
+        )
+        .expect("gossip send should pass");
+
+    let events = processor_transport
+        .drain_runtime_events()
+        .expect("runtime events should drain");
+    assert_eq!(events.len(), 5);
+    assert_eq!(
+        events
+            .iter()
+            .map(|event| event.kind())
+            .collect::<Vec<Libp2pRuntimeEventKind>>(),
+        vec![
+            Libp2pRuntimeEventKind::PeerAdvertised,
+            Libp2pRuntimeEventKind::PeerAdvertised,
+            Libp2pRuntimeEventKind::PeerDiscovered,
+            Libp2pRuntimeEventKind::GossipPublished,
+            Libp2pRuntimeEventKind::GossipReceived,
+        ]
+    );
+    assert!(events
+        .iter()
+        .all(|event| event.schema_marker() == "kamn.libp2p.runtime-event.v1"));
+}
+
+#[test]
 fn integration_live_transport_invalid_event_retries_are_idempotent() {
     let transport =
         Libp2pLivePeerLifecycleTransport::new(live_swarm_config(), P2pSwarmHarnessMode::DryRun)
@@ -270,6 +366,14 @@ fn regression_live_transport_invalid_transition_reason_code_stable() {
         .apply_live_transport_signal(PeerLifecycleEvent::HeartbeatRestored)
         .expect_err("heartbeat restore from disconnected must fail");
     assert_eq!(error.reason_code(), "runtime_peer_transition_invalid");
+}
+
+#[test]
+fn regression_libp2p_topic_normalization_invalid_topic_reason_code_stable() {
+    // Regression: #3668
+    let error =
+        canonical_libp2p_topic_id("bad|topic").expect_err("wire-delimited topics must fail closed");
+    assert_eq!(error.reason_code(), "p2p_transport_invalid_topic");
 }
 
 #[test]

--- a/docs/architecture/p2p-transport.md
+++ b/docs/architecture/p2p-transport.md
@@ -89,11 +89,24 @@ libp2p I/O integration while preserving low-cost default CI behavior.
     - `identify`
     - `kad`
     - `gossipsub`
+  - canonical protocol-id/topic-namespace metadata:
+    - `canonical_libp2p_identify_protocol_id()`
+    - `canonical_libp2p_topic_id(...)`
 - `P2pSwarmHarnessTask`
   - controlled runtime-harness startup surface for deterministic `DryRun` / `Run`
     execution modes used by local integration tests.
   - feature-enabled `Run` mode validates native libp2p stack composition and
     appends `libp2p-runtime-swarm` to harness behavior markers.
+- `Libp2pRuntimeEvent`
+  - normalized runtime event payload schema:
+    - `kamn.libp2p.runtime-event.v1`
+    - `PeerAdvertised`
+    - `PeerDiscovered`
+    - `GossipPublished`
+    - `GossipReceived`
+    - `BehaviorFailure`
+- `Libp2pBehaviorFailureClass`
+  - typed behavior-failure taxonomy mapped to deterministic reason codes.
 - `LiveTransportReconnectPolicy`
   - deterministic reconnect/backoff evaluator for live transport faults.
 - `LiveTransportReconnectDecision`
@@ -144,6 +157,9 @@ deterministic network identity.
 
 - `Libp2pLivePeerLifecycleTransport::live_data_plane_network_id()`
   - exposes the deterministic network identifier used for adapter mesh routing.
+- `Libp2pLivePeerLifecycleTransport::drain_runtime_events()`
+  - drains normalized runtime events emitted by advertise/discover/send paths for
+    deterministic adapter-policy validation.
 - Independent live adapter instances with matching deterministic network inputs
   can discover and exchange gossip frames without cloning one shared adapter.
 - Unsupported lifecycle transitions still fail closed through
@@ -217,6 +233,13 @@ Deterministic reason-code markers:
   - lifecycle state remains unchanged across retries.
   - `P2pTransportError::reason_code()` remains stable at
     `runtime_peer_transition_invalid` for invalid transition retries.
+- Runtime event normalization emits deterministic reason-code contracts:
+  - `p2p_libp2p_event_peer_advertised`
+  - `p2p_libp2p_event_peer_discovered`
+  - `p2p_libp2p_event_gossip_published`
+  - `p2p_libp2p_event_gossip_received`
+  - `p2p_transport_unknown_sender_peer`
+  - `p2p_transport_unknown_recipient_peer`
 
 ## Peer Lifecycle Proptest Invariants
 
@@ -251,8 +274,10 @@ cargo test -p kamn-core --test p2p_transport_feature_gates
 cargo test -p kamn-core --test p2p_transport_feature_gates --features libp2p-live-transport
 cargo test -p kamn-core --test p2p_libp2p_native_adapter_runtime --features libp2p-live-transport
 cargo test -p kamn-core --test p2p_live_transport_runtime integration_live_transport_data_plane_supports_independent_adapter_exchange -- --exact
+cargo test -p kamn-core --test p2p_live_transport_runtime functional_live_transport_emits_normalized_runtime_events -- --exact
 cargo test -p kamn-core --test p2p_live_transport_runtime integration_live_transport_invalid_event_retries_are_idempotent -- --exact
 cargo test -p kamn-core --test p2p_live_transport_runtime regression_live_transport_invalid_transition_reason_code_stable -- --exact
+cargo test -p kamn-core --test p2p_live_transport_runtime unit_libp2p_runtime_protocol_and_topic_ids_are_deterministic -- --exact
 cargo test -p kamn-core --test p2p_reconnect_policy_runtime
 cargo test -p kamn-core --test peer_lifecycle_proptest_invariants unit_peer_lifecycle_proptest_config_is_deterministic_and_persistent -- --exact
 cargo test -p kamn-core --test peer_lifecycle_proptest_invariants functional_peer_lifecycle_proptest_enforces_legal_transition_graph -- --exact


### PR DESCRIPTION
## Summary
- Implement deterministic libp2p runtime event normalization primitives and expose canonical protocol/topic identifiers.
- Wire normalized event emission into live transport advertise/discover/send paths and expose event-drain APIs for runtime policy consumption.
- Update p2p architecture docs and add regression coverage for event schema and topic normalization contracts.

## Linked Issues
- Closes #3668

## Validation
- [x] Relevant local checks passed.
- [x] CI fast-gate checks expected to pass.

## CI Impact Declaration
- [x] No CI scope impact.
- [ ] CI scope impact present (explain below).

CI scope impact details (required when CI scope impact is present):
- Workflow(s) touched: N/A
- Expected runtime delta: N/A
- Expected runner-minute delta: N/A
- Rollback plan if CI cost/runtime regresses: Revert this PR.

## Changes
- `crates/kamn-core/src/p2p_transport.rs`
  - Added canonical ID helpers: `canonical_libp2p_identify_protocol_id()` and `canonical_libp2p_topic_id(...)`.
  - Added normalized runtime event schema/types: `Libp2pRuntimeEvent`, `Libp2pRuntimeEventKind`, `Libp2pBehaviorFailureClass`.
  - Extended `Libp2pLivePeerLifecycleTransport` with `drain_runtime_events()`.
  - Wired runtime event emission into advertise/discover/send in both contract and feature-enabled native loop paths.
  - Added deterministic protocol metadata on `P2pSwarmBehaviorStack`.
- `crates/kamn-core/src/lib.rs`
  - Re-exported new libp2p normalization APIs and types.
- `crates/kamn-core/tests/p2p_live_transport_runtime.rs`
  - Added deterministic protocol/topic ID test.
  - Added normalized runtime event emission functional test.
  - Added regression test for invalid-topic reason-code stability.
- `docs/architecture/p2p-transport.md`
  - Documented canonical IDs, runtime event schema, failure taxonomy, and validation commands.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
`cargo test -p kamn-core --test p2p_live_transport_runtime`

Observed failure before implementation:
- unresolved imports in `kamn_core` for:
  - `canonical_libp2p_identify_protocol_id`
  - `canonical_libp2p_topic_id`
  - `Libp2pRuntimeEventKind`
- missing method:
  - `Libp2pLivePeerLifecycleTransport::drain_runtime_events()`

### 🟢 Green Phase
Commands:
- `cargo test -p kamn-core --test p2p_live_transport_runtime`
- `cargo test -p kamn-core --test p2p_swarm_stack_runtime`
- `cargo test -p kamn-core --test p2p_libp2p_native_adapter_runtime --features libp2p-live-transport`

Result:
- All tests pass.

### 🔁 Regression
Commands:
- `cargo test -p kamn-core --test p2p_transport_docs`
- `cargo test -p kamn-core p2p_transport::tests`
- `cargo fmt --check`
- `cargo clippy -p kamn-core -- -D warnings`

Result:
- Regression/documentation checks pass and lint/format are clean.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `unit_libp2p_runtime_protocol_and_topic_ids_are_deterministic`; `p2p_transport::tests` reason-code/transport unit checks rerun | |
| Functional   | ✅     | `functional_live_transport_emits_normalized_runtime_events` | |
| Integration  | ✅     | `p2p_libp2p_native_adapter_runtime` (feature-enabled) and live transport integration suite | |
| Regression   | ✅     | `regression_libp2p_topic_normalization_invalid_topic_reason_code_stable`; `p2p_transport_docs` | |
| Performance  | N/A    | | Existing performance guard in `p2p_libp2p_native_adapter_runtime` remains unchanged |

## Risks & Rollback
- Risk: runtime event queue semantics are new and may require consumer-side adjustments in subsequent adapter wiring tasks.
- Rollback plan: revert this PR to restore previous live transport state behavior and API surface.

## Documentation Updates
- Updated `docs/architecture/p2p-transport.md`.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (run as `cargo clippy -p kamn-core -- -D warnings`)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (relevant p2p regression slice)
- [x] Docs updated (or justified why not)
