### PR TITLE
fix(networking): add fail-closed transport remediation diagnostics

### DIFF
--- a/crates/kamn-node/src/main_tests/runtime_tests.rs
+++ b/crates/kamn-node/src/main_tests/runtime_tests.rs
@@ -855,6 +855,49 @@ fn functional_production_transport_profile_classifier_rejects_in_memory_fallback
 }
 
 #[test]
+fn regression_production_transport_policy_error_detail_includes_remediation_guidance() {
+    // Regression: #3673
+    let parsed = parse_args(vec![
+        "kamn-node".to_owned(),
+        "--role".to_owned(),
+        "processor".to_owned(),
+        "--runtime-mode".to_owned(),
+        "full".to_owned(),
+        "--disable-gossip".to_owned(),
+        "--daemon-max-ticks".to_owned(),
+        "1".to_owned(),
+        "--daemon-tick-interval-ms".to_owned(),
+        "5".to_owned(),
+        "--api-bind".to_owned(),
+        "127.0.0.1:19093".to_owned(),
+    ])
+    .expect("full args should parse");
+
+    let error = execute(parsed).expect_err("production transport policy must fail closed");
+    match error {
+        ConfigError::RuntimeStoreCompatibility {
+            reason_code,
+            detail,
+            ..
+        } => {
+            assert_eq!(
+                reason_code,
+                "runtime_transport_profile_gossip_disabled_for_production"
+            );
+            assert!(
+                detail.contains("remove --disable-gossip"),
+                "detail should include actionable gossip remediation guidance"
+            );
+            assert!(
+                detail.contains("or use non-production runtime modes"),
+                "detail should include non-production fallback guidance"
+            );
+        }
+        other => panic!("expected runtime store compatibility failure, found {other:?}"),
+    }
+}
+
+#[test]
 fn integration_runtime_full_uses_live_transport_profile_components_by_default() {
     let parsed = parse_args(vec![
         "kamn-node".to_owned(),

--- a/crates/kamn-node/src/runtime_orchestration.rs
+++ b/crates/kamn-node/src/runtime_orchestration.rs
@@ -38,6 +38,35 @@ const RUNTIME_TRANSPORT_PROFILE_LIVE_MARKER_MISSING_REASON: &str =
 const RUNTIME_TRANSPORT_PROFILE_LIVE_PROVIDER_MISSING_REASON: &str =
     "runtime_transport_profile_live_provider_missing";
 
+fn production_transport_profile_remediation(reason_code: &'static str) -> &'static str {
+    match reason_code {
+        RUNTIME_TRANSPORT_PROFILE_GOSSIP_DISABLED_FOR_PRODUCTION_REASON => {
+            "remove --disable-gossip (or set enable_gossip=true in config), or use non-production runtime modes (planning/recovery-check)"
+        }
+        RUNTIME_TRANSPORT_PROFILE_IN_MEMORY_FALLBACK_FORBIDDEN_REASON => {
+            "ensure runtime wiring emits p2p-transport-profile:libp2p-live and remove in-memory fallback markers"
+        }
+        RUNTIME_TRANSPORT_PROFILE_LIVE_MARKER_MISSING_REASON => {
+            "ensure bootstrap uses RuntimeTransportProfile::Libp2pLive for production runtime modes"
+        }
+        RUNTIME_TRANSPORT_PROFILE_LIVE_PROVIDER_MISSING_REASON => {
+            "ensure p2p-live-libp2p-provider marker is present and provider wiring is initialized"
+        }
+        _ => "verify runtime transport profile wiring against production policy contract",
+    }
+}
+
+fn build_production_transport_profile_violation_detail(
+    runtime_mode: RuntimeMode,
+    reason_code: &'static str,
+) -> String {
+    format!(
+        "runtime mode {} requires live libp2p transport profile wiring; remediation: {}",
+        runtime_mode.as_str(),
+        production_transport_profile_remediation(reason_code),
+    )
+}
+
 fn runtime_mode_requires_live_transport_profile(runtime_mode: RuntimeMode) -> bool {
     matches!(
         runtime_mode.kind,
@@ -106,10 +135,7 @@ fn enforce_production_transport_profile_policy(
         return Err(ConfigError::RuntimeStoreCompatibility {
             store: RUNTIME_TRANSPORT_PROFILE_POLICY_STORE,
             reason_code,
-            detail: format!(
-                "runtime mode {} requires live libp2p transport profile wiring",
-                runtime_mode.as_str()
-            ),
+            detail: build_production_transport_profile_violation_detail(runtime_mode, reason_code),
         });
     }
     Ok(())

--- a/docs/architecture/p2p-transport.md
+++ b/docs/architecture/p2p-transport.md
@@ -240,6 +240,11 @@ Deterministic reason-code markers:
   - `p2p_libp2p_event_gossip_received`
   - `p2p_transport_unknown_sender_peer`
   - `p2p_transport_unknown_recipient_peer`
+- Production transport-profile policy failures remain fail-closed with remediation:
+  - `runtime_transport_profile_gossip_disabled_for_production`
+    - remediation: remove `--disable-gossip` or switch to non-production runtime mode
+  - `runtime_transport_profile_in_memory_fallback_forbidden`
+    - remediation: remove in-memory fallback markers and enforce live profile markers
 
 ## Peer Lifecycle Proptest Invariants
 

--- a/docs/foundation/runtime-network.md
+++ b/docs/foundation/runtime-network.md
@@ -150,6 +150,17 @@ This document captures the initial runtime-network foundation slice for peer lif
   - `runtime_transport_profile_in_memory_fallback_forbidden`
   - `runtime_transport_profile_live_marker_missing`
   - `runtime_transport_profile_live_provider_missing`
+- Operator remediation contract for production policy failures:
+  - `runtime_transport_profile_gossip_disabled_for_production`
+    - remove `--disable-gossip` (or set `enable_gossip=true`) for production modes
+    - otherwise switch to non-production runtime modes (`planning`/`recovery-check`)
+  - `runtime_transport_profile_in_memory_fallback_forbidden`
+    - remove in-memory fallback profile markers
+    - ensure runtime wiring emits `p2p-transport-profile:libp2p-live`
+  - `runtime_transport_profile_live_marker_missing`
+    - ensure bootstrap path selects `RuntimeTransportProfile::Libp2pLive`
+  - `runtime_transport_profile_live_provider_missing`
+    - ensure `p2p-live-libp2p-provider` marker is present and provider wiring is initialized
 
 ## Node Observability Ingress Runtime Mapping
 - `kamn-node` observability export serving path is runtime-aligned and async-driven:


### PR DESCRIPTION
## Summary
- Add deterministic operator remediation diagnostics to production transport-profile fail-closed policy errors.
- Extend regression coverage so production policy failures must include actionable remediation guidance.
- Update runtime-network and p2p architecture docs with remediation contracts.

## Linked Issues
- Closes #3673

## Validation
- [x] Relevant local checks passed.
- [x] CI fast-gate checks expected to pass.

## CI Impact Declaration
- [x] No CI scope impact.
- [ ] CI scope impact present (explain below).

CI scope impact details (required when CI scope impact is present):
- Workflow(s) touched: N/A
- Expected runtime delta: N/A
- Expected runner-minute delta: N/A
- Rollback plan if CI cost/runtime regresses: Revert this PR.

## Changes
- `crates/kamn-node/src/runtime_orchestration.rs`
  - Added deterministic remediation guidance mapping for each production transport-profile reason code.
  - Added structured policy detail builder used in fail-closed `RuntimeStoreCompatibility` errors.
- `crates/kamn-node/src/main_tests/runtime_tests.rs`
  - Added regression test ensuring production policy failure detail includes actionable remediation guidance.
- `docs/foundation/runtime-network.md`
  - Added operator remediation contract section for production transport-profile reason codes.
- `docs/architecture/p2p-transport.md`
  - Added production transport-profile remediation bullets alongside fail-closed reason codes.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
`cargo test -p kamn-node main_tests::runtime_tests::regression_production_transport_policy_error_detail_includes_remediation_guidance -- --exact`

Observed failure before implementation:
- assertion failure: detail did not include actionable remediation guidance (`remove --disable-gossip` / non-production mode fallback guidance).

### 🟢 Green Phase
Commands:
- `cargo test -p kamn-node main_tests::runtime_tests::regression_production_transport_policy_error_detail_includes_remediation_guidance -- --exact`
- `cargo test -p kamn-node main_tests::runtime_tests::functional_production_transport_profile_classifier_rejects_in_memory_fallback -- --exact`
- `cargo test -p kamn-node main_tests::runtime_tests::regression_production_transport_profile_in_memory_rejection_reason_code_is_stable -- --exact`

Result:
- All tests pass.

### 🔁 Regression
Commands:
- `cargo test -p kamn-core --test p2p_transport_docs`
- `cargo test -p kamn-core --test runtime_network_docs`
- `cargo fmt --check`
- `cargo clippy -p kamn-node -- -D warnings`
- `cargo clippy -p kamn-core -- -D warnings`

Result:
- Regression/doc tests and lint/format checks pass.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | Existing unit classifier test rerun; deterministic remediation helper exercised via new regression path | |
| Functional   | ✅     | Existing functional classifier enforcement test rerun | |
| Integration  | N/A    | | Scope is policy diagnostics + docs; no new cross-service integration path introduced |
| Regression   | ✅     | `regression_production_transport_policy_error_detail_includes_remediation_guidance` | |
| Performance  | N/A    | | No runtime throughput behavior changes |

## Risks & Rollback
- Risk: detail-string changes may require downstream parser adjustment if any consumer parses full error text instead of reason code.
- Rollback plan: revert this PR to restore previous detail text while preserving existing reason codes.

## Documentation Updates
- Updated `docs/foundation/runtime-network.md`.
- Updated `docs/architecture/p2p-transport.md`.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (run as `cargo clippy -p kamn-node -- -D warnings` and `cargo clippy -p kamn-core -- -D warnings`)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
