### PR TITLE
feat(runtime): enforce native compile marker in process-isolated convergence lane

### DIFF
--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -388,6 +388,7 @@ Versioned thresholds are defined in `.ci/ci-budget.env`.
   - lane emits deterministic no-shared-state zero-delivery marker (`no_shared_state_zero_delivery_status=verified`) with guard reason marker (`no_shared_state_unexpected_delivery_reason_code=no_shared_state_unexpected_delivery_detected`) and deterministic zero-delivery count (`no_shared_state_delivery_count=0`).
   - lane emits deterministic two-node discovery marker (`two_node_discovery_status=verified`).
   - lane emits deterministic two-node gossip marker (`two_node_gossip_status=verified`).
+  - lane emits deterministic native compile-mode marker (`native_compile_mode_status=verified`).
   - lane emits deterministic three-node partition/rejoin marker (`three_node_partition_rejoin_status=verified`).
   - lane emits deterministic three-node publish-drop recovery marker (`three_node_publish_drop_recovery_status=verified`).
   - lane emits deterministic convergence reason-code marker (`convergence_reason_code_status=verified`) with reason-code matrix (`convergence_reason_codes=fork_choice_stale_block_height`).

--- a/docs/foundation/runtime-network.md
+++ b/docs/foundation/runtime-network.md
@@ -193,6 +193,8 @@ This document captures the initial runtime-network foundation slice for peer lif
     `two_node_disconnected_fail_closed_reason_code=p2p_transport_live_socket_send_failed`.
   - connected two-node drill must succeed and emit
     `two_node_connected_delivery_status=verified`.
+  - lane must emit deterministic native compile-mode marker
+    `native_compile_mode_status=verified`.
   - no-shared-state invariant must emit deterministic zero-delivery marker
     `no_shared_state_zero_delivery_status=verified` with guard reason marker
     `no_shared_state_unexpected_delivery_reason_code=no_shared_state_unexpected_delivery_detected`

--- a/scripts/runtime/libp2p_convergence_process_isolated_live_contract.py
+++ b/scripts/runtime/libp2p_convergence_process_isolated_live_contract.py
@@ -70,6 +70,20 @@ SMOKE_TESTS: list[tuple[str, list[str]]] = [
             "--exact",
         ],
     ),
+    (
+        "native_runtime_marker_contract",
+        [
+            "cargo",
+            "test",
+            "-p",
+            "kamn-node",
+            "--test",
+            "native_libp2p_feature_contract",
+            "dependency_contract_enables_native_libp2p_transport_feature_for_kamn_core",
+            "--",
+            "--exact",
+        ],
+    ),
 ]
 
 DEEP_HARNESS_VALIDATION = (
@@ -215,6 +229,7 @@ def _run_lane(args: argparse.Namespace) -> int:
         "no_shared_state_delivery_count": 0,
         "two_node_discovery_status": "verified",
         "two_node_gossip_status": "verified",
+        "native_compile_mode_status": "verified",
         "three_node_partition_rejoin_status": "verified",
         "three_node_publish_drop_recovery_status": "verified",
         "convergence_reason_code_status": "verified",
@@ -225,6 +240,7 @@ def _run_lane(args: argparse.Namespace) -> int:
             "two_node_connected_delivery_status",
             "two_node_discovery_status",
             "two_node_gossip_status",
+            "native_compile_mode_status",
             "three_node_partition_rejoin_status",
             "three_node_publish_drop_recovery_status",
             "convergence_reason_code_status",
@@ -265,6 +281,7 @@ def _run_lane(args: argparse.Namespace) -> int:
     print("no_shared_state_delivery_count=0")
     print("two_node_discovery_status=verified")
     print("two_node_gossip_status=verified")
+    print("native_compile_mode_status=verified")
     print("three_node_partition_rejoin_status=verified")
     print("three_node_publish_drop_recovery_status=verified")
     print("convergence_reason_code_status=verified")
@@ -315,6 +332,7 @@ def _check_policy(args: argparse.Namespace) -> int:
         "no_shared_state_delivery_count",
         "two_node_discovery_status",
         "two_node_gossip_status",
+        "native_compile_mode_status",
         "three_node_partition_rejoin_status",
         "three_node_publish_drop_recovery_status",
         "convergence_reason_code_status",
@@ -356,6 +374,7 @@ def _check_policy(args: argparse.Namespace) -> int:
         "two_node_connected_delivery_status",
         "two_node_discovery_status",
         "two_node_gossip_status",
+        "native_compile_mode_status",
         "three_node_partition_rejoin_status",
         "three_node_publish_drop_recovery_status",
         "convergence_reason_code_status",
@@ -412,6 +431,7 @@ def _check_policy(args: argparse.Namespace) -> int:
         "two_node_connected_delivery_status",
         "two_node_discovery_status",
         "two_node_gossip_status",
+        "native_compile_mode_status",
         "three_node_partition_rejoin_status",
         "three_node_publish_drop_recovery_status",
         "convergence_reason_code_status",

--- a/scripts/runtime/test_check_libp2p_convergence_process_isolated_live_policy.sh
+++ b/scripts/runtime/test_check_libp2p_convergence_process_isolated_live_policy.sh
@@ -33,6 +33,7 @@ cat > "$report_file" <<'JSON'
   "no_shared_state_delivery_count": 0,
   "two_node_discovery_status": "verified",
   "two_node_gossip_status": "verified",
+  "native_compile_mode_status": "verified",
   "three_node_partition_rejoin_status": "verified",
   "three_node_publish_drop_recovery_status": "verified",
   "convergence_reason_code_status": "verified",
@@ -43,6 +44,7 @@ cat > "$report_file" <<'JSON'
     "two_node_connected_delivery_status",
     "two_node_discovery_status",
     "two_node_gossip_status",
+    "native_compile_mode_status",
     "three_node_partition_rejoin_status",
     "three_node_publish_drop_recovery_status",
     "convergence_reason_code_status"
@@ -171,6 +173,7 @@ cat > "$deep_report" <<JSON
   "no_shared_state_delivery_count": 0,
   "two_node_discovery_status": "verified",
   "two_node_gossip_status": "verified",
+  "native_compile_mode_status": "verified",
   "three_node_partition_rejoin_status": "verified",
   "three_node_publish_drop_recovery_status": "verified",
   "convergence_reason_code_status": "verified",
@@ -181,6 +184,7 @@ cat > "$deep_report" <<JSON
     "two_node_connected_delivery_status",
     "two_node_discovery_status",
     "two_node_gossip_status",
+    "native_compile_mode_status",
     "three_node_partition_rejoin_status",
     "three_node_publish_drop_recovery_status",
     "convergence_reason_code_status"

--- a/scripts/runtime/test_validate_libp2p_convergence_process_isolated_live.sh
+++ b/scripts/runtime/test_validate_libp2p_convergence_process_isolated_live.sh
@@ -71,6 +71,10 @@ if ! printf '%s\n' "$validation_output" | grep -q '^two_node_gossip_status=verif
   echo "expected process-isolated convergence two-node gossip marker" >&2
   exit 1
 fi
+if ! printf '%s\n' "$validation_output" | grep -q '^native_compile_mode_status=verified$'; then
+  echo "expected process-isolated convergence native compile-mode marker" >&2
+  exit 1
+fi
 if ! printf '%s\n' "$validation_output" | grep -q '^three_node_partition_rejoin_status=verified$'; then
   echo "expected process-isolated convergence partition/rejoin marker" >&2
   exit 1
@@ -123,6 +127,8 @@ if payload.get("no_shared_state_unexpected_delivery_reason_code") != "no_shared_
     raise SystemExit("expected no-shared-state unexpected-delivery reason marker")
 if payload.get("no_shared_state_delivery_count") != 0:
     raise SystemExit("expected no-shared-state delivery-count marker")
+if payload.get("native_compile_mode_status") != "verified":
+    raise SystemExit("expected native compile-mode marker")
 PY
 
 smoke_run_output="$(
@@ -137,8 +143,8 @@ if ! printf '%s\n' "$smoke_run_output" | grep -q '^execution_reason_code=run_mod
   echo "expected smoke run-mode command execution marker" >&2
   exit 1
 fi
-if ! printf '%s\n' "$smoke_run_output" | grep -q '^command_count=2$'; then
-  echo "expected smoke run-mode command_count=2 marker" >&2
+if ! printf '%s\n' "$smoke_run_output" | grep -q '^command_count=3$'; then
+  echo "expected smoke run-mode command_count=3 marker" >&2
   exit 1
 fi
 

--- a/scripts/runtime/validate_libp2p_convergence_process_isolated_live_contract_lane.sh
+++ b/scripts/runtime/validate_libp2p_convergence_process_isolated_live_contract_lane.sh
@@ -149,6 +149,10 @@ if ! printf '%s\n' "$validation_output" | grep -q '^two_node_gossip_status=verif
   echo "expected process-isolated convergence two-node gossip marker" >&2
   exit 1
 fi
+if ! printf '%s\n' "$validation_output" | grep -q '^native_compile_mode_status=verified$'; then
+  echo "expected process-isolated convergence native compile-mode marker" >&2
+  exit 1
+fi
 if ! printf '%s\n' "$validation_output" | grep -q '^three_node_partition_rejoin_status=verified$'; then
   echo "expected process-isolated convergence three-node partition/rejoin marker" >&2
   exit 1


### PR DESCRIPTION
Closes #3707
Closes #3708
Closes #3709

## Summary
Extends the process-isolated libp2p convergence lane to include an explicit native compile-mode contract marker and policy enforcement. This hardens two-node lane evidence so native build-marker drift fails closed in both lane reports and policy checks.

## Changes
- `scripts/runtime/libp2p_convergence_process_isolated_live_contract.py`
  - Added a third smoke command that validates native build wiring via `kamn-node` dependency contract test.
  - Added `native_compile_mode_status=verified` marker to lane output and report payload.
  - Added native marker to required fields, marker-validation loop, and evidence-key set in policy checks.
- `scripts/runtime/test_validate_libp2p_convergence_process_isolated_live.sh`
  - Added native marker assertions and updated smoke command count expectation from `2` to `3`.
- `scripts/runtime/test_check_libp2p_convergence_process_isolated_live_policy.sh`
  - Added native marker to baseline report fixtures and evidence key sets.
- `scripts/runtime/validate_libp2p_convergence_process_isolated_live_contract_lane.sh`
  - Added contract-lane assertion for native compile-mode marker.
- `docs/foundation/runtime-network.md`
  - Documented native compile-mode marker in process-isolated convergence evidence contracts.
- `docs/ci/strategy.md`
  - Added native compile-mode marker to process-isolated convergence lane evidence contracts.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- Added new marker expectations in lane and policy test fixtures:
  - `native_compile_mode_status=verified`
  - smoke run command count updated to include native marker contract test.
- Without implementation updates, these expectations fail because lane payload/policy did not emit or validate the native marker.

### 🟢 Green Phase
- `bash scripts/runtime/test_validate_libp2p_convergence_process_isolated_live.sh`
- `bash scripts/runtime/test_check_libp2p_convergence_process_isolated_live_policy.sh`
- `bash scripts/runtime/test_validate_libp2p_convergence_process_isolated_live_contract_lane.sh`

### 🔁 Regression
- `bash scripts/ci/test_libp2p_convergence_process_isolated_ci_exclusion_policy.sh`
- `cargo test -p kamn-core --test ci_strategy_docs`
- `cargo test -p kamn-core --test runtime_network_docs doc_contains_runtime_network_scope_and_models -- --exact`

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | lane report/policy marker validation paths in contract python | |
| Functional   | ✅ | smoke lane output now requires native compile marker | |
| Integration  | ✅ | contract-lane + policy fixture tests across scripts | |
| Regression   | ✅ | CI exclusion policy + docs contracts rerun and green | |
| Performance  | N/A | | no runtime algorithm changes; contract marker and bounded command matrix update only |

## Risks & Rollback
- Risk: smoke lane now runs one additional bounded command (`native_libp2p_feature_contract`), slightly increasing local lane runtime.
- Rollback: revert commit `66e2bc3b`.

## Documentation Updates
- `docs/foundation/runtime-network.md`
- `docs/ci/strategy.md`

## Validation Checklist
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing for changed scope
- [x] Docs updated
