### PR TITLE
feat(runtime): combine native libp2p convergence with Kolme full-stack lane

### DIFF
--- a/docs/architecture/kolme-live-integration.md
+++ b/docs/architecture/kolme-live-integration.md
@@ -9,8 +9,9 @@ runtime signing and `njfio/kolme_fork` compatibility expectations.
   - `scripts/runtime/validate_local_full_stack_integration_live.sh` is the top-level composed runtime lane.
   - run-mode composition includes:
     - `scripts/runtime/validate_full_io_scenario_matrix_live.sh`
-    - `scripts/runtime/validate_local_full_runtime_live.sh`
-    - `scripts/kolme/run_local_kamn_live_runtime_integration_contract_lane.sh`
+    - `scripts/runtime/validate_libp2p_convergence_process_isolated_live.sh`
+    - `scripts/runtime/check_libp2p_convergence_process_isolated_live_policy.sh`
+    - `scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh`
 - Evidence lineage:
   - top-level summary schema: `kamn.runtime.local-full-stack-integration-live-report.v1`
   - nested Kolme summary schema: `kamn.kolme.local-kamn-live-runtime-integration-summary.v1`
@@ -22,13 +23,20 @@ runtime signing and `njfio/kolme_fork` compatibility expectations.
   - `signer_provenance_status`
   - `runtime_commit_submission_status`
   - `runtime_commit_finality_status`
-  - `runtime_commit_failure_taxonomy`
+  - `combined_reason_taxonomy_version=kamn.runtime.local-full-stack-integration-reason-taxonomy.v1`
+  - `combined_transport_reason_codes=fork_choice_stale_block_height`
+  - `combined_kolme_runtime_reason_code`
+  - `kolme_runtime_commit_failure_taxonomy_version=v1`
+  - `kolme_runtime_commit_failure_taxonomy`
+  - `kolme_fixture_profile=real-node-non-synthetic-v1`
+  - `kolme_fixture_profile_version=v1`
+  - `kolme_fixture_profile_status`
   - `runtime_provider_contract_status`
   - `runtime_provider_client_contract=KolmeRuntimeCommitLiveProvider`
   - `runtime_signing_profile=kolme-fork-secp256k1-v1`
   - `runtime_signer_attestation_schema_version=kamn.kolme.runtime-signer-attestation.v1`
 - Deterministic fail-closed reasons:
-  - `local_full_stack_integration_policy_runtime_commit_finality_status_mismatch`
+  - `local_full_stack_integration_policy_reason_taxonomy_version_mismatch`
   - `local_full_stack_integration_policy_kolme_summary_schema_mismatch`
   - `local_full_stack_integration_policy_kolme_policy_final_decision_mismatch`
   - `release_manifest_missing_required_artifact:local_full_stack_integration`

--- a/docs/architecture/service-runtime.md
+++ b/docs/architecture/service-runtime.md
@@ -58,3 +58,26 @@ hand-rolled parser/listener path.
   - `GET` requests with non-empty body indicators (`Content-Length > 0` or
     `Transfer-Encoding`) resolve to deterministic `404 not found`
   - request budget and idle timeout remain deterministic and fail closed
+
+## Combined Native Transport + Kolme Commit Validation Flow
+
+The local full-stack integration lane composes native libp2p transport and
+Kolme runtime-commit checks in one local-heavy run.
+
+- Entry lane:
+  - `scripts/runtime/validate_local_full_stack_integration_live.sh`
+- Composed run-mode lanes:
+  - `scripts/runtime/validate_full_io_scenario_matrix_live.sh`
+  - `scripts/runtime/validate_libp2p_convergence_process_isolated_live.sh`
+  - `scripts/runtime/check_libp2p_convergence_process_isolated_live_policy.sh`
+  - `scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh`
+  - `scripts/kolme/check_local_kamn_live_runtime_integration_policy.py`
+- Combined fail-closed taxonomy contracts:
+  - `combined_reason_taxonomy_version=kamn.runtime.local-full-stack-integration-reason-taxonomy.v1`
+  - `combined_transport_reason_codes=fork_choice_stale_block_height`
+  - `combined_kolme_runtime_reason_code`
+  - `kolme_runtime_commit_failure_taxonomy_version=v1`
+  - `kolme_runtime_commit_failure_taxonomy`
+  - `kolme_fixture_profile=real-node-non-synthetic-v1`
+  - `kolme_fixture_profile_version=v1`
+  - `kolme_fixture_profile_status`

--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -45,7 +45,7 @@ Versioned thresholds are defined in `.ci/ci-budget.env`.
   - regression command surfaces must retain dry-run policy and contract-lane tests for both lanes in `scripts/ci/test_ci_tools.sh`.
 - Deterministic drift markers:
   - `full_io_scenario_matrix_policy_multinode_propagation_mismatch`
-  - `local_full_stack_integration_policy_runtime_commit_finality_status_mismatch`
+  - `local_full_stack_integration_policy_reason_taxonomy_version_mismatch`
   - `sqlite_crash_recovery_policy_fast_gate_exclusion_mismatch`
   - `live_transport_fault_matrix_policy_marker_missing:partition_rejoin_status`
   - `libp2p_process_isolated_convergence_policy_marker_missing:three_node_partition_rejoin_status`
@@ -468,7 +468,8 @@ Versioned thresholds are defined in `.ci/ci-budget.env`.
 - manual-hardened mode: manual
 - Integration composition contract:
   - composes full I/O scenario matrix lane (`validate_full_io_scenario_matrix_live.sh`) in run mode.
-  - composes full-runtime supervisor lane (`validate_local_full_runtime_live.sh`) in run mode.
+  - composes native libp2p convergence lane (`validate_libp2p_convergence_process_isolated_live.sh`) in deep run mode.
+  - composes native libp2p convergence policy checker (`check_libp2p_convergence_process_isolated_live_policy.sh`) in run mode.
   - composes Kolme runtime integration lane (`run_local_kamn_live_runtime_integration_lane.sh`) in run mode.
   - enforces top-level marker domains for:
     - transport convergence
@@ -478,6 +479,9 @@ Versioned thresholds are defined in `.ci/ci-budget.env`.
     - runtime provider contract (`KolmeRuntimeCommitLiveProvider`)
     - local-only Kolme checkout/remote/ref/base-url/fork-chain prerequisites
     - nested Kolme local-only enforcement and run-mode policy markers
+    - deterministic combined reason taxonomy version (`kamn.runtime.local-full-stack-integration-reason-taxonomy.v1`)
+    - deterministic transport reason taxonomy (`fork_choice_stale_block_height`)
+    - deterministic Kolme fixture profile (`real-node-non-synthetic-v1`, profile version `v1`)
   - architecture boundary reference: `docs/architecture/kolme-live-integration.md`
   - emits deterministic evidence bundle schema `kamn.runtime.local-full-stack-integration-evidence-bundle.v1`.
 - Cost controls:
@@ -486,7 +490,7 @@ Versioned thresholds are defined in `.ci/ci-budget.env`.
   - nested run-mode commands propagate local-only opt-in for composed lanes.
   - local full-stack integration run-mode commands remain excluded from ci-fast-gate and ci-tools fast mode.
 - Deterministic fail-closed marker for policy tamper drills:
-  - `local_full_stack_integration_policy_runtime_commit_finality_status_mismatch`
+  - `local_full_stack_integration_policy_reason_taxonomy_version_mismatch`
 
 ## Deploy Compose Topology Contract Lane
 - Entry commands:

--- a/docs/deploy/kolme_devnet_ops.md
+++ b/docs/deploy/kolme_devnet_ops.md
@@ -1,0 +1,9 @@
+# Kolme Devnet Ops (Compatibility Redirect)
+
+Canonical operations guidance for Kolme local-heavy and combined runtime
+validation lives in:
+
+- `docs/planning/kolme-devnet-ops.md`
+
+This compatibility path is kept so issue and PR references using
+`docs/deploy/kolme_devnet_ops.md` remain valid.

--- a/docs/foundation/runtime-network.md
+++ b/docs/foundation/runtime-network.md
@@ -678,6 +678,29 @@ This document captures the initial runtime-network foundation slice for peer lif
   - scheduled concurrency stress deep lane hook (`--ignored`)
   - scheduled snapshot recovery deep lane stress hook (`--ignored`)
 
+## Combined Native libp2p + Kolme Runtime Commit Taxonomy
+
+The combined local-heavy lane keeps runtime transport and Kolme commit evidence
+in a single fail-closed taxonomy surface.
+
+- Lane composition:
+  - `scripts/runtime/validate_local_full_stack_integration_live.sh`
+  - `scripts/runtime/validate_libp2p_convergence_process_isolated_live.sh`
+  - `scripts/runtime/check_libp2p_convergence_process_isolated_live_policy.sh`
+  - `scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh`
+  - `scripts/kolme/check_local_kamn_live_runtime_integration_policy.py`
+- Top-level taxonomy markers:
+  - `combined_reason_taxonomy_version=kamn.runtime.local-full-stack-integration-reason-taxonomy.v1`
+  - `combined_transport_reason_codes=fork_choice_stale_block_height`
+  - `combined_kolme_runtime_reason_code`
+  - `kolme_runtime_commit_failure_taxonomy_version=v1`
+  - `kolme_runtime_commit_failure_taxonomy`
+  - `kolme_fixture_profile=real-node-non-synthetic-v1`
+  - `kolme_fixture_profile_version=v1`
+  - `kolme_fixture_profile_status`
+- Deterministic fail-closed drift marker:
+  - `local_full_stack_integration_policy_reason_taxonomy_version_mismatch`
+
 ## Fast and Cost-Effective Validation
 Run targeted checks first:
 

--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -25,7 +25,8 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
 - Composition contract:
   - run-mode composes:
     - `scripts/runtime/validate_full_io_scenario_matrix_live.sh`
-    - `scripts/runtime/validate_local_full_runtime_live.sh`
+    - `scripts/runtime/validate_libp2p_convergence_process_isolated_live.sh`
+    - `scripts/runtime/check_libp2p_convergence_process_isolated_live_policy.sh`
     - `scripts/kolme/run_local_kamn_live_runtime_integration_lane.sh`
   - nested Kolme summary/policy evidence is fail-closed for:
     - signer provenance markers
@@ -34,8 +35,11 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
     - provider contract marker `KolmeRuntimeCommitLiveProvider`
     - local checkout/remote/ref/base-url/fork-chain prerequisite markers
     - local-only enforcement and nested run-mode policy reason-code marker `live_runtime_integration_passed`
+    - combined reason taxonomy marker `kamn.runtime.local-full-stack-integration-reason-taxonomy.v1`
+    - combined transport reason marker `fork_choice_stale_block_height`
+    - deterministic Kolme fixture profile markers (`real-node-non-synthetic-v1`, profile version `v1`)
 - Deterministic tamper reason:
-  - `local_full_stack_integration_policy_runtime_commit_finality_status_mismatch`
+  - `local_full_stack_integration_policy_reason_taxonomy_version_mismatch`
 - Release go/no-go linkage:
   - `scripts/runtime/release_evidence_manifest.json` includes required artifact ids:
     `local_full_stack_integration`,

--- a/scripts/runtime/local_full_stack_integration_live_contract.py
+++ b/scripts/runtime/local_full_stack_integration_live_contract.py
@@ -29,17 +29,25 @@ from framework.contract_framework import (  # noqa: E402
 RUN_LANE_SCHEMA = "kamn.runtime.local-full-stack-integration-live-report.v1"
 POLICY_SCHEMA = "kamn.runtime.local-full-stack-integration-live-policy-report.v1"
 EVIDENCE_BUNDLE_SCHEMA = "kamn.runtime.local-full-stack-integration-evidence-bundle.v1"
+LIBP2P_CONVERGENCE_REPORT_SCHEMA = "kamn.runtime.libp2p-convergence-process-isolated-live-report.v1"
+LIBP2P_CONVERGENCE_POLICY_SCHEMA = "kamn.runtime.libp2p-convergence-process-isolated-live-policy-report.v1"
+LIBP2P_RUNTIME_TRANSPORT_MODE = "libp2p_process_isolated_convergence"
+LIBP2P_CONVERGENCE_REASON_CODE = "fork_choice_stale_block_height"
 KOLME_INTEGRATION_REPORT_SCHEMA = "kamn.kolme.local-kamn-live-runtime-integration-summary.v1"
 KOLME_INTEGRATION_POLICY_SCHEMA = "kamn.kolme.local-kamn-live-runtime-integration-policy-report.v1"
 KOLME_PROVIDER_CLIENT_CONTRACT = "KolmeRuntimeCommitLiveProvider"
 KOLME_RUNTIME_SIGNING_PROFILE = "kolme-fork-secp256k1-v1"
 KOLME_SIGNER_ATTESTATION_SCHEMA = "kamn.kolme.runtime-signer-attestation.v1"
+KOLME_RUNTIME_COMMIT_PROFILE = "real-node-non-synthetic-v1"
+KOLME_RUNTIME_COMMIT_PROFILE_VERSION = "v1"
+KOLME_RUNTIME_COMMIT_FAILURE_TAXONOMY_VERSION = "v1"
 KOLME_RUNTIME_INTEGRATION_RUN_REASON = "live_runtime_integration_passed"
 KOLME_DEFAULT_CHECKOUT_PATH = "/tmp/kolme_fork"
 KOLME_DEFAULT_EXPECTED_REMOTE_URL = "https://github.com/njfio/kolme_fork.git"
 KOLME_DEFAULT_EXPECTED_REF = "refs/heads/main"
 KOLME_DEFAULT_BASE_URL = "http://127.0.0.1:3000"
 KOLME_DEFAULT_FORK_CHAIN_VERSION = "v0.15.2"
+COMBINED_REASON_TAXONOMY_VERSION = "kamn.runtime.local-full-stack-integration-reason-taxonomy.v1"
 OPT_IN_ENV = "KAMN_LOCAL_FULL_STACK_INTEGRATION_OPT_IN"
 DRY_RUN_REASON = "dry_run_no_commands_executed"
 RUN_REASON = "local_full_stack_integration_live_validation_executed"
@@ -182,11 +190,19 @@ def run_lane(args: argparse.Namespace) -> int:
     kolme_local_only_enforced_status = "planned" if mode == "dry-run" else "verified"
     kolme_integration_mode_status = "planned" if mode == "dry-run" else "verified"
     kolme_integration_policy_status = "planned" if mode == "dry-run" else "verified"
+    kolme_fixture_profile_status = "planned" if mode == "dry-run" else "verified"
+    combined_transport_reason_codes: list[str] = [LIBP2P_CONVERGENCE_REASON_CODE]
+    combined_kolme_runtime_reason_code = "not_run"
+    kolme_runtime_commit_failure_taxonomy_version = KOLME_RUNTIME_COMMIT_FAILURE_TAXONOMY_VERSION
+    kolme_runtime_commit_failure_taxonomy = "not_run"
+    kolme_fixture_profile = KOLME_RUNTIME_COMMIT_PROFILE
+    kolme_fixture_profile_version = KOLME_RUNTIME_COMMIT_PROFILE_VERSION
 
     if mode == "run":
         artifact_dir = Path(tempfile.mkdtemp(prefix="local-full-stack-integration-live-"))
         full_io_report = artifact_dir / "full-io-scenario-matrix-report.json"
-        full_runtime_report = artifact_dir / "local-full-runtime-report.json"
+        libp2p_convergence_report = artifact_dir / "libp2p-convergence-process-isolated-report.json"
+        libp2p_convergence_policy_report = artifact_dir / "libp2p-convergence-process-isolated-policy.json"
         kolme_integration_report = artifact_dir / "kolme-runtime-integration-summary.json"
         kolme_integration_policy_report = artifact_dir / "kolme-runtime-integration-policy.json"
         evidence_bundle_file = artifact_dir / "local-full-stack-evidence-bundle.json"
@@ -213,12 +229,14 @@ def run_lane(args: argparse.Namespace) -> int:
             fail("full I/O scenario matrix command did not emit final_decision=GO")
         commands_executed += 1
 
-        full_runtime_output = _run_command(
+        libp2p_output = _run_command(
             [
                 "bash",
-                "scripts/runtime/validate_local_full_runtime_live.sh",
+                "scripts/runtime/validate_libp2p_convergence_process_isolated_live.sh",
                 "--mode",
                 "run",
+                "--lane-profile",
+                "deep",
                 "--ci-fast-gate",
                 "FAIL",
                 "--max-seconds",
@@ -226,15 +244,41 @@ def run_lane(args: argparse.Namespace) -> int:
                 "--command-max-seconds",
                 str(min(command_max_seconds, 180)),
                 "--output-json",
-                str(full_runtime_report),
+                str(libp2p_convergence_report),
             ],
             timeout_seconds=command_max_seconds,
-            env={**os.environ, "KAMN_LOCAL_FULL_RUNTIME_LIVE_OPT_IN": "1"},
+            env={
+                **os.environ,
+                "KAMN_LIBP2P_CONVERGENCE_PROCESS_ISOLATED_DEEP_OPT_IN": "1",
+            },
         )
-        if _extract_line_value(full_runtime_output, "status") != "pass":
-            fail("local full-runtime command did not emit status=pass")
-        if _extract_line_value(full_runtime_output, "final_decision") != "GO":
-            fail("local full-runtime command did not emit final_decision=GO")
+        if _extract_line_value(libp2p_output, "status") != "pass":
+            fail("native libp2p convergence command did not emit status=pass")
+        if _extract_line_value(libp2p_output, "final_decision") != "GO":
+            fail("native libp2p convergence command did not emit final_decision=GO")
+        if _extract_line_value(libp2p_output, "lane_profile") != "deep":
+            fail("native libp2p convergence command did not emit lane_profile=deep")
+        commands_executed += 1
+
+        libp2p_policy_output = _run_command(
+            [
+                "bash",
+                "scripts/runtime/check_libp2p_convergence_process_isolated_live_policy.sh",
+                "--report-file",
+                str(libp2p_convergence_report),
+                "--expected-final-decision",
+                "GO",
+                "--ci-fast-gate",
+                "FAIL",
+                "--output-json",
+                str(libp2p_convergence_policy_report),
+            ],
+            timeout_seconds=command_max_seconds,
+        )
+        if _extract_line_value(libp2p_policy_output, "status") != "ok":
+            fail("native libp2p convergence policy checker did not emit status=ok")
+        if _extract_line_value(libp2p_policy_output, "final_decision") != "GO":
+            fail("native libp2p convergence policy checker did not emit final_decision=GO")
         commands_executed += 1
 
         kolme_output = _run_command(
@@ -294,9 +338,13 @@ def run_lane(args: argparse.Namespace) -> int:
             full_io_report,
             failure_reason="full_i_o_scenario_matrix_report_invalid",
         )
-        full_runtime_payload = _read_json_dict(
-            full_runtime_report,
-            failure_reason="local_full_runtime_report_invalid",
+        libp2p_convergence_payload = _read_json_dict(
+            libp2p_convergence_report,
+            failure_reason="native_libp2p_convergence_report_invalid",
+        )
+        libp2p_policy_payload = _read_json_dict(
+            libp2p_convergence_policy_report,
+            failure_reason="native_libp2p_convergence_policy_report_invalid",
         )
         kolme_integration_payload = _read_json_dict(
             kolme_integration_report,
@@ -309,8 +357,32 @@ def run_lane(args: argparse.Namespace) -> int:
 
         if full_io_payload.get("final_decision") != "GO":
             fail("full I/O scenario matrix report missing final_decision=GO")
-        if full_runtime_payload.get("final_decision") != "GO":
-            fail("local full-runtime report missing final_decision=GO")
+        if libp2p_convergence_payload.get("schema_version") != LIBP2P_CONVERGENCE_REPORT_SCHEMA:
+            fail("native libp2p convergence report schema mismatch")
+        if libp2p_convergence_payload.get("status") != "pass":
+            fail("native libp2p convergence report status mismatch")
+        if libp2p_convergence_payload.get("final_decision") != "GO":
+            fail("native libp2p convergence report final_decision mismatch")
+        if libp2p_convergence_payload.get("lane_mode") != "run":
+            fail("native libp2p convergence report lane mode mismatch")
+        if libp2p_convergence_payload.get("lane_profile") != "deep":
+            fail("native libp2p convergence report lane profile mismatch")
+        if libp2p_convergence_payload.get("runtime_transport_mode") != LIBP2P_RUNTIME_TRANSPORT_MODE:
+            fail("native libp2p convergence report runtime transport mode mismatch")
+        if (
+            libp2p_convergence_payload.get("convergence_reason_codes")
+            != [LIBP2P_CONVERGENCE_REASON_CODE]
+        ):
+            fail("native libp2p convergence report reason taxonomy mismatch")
+        if libp2p_policy_payload.get("schema_version") != LIBP2P_CONVERGENCE_POLICY_SCHEMA:
+            fail("native libp2p convergence policy schema mismatch")
+        if libp2p_policy_payload.get("final_decision") != "GO":
+            fail("native libp2p convergence policy final_decision mismatch")
+        if (
+            libp2p_policy_payload.get("libp2p_process_isolated_convergence_policy_status")
+            != "verified"
+        ):
+            fail("native libp2p convergence policy status mismatch")
         if kolme_integration_payload.get("schema_version") != KOLME_INTEGRATION_REPORT_SCHEMA:
             fail("kolme runtime integration report schema mismatch")
         if kolme_integration_payload.get("status") != "ok":
@@ -350,6 +422,28 @@ def run_lane(args: argparse.Namespace) -> int:
             != KOLME_SIGNER_ATTESTATION_SCHEMA
         ):
             fail("kolme runtime integration report signer attestation schema mismatch")
+        if (
+            kolme_integration_payload.get("runtime_commit_command_profile")
+            != KOLME_RUNTIME_COMMIT_PROFILE
+        ):
+            fail("kolme runtime integration report fixture command profile mismatch")
+        if (
+            kolme_integration_payload.get("runtime_commit_policy_command_profile")
+            != KOLME_RUNTIME_COMMIT_PROFILE
+        ):
+            fail("kolme runtime integration report fixture policy profile mismatch")
+        if (
+            kolme_integration_payload.get("runtime_commit_command_profile_version")
+            != KOLME_RUNTIME_COMMIT_PROFILE_VERSION
+        ):
+            fail("kolme runtime integration report fixture profile version mismatch")
+        if (
+            kolme_integration_payload.get("runtime_commit_failure_taxonomy_version")
+            != KOLME_RUNTIME_COMMIT_FAILURE_TAXONOMY_VERSION
+        ):
+            fail("kolme runtime integration report failure taxonomy version mismatch")
+        if kolme_integration_payload.get("runtime_commit_failure_taxonomy") != "none":
+            fail("kolme runtime integration report failure taxonomy mismatch")
         runtime_commit_command = kolme_integration_payload.get("runtime_commit_command")
         if (
             not isinstance(runtime_commit_command, str)
@@ -364,13 +458,21 @@ def run_lane(args: argparse.Namespace) -> int:
         if kolme_policy_payload.get("observed_reason_code") != KOLME_RUNTIME_INTEGRATION_RUN_REASON:
             fail("kolme runtime integration policy observed reason code mismatch")
 
+        combined_transport_reason_codes = [LIBP2P_CONVERGENCE_REASON_CODE]
+        combined_kolme_runtime_reason_code = KOLME_RUNTIME_INTEGRATION_RUN_REASON
+        kolme_runtime_commit_failure_taxonomy_version = KOLME_RUNTIME_COMMIT_FAILURE_TAXONOMY_VERSION
+        kolme_runtime_commit_failure_taxonomy = "none"
+        kolme_fixture_profile = KOLME_RUNTIME_COMMIT_PROFILE
+        kolme_fixture_profile_version = KOLME_RUNTIME_COMMIT_PROFILE_VERSION
+
         evidence_bundle = {
             "schema_version": EVIDENCE_BUNDLE_SCHEMA,
             "status": "pass",
             "final_decision": "GO",
             "lane_mode": mode,
             "full_io_matrix_report_file": str(full_io_report),
-            "full_runtime_report_file": str(full_runtime_report),
+            "native_libp2p_convergence_report_file": str(libp2p_convergence_report),
+            "native_libp2p_convergence_policy_report_file": str(libp2p_convergence_policy_report),
             "kolme_runtime_integration_report_file": str(kolme_integration_report),
             "kolme_runtime_integration_policy_report_file": str(kolme_integration_policy_report),
             "transport_convergence_status": transport_convergence_status,
@@ -390,6 +492,14 @@ def run_lane(args: argparse.Namespace) -> int:
             "kolme_expected_ref": kolme_expected_ref,
             "kolme_base_url": kolme_base_url,
             "kolme_fork_chain_version": kolme_fork_chain_version,
+            "combined_reason_taxonomy_version": COMBINED_REASON_TAXONOMY_VERSION,
+            "combined_transport_reason_codes": combined_transport_reason_codes,
+            "combined_kolme_runtime_reason_code": combined_kolme_runtime_reason_code,
+            "kolme_runtime_commit_failure_taxonomy_version": kolme_runtime_commit_failure_taxonomy_version,
+            "kolme_runtime_commit_failure_taxonomy": kolme_runtime_commit_failure_taxonomy,
+            "kolme_fixture_profile": kolme_fixture_profile,
+            "kolme_fixture_profile_version": kolme_fixture_profile_version,
+            "kolme_fixture_profile_status": kolme_fixture_profile_status,
             "commands_executed": commands_executed,
             "ci_fast_gate_eligibility": "excluded_local_heavy",
         }
@@ -397,7 +507,8 @@ def run_lane(args: argparse.Namespace) -> int:
 
         artifact_paths = {
             "full_io_matrix_report": str(full_io_report),
-            "full_runtime_report": str(full_runtime_report),
+            "native_libp2p_convergence_report": str(libp2p_convergence_report),
+            "native_libp2p_convergence_policy_report": str(libp2p_convergence_policy_report),
             "kolme_runtime_integration_summary_report": str(kolme_integration_report),
             "kolme_runtime_integration_policy_report": str(kolme_integration_policy_report),
             "evidence_bundle_file": str(evidence_bundle_file),
@@ -425,6 +536,10 @@ def run_lane(args: argparse.Namespace) -> int:
         "fast_gate_exclusion_reason_code": FAST_GATE_EXCLUSION_REASON,
         "scenario_matrix_status": "verified",
         "full_runtime_status": "verified",
+        "native_libp2p_convergence_status": transport_convergence_status,
+        "libp2p_runtime_transport_mode": LIBP2P_RUNTIME_TRANSPORT_MODE,
+        "libp2p_convergence_report_schema_version": LIBP2P_CONVERGENCE_REPORT_SCHEMA,
+        "libp2p_convergence_policy_schema_version": LIBP2P_CONVERGENCE_POLICY_SCHEMA,
         "evidence_bundle_status": "verified",
         "transport_convergence_status": transport_convergence_status,
         "signer_provenance_status": signer_provenance_status,
@@ -445,6 +560,14 @@ def run_lane(args: argparse.Namespace) -> int:
         "kolme_fork_chain_version": kolme_fork_chain_version,
         "kolme_integration_report_schema_version": KOLME_INTEGRATION_REPORT_SCHEMA,
         "kolme_integration_policy_schema_version": KOLME_INTEGRATION_POLICY_SCHEMA,
+        "combined_reason_taxonomy_version": COMBINED_REASON_TAXONOMY_VERSION,
+        "combined_transport_reason_codes": combined_transport_reason_codes,
+        "combined_kolme_runtime_reason_code": combined_kolme_runtime_reason_code,
+        "kolme_runtime_commit_failure_taxonomy_version": kolme_runtime_commit_failure_taxonomy_version,
+        "kolme_runtime_commit_failure_taxonomy": kolme_runtime_commit_failure_taxonomy,
+        "kolme_fixture_profile": kolme_fixture_profile,
+        "kolme_fixture_profile_version": kolme_fixture_profile_version,
+        "kolme_fixture_profile_status": kolme_fixture_profile_status,
         "run_mode_command_status": run_mode_command_status,
         "run_mode_command_count": commands_executed,
         "reason_code": reason_code,
@@ -465,6 +588,10 @@ def run_lane(args: argparse.Namespace) -> int:
     print(f"fast_gate_exclusion_reason_code={FAST_GATE_EXCLUSION_REASON}")
     print("scenario_matrix_status=verified")
     print("full_runtime_status=verified")
+    print(f"native_libp2p_convergence_status={transport_convergence_status}")
+    print(f"libp2p_runtime_transport_mode={LIBP2P_RUNTIME_TRANSPORT_MODE}")
+    print(f"libp2p_convergence_report_schema_version={LIBP2P_CONVERGENCE_REPORT_SCHEMA}")
+    print(f"libp2p_convergence_policy_schema_version={LIBP2P_CONVERGENCE_POLICY_SCHEMA}")
     print("evidence_bundle_status=verified")
     print(f"transport_convergence_status={transport_convergence_status}")
     print(f"signer_provenance_status={signer_provenance_status}")
@@ -485,6 +612,17 @@ def run_lane(args: argparse.Namespace) -> int:
     print(f"kolme_fork_chain_version={kolme_fork_chain_version}")
     print(f"kolme_integration_report_schema_version={KOLME_INTEGRATION_REPORT_SCHEMA}")
     print(f"kolme_integration_policy_schema_version={KOLME_INTEGRATION_POLICY_SCHEMA}")
+    print(f"combined_reason_taxonomy_version={COMBINED_REASON_TAXONOMY_VERSION}")
+    print(f"combined_transport_reason_codes={','.join(combined_transport_reason_codes)}")
+    print(f"combined_kolme_runtime_reason_code={combined_kolme_runtime_reason_code}")
+    print(
+        "kolme_runtime_commit_failure_taxonomy_version="
+        f"{kolme_runtime_commit_failure_taxonomy_version}"
+    )
+    print(f"kolme_runtime_commit_failure_taxonomy={kolme_runtime_commit_failure_taxonomy}")
+    print(f"kolme_fixture_profile={kolme_fixture_profile}")
+    print(f"kolme_fixture_profile_version={kolme_fixture_profile_version}")
+    print(f"kolme_fixture_profile_status={kolme_fixture_profile_status}")
     print(f"run_mode_command_status={run_mode_command_status}")
     print(f"run_mode_command_count={commands_executed}")
     print(f"reason_code={reason_code}")
@@ -537,6 +675,22 @@ def check_policy(args: argparse.Namespace) -> int:
         "local_full_stack_integration_policy_full_runtime_status_mismatch",
     )
     checks.reject_if(
+        payload.get("native_libp2p_convergence_status") not in ("planned", "verified"),
+        "local_full_stack_integration_policy_native_libp2p_convergence_status_mismatch",
+    )
+    checks.reject_if(
+        payload.get("libp2p_runtime_transport_mode") != LIBP2P_RUNTIME_TRANSPORT_MODE,
+        "local_full_stack_integration_policy_libp2p_transport_mode_mismatch",
+    )
+    checks.reject_if(
+        payload.get("libp2p_convergence_report_schema_version") != LIBP2P_CONVERGENCE_REPORT_SCHEMA,
+        "local_full_stack_integration_policy_libp2p_report_schema_contract_mismatch",
+    )
+    checks.reject_if(
+        payload.get("libp2p_convergence_policy_schema_version") != LIBP2P_CONVERGENCE_POLICY_SCHEMA,
+        "local_full_stack_integration_policy_libp2p_policy_schema_contract_mismatch",
+    )
+    checks.reject_if(
         payload.get("evidence_bundle_status") != "verified",
         "local_full_stack_integration_policy_evidence_bundle_status_mismatch",
     )
@@ -560,6 +714,23 @@ def check_policy(args: argparse.Namespace) -> int:
         payload.get("kolme_integration_policy_schema_version") != KOLME_INTEGRATION_POLICY_SCHEMA,
         "local_full_stack_integration_policy_kolme_policy_schema_contract_mismatch",
     )
+    checks.reject_if(
+        payload.get("combined_reason_taxonomy_version") != COMBINED_REASON_TAXONOMY_VERSION,
+        "local_full_stack_integration_policy_reason_taxonomy_version_mismatch",
+    )
+    checks.reject_if(
+        payload.get("kolme_runtime_commit_failure_taxonomy_version")
+        != KOLME_RUNTIME_COMMIT_FAILURE_TAXONOMY_VERSION,
+        "local_full_stack_integration_policy_kolme_runtime_failure_taxonomy_version_mismatch",
+    )
+    checks.reject_if(
+        payload.get("kolme_fixture_profile") != KOLME_RUNTIME_COMMIT_PROFILE,
+        "local_full_stack_integration_policy_kolme_fixture_profile_mismatch",
+    )
+    checks.reject_if(
+        payload.get("kolme_fixture_profile_version") != KOLME_RUNTIME_COMMIT_PROFILE_VERSION,
+        "local_full_stack_integration_policy_kolme_fixture_profile_version_mismatch",
+    )
 
     lane_mode = payload.get("lane_mode")
     checks.reject_if(
@@ -573,6 +744,17 @@ def check_policy(args: argparse.Namespace) -> int:
     )
     command_status = payload.get("run_mode_command_status")
     reason_code = payload.get("reason_code")
+    checks.reject_if(
+        reason_code not in {DRY_RUN_REASON, RUN_REASON},
+        "local_full_stack_integration_policy_reason_code_unsupported",
+    )
+    combined_transport_reason_codes = payload.get("combined_transport_reason_codes")
+    checks.reject_if(
+        combined_transport_reason_codes != [LIBP2P_CONVERGENCE_REASON_CODE],
+        "local_full_stack_integration_policy_transport_reason_taxonomy_mismatch",
+    )
+    combined_kolme_runtime_reason_code = payload.get("combined_kolme_runtime_reason_code")
+    kolme_runtime_commit_failure_taxonomy = payload.get("kolme_runtime_commit_failure_taxonomy")
     artifact_paths = payload.get("artifact_paths")
     checks.reject_if(
         not isinstance(artifact_paths, dict),
@@ -614,6 +796,14 @@ def check_policy(args: argparse.Namespace) -> int:
     checks.reject_if(
         payload.get("kolme_integration_policy_status") != expected_domain_status,
         "local_full_stack_integration_policy_kolme_integration_policy_status_mismatch",
+    )
+    checks.reject_if(
+        payload.get("native_libp2p_convergence_status") != expected_domain_status,
+        "local_full_stack_integration_policy_native_libp2p_convergence_domain_status_mismatch",
+    )
+    checks.reject_if(
+        payload.get("kolme_fixture_profile_status") != expected_domain_status,
+        "local_full_stack_integration_policy_kolme_fixture_profile_status_mismatch",
     )
 
     kolme_checkout_path = payload.get("kolme_checkout_path")
@@ -660,13 +850,21 @@ def check_policy(args: argparse.Namespace) -> int:
             reason_code != DRY_RUN_REASON,
             "local_full_stack_integration_policy_dry_run_reason_code_mismatch",
         )
+        checks.reject_if(
+            combined_kolme_runtime_reason_code != "not_run",
+            "local_full_stack_integration_policy_dry_run_kolme_reason_code_mismatch",
+        )
+        checks.reject_if(
+            kolme_runtime_commit_failure_taxonomy != "not_run",
+            "local_full_stack_integration_policy_dry_run_kolme_failure_taxonomy_mismatch",
+        )
     elif lane_mode == "run":
         checks.reject_if(
             payload.get("ci_fast_gate_eligibility") != "excluded_local_heavy",
             "local_full_stack_integration_policy_run_mode_exclusion_mismatch",
         )
         checks.reject_if(
-            command_count < 4,
+            command_count < 5,
             "local_full_stack_integration_policy_run_mode_command_count_mismatch",
         )
         checks.reject_if(
@@ -677,13 +875,24 @@ def check_policy(args: argparse.Namespace) -> int:
             reason_code != RUN_REASON,
             "local_full_stack_integration_policy_run_mode_reason_code_mismatch",
         )
+        checks.reject_if(
+            combined_kolme_runtime_reason_code != KOLME_RUNTIME_INTEGRATION_RUN_REASON,
+            "local_full_stack_integration_policy_run_mode_kolme_reason_code_mismatch",
+        )
+        checks.reject_if(
+            kolme_runtime_commit_failure_taxonomy != "none",
+            "local_full_stack_integration_policy_run_mode_kolme_failure_taxonomy_mismatch",
+        )
         required_artifacts = (
             "full_io_matrix_report",
-            "full_runtime_report",
+            "native_libp2p_convergence_report",
+            "native_libp2p_convergence_policy_report",
             "kolme_runtime_integration_summary_report",
             "kolme_runtime_integration_policy_report",
             "evidence_bundle_file",
         )
+        libp2p_summary_report_path = ""
+        libp2p_policy_report_path = ""
         kolme_summary_report_path = ""
         kolme_policy_report_path = ""
         if isinstance(artifact_paths, dict):
@@ -693,12 +902,96 @@ def check_policy(args: argparse.Namespace) -> int:
                     not isinstance(artifact_value, str) or not Path(artifact_value).is_file(),
                     f"local_full_stack_integration_policy_artifact_missing:{artifact_key}",
                 )
+            libp2p_summary_value = artifact_paths.get("native_libp2p_convergence_report")
+            libp2p_policy_value = artifact_paths.get("native_libp2p_convergence_policy_report")
             summary_value = artifact_paths.get("kolme_runtime_integration_summary_report")
             policy_value = artifact_paths.get("kolme_runtime_integration_policy_report")
+            if isinstance(libp2p_summary_value, str):
+                libp2p_summary_report_path = libp2p_summary_value
+            if isinstance(libp2p_policy_value, str):
+                libp2p_policy_report_path = libp2p_policy_value
             if isinstance(summary_value, str):
                 kolme_summary_report_path = summary_value
             if isinstance(policy_value, str):
                 kolme_policy_report_path = policy_value
+
+        if libp2p_summary_report_path:
+            try:
+                libp2p_summary_payload = json.loads(
+                    Path(libp2p_summary_report_path).read_text(encoding="utf-8")
+                )
+            except (OSError, json.JSONDecodeError):
+                libp2p_summary_payload = {}
+                checks.reject_if(
+                    True,
+                    "local_full_stack_integration_policy_libp2p_summary_json_invalid",
+                )
+            if not isinstance(libp2p_summary_payload, dict):
+                libp2p_summary_payload = {}
+                checks.reject_if(
+                    True,
+                    "local_full_stack_integration_policy_libp2p_summary_root_invalid",
+                )
+            checks.reject_if(
+                libp2p_summary_payload.get("schema_version") != LIBP2P_CONVERGENCE_REPORT_SCHEMA,
+                "local_full_stack_integration_policy_libp2p_summary_schema_mismatch",
+            )
+            checks.reject_if(
+                libp2p_summary_payload.get("status") != "pass",
+                "local_full_stack_integration_policy_libp2p_summary_status_mismatch",
+            )
+            checks.reject_if(
+                libp2p_summary_payload.get("final_decision") != "GO",
+                "local_full_stack_integration_policy_libp2p_summary_final_decision_mismatch",
+            )
+            checks.reject_if(
+                libp2p_summary_payload.get("lane_mode") != "run",
+                "local_full_stack_integration_policy_libp2p_summary_lane_mode_mismatch",
+            )
+            checks.reject_if(
+                libp2p_summary_payload.get("lane_profile") != "deep",
+                "local_full_stack_integration_policy_libp2p_summary_lane_profile_mismatch",
+            )
+            checks.reject_if(
+                libp2p_summary_payload.get("runtime_transport_mode") != LIBP2P_RUNTIME_TRANSPORT_MODE,
+                "local_full_stack_integration_policy_libp2p_summary_runtime_transport_mode_mismatch",
+            )
+            checks.reject_if(
+                libp2p_summary_payload.get("convergence_reason_codes")
+                != [LIBP2P_CONVERGENCE_REASON_CODE],
+                "local_full_stack_integration_policy_libp2p_summary_reason_taxonomy_mismatch",
+            )
+
+        if libp2p_policy_report_path:
+            try:
+                libp2p_policy_payload = json.loads(
+                    Path(libp2p_policy_report_path).read_text(encoding="utf-8")
+                )
+            except (OSError, json.JSONDecodeError):
+                libp2p_policy_payload = {}
+                checks.reject_if(
+                    True,
+                    "local_full_stack_integration_policy_libp2p_policy_json_invalid",
+                )
+            if not isinstance(libp2p_policy_payload, dict):
+                libp2p_policy_payload = {}
+                checks.reject_if(
+                    True,
+                    "local_full_stack_integration_policy_libp2p_policy_root_invalid",
+                )
+            checks.reject_if(
+                libp2p_policy_payload.get("schema_version") != LIBP2P_CONVERGENCE_POLICY_SCHEMA,
+                "local_full_stack_integration_policy_libp2p_policy_schema_mismatch",
+            )
+            checks.reject_if(
+                libp2p_policy_payload.get("final_decision") != "GO",
+                "local_full_stack_integration_policy_libp2p_policy_final_decision_mismatch",
+            )
+            checks.reject_if(
+                libp2p_policy_payload.get("libp2p_process_isolated_convergence_policy_status")
+                != "verified",
+                "local_full_stack_integration_policy_libp2p_policy_status_mismatch",
+            )
 
         if kolme_summary_report_path:
             try:
@@ -784,6 +1077,30 @@ def check_policy(args: argparse.Namespace) -> int:
                 kolme_summary_payload.get("runtime_signer_attestation_schema_version")
                 != KOLME_SIGNER_ATTESTATION_SCHEMA,
                 "local_full_stack_integration_policy_kolme_summary_signer_attestation_schema_mismatch",
+            )
+            checks.reject_if(
+                kolme_summary_payload.get("runtime_commit_command_profile")
+                != KOLME_RUNTIME_COMMIT_PROFILE,
+                "local_full_stack_integration_policy_kolme_summary_fixture_profile_mismatch",
+            )
+            checks.reject_if(
+                kolme_summary_payload.get("runtime_commit_policy_command_profile")
+                != KOLME_RUNTIME_COMMIT_PROFILE,
+                "local_full_stack_integration_policy_kolme_summary_fixture_policy_profile_mismatch",
+            )
+            checks.reject_if(
+                kolme_summary_payload.get("runtime_commit_command_profile_version")
+                != KOLME_RUNTIME_COMMIT_PROFILE_VERSION,
+                "local_full_stack_integration_policy_kolme_summary_fixture_profile_version_mismatch",
+            )
+            checks.reject_if(
+                kolme_summary_payload.get("runtime_commit_failure_taxonomy_version")
+                != KOLME_RUNTIME_COMMIT_FAILURE_TAXONOMY_VERSION,
+                "local_full_stack_integration_policy_kolme_summary_failure_taxonomy_version_mismatch",
+            )
+            checks.reject_if(
+                kolme_summary_payload.get("runtime_commit_failure_taxonomy") != "none",
+                "local_full_stack_integration_policy_kolme_summary_failure_taxonomy_mismatch",
             )
             runtime_commit_command = kolme_summary_payload.get("runtime_commit_command")
             checks.reject_if(

--- a/scripts/runtime/test_check_local_full_stack_integration_live_policy.sh
+++ b/scripts/runtime/test_check_local_full_stack_integration_live_policy.sh
@@ -25,6 +25,10 @@ cat >"$TMP_REPORT" <<'JSON'
   "fast_gate_exclusion_reason_code": "local_full_stack_integration_run_mode_excluded_from_fast_gate",
   "scenario_matrix_status": "verified",
   "full_runtime_status": "verified",
+  "native_libp2p_convergence_status": "planned",
+  "libp2p_runtime_transport_mode": "libp2p_process_isolated_convergence",
+  "libp2p_convergence_report_schema_version": "kamn.runtime.libp2p-convergence-process-isolated-live-report.v1",
+  "libp2p_convergence_policy_schema_version": "kamn.runtime.libp2p-convergence-process-isolated-live-policy-report.v1",
   "evidence_bundle_status": "verified",
   "transport_convergence_status": "planned",
   "signer_provenance_status": "planned",
@@ -45,6 +49,14 @@ cat >"$TMP_REPORT" <<'JSON'
   "kolme_fork_chain_version": "v0.15.2",
   "kolme_integration_report_schema_version": "kamn.kolme.local-kamn-live-runtime-integration-summary.v1",
   "kolme_integration_policy_schema_version": "kamn.kolme.local-kamn-live-runtime-integration-policy-report.v1",
+  "combined_reason_taxonomy_version": "kamn.runtime.local-full-stack-integration-reason-taxonomy.v1",
+  "combined_transport_reason_codes": ["fork_choice_stale_block_height"],
+  "combined_kolme_runtime_reason_code": "not_run",
+  "kolme_runtime_commit_failure_taxonomy_version": "v1",
+  "kolme_runtime_commit_failure_taxonomy": "not_run",
+  "kolme_fixture_profile": "real-node-non-synthetic-v1",
+  "kolme_fixture_profile_version": "v1",
+  "kolme_fixture_profile_status": "planned",
   "run_mode_command_status": "dry_run_no_commands_executed",
   "run_mode_command_count": 0,
   "reason_code": "dry_run_no_commands_executed",
@@ -150,6 +162,37 @@ if [ "$tampered_kolme_marker_code" -eq 0 ]; then
 fi
 if ! printf '%s\n' "$tampered_kolme_marker_output" | grep -q 'local_full_stack_integration_policy_kolme_local_prerequisite_status_mismatch'; then
   echo "expected deterministic reason marker for tampered Kolme local prerequisite status" >&2
+  exit 1
+fi
+
+cp "$TMP_REPORT" "$TMP_TAMPERED"
+python3 - "$TMP_TAMPERED" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+payload = json.loads(path.read_text(encoding="utf-8"))
+payload["combined_reason_taxonomy_version"] = "v0"
+path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+set +e
+tampered_reason_taxonomy_output="$(
+  bash "$POLICY_SCRIPT" \
+    --report-file "$TMP_TAMPERED" \
+    --expected-final-decision GO \
+    --ci-fast-gate PASS \
+    --output-json "$TMP_POLICY" 2>&1
+)"
+tampered_reason_taxonomy_code=$?
+set -e
+if [ "$tampered_reason_taxonomy_code" -eq 0 ]; then
+  echo "expected tampered combined reason taxonomy version to fail policy check" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$tampered_reason_taxonomy_output" | grep -q 'local_full_stack_integration_policy_reason_taxonomy_version_mismatch'; then
+  echo "expected deterministic reason marker for tampered combined reason taxonomy version" >&2
   exit 1
 fi
 

--- a/scripts/runtime/test_validate_local_full_stack_integration_live.sh
+++ b/scripts/runtime/test_validate_local_full_stack_integration_live.sh
@@ -39,6 +39,22 @@ if ! printf '%s\n' "$validation_output" | grep -q '^full_runtime_status=verified
   echo "expected local full-stack integration full runtime marker" >&2
   exit 1
 fi
+if ! printf '%s\n' "$validation_output" | grep -q '^native_libp2p_convergence_status=planned$'; then
+  echo "expected local full-stack integration native libp2p convergence marker in dry-run" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^libp2p_runtime_transport_mode=libp2p_process_isolated_convergence$'; then
+  echo "expected local full-stack integration libp2p runtime transport mode marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^libp2p_convergence_report_schema_version=kamn.runtime.libp2p-convergence-process-isolated-live-report.v1$'; then
+  echo "expected local full-stack integration libp2p convergence report schema marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^libp2p_convergence_policy_schema_version=kamn.runtime.libp2p-convergence-process-isolated-live-policy-report.v1$'; then
+  echo "expected local full-stack integration libp2p convergence policy schema marker" >&2
+  exit 1
+fi
 if ! printf '%s\n' "$validation_output" | grep -q '^evidence_bundle_status=verified$'; then
   echo "expected local full-stack integration evidence bundle marker" >&2
   exit 1
@@ -91,6 +107,38 @@ if ! printf '%s\n' "$validation_output" | grep -q '^kolme_integration_policy_sta
   echo "expected local full-stack integration Kolme integration policy marker in dry-run" >&2
   exit 1
 fi
+if ! printf '%s\n' "$validation_output" | grep -q '^combined_reason_taxonomy_version=kamn.runtime.local-full-stack-integration-reason-taxonomy.v1$'; then
+  echo "expected local full-stack integration combined reason taxonomy version marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^combined_transport_reason_codes=fork_choice_stale_block_height$'; then
+  echo "expected local full-stack integration combined transport reason marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^combined_kolme_runtime_reason_code=not_run$'; then
+  echo "expected local full-stack integration combined Kolme reason marker in dry-run" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^kolme_runtime_commit_failure_taxonomy_version=v1$'; then
+  echo "expected local full-stack integration Kolme runtime commit failure taxonomy version marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^kolme_runtime_commit_failure_taxonomy=not_run$'; then
+  echo "expected local full-stack integration Kolme runtime commit failure taxonomy marker in dry-run" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^kolme_fixture_profile=real-node-non-synthetic-v1$'; then
+  echo "expected local full-stack integration Kolme fixture profile marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^kolme_fixture_profile_version=v1$'; then
+  echo "expected local full-stack integration Kolme fixture profile version marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^kolme_fixture_profile_status=planned$'; then
+  echo "expected local full-stack integration Kolme fixture profile status marker in dry-run" >&2
+  exit 1
+fi
 if ! printf '%s\n' "$validation_output" | grep -q '^run_mode_command_status=dry_run_no_commands_executed$'; then
   echo "expected local full-stack integration dry-run command marker" >&2
   exit 1
@@ -136,6 +184,30 @@ if payload.get("kolme_integration_report_schema_version") != "kamn.kolme.local-k
     raise SystemExit("expected kolme_integration_report_schema_version marker")
 if payload.get("kolme_integration_policy_schema_version") != "kamn.kolme.local-kamn-live-runtime-integration-policy-report.v1":
     raise SystemExit("expected kolme_integration_policy_schema_version marker")
+if payload.get("native_libp2p_convergence_status") != "planned":
+    raise SystemExit("expected native_libp2p_convergence_status=planned in dry-run")
+if payload.get("libp2p_runtime_transport_mode") != "libp2p_process_isolated_convergence":
+    raise SystemExit("expected libp2p_runtime_transport_mode marker")
+if payload.get("libp2p_convergence_report_schema_version") != "kamn.runtime.libp2p-convergence-process-isolated-live-report.v1":
+    raise SystemExit("expected libp2p_convergence_report_schema_version marker")
+if payload.get("libp2p_convergence_policy_schema_version") != "kamn.runtime.libp2p-convergence-process-isolated-live-policy-report.v1":
+    raise SystemExit("expected libp2p_convergence_policy_schema_version marker")
+if payload.get("combined_reason_taxonomy_version") != "kamn.runtime.local-full-stack-integration-reason-taxonomy.v1":
+    raise SystemExit("expected combined_reason_taxonomy_version marker")
+if payload.get("combined_transport_reason_codes") != ["fork_choice_stale_block_height"]:
+    raise SystemExit("expected combined_transport_reason_codes marker")
+if payload.get("combined_kolme_runtime_reason_code") != "not_run":
+    raise SystemExit("expected combined_kolme_runtime_reason_code=not_run in dry-run")
+if payload.get("kolme_runtime_commit_failure_taxonomy_version") != "v1":
+    raise SystemExit("expected kolme_runtime_commit_failure_taxonomy_version marker")
+if payload.get("kolme_runtime_commit_failure_taxonomy") != "not_run":
+    raise SystemExit("expected kolme_runtime_commit_failure_taxonomy=not_run in dry-run")
+if payload.get("kolme_fixture_profile") != "real-node-non-synthetic-v1":
+    raise SystemExit("expected kolme_fixture_profile marker")
+if payload.get("kolme_fixture_profile_version") != "v1":
+    raise SystemExit("expected kolme_fixture_profile_version marker")
+if payload.get("kolme_fixture_profile_status") != "planned":
+    raise SystemExit("expected kolme_fixture_profile_status=planned")
 if payload.get("kolme_local_prerequisite_status") != "planned":
     raise SystemExit("expected kolme_local_prerequisite_status=planned")
 if payload.get("kolme_local_only_enforced_status") != "planned":

--- a/scripts/runtime/test_validate_local_full_stack_integration_live_contract_lane.sh
+++ b/scripts/runtime/test_validate_local_full_stack_integration_live_contract_lane.sh
@@ -71,6 +71,14 @@ if ! printf '%s\n' "$lane_output" | grep -q '^runtime_provider_contract_status=p
   echo "expected local full-stack integration contract lane provider marker in dry-run" >&2
   exit 1
 fi
+if ! printf '%s\n' "$lane_output" | grep -q '^native_libp2p_convergence_status=planned$'; then
+  echo "expected local full-stack integration contract lane native libp2p marker in dry-run" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$lane_output" | grep -q '^libp2p_runtime_transport_mode=libp2p_process_isolated_convergence$'; then
+  echo "expected local full-stack integration contract lane libp2p runtime transport mode marker" >&2
+  exit 1
+fi
 if ! printf '%s\n' "$lane_output" | grep -q '^kolme_local_prerequisite_status=planned$'; then
   echo "expected local full-stack integration contract lane Kolme local prerequisite marker in dry-run" >&2
   exit 1
@@ -87,7 +95,39 @@ if ! printf '%s\n' "$lane_output" | grep -q '^kolme_integration_policy_status=pl
   echo "expected local full-stack integration contract lane Kolme integration policy marker in dry-run" >&2
   exit 1
 fi
-if ! printf '%s\n' "$lane_output" | grep -q '^fail_closed_reason_code=local_full_stack_integration_policy_runtime_commit_finality_status_mismatch$'; then
+if ! printf '%s\n' "$lane_output" | grep -q '^combined_reason_taxonomy_version=kamn.runtime.local-full-stack-integration-reason-taxonomy.v1$'; then
+  echo "expected local full-stack integration contract lane combined reason taxonomy version marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$lane_output" | grep -q '^combined_transport_reason_codes=fork_choice_stale_block_height$'; then
+  echo "expected local full-stack integration contract lane combined transport reason marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$lane_output" | grep -q '^combined_kolme_runtime_reason_code=not_run$'; then
+  echo "expected local full-stack integration contract lane combined Kolme reason marker in dry-run" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$lane_output" | grep -q '^kolme_runtime_commit_failure_taxonomy_version=v1$'; then
+  echo "expected local full-stack integration contract lane Kolme runtime commit failure taxonomy version marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$lane_output" | grep -q '^kolme_runtime_commit_failure_taxonomy=not_run$'; then
+  echo "expected local full-stack integration contract lane Kolme runtime commit failure taxonomy marker in dry-run" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$lane_output" | grep -q '^kolme_fixture_profile=real-node-non-synthetic-v1$'; then
+  echo "expected local full-stack integration contract lane Kolme fixture profile marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$lane_output" | grep -q '^kolme_fixture_profile_version=v1$'; then
+  echo "expected local full-stack integration contract lane Kolme fixture profile version marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$lane_output" | grep -q '^kolme_fixture_profile_status=planned$'; then
+  echo "expected local full-stack integration contract lane Kolme fixture profile status marker in dry-run" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$lane_output" | grep -q '^fail_closed_reason_code=local_full_stack_integration_policy_reason_taxonomy_version_mismatch$'; then
   echo "expected local full-stack integration contract lane fail-closed reason marker" >&2
   exit 1
 fi
@@ -128,6 +168,14 @@ if lane_payload.get("runtime_signing_profile") != "kolme-fork-secp256k1-v1":
     raise SystemExit("expected runtime_signing_profile marker")
 if lane_payload.get("runtime_signer_attestation_schema_version") != "kamn.kolme.runtime-signer-attestation.v1":
     raise SystemExit("expected runtime_signer_attestation_schema_version marker")
+if lane_payload.get("native_libp2p_convergence_status") != "planned":
+    raise SystemExit("expected native_libp2p_convergence_status=planned in dry-run")
+if lane_payload.get("libp2p_runtime_transport_mode") != "libp2p_process_isolated_convergence":
+    raise SystemExit("expected libp2p_runtime_transport_mode marker")
+if lane_payload.get("libp2p_convergence_report_schema_version") != "kamn.runtime.libp2p-convergence-process-isolated-live-report.v1":
+    raise SystemExit("expected libp2p_convergence_report_schema_version marker")
+if lane_payload.get("libp2p_convergence_policy_schema_version") != "kamn.runtime.libp2p-convergence-process-isolated-live-policy-report.v1":
+    raise SystemExit("expected libp2p_convergence_policy_schema_version marker")
 if lane_payload.get("kolme_local_prerequisite_status") != "planned":
     raise SystemExit("expected kolme_local_prerequisite_status=planned in dry-run")
 if lane_payload.get("kolme_local_only_enforced_status") != "planned":
@@ -136,6 +184,22 @@ if lane_payload.get("kolme_integration_mode_status") != "planned":
     raise SystemExit("expected kolme_integration_mode_status=planned in dry-run")
 if lane_payload.get("kolme_integration_policy_status") != "planned":
     raise SystemExit("expected kolme_integration_policy_status=planned in dry-run")
+if lane_payload.get("combined_reason_taxonomy_version") != "kamn.runtime.local-full-stack-integration-reason-taxonomy.v1":
+    raise SystemExit("expected combined_reason_taxonomy_version marker")
+if lane_payload.get("combined_transport_reason_codes") != ["fork_choice_stale_block_height"]:
+    raise SystemExit("expected combined_transport_reason_codes marker")
+if lane_payload.get("combined_kolme_runtime_reason_code") != "not_run":
+    raise SystemExit("expected combined_kolme_runtime_reason_code=not_run in dry-run")
+if lane_payload.get("kolme_runtime_commit_failure_taxonomy_version") != "v1":
+    raise SystemExit("expected kolme_runtime_commit_failure_taxonomy_version marker")
+if lane_payload.get("kolme_runtime_commit_failure_taxonomy") != "not_run":
+    raise SystemExit("expected kolme_runtime_commit_failure_taxonomy=not_run in dry-run")
+if lane_payload.get("kolme_fixture_profile") != "real-node-non-synthetic-v1":
+    raise SystemExit("expected kolme_fixture_profile marker")
+if lane_payload.get("kolme_fixture_profile_version") != "v1":
+    raise SystemExit("expected kolme_fixture_profile_version marker")
+if lane_payload.get("kolme_fixture_profile_status") != "planned":
+    raise SystemExit("expected kolme_fixture_profile_status=planned in dry-run")
 if lane_payload.get("kolme_checkout_path") != "/tmp/kolme_fork":
     raise SystemExit("expected default kolme_checkout_path marker")
 if lane_payload.get("kolme_expected_remote_url") != "https://github.com/njfio/kolme_fork.git":
@@ -166,6 +230,14 @@ if ! grep -q "check_local_full_stack_integration_live_policy.sh" "$CONTRACT_LANE
 fi
 if ! grep -q "validate_local_full_stack_integration_live.sh" "$CONTRACT_LANE"; then
   echo "expected local full-stack integration contract lane to compose validation lane" >&2
+  exit 1
+fi
+if ! grep -q "validate_libp2p_convergence_process_isolated_live.sh" "$CONTRACT_LANE"; then
+  echo "expected local full-stack integration contract lane to compose native libp2p convergence lane" >&2
+  exit 1
+fi
+if ! grep -q "check_libp2p_convergence_process_isolated_live_policy.sh" "$CONTRACT_LANE"; then
+  echo "expected local full-stack integration contract lane to compose native libp2p convergence policy checker" >&2
   exit 1
 fi
 

--- a/scripts/runtime/validate_local_full_stack_integration_live_contract_lane.sh
+++ b/scripts/runtime/validate_local_full_stack_integration_live_contract_lane.sh
@@ -214,7 +214,7 @@ import sys
 
 path = pathlib.Path(sys.argv[1])
 payload = json.loads(path.read_text(encoding="utf-8"))
-payload["runtime_commit_finality_status"] = "missing"
+payload["combined_reason_taxonomy_version"] = "v0"
 path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
 PY
 
@@ -232,7 +232,7 @@ if [ "$tampered_policy_code" -eq 0 ]; then
   echo "expected tampered local full-stack integration report to fail policy validation" >&2
   exit 1
 fi
-if ! printf '%s\n' "$tampered_policy_output" | grep -q 'local_full_stack_integration_policy_runtime_commit_finality_status_mismatch'; then
+if ! printf '%s\n' "$tampered_policy_output" | grep -q 'local_full_stack_integration_policy_reason_taxonomy_version_mismatch'; then
   echo "expected deterministic fail-closed reason for tampered local full-stack integration report" >&2
   exit 1
 fi
@@ -241,6 +241,8 @@ for required_ref in \
   "validate_local_full_stack_integration_live.sh" \
   "check_local_full_stack_integration_live_policy.sh" \
   "validate_local_full_stack_integration_live_contract_lane.sh" \
+  "validate_libp2p_convergence_process_isolated_live.sh" \
+  "check_libp2p_convergence_process_isolated_live_policy.sh" \
   "test_validate_local_full_stack_integration_live.sh" \
   "test_check_local_full_stack_integration_live_policy.sh" \
   "test_validate_local_full_stack_integration_live_contract_lane.sh"; do
@@ -272,6 +274,7 @@ lane_report_file = pathlib.Path(sys.argv[3])
 elapsed_seconds = int(sys.argv[4])
 max_seconds = int(sys.argv[5])
 mode = sys.argv[6]
+expected_domain_status = "planned" if mode == "dry-run" else "verified"
 
 if summary_report.get("schema_version") != "kamn.runtime.local-full-stack-integration-live-report.v1":
     raise SystemExit("unexpected local full-stack integration summary schema")
@@ -287,10 +290,36 @@ if summary_report.get("runtime_signing_profile") != "kolme-fork-secp256k1-v1":
     raise SystemExit("expected runtime signing profile marker in summary report")
 if summary_report.get("runtime_signer_attestation_schema_version") != "kamn.kolme.runtime-signer-attestation.v1":
     raise SystemExit("expected runtime signer attestation schema marker in summary report")
+if summary_report.get("native_libp2p_convergence_status") != expected_domain_status:
+    raise SystemExit(f"expected native_libp2p_convergence_status={expected_domain_status} in summary report")
+if summary_report.get("libp2p_runtime_transport_mode") != "libp2p_process_isolated_convergence":
+    raise SystemExit("expected libp2p runtime transport mode marker in summary report")
+if summary_report.get("libp2p_convergence_report_schema_version") != "kamn.runtime.libp2p-convergence-process-isolated-live-report.v1":
+    raise SystemExit("expected libp2p convergence report schema marker in summary report")
+if summary_report.get("libp2p_convergence_policy_schema_version") != "kamn.runtime.libp2p-convergence-process-isolated-live-policy-report.v1":
+    raise SystemExit("expected libp2p convergence policy schema marker in summary report")
 if summary_report.get("kolme_integration_report_schema_version") != "kamn.kolme.local-kamn-live-runtime-integration-summary.v1":
     raise SystemExit("expected kolme integration report schema marker in summary report")
 if summary_report.get("kolme_integration_policy_schema_version") != "kamn.kolme.local-kamn-live-runtime-integration-policy-report.v1":
     raise SystemExit("expected kolme integration policy schema marker in summary report")
+if summary_report.get("combined_reason_taxonomy_version") != "kamn.runtime.local-full-stack-integration-reason-taxonomy.v1":
+    raise SystemExit("expected combined reason taxonomy version marker in summary report")
+if summary_report.get("combined_transport_reason_codes") != ["fork_choice_stale_block_height"]:
+    raise SystemExit("expected combined transport reason code marker in summary report")
+expected_combined_kolme_reason = "not_run" if mode == "dry-run" else "live_runtime_integration_passed"
+if summary_report.get("combined_kolme_runtime_reason_code") != expected_combined_kolme_reason:
+    raise SystemExit("expected combined Kolme reason code marker in summary report")
+if summary_report.get("kolme_runtime_commit_failure_taxonomy_version") != "v1":
+    raise SystemExit("expected Kolme runtime commit failure taxonomy version marker in summary report")
+expected_failure_taxonomy = "not_run" if mode == "dry-run" else "none"
+if summary_report.get("kolme_runtime_commit_failure_taxonomy") != expected_failure_taxonomy:
+    raise SystemExit("expected Kolme runtime commit failure taxonomy marker in summary report")
+if summary_report.get("kolme_fixture_profile") != "real-node-non-synthetic-v1":
+    raise SystemExit("expected Kolme fixture profile marker in summary report")
+if summary_report.get("kolme_fixture_profile_version") != "v1":
+    raise SystemExit("expected Kolme fixture profile version marker in summary report")
+if summary_report.get("kolme_fixture_profile_status") != expected_domain_status:
+    raise SystemExit(f"expected kolme_fixture_profile_status={expected_domain_status} in summary report")
 if summary_report.get("kolme_checkout_path") != sys.argv[7]:
     raise SystemExit("expected kolme checkout path marker in summary report")
 if summary_report.get("kolme_expected_remote_url") != sys.argv[8]:
@@ -302,7 +331,6 @@ if summary_report.get("kolme_base_url") != sys.argv[10]:
 if summary_report.get("kolme_fork_chain_version") != sys.argv[11]:
     raise SystemExit("expected kolme fork chain version marker in summary report")
 
-expected_domain_status = "planned" if mode == "dry-run" else "verified"
 for marker in (
     "transport_convergence_status",
     "signer_provenance_status",
@@ -337,10 +365,34 @@ lane_report = {
         "runtime_signer_attestation_schema_version",
         "",
     ),
+    "native_libp2p_convergence_status": summary_report.get("native_libp2p_convergence_status", "unknown"),
+    "libp2p_runtime_transport_mode": summary_report.get("libp2p_runtime_transport_mode", ""),
+    "libp2p_convergence_report_schema_version": summary_report.get(
+        "libp2p_convergence_report_schema_version",
+        "",
+    ),
+    "libp2p_convergence_policy_schema_version": summary_report.get(
+        "libp2p_convergence_policy_schema_version",
+        "",
+    ),
     "kolme_local_prerequisite_status": summary_report.get("kolme_local_prerequisite_status", "unknown"),
     "kolme_local_only_enforced_status": summary_report.get("kolme_local_only_enforced_status", "unknown"),
     "kolme_integration_mode_status": summary_report.get("kolme_integration_mode_status", "unknown"),
     "kolme_integration_policy_status": summary_report.get("kolme_integration_policy_status", "unknown"),
+    "combined_reason_taxonomy_version": summary_report.get("combined_reason_taxonomy_version", ""),
+    "combined_transport_reason_codes": summary_report.get("combined_transport_reason_codes", []),
+    "combined_kolme_runtime_reason_code": summary_report.get("combined_kolme_runtime_reason_code", ""),
+    "kolme_runtime_commit_failure_taxonomy_version": summary_report.get(
+        "kolme_runtime_commit_failure_taxonomy_version",
+        "",
+    ),
+    "kolme_runtime_commit_failure_taxonomy": summary_report.get(
+        "kolme_runtime_commit_failure_taxonomy",
+        "",
+    ),
+    "kolme_fixture_profile": summary_report.get("kolme_fixture_profile", ""),
+    "kolme_fixture_profile_version": summary_report.get("kolme_fixture_profile_version", ""),
+    "kolme_fixture_profile_status": summary_report.get("kolme_fixture_profile_status", "unknown"),
     "kolme_checkout_path": summary_report.get("kolme_checkout_path", ""),
     "kolme_expected_remote_url": summary_report.get("kolme_expected_remote_url", ""),
     "kolme_expected_ref": summary_report.get("kolme_expected_ref", ""),
@@ -360,7 +412,7 @@ lane_report = {
     "max_seconds": max_seconds,
     "summary_report_file": str(pathlib.Path(sys.argv[1]).resolve()),
     "policy_report_file": str(pathlib.Path(sys.argv[2]).resolve()),
-    "fail_closed_reason_code": "local_full_stack_integration_policy_runtime_commit_finality_status_mismatch",
+    "fail_closed_reason_code": "local_full_stack_integration_policy_reason_taxonomy_version_mismatch",
 }
 lane_report_file.write_text(json.dumps(lane_report, sort_keys=True, indent=2) + "\n", encoding="utf-8")
 PY
@@ -385,10 +437,27 @@ echo "runtime_provider_contract_status=${domain_expected_status}"
 echo "runtime_provider_client_contract=KolmeRuntimeCommitLiveProvider"
 echo "runtime_signing_profile=kolme-fork-secp256k1-v1"
 echo "runtime_signer_attestation_schema_version=kamn.kolme.runtime-signer-attestation.v1"
+echo "native_libp2p_convergence_status=${domain_expected_status}"
+echo "libp2p_runtime_transport_mode=libp2p_process_isolated_convergence"
+echo "libp2p_convergence_report_schema_version=kamn.runtime.libp2p-convergence-process-isolated-live-report.v1"
+echo "libp2p_convergence_policy_schema_version=kamn.runtime.libp2p-convergence-process-isolated-live-policy-report.v1"
 echo "kolme_local_prerequisite_status=${domain_expected_status}"
 echo "kolme_local_only_enforced_status=${domain_expected_status}"
 echo "kolme_integration_mode_status=${domain_expected_status}"
 echo "kolme_integration_policy_status=${domain_expected_status}"
+echo "combined_reason_taxonomy_version=kamn.runtime.local-full-stack-integration-reason-taxonomy.v1"
+echo "combined_transport_reason_codes=fork_choice_stale_block_height"
+if [[ "$mode" == "run" ]]; then
+  echo "combined_kolme_runtime_reason_code=live_runtime_integration_passed"
+  echo "kolme_runtime_commit_failure_taxonomy=none"
+else
+  echo "combined_kolme_runtime_reason_code=not_run"
+  echo "kolme_runtime_commit_failure_taxonomy=not_run"
+fi
+echo "kolme_runtime_commit_failure_taxonomy_version=v1"
+echo "kolme_fixture_profile=real-node-non-synthetic-v1"
+echo "kolme_fixture_profile_version=v1"
+echo "kolme_fixture_profile_status=${domain_expected_status}"
 echo "kolme_checkout_path=${kolme_checkout_path}"
 echo "kolme_expected_remote_url=${kolme_expected_remote_url}"
 echo "kolme_expected_ref=${kolme_expected_ref}"
@@ -398,7 +467,7 @@ echo "kolme_integration_report_schema_version=kamn.kolme.local-kamn-live-runtime
 echo "kolme_integration_policy_schema_version=kamn.kolme.local-kamn-live-runtime-integration-policy-report.v1"
 echo "docs_contract_status=verified"
 echo "performance_budget_status=verified"
-echo "fail_closed_reason_code=local_full_stack_integration_policy_runtime_commit_finality_status_mismatch"
+echo "fail_closed_reason_code=local_full_stack_integration_policy_reason_taxonomy_version_mismatch"
 if [[ -n "$output_json" ]]; then
   echo "report_file=$(realpath "$output_json")"
 fi


### PR DESCRIPTION
## Summary
This change updates the local full-stack integration lane to validate native libp2p convergence and Kolme live runtime-commit flow in one combined contract surface. It adds deterministic fixture-profile and reason-taxonomy markers, with fail-closed policy checks and tamper drills.

Closes #3713
Closes #3714
Closes #3715

## Changes
- `scripts/runtime/local_full_stack_integration_live_contract.py`: replaced full-runtime composition with native libp2p convergence + policy checker, added combined taxonomy + fixture-profile markers, and tightened run-mode artifact/policy contracts.
- `scripts/runtime/validate_local_full_stack_integration_live_contract_lane.sh`: updated tamper drill to reason-taxonomy drift, added native libp2p + fixture/taxonomy marker propagation, and updated fail-closed reason marker.
- `scripts/runtime/test_validate_local_full_stack_integration_live.sh`: added assertions for native libp2p schema/transport markers and combined taxonomy/fixture markers.
- `scripts/runtime/test_check_local_full_stack_integration_live_policy.sh`: added synthetic report fields for new contracts and taxonomy drift tamper regression.
- `scripts/runtime/test_validate_local_full_stack_integration_live_contract_lane.sh`: added assertions for native libp2p + taxonomy/fixture markers and updated fail-closed reason checks.
- `docs/ci/strategy.md`: updated composed-lane contract and drift marker to reason-taxonomy mismatch.
- `docs/architecture/kolme-live-integration.md`: updated architecture composition and top-level marker taxonomy.
- `docs/architecture/service-runtime.md`: added combined native transport + Kolme validation flow section.
- `docs/foundation/runtime-network.md`: added combined lane taxonomy section and fail-closed drift marker.
- `docs/planning/kolme-devnet-ops.md`: updated composed lane runbook markers/composition.
- `docs/deploy/kolme_devnet_ops.md`: added compatibility redirect to canonical runbook path.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- Command:
  - `bash scripts/runtime/test_validate_local_full_stack_integration_live_contract_lane.sh`
- Failure observed:
  - `NameError: name 'expected_domain_status' is not defined`

### 🟢 Green Phase
- Commands:
  - `bash scripts/runtime/test_validate_local_full_stack_integration_live.sh`
  - `bash scripts/runtime/test_check_local_full_stack_integration_live_policy.sh`
  - `bash scripts/runtime/test_validate_local_full_stack_integration_live_contract_lane.sh`
- Result:
  - all pass

### 🔁 Regression
- Commands:
  - `bash scripts/runtime/test_validate_local_full_stack_integration_live.sh`
  - `bash scripts/runtime/test_check_local_full_stack_integration_live_policy.sh`
  - `bash scripts/runtime/test_validate_local_full_stack_integration_live_contract_lane.sh`
  - `python3 -m py_compile scripts/runtime/local_full_stack_integration_live_contract.py`
- Result:
  - all pass

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | policy/taxonomy/fixture marker assertions in script-level tests | |
| Functional   | ✅ | combined lane summary/policy contract checks | |
| Integration  | ✅ | full-stack contract-lane wrapper composition tests | |
| Regression   | ✅ | taxonomy drift + tamper fail-closed checks | |
| Performance  | ✅ | bounded command count/runtime budget policy assertions retained | |

## Risks & Rollback
- No runtime API surface changes; risk is limited to contract-lane orchestration/policy logic and docs alignment.
- Rollback: revert commit `0ca787c4abd9972bda397b28e1904a72f09c7025`.

## Documentation Updates
- `docs/ci/strategy.md`
- `docs/architecture/kolme-live-integration.md`
- `docs/architecture/service-runtime.md`
- `docs/foundation/runtime-network.md`
- `docs/planning/kolme-devnet-ops.md`
- `docs/deploy/kolme_devnet_ops.md`

## Validation Checklist
- [ ] `cargo fmt --check` — clean
- [ ] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (targeted lane suite)
- [x] Docs updated (or justified why not)
