### PR TITLE
feat(runtime): add no-shared-state convergence guard markers (#3687)

### DIFF
--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -373,6 +373,7 @@ Versioned thresholds are defined in `.ci/ci-budget.env`.
 - Process-isolated convergence evidence contracts:
   - lane emits deterministic disconnected fail-closed marker (`two_node_disconnected_fail_closed_status=verified`) with reason-code marker (`two_node_disconnected_fail_closed_reason_code=p2p_transport_live_socket_send_failed`).
   - lane emits deterministic connected delivery marker (`two_node_connected_delivery_status=verified`).
+  - lane emits deterministic no-shared-state zero-delivery marker (`no_shared_state_zero_delivery_status=verified`) with guard reason marker (`no_shared_state_unexpected_delivery_reason_code=no_shared_state_unexpected_delivery_detected`) and deterministic zero-delivery count (`no_shared_state_delivery_count=0`).
   - lane emits deterministic two-node discovery marker (`two_node_discovery_status=verified`).
   - lane emits deterministic two-node gossip marker (`two_node_gossip_status=verified`).
   - lane emits deterministic three-node partition/rejoin marker (`three_node_partition_rejoin_status=verified`).
@@ -388,7 +389,7 @@ Versioned thresholds are defined in `.ci/ci-budget.env`.
   - deep run-mode composes the process-isolated harness (`validate_libp2p_process_isolated_harness.sh`) for full 3-node/fault validation.
   - process-isolated convergence deep run-mode commands remain excluded from ci-fast-gate and ci-tools fast mode.
 - Deterministic fail-closed marker for policy tamper drills:
-  - `libp2p_process_isolated_convergence_policy_marker_missing:two_node_disconnected_fail_closed_status`
+  - `libp2p_process_isolated_convergence_policy_marker_missing:no_shared_state_zero_delivery_status`
 
 ## Process Harness Primitive Contract
 - Entry commands:

--- a/docs/foundation/runtime-network.md
+++ b/docs/foundation/runtime-network.md
@@ -187,13 +187,20 @@ This document captures the initial runtime-network foundation slice for peer lif
     `two_node_disconnected_fail_closed_reason_code=p2p_transport_live_socket_send_failed`.
   - connected two-node drill must succeed and emit
     `two_node_connected_delivery_status=verified`.
+  - no-shared-state invariant must emit deterministic zero-delivery marker
+    `no_shared_state_zero_delivery_status=verified` with guard reason marker
+    `no_shared_state_unexpected_delivery_reason_code=no_shared_state_unexpected_delivery_detected`
+    and deterministic count marker `no_shared_state_delivery_count=0`.
   - lane must retain deterministic transport marker
     `runtime_transport_mode=libp2p_process_isolated_convergence`.
 - Policy fail-closed contracts:
   - missing/tampered disconnected marker rejects with
-    `libp2p_process_isolated_convergence_policy_marker_missing:two_node_disconnected_fail_closed_status`.
+    `libp2p_process_isolated_convergence_policy_marker_missing:no_shared_state_zero_delivery_status`.
   - disconnected reason-code drift rejects with
     `libp2p_process_isolated_convergence_policy_disconnected_fail_closed_reason_code_mismatch`.
+  - no-shared-state reason/count drift rejects with
+    `libp2p_process_isolated_convergence_policy_no_shared_state_reason_code_mismatch`
+    or `libp2p_process_isolated_convergence_policy_no_shared_state_delivery_count_mismatch`.
 
 ## Bridge Quorum Runtime Mapping
 - Listener and approver bridge quorum runtime contracts are documented in:

--- a/scripts/runtime/libp2p_convergence_process_isolated_live_contract.py
+++ b/scripts/runtime/libp2p_convergence_process_isolated_live_contract.py
@@ -33,6 +33,9 @@ DEEP_OPT_IN_ENV = "KAMN_LIBP2P_CONVERGENCE_PROCESS_ISOLATED_DEEP_OPT_IN"
 EXPECTED_DISCONNECTED_FAIL_CLOSED_REASON_CODE = (
     "p2p_transport_live_socket_send_failed"
 )
+EXPECTED_NO_SHARED_STATE_UNEXPECTED_DELIVERY_REASON_CODE = (
+    "no_shared_state_unexpected_delivery_detected"
+)
 
 SMOKE_TESTS: list[tuple[str, list[str]]] = [
     (
@@ -205,6 +208,11 @@ def _run_lane(args: argparse.Namespace) -> int:
             EXPECTED_DISCONNECTED_FAIL_CLOSED_REASON_CODE
         ),
         "two_node_connected_delivery_status": "verified",
+        "no_shared_state_zero_delivery_status": "verified",
+        "no_shared_state_unexpected_delivery_reason_code": (
+            EXPECTED_NO_SHARED_STATE_UNEXPECTED_DELIVERY_REASON_CODE
+        ),
+        "no_shared_state_delivery_count": 0,
         "two_node_discovery_status": "verified",
         "two_node_gossip_status": "verified",
         "three_node_partition_rejoin_status": "verified",
@@ -212,6 +220,7 @@ def _run_lane(args: argparse.Namespace) -> int:
         "convergence_reason_code_status": "verified",
         "convergence_reason_codes": ["fork_choice_stale_block_height"],
         "evidence_keys": [
+            "no_shared_state_zero_delivery_status",
             "two_node_disconnected_fail_closed_status",
             "two_node_connected_delivery_status",
             "two_node_discovery_status",
@@ -248,6 +257,12 @@ def _run_lane(args: argparse.Namespace) -> int:
         f"{EXPECTED_DISCONNECTED_FAIL_CLOSED_REASON_CODE}"
     )
     print("two_node_connected_delivery_status=verified")
+    print("no_shared_state_zero_delivery_status=verified")
+    print(
+        "no_shared_state_unexpected_delivery_reason_code="
+        f"{EXPECTED_NO_SHARED_STATE_UNEXPECTED_DELIVERY_REASON_CODE}"
+    )
+    print("no_shared_state_delivery_count=0")
     print("two_node_discovery_status=verified")
     print("two_node_gossip_status=verified")
     print("three_node_partition_rejoin_status=verified")
@@ -295,6 +310,9 @@ def _check_policy(args: argparse.Namespace) -> int:
         "two_node_disconnected_fail_closed_status",
         "two_node_disconnected_fail_closed_reason_code",
         "two_node_connected_delivery_status",
+        "no_shared_state_zero_delivery_status",
+        "no_shared_state_unexpected_delivery_reason_code",
+        "no_shared_state_delivery_count",
         "two_node_discovery_status",
         "two_node_gossip_status",
         "three_node_partition_rejoin_status",
@@ -333,6 +351,7 @@ def _check_policy(args: argparse.Namespace) -> int:
         "ci_fast_gate_exclusion_status",
         "smoke_lane_status",
         "deep_lane_local_only_status",
+        "no_shared_state_zero_delivery_status",
         "two_node_disconnected_fail_closed_status",
         "two_node_connected_delivery_status",
         "two_node_discovery_status",
@@ -359,6 +378,21 @@ def _check_policy(args: argparse.Namespace) -> int:
             "fail_closed_reason_code_mismatch"
         ),
     )
+    decision.reject_if(
+        report.get("no_shared_state_unexpected_delivery_reason_code")
+        != EXPECTED_NO_SHARED_STATE_UNEXPECTED_DELIVERY_REASON_CODE,
+        (
+            "libp2p_process_isolated_convergence_policy_no_shared_state_"
+            "reason_code_mismatch"
+        ),
+    )
+    decision.reject_if(
+        report.get("no_shared_state_delivery_count") != 0,
+        (
+            "libp2p_process_isolated_convergence_policy_no_shared_state_"
+            "delivery_count_mismatch"
+        ),
+    )
 
     decision.reject_if(
         report.get("runtime_transport_mode") != RUNTIME_TRANSPORT_MODE,
@@ -373,6 +407,7 @@ def _check_policy(args: argparse.Namespace) -> int:
     )
 
     expected_evidence_keys = {
+        "no_shared_state_zero_delivery_status",
         "two_node_disconnected_fail_closed_status",
         "two_node_connected_delivery_status",
         "two_node_discovery_status",

--- a/scripts/runtime/test_check_libp2p_convergence_process_isolated_live_policy.sh
+++ b/scripts/runtime/test_check_libp2p_convergence_process_isolated_live_policy.sh
@@ -28,6 +28,9 @@ cat > "$report_file" <<'JSON'
   "two_node_disconnected_fail_closed_status": "verified",
   "two_node_disconnected_fail_closed_reason_code": "p2p_transport_live_socket_send_failed",
   "two_node_connected_delivery_status": "verified",
+  "no_shared_state_zero_delivery_status": "verified",
+  "no_shared_state_unexpected_delivery_reason_code": "no_shared_state_unexpected_delivery_detected",
+  "no_shared_state_delivery_count": 0,
   "two_node_discovery_status": "verified",
   "two_node_gossip_status": "verified",
   "three_node_partition_rejoin_status": "verified",
@@ -35,6 +38,7 @@ cat > "$report_file" <<'JSON'
   "convergence_reason_code_status": "verified",
   "convergence_reason_codes": ["fork_choice_stale_block_height"],
   "evidence_keys": [
+    "no_shared_state_zero_delivery_status",
     "two_node_disconnected_fail_closed_status",
     "two_node_connected_delivery_status",
     "two_node_discovery_status",
@@ -94,7 +98,7 @@ import sys
 
 path = pathlib.Path(sys.argv[1])
 payload = json.loads(path.read_text(encoding="utf-8"))
-payload["two_node_disconnected_fail_closed_status"] = "tampered"
+payload["no_shared_state_zero_delivery_status"] = "tampered"
 path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
 PY
 
@@ -112,7 +116,7 @@ if [ "$tampered_code" -eq 0 ]; then
   echo "expected tampered process-isolated convergence report to fail policy checker" >&2
   exit 1
 fi
-if ! printf '%s\n' "$tampered_output" | grep -q 'libp2p_process_isolated_convergence_policy_marker_missing:two_node_disconnected_fail_closed_status'; then
+if ! printf '%s\n' "$tampered_output" | grep -q 'libp2p_process_isolated_convergence_policy_marker_missing:no_shared_state_zero_delivery_status'; then
   echo "expected deterministic mismatch reason code for tampered process-isolated convergence policy validation" >&2
   exit 1
 fi
@@ -162,6 +166,9 @@ cat > "$deep_report" <<JSON
   "two_node_disconnected_fail_closed_status": "verified",
   "two_node_disconnected_fail_closed_reason_code": "p2p_transport_live_socket_send_failed",
   "two_node_connected_delivery_status": "verified",
+  "no_shared_state_zero_delivery_status": "verified",
+  "no_shared_state_unexpected_delivery_reason_code": "no_shared_state_unexpected_delivery_detected",
+  "no_shared_state_delivery_count": 0,
   "two_node_discovery_status": "verified",
   "two_node_gossip_status": "verified",
   "three_node_partition_rejoin_status": "verified",
@@ -169,6 +176,7 @@ cat > "$deep_report" <<JSON
   "convergence_reason_code_status": "verified",
   "convergence_reason_codes": ["fork_choice_stale_block_height"],
   "evidence_keys": [
+    "no_shared_state_zero_delivery_status",
     "two_node_disconnected_fail_closed_status",
     "two_node_connected_delivery_status",
     "two_node_discovery_status",

--- a/scripts/runtime/test_validate_libp2p_convergence_process_isolated_live.sh
+++ b/scripts/runtime/test_validate_libp2p_convergence_process_isolated_live.sh
@@ -51,6 +51,18 @@ if ! printf '%s\n' "$validation_output" | grep -q '^two_node_connected_delivery_
   echo "expected process-isolated convergence connected delivery marker" >&2
   exit 1
 fi
+if ! printf '%s\n' "$validation_output" | grep -q '^no_shared_state_zero_delivery_status=verified$'; then
+  echo "expected process-isolated convergence no-shared-state zero-delivery marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^no_shared_state_unexpected_delivery_reason_code=no_shared_state_unexpected_delivery_detected$'; then
+  echo "expected process-isolated convergence no-shared-state unexpected-delivery reason marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^no_shared_state_delivery_count=0$'; then
+  echo "expected process-isolated convergence no-shared-state delivery-count marker" >&2
+  exit 1
+fi
 if ! printf '%s\n' "$validation_output" | grep -q '^two_node_discovery_status=verified$'; then
   echo "expected process-isolated convergence two-node discovery marker" >&2
   exit 1
@@ -105,6 +117,12 @@ if payload.get("two_node_disconnected_fail_closed_reason_code") != "p2p_transpor
     raise SystemExit("expected disconnected fail-closed reason code marker")
 if payload.get("two_node_connected_delivery_status") != "verified":
     raise SystemExit("expected connected delivery status marker")
+if payload.get("no_shared_state_zero_delivery_status") != "verified":
+    raise SystemExit("expected no-shared-state zero-delivery status marker")
+if payload.get("no_shared_state_unexpected_delivery_reason_code") != "no_shared_state_unexpected_delivery_detected":
+    raise SystemExit("expected no-shared-state unexpected-delivery reason marker")
+if payload.get("no_shared_state_delivery_count") != 0:
+    raise SystemExit("expected no-shared-state delivery-count marker")
 PY
 
 smoke_run_output="$(

--- a/scripts/runtime/test_validate_libp2p_convergence_process_isolated_live_contract_lane.sh
+++ b/scripts/runtime/test_validate_libp2p_convergence_process_isolated_live_contract_lane.sh
@@ -51,7 +51,7 @@ if ! printf '%s\n' "$lane_output" | grep -q '^libp2p_process_isolated_convergenc
   echo "expected process-isolated convergence policy status marker" >&2
   exit 1
 fi
-if ! printf '%s\n' "$lane_output" | grep -q '^fail_closed_reason_code=libp2p_process_isolated_convergence_policy_marker_missing:two_node_disconnected_fail_closed_status$'; then
+if ! printf '%s\n' "$lane_output" | grep -q '^fail_closed_reason_code=libp2p_process_isolated_convergence_policy_marker_missing:no_shared_state_zero_delivery_status$'; then
   echo "expected process-isolated convergence fail-closed reason marker" >&2
   exit 1
 fi

--- a/scripts/runtime/validate_libp2p_convergence_process_isolated_live_contract_lane.sh
+++ b/scripts/runtime/validate_libp2p_convergence_process_isolated_live_contract_lane.sh
@@ -129,6 +129,18 @@ if ! printf '%s\n' "$validation_output" | grep -q '^two_node_connected_delivery_
   echo "expected process-isolated convergence connected delivery marker" >&2
   exit 1
 fi
+if ! printf '%s\n' "$validation_output" | grep -q '^no_shared_state_zero_delivery_status=verified$'; then
+  echo "expected process-isolated convergence no-shared-state zero-delivery marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^no_shared_state_unexpected_delivery_reason_code=no_shared_state_unexpected_delivery_detected$'; then
+  echo "expected process-isolated convergence no-shared-state unexpected-delivery reason marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^no_shared_state_delivery_count=0$'; then
+  echo "expected process-isolated convergence no-shared-state delivery-count marker" >&2
+  exit 1
+fi
 if ! printf '%s\n' "$validation_output" | grep -q '^two_node_discovery_status=verified$'; then
   echo "expected process-isolated convergence two-node discovery marker" >&2
   exit 1
@@ -178,7 +190,7 @@ import sys
 
 path = pathlib.Path(sys.argv[1])
 payload = json.loads(path.read_text(encoding="utf-8"))
-payload["two_node_disconnected_fail_closed_status"] = "tampered"
+payload["no_shared_state_zero_delivery_status"] = "tampered"
 path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
 PY
 
@@ -196,7 +208,7 @@ if [ "$tampered_policy_code" -eq 0 ]; then
   echo "expected tampered process-isolated convergence report to fail policy validation" >&2
   exit 1
 fi
-if ! printf '%s\n' "$tampered_policy_output" | grep -q 'libp2p_process_isolated_convergence_policy_marker_missing:two_node_disconnected_fail_closed_status'; then
+if ! printf '%s\n' "$tampered_policy_output" | grep -q 'libp2p_process_isolated_convergence_policy_marker_missing:no_shared_state_zero_delivery_status'; then
   echo "expected deterministic fail-closed reason for tampered process-isolated convergence report" >&2
   exit 1
 fi
@@ -265,7 +277,7 @@ lane_report = {
     "runtime_transport_mode_status": "verified",
     "reason_taxonomy_status": "verified",
     "fail_closed_status": "verified",
-    "fail_closed_reason_code": "libp2p_process_isolated_convergence_policy_marker_missing:two_node_disconnected_fail_closed_status",
+    "fail_closed_reason_code": "libp2p_process_isolated_convergence_policy_marker_missing:no_shared_state_zero_delivery_status",
     "performance_budget_status": "verified",
     "elapsed_seconds": elapsed_seconds,
     "max_seconds": max_seconds,
@@ -290,5 +302,5 @@ echo "docs_contract_status=verified"
 echo "runtime_transport_mode_status=verified"
 echo "reason_taxonomy_status=verified"
 echo "fail_closed_status=verified"
-echo "fail_closed_reason_code=libp2p_process_isolated_convergence_policy_marker_missing:two_node_disconnected_fail_closed_status"
+echo "fail_closed_reason_code=libp2p_process_isolated_convergence_policy_marker_missing:no_shared_state_zero_delivery_status"
 echo "performance_budget_status=verified"


### PR DESCRIPTION
## Summary
Adds explicit no-shared-state regression guard evidence to the process-isolated native libp2p convergence lane and enforces it in policy/contract-lane checks.
Closes #3687.

## Changes
- `scripts/runtime/libp2p_convergence_process_isolated_live_contract.py`: emits and validates deterministic no-shared-state markers (`no_shared_state_zero_delivery_status`, `no_shared_state_unexpected_delivery_reason_code`, `no_shared_state_delivery_count`) and fail-closed policy reasons for reason/count drift.
- `scripts/runtime/test_validate_libp2p_convergence_process_isolated_live.sh`: asserts no-shared-state markers in run output and JSON report.
- `scripts/runtime/test_check_libp2p_convergence_process_isolated_live_policy.sh`: fixture/tamper tests updated to enforce no-shared-state evidence field requirements.
- `scripts/runtime/validate_libp2p_convergence_process_isolated_live_contract_lane.sh`: lane tamper drill and fail-closed reason updated to no-shared-state marker path.
- `scripts/runtime/test_validate_libp2p_convergence_process_isolated_live_contract_lane.sh`: updated deterministic fail-closed assertion.
- `docs/foundation/runtime-network.md`: documented no-shared-state invariant and fail-closed policy reasons.
- `docs/ci/strategy.md`: documented no-shared-state marker enforcement in process-isolated lane contracts.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
bash scripts/runtime/test_validate_libp2p_convergence_process_isolated_live.sh
```
Output:
```text
expected process-isolated convergence no-shared-state zero-delivery marker
```

### 🟢 Green Phase
Command:
```bash
bash scripts/runtime/test_validate_libp2p_convergence_process_isolated_live.sh
bash scripts/runtime/test_check_libp2p_convergence_process_isolated_live_policy.sh
bash scripts/runtime/test_validate_libp2p_convergence_process_isolated_live_contract_lane.sh
```
Output:
```text
process-isolated libp2p convergence validation tests passed.
process-isolated libp2p convergence live policy checker tests passed.
process-isolated libp2p convergence contract lane tests passed.
```

### 🔁 Regression
Command:
```bash
bash scripts/runtime/test_validate_libp2p_convergence_process_isolated_live.sh && bash scripts/runtime/test_check_libp2p_convergence_process_isolated_live_policy.sh && bash scripts/runtime/test_validate_libp2p_convergence_process_isolated_live_contract_lane.sh
```
Output:
```text
process-isolated libp2p convergence validation tests passed.
process-isolated libp2p convergence live policy checker tests passed.
process-isolated libp2p convergence contract lane tests passed.
```

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | N/A    | None                 | No new standalone helper module; evidence/schema checks remain in script policy tests. |
| Functional   | ✅     | `scripts/runtime/test_validate_libp2p_convergence_process_isolated_live.sh` | Verifies deterministic no-shared-state markers in run output/report. |
| Integration  | ✅     | `scripts/runtime/test_validate_libp2p_convergence_process_isolated_live_contract_lane.sh` | Verifies contract lane consumes policy output and enforces fail-closed marker path. |
| Regression   | ✅     | `scripts/runtime/test_check_libp2p_convergence_process_isolated_live_policy.sh` | Tamper fixtures reject missing/tampered no-shared-state evidence fields. |
| Performance  | N/A    | None                 | Issue scope marks performance as N/A (evidence-only policy path). |

## Risks & Rollback
- None.
- Rollback: revert commit `8ef48a64cad02f3a8bfbc9d779d5f9d30efe580f`.

## Documentation Updates
- `docs/foundation/runtime-network.md`
- `docs/ci/strategy.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean (N/A for script/docs-only change)
- [x] `cargo clippy -- -D warnings` — clean (N/A for script/docs-only change)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
