### PR TITLE
test(escrow): restore strict clippy cleanliness for kamn-core tests

### DIFF
--- a/crates/kamn-core/tests/task_escrow_proptest_invariants.rs
+++ b/crates/kamn-core/tests/task_escrow_proptest_invariants.rs
@@ -94,7 +94,7 @@ fn apply_escrow_action(
             let amount = if remaining == 0 {
                 1
             } else {
-                (remaining.saturating_mul(u128::from(scale)) + 15) / 16
+                remaining.saturating_mul(u128::from(scale)).div_ceil(16)
             }
             .max(1);
             escrow.release(amount)


### PR DESCRIPTION
Closes #3690
Refs #3631

## Summary
This change fixes a strict clippy warning-as-error blocker in kamn-core tests by replacing a manual ceiling-division expression with the idiomatic `div_ceil` API. It restores clean execution for the strict clippy gate used for reliability checks.

## Changes
- `crates/kamn-core/tests/task_escrow_proptest_invariants.rs`: replaced manual `(x + 15) / 16` style expression with `x.div_ceil(16)` in escrow action scaling logic

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
`cargo clippy -p kamn-core --features libp2p-live-transport --tests -- -D warnings`

Failure:
`clippy::manual_div_ceil` at `crates/kamn-core/tests/task_escrow_proptest_invariants.rs:97`

### 🟢 Green Phase
Command:
`cargo clippy -p kamn-core --features libp2p-live-transport --tests -- -D warnings`

Result:
Passes clean with no warnings/errors.

### 🔁 Regression
Commands:
- `cargo fmt --check`
- `cargo test -p kamn-core --features libp2p-live-transport --test task_escrow_proptest_invariants`

Result:
All pass (`5 passed; 0 failed`).

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | N/A    | None                 | Lint-only expression change in existing test harness logic |
| Functional   | ✅     | Existing task escrow proptest functional invariant test | N/A |
| Integration  | ✅     | Existing `task_escrow_proptest_invariants` integration target | N/A |
| Regression   | ✅     | Strict clippy red/green command rerun | N/A |
| Performance  | N/A    | None                 | No runtime-path performance behavior changed |

## Risks & Rollback
- None.
- Rollback: revert this commit to restore previous expression.

## Documentation Updates
- None required; this task resolves a lint gate defect and does not alter runtime/API behavior.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (executed as `cargo clippy -p kamn-core --features libp2p-live-transport --tests -- -D warnings`)
- [x] TDD Red/Green evidence included above
