### PR TITLE
feat: fail-closed combined release evidence contracts

### DIFF
--- a/docs/deploy/kolme_devnet_ops.md
+++ b/docs/deploy/kolme_devnet_ops.md
@@ -7,3 +7,29 @@ validation lives in:
 
 This compatibility path is kept so issue and PR references using
 `docs/deploy/kolme_devnet_ops.md` remain valid.
+
+## Release Evidence and Remediation Matrix
+
+Release go/no-go evidence must include deterministic combined native libp2p +
+Kolme markers from `kamn.runtime.go-no-go-gate-report.v1`:
+
+- `combined_reason_taxonomy_version=kamn.runtime.local-full-stack-integration-reason-taxonomy.v1`
+- `combined_transport_reason_codes=["fork_choice_stale_block_height"]`
+- `combined_kolme_runtime_reason_code in {"not_run","live_runtime_integration_passed"}`
+- `kolme_runtime_commit_failure_taxonomy_version=v1`
+- `kolme_fixture_profile=real-node-non-synthetic-v1`
+- `kolme_fixture_profile_version=v1`
+- `combined_lane_marker_contract_status=verified`
+
+Fail-closed remediation reason codes are emitted in milestone bundles by
+`scripts/deploy/gonogo_evidence_contract.py` and must block promotion when
+present, including:
+
+- `milestone_review_go_no_go_gate_combined_reason_taxonomy_version_mismatch`
+- `milestone_review_go_no_go_gate_combined_transport_reason_codes_mismatch`
+- `milestone_review_go_no_go_gate_combined_kolme_runtime_reason_code_mismatch`
+- `milestone_review_go_no_go_gate_kolme_runtime_commit_failure_taxonomy_version_mismatch`
+- `milestone_review_go_no_go_gate_kolme_fixture_profile_mismatch`
+- `milestone_review_go_no_go_gate_kolme_fixture_profile_version_mismatch`
+- `milestone_review_go_no_go_gate_kolme_fixture_profile_status_mismatch`
+- `milestone_review_go_no_go_gate_combined_lane_marker_contract_status_mismatch`

--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -37,6 +37,9 @@ The live backend contract inventory for `njfio/kolme_fork` is tracked in:
     - local-only enforcement and nested run-mode policy reason-code marker `live_runtime_integration_passed`
     - combined reason taxonomy marker `kamn.runtime.local-full-stack-integration-reason-taxonomy.v1`
     - combined transport reason marker `fork_choice_stale_block_height`
+    - combined Kolme runtime reason marker (`not_run` in dry-run, `live_runtime_integration_passed` in run mode)
+    - combined lane marker contract status marker `combined_lane_marker_contract_status=verified`
+    - Kolme runtime commit failure taxonomy version marker `v1`
     - deterministic Kolme fixture profile markers (`real-node-non-synthetic-v1`, profile version `v1`)
 - Deterministic tamper reason:
   - `local_full_stack_integration_policy_reason_taxonomy_version_mismatch`

--- a/docs/plans/2026-02-14-production-service-next-steps.md
+++ b/docs/plans/2026-02-14-production-service-next-steps.md
@@ -70,6 +70,22 @@ This refreshed version separates:
 - Delivery includes composed local-heavy integration evidence bundle, release go/no-go linkage, and architecture/documentation lineage.
 - Promotion evidence gate lineage now fails closed when operator runbook markers drift or go missing (`milestone_review_operator_runbook_missing`, `milestone_review_operator_runbook_markers_missing`) in `scripts/deploy/gonogo_evidence_contract.py`.
 - Local validation drill override for runbook-marker regression uses `KAMN_GONOGO_RUNBOOK_DOC_FILE=<path>`.
+- Milestone closure criteria (chain `#3716 -> #3718`) for release promotion now additionally require deterministic combined lane markers in `kamn.runtime.go-no-go-gate-report.v1`:
+  - `combined_reason_taxonomy_version=kamn.runtime.local-full-stack-integration-reason-taxonomy.v1`
+  - `combined_transport_reason_codes=["fork_choice_stale_block_height"]`
+  - `combined_kolme_runtime_reason_code` in `{"not_run","live_runtime_integration_passed"}`
+  - `kolme_runtime_commit_failure_taxonomy_version=v1`
+  - `kolme_fixture_profile=real-node-non-synthetic-v1` and `kolme_fixture_profile_version=v1`
+  - `combined_lane_marker_contract_status=verified`
+- Milestone bundle reason-code surface fails closed for marker/taxonomy drift via:
+  - `milestone_review_go_no_go_gate_combined_reason_taxonomy_version_mismatch`
+  - `milestone_review_go_no_go_gate_combined_transport_reason_codes_mismatch`
+  - `milestone_review_go_no_go_gate_combined_kolme_runtime_reason_code_mismatch`
+  - `milestone_review_go_no_go_gate_kolme_runtime_commit_failure_taxonomy_version_mismatch`
+  - `milestone_review_go_no_go_gate_kolme_fixture_profile_mismatch`
+  - `milestone_review_go_no_go_gate_kolme_fixture_profile_version_mismatch`
+  - `milestone_review_go_no_go_gate_kolme_fixture_profile_status_mismatch`
+  - `milestone_review_go_no_go_gate_combined_lane_marker_contract_status_mismatch`
 
 ### Runtime observability reason-code/checkpoint projection
 - Delivered chain: `#3333 -> #3471 -> #3472 -> #3473 -> #3474 -> #3490`.

--- a/scripts/ci/test_kolme_live_integration_architecture_contract.sh
+++ b/scripts/ci/test_kolme_live_integration_architecture_contract.sh
@@ -21,15 +21,15 @@ check_architecture_markers() {
   local required_markers=(
     "Composed Full-Stack E2E Boundary (Task #3433)"
     "validate_local_full_stack_integration_live.sh"
-    "run_local_kamn_live_runtime_integration_contract_lane.sh"
+    "run_local_kamn_live_runtime_integration_lane.sh"
     "run_go_no_go_gate_lane.sh"
     "transport_convergence_status"
     "signer_provenance_status"
     "runtime_commit_submission_status"
     "runtime_commit_finality_status"
-    "runtime_commit_failure_taxonomy"
+    "\`kolme_runtime_commit_failure_taxonomy\`"
     "runtime_provider_client_contract=KolmeRuntimeCommitLiveProvider"
-    "local_full_stack_integration_policy_runtime_commit_finality_status_mismatch"
+    "local_full_stack_integration_policy_reason_taxonomy_version_mismatch"
     "release_manifest_missing_required_artifact:local_full_stack_integration"
   )
 
@@ -65,7 +65,11 @@ import sys
 path = pathlib.Path(sys.argv[1])
 text = path.read_text(encoding="utf-8")
 path.write_text(
-    text.replace("runtime_commit_failure_taxonomy", "runtime_commit_failure_classification", 1),
+    text.replace(
+        "`kolme_runtime_commit_failure_taxonomy`",
+        "`kolme_runtime_commit_failure_classification`",
+        1,
+    ),
     encoding="utf-8",
 )
 PY
@@ -74,7 +78,7 @@ if check_architecture_markers "$BROKEN_ARCH_DOC" >"$TMP_DIR/broken.out" 2>"$TMP_
   echo "expected architecture marker check to fail for tampered document" >&2
   exit 1
 fi
-if ! grep -Fq "marker_missing:runtime_commit_failure_taxonomy" "$TMP_DIR/broken.err"; then
+if ! grep -Fq "marker_missing:\`kolme_runtime_commit_failure_taxonomy\`" "$TMP_DIR/broken.err"; then
   echo "expected deterministic marker_missing reason for tampered architecture marker" >&2
   cat "$TMP_DIR/broken.err" >&2 || true
   exit 1

--- a/scripts/deploy/gonogo_evidence_contract.py
+++ b/scripts/deploy/gonogo_evidence_contract.py
@@ -51,6 +51,17 @@ PREFLIGHT_POLICY_SCHEMA = "kamn.kolme.local-live-deployment-preflight-policy-rep
 LIVE_BUNDLE_SUMMARY_SCHEMA = "kamn.kolme.local-live-node-validation-bundle-summary.v1"
 LIVE_BUNDLE_POLICY_SCHEMA = "kamn.kolme.local-live-node-validation-bundle-policy-report.v1"
 GO_NO_GO_GATE_SCHEMA = "kamn.runtime.go-no-go-gate-report.v1"
+COMBINED_REASON_TAXONOMY_VERSION = "kamn.runtime.local-full-stack-integration-reason-taxonomy.v1"
+COMBINED_TRANSPORT_REASON_CODES = [  # deterministic singleton today; model as list for schema stability.
+    "fork_choice_stale_block_height",
+]
+ALLOWED_COMBINED_KOLME_REASON_CODES = {
+    "not_run",
+    "live_runtime_integration_passed",
+}
+KOLME_RUNTIME_COMMIT_FAILURE_TAXONOMY_VERSION = "v1"
+KOLME_RUNTIME_COMMIT_PROFILE = "real-node-non-synthetic-v1"
+KOLME_RUNTIME_COMMIT_PROFILE_VERSION = "v1"
 
 MILESTONE_ARTIFACT_ARGS = (
     ("deployment_preflight_summary_file", "deployment_preflight_summary_file"),
@@ -250,6 +261,14 @@ def _build_milestone_review_bundle(artifact_paths: dict[str, Path]) -> dict[str,
 
     gate_status = ""
     gate_final_decision = ""
+    combined_reason_taxonomy_version = ""
+    combined_transport_reason_codes: list[str] = []
+    combined_kolme_runtime_reason_code = ""
+    gate_kolme_runtime_commit_failure_taxonomy_version = ""
+    gate_kolme_fixture_profile = ""
+    gate_kolme_fixture_profile_version = ""
+    gate_kolme_fixture_profile_status = ""
+    gate_combined_lane_marker_contract_status = ""
     if gate_report is not None:
         if gate_report.get("schema_version") != GO_NO_GO_GATE_SCHEMA:
             reason_codes.append("milestone_review_go_no_go_gate_schema_mismatch")
@@ -259,6 +278,68 @@ def _build_milestone_review_bundle(artifact_paths: dict[str, Path]) -> dict[str,
         gate_final_decision = str(gate_report.get("final_decision", ""))
         if gate_final_decision != GO_DECISION:
             reason_codes.append("milestone_review_go_no_go_gate_final_decision_mismatch")
+
+        combined_reason_taxonomy_version = str(gate_report.get("combined_reason_taxonomy_version", ""))
+        if combined_reason_taxonomy_version != COMBINED_REASON_TAXONOMY_VERSION:
+            reason_codes.append(
+                "milestone_review_go_no_go_gate_combined_reason_taxonomy_version_mismatch"
+            )
+
+        combined_transport_reason_codes_raw = gate_report.get("combined_transport_reason_codes")
+        if isinstance(combined_transport_reason_codes_raw, list):
+            combined_transport_reason_codes = [
+                value
+                for value in combined_transport_reason_codes_raw
+                if isinstance(value, str) and value
+            ]
+        if combined_transport_reason_codes != COMBINED_TRANSPORT_REASON_CODES:
+            reason_codes.append(
+                "milestone_review_go_no_go_gate_combined_transport_reason_codes_mismatch"
+            )
+
+        combined_kolme_runtime_reason_code = str(
+            gate_report.get("combined_kolme_runtime_reason_code", "")
+        )
+        if combined_kolme_runtime_reason_code not in ALLOWED_COMBINED_KOLME_REASON_CODES:
+            reason_codes.append(
+                "milestone_review_go_no_go_gate_combined_kolme_runtime_reason_code_mismatch"
+            )
+
+        gate_kolme_runtime_commit_failure_taxonomy_version = str(
+            gate_report.get("kolme_runtime_commit_failure_taxonomy_version", "")
+        )
+        if (
+            gate_kolme_runtime_commit_failure_taxonomy_version
+            != KOLME_RUNTIME_COMMIT_FAILURE_TAXONOMY_VERSION
+        ):
+            reason_codes.append(
+                "milestone_review_go_no_go_gate_kolme_runtime_commit_failure_"
+                "taxonomy_version_mismatch"
+            )
+
+        gate_kolme_fixture_profile = str(gate_report.get("kolme_fixture_profile", ""))
+        if gate_kolme_fixture_profile != KOLME_RUNTIME_COMMIT_PROFILE:
+            reason_codes.append("milestone_review_go_no_go_gate_kolme_fixture_profile_mismatch")
+
+        gate_kolme_fixture_profile_version = str(gate_report.get("kolme_fixture_profile_version", ""))
+        if gate_kolme_fixture_profile_version != KOLME_RUNTIME_COMMIT_PROFILE_VERSION:
+            reason_codes.append(
+                "milestone_review_go_no_go_gate_kolme_fixture_profile_version_mismatch"
+            )
+
+        gate_kolme_fixture_profile_status = str(gate_report.get("kolme_fixture_profile_status", ""))
+        if gate_kolme_fixture_profile_status not in {"planned", "verified"}:
+            reason_codes.append(
+                "milestone_review_go_no_go_gate_kolme_fixture_profile_status_mismatch"
+            )
+
+        gate_combined_lane_marker_contract_status = str(
+            gate_report.get("combined_lane_marker_contract_status", "")
+        )
+        if gate_combined_lane_marker_contract_status != "verified":
+            reason_codes.append(
+                "milestone_review_go_no_go_gate_combined_lane_marker_contract_status_mismatch"
+            )
 
     reason_codes = sorted(set(reason_codes))
     final_decision = GO_DECISION if not reason_codes else NO_GO_DECISION
@@ -284,6 +365,18 @@ def _build_milestone_review_bundle(artifact_paths: dict[str, Path]) -> dict[str,
             "live_node_validation_policy_final_decision": live_policy_final_decision,
             "go_no_go_gate_status": gate_status,
             "go_no_go_gate_final_decision": gate_final_decision,
+            "go_no_go_gate_combined_reason_taxonomy_version": combined_reason_taxonomy_version,
+            "go_no_go_gate_combined_transport_reason_codes": combined_transport_reason_codes,
+            "go_no_go_gate_combined_kolme_runtime_reason_code": combined_kolme_runtime_reason_code,
+            "go_no_go_gate_kolme_runtime_commit_failure_taxonomy_version": (
+                gate_kolme_runtime_commit_failure_taxonomy_version
+            ),
+            "go_no_go_gate_kolme_fixture_profile": gate_kolme_fixture_profile,
+            "go_no_go_gate_kolme_fixture_profile_version": gate_kolme_fixture_profile_version,
+            "go_no_go_gate_kolme_fixture_profile_status": gate_kolme_fixture_profile_status,
+            "go_no_go_gate_combined_lane_marker_contract_status": (
+                gate_combined_lane_marker_contract_status
+            ),
             "deployment_preflight_contract_scope": preflight_scope,
             "live_node_validation_contract_scope": live_scope,
             "live_node_validation_runtime_provider_client_contract": live_runtime_provider,
@@ -305,6 +398,24 @@ def _build_milestone_review_bundle(artifact_paths: dict[str, Path]) -> dict[str,
             "live_bundle_policy_final_decision_required": GO_DECISION,
             "go_no_go_gate_status_required": "pass",
             "go_no_go_gate_final_decision_required": GO_DECISION,
+            "go_no_go_gate_combined_reason_taxonomy_version_required": (
+                COMBINED_REASON_TAXONOMY_VERSION
+            ),
+            "go_no_go_gate_combined_transport_reason_codes_required": list(
+                COMBINED_TRANSPORT_REASON_CODES
+            ),
+            "go_no_go_gate_combined_kolme_runtime_reason_codes_allowed": sorted(
+                ALLOWED_COMBINED_KOLME_REASON_CODES
+            ),
+            "go_no_go_gate_kolme_runtime_commit_failure_taxonomy_version_required": (
+                KOLME_RUNTIME_COMMIT_FAILURE_TAXONOMY_VERSION
+            ),
+            "go_no_go_gate_kolme_fixture_profile_required": KOLME_RUNTIME_COMMIT_PROFILE,
+            "go_no_go_gate_kolme_fixture_profile_version_required": (
+                KOLME_RUNTIME_COMMIT_PROFILE_VERSION
+            ),
+            "go_no_go_gate_kolme_fixture_profile_status_allowed": ["planned", "verified"],
+            "go_no_go_gate_combined_lane_marker_contract_status_required": "verified",
         },
     }
 

--- a/scripts/deploy/gonogo_evidence_contract_lane_contract.sh
+++ b/scripts/deploy/gonogo_evidence_contract_lane_contract.sh
@@ -87,7 +87,17 @@ cat >"$milestone_gate_report" <<'JSON'
 {
   "schema_version": "kamn.runtime.go-no-go-gate-report.v1",
   "status": "pass",
-  "final_decision": "GO"
+  "final_decision": "GO",
+  "combined_reason_taxonomy_version": "kamn.runtime.local-full-stack-integration-reason-taxonomy.v1",
+  "combined_transport_reason_codes": [
+    "fork_choice_stale_block_height"
+  ],
+  "combined_kolme_runtime_reason_code": "not_run",
+  "kolme_runtime_commit_failure_taxonomy_version": "v1",
+  "kolme_fixture_profile": "real-node-non-synthetic-v1",
+  "kolme_fixture_profile_version": "v1",
+  "kolme_fixture_profile_status": "planned",
+  "combined_lane_marker_contract_status": "verified"
 }
 JSON
 

--- a/scripts/deploy/test_generate_gonogo_evidence_bundle.sh
+++ b/scripts/deploy/test_generate_gonogo_evidence_bundle.sh
@@ -213,7 +213,17 @@ cat >"$milestone_gate_report" <<'JSON'
 {
   "schema_version": "kamn.runtime.go-no-go-gate-report.v1",
   "status": "pass",
-  "final_decision": "GO"
+  "final_decision": "GO",
+  "combined_reason_taxonomy_version": "kamn.runtime.local-full-stack-integration-reason-taxonomy.v1",
+  "combined_transport_reason_codes": [
+    "fork_choice_stale_block_height"
+  ],
+  "combined_kolme_runtime_reason_code": "not_run",
+  "kolme_runtime_commit_failure_taxonomy_version": "v1",
+  "kolme_fixture_profile": "real-node-non-synthetic-v1",
+  "kolme_fixture_profile_version": "v1",
+  "kolme_fixture_profile_status": "planned",
+  "combined_lane_marker_contract_status": "verified"
 }
 JSON
 
@@ -263,6 +273,25 @@ if contracts.get("linked_artifact_lineage_required") is not True:
     raise SystemExit("expected linked_artifact_lineage_required=true in milestone review contracts")
 if contracts.get("live_bundle_runtime_provider_client_required") != "KolmeRuntimeCommitLiveProvider":
     raise SystemExit("expected milestone review runtime provider contract marker")
+if contracts.get("go_no_go_gate_combined_reason_taxonomy_version_required") != "kamn.runtime.local-full-stack-integration-reason-taxonomy.v1":
+    raise SystemExit("expected milestone review combined reason taxonomy contract marker")
+if contracts.get("go_no_go_gate_combined_transport_reason_codes_required") != ["fork_choice_stale_block_height"]:
+    raise SystemExit("expected milestone review combined transport reason-code contract marker")
+if contracts.get("go_no_go_gate_combined_kolme_runtime_reason_codes_allowed") != ["live_runtime_integration_passed", "not_run"]:
+    raise SystemExit("expected milestone review allowed combined Kolme reason-code contract marker")
+if contracts.get("go_no_go_gate_combined_lane_marker_contract_status_required") != "verified":
+    raise SystemExit("expected milestone review combined marker contract status contract marker")
+observed = milestone.get("observed")
+if not isinstance(observed, dict):
+    raise SystemExit("expected milestone review observed object")
+if observed.get("go_no_go_gate_combined_reason_taxonomy_version") != "kamn.runtime.local-full-stack-integration-reason-taxonomy.v1":
+    raise SystemExit("expected observed combined reason taxonomy marker")
+if observed.get("go_no_go_gate_combined_transport_reason_codes") != ["fork_choice_stale_block_height"]:
+    raise SystemExit("expected observed combined transport reason codes marker")
+if observed.get("go_no_go_gate_combined_kolme_runtime_reason_code") != "not_run":
+    raise SystemExit("expected observed combined Kolme reason code marker")
+if observed.get("go_no_go_gate_combined_lane_marker_contract_status") != "verified":
+    raise SystemExit("expected observed combined lane marker contract status marker")
 PY
 
 milestone_policy_output="$(bash "$POLICY_CHECKER" --bundle-file "$milestone_bundle")"
@@ -419,6 +448,61 @@ milestone_missing_runbook_policy_output="$(
 )"
 assert_eq "$(extract_value "$milestone_missing_runbook_policy_output" "status")" "ok" "expected policy checker to preserve deterministic NO-GO for missing runbook marker bundle"
 assert_eq "$(extract_value "$milestone_missing_runbook_policy_output" "final_decision")" "NO-GO" "expected policy checker NO-GO decision for missing runbook marker bundle"
+
+milestone_taxonomy_drift_gate_report="$TMP_DIR/milestone-go-no-go-gate-report.taxonomy-drift.json"
+cp "$milestone_gate_report" "$milestone_taxonomy_drift_gate_report"
+python3 - "$milestone_taxonomy_drift_gate_report" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+payload = json.loads(path.read_text(encoding="utf-8"))
+payload["combined_reason_taxonomy_version"] = "kamn.runtime.local-full-stack-integration-reason-taxonomy.v0"
+path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+milestone_taxonomy_drift_bundle="$TMP_DIR/gonogo-milestone-taxonomy-drift.json"
+milestone_taxonomy_drift_output="$(
+  bash "$GENERATOR" \
+    --output-file "$milestone_taxonomy_drift_bundle" \
+    --release-candidate "v1.0.0-rc.7" \
+    --schema-target-version "1.0.0" \
+    --runtime-image-digest "sha256:milestone-taxonomy-drift" \
+    --ci-fast-gate PASS \
+    --ci-deep-lane PASS \
+    --rollback-precheck PASS \
+    --rollback-trigger-status CLEAR \
+    --required-approvals 2 \
+    --received-approvals 2 \
+    --deployment-preflight-summary-file "$milestone_preflight_summary" \
+    --deployment-preflight-policy-file "$milestone_preflight_policy" \
+    --live-node-validation-summary-file "$milestone_live_bundle_summary" \
+    --live-node-validation-policy-file "$milestone_live_bundle_policy" \
+    --go-no-go-gate-report-file "$milestone_taxonomy_drift_gate_report"
+)"
+
+assert_eq "$(extract_value "$milestone_taxonomy_drift_output" "final_decision")" "NO-GO" "expected milestone bundle to fail closed on combined reason taxonomy drift"
+
+python3 - "$milestone_taxonomy_drift_bundle" <<'PY'
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+milestone = payload.get("milestone_review_bundle", {})
+reason_codes = milestone.get("reason_codes")
+if not isinstance(reason_codes, list):
+    raise SystemExit("expected milestone reason_codes list for taxonomy drift case")
+if "milestone_review_go_no_go_gate_combined_reason_taxonomy_version_mismatch" not in reason_codes:
+    raise SystemExit("expected combined reason taxonomy mismatch reason code in milestone review bundle")
+if milestone.get("lineage_status") != "fail-closed":
+    raise SystemExit("expected fail-closed lineage status for combined reason taxonomy drift case")
+PY
+
+milestone_taxonomy_drift_policy_output="$(bash "$POLICY_CHECKER" --bundle-file "$milestone_taxonomy_drift_bundle")"
+assert_eq "$(extract_value "$milestone_taxonomy_drift_policy_output" "status")" "ok" "expected policy checker to preserve deterministic NO-GO for taxonomy drift bundle"
+assert_eq "$(extract_value "$milestone_taxonomy_drift_policy_output" "final_decision")" "NO-GO" "expected policy checker NO-GO decision for taxonomy drift bundle"
 
 milestone_lineage_tampered_bundle="$TMP_DIR/gonogo-milestone-lineage-tampered.json"
 cp "$milestone_bundle" "$milestone_lineage_tampered_bundle"

--- a/scripts/runtime/go_no_go_gate_lane_contract.py
+++ b/scripts/runtime/go_no_go_gate_lane_contract.py
@@ -32,6 +32,11 @@ RUN_MODE_OPT_IN_ENV = "KAMN_GONOGO_GATE_LOCAL_OPT_IN"
 WAIVER_SCHEMA = "kamn.runtime.go-no-go-gate-waiver.v1"
 WAIVER_SCOPE = "runtime_go_no_go_gate_required_artifacts"
 WAIVER_APPLIED_REASON = "release_manifest_required_artifact_waiver_applied"
+COMBINED_REASON_TAXONOMY_VERSION = "kamn.runtime.local-full-stack-integration-reason-taxonomy.v1"
+COMBINED_TRANSPORT_REASON_CODE = "fork_choice_stale_block_height"
+KOLME_RUNTIME_COMMIT_FAILURE_TAXONOMY_VERSION = "v1"
+KOLME_RUNTIME_COMMIT_PROFILE = "real-node-non-synthetic-v1"
+KOLME_RUNTIME_COMMIT_PROFILE_VERSION = "v1"
 REQUIRED_ARTIFACT_IDS = (
     "go_no_go_evidence",
     "rollback_readiness",
@@ -114,6 +119,21 @@ def _run_command(command: list[str]) -> subprocess.CompletedProcess[str]:
         text=True,
         check=False,
     )
+
+
+def _extract_line_value(output: str, key: str) -> str:
+    prefix = f"{key}="
+    for line in output.splitlines():
+        if line.startswith(prefix):
+            return line[len(prefix) :]
+    return ""
+
+
+def _require_line_value(output: str, key: str, reason_code: str) -> str:
+    value = _extract_line_value(output, key)
+    if not value:
+        fail(reason_code)
+    return value
 
 
 def _resolve_manifest_path(raw: str) -> Path:
@@ -368,6 +388,14 @@ def run_go_no_go_gate_lane(args: argparse.Namespace) -> int:
         reason_codes.append(WAIVER_APPLIED_REASON)
     artifact_inventory: list[dict[str, str]] = []
     run_mode_command_count = 0
+    combined_reason_taxonomy_version = COMBINED_REASON_TAXONOMY_VERSION
+    combined_transport_reason_codes = [COMBINED_TRANSPORT_REASON_CODE]
+    combined_kolme_runtime_reason_code = "not_run"
+    kolme_runtime_commit_failure_taxonomy_version = KOLME_RUNTIME_COMMIT_FAILURE_TAXONOMY_VERSION
+    kolme_runtime_commit_failure_taxonomy = "not_run"
+    kolme_fixture_profile = KOLME_RUNTIME_COMMIT_PROFILE
+    kolme_fixture_profile_version = KOLME_RUNTIME_COMMIT_PROFILE_VERSION
+    kolme_fixture_profile_status = "planned" if lane_mode == "dry-run" else "verified"
 
     for artifact in required_artifacts:
         artifact_id = artifact["artifact_id"]
@@ -394,6 +422,78 @@ def run_go_no_go_gate_lane(args: argparse.Namespace) -> int:
                 fail(f"release_manifest_artifact_execution_failed:{artifact_id}:{detail}")
             if expected_marker not in run_result.stdout:
                 fail(f"release_manifest_required_marker_missing:{artifact_id}")
+
+            if artifact_id == "local_full_stack_integration":
+                combined_reason_taxonomy_version = _require_line_value(
+                    run_result.stdout,
+                    "combined_reason_taxonomy_version",
+                    "local_full_stack_integration_combined_reason_taxonomy_version_missing",
+                )
+                if combined_reason_taxonomy_version != COMBINED_REASON_TAXONOMY_VERSION:
+                    fail("local_full_stack_integration_combined_reason_taxonomy_version_mismatch")
+
+                combined_transport_reason_codes_csv = _require_line_value(
+                    run_result.stdout,
+                    "combined_transport_reason_codes",
+                    "local_full_stack_integration_combined_transport_reason_codes_missing",
+                )
+                if combined_transport_reason_codes_csv != COMBINED_TRANSPORT_REASON_CODE:
+                    fail("local_full_stack_integration_combined_transport_reason_codes_mismatch")
+                combined_transport_reason_codes = [combined_transport_reason_codes_csv]
+
+                combined_kolme_runtime_reason_code = _require_line_value(
+                    run_result.stdout,
+                    "combined_kolme_runtime_reason_code",
+                    "local_full_stack_integration_combined_kolme_runtime_reason_code_missing",
+                )
+
+                kolme_runtime_commit_failure_taxonomy_version = _require_line_value(
+                    run_result.stdout,
+                    "kolme_runtime_commit_failure_taxonomy_version",
+                    (
+                        "local_full_stack_integration_kolme_runtime_commit_"
+                        "failure_taxonomy_version_missing"
+                    ),
+                )
+                if (
+                    kolme_runtime_commit_failure_taxonomy_version
+                    != KOLME_RUNTIME_COMMIT_FAILURE_TAXONOMY_VERSION
+                ):
+                    fail(
+                        "local_full_stack_integration_kolme_runtime_commit_"
+                        "failure_taxonomy_version_mismatch"
+                    )
+
+                kolme_runtime_commit_failure_taxonomy = _require_line_value(
+                    run_result.stdout,
+                    "kolme_runtime_commit_failure_taxonomy",
+                    "local_full_stack_integration_kolme_runtime_commit_failure_taxonomy_missing",
+                )
+
+                kolme_fixture_profile = _require_line_value(
+                    run_result.stdout,
+                    "kolme_fixture_profile",
+                    "local_full_stack_integration_kolme_fixture_profile_missing",
+                )
+                if kolme_fixture_profile != KOLME_RUNTIME_COMMIT_PROFILE:
+                    fail("local_full_stack_integration_kolme_fixture_profile_mismatch")
+
+                kolme_fixture_profile_version = _require_line_value(
+                    run_result.stdout,
+                    "kolme_fixture_profile_version",
+                    "local_full_stack_integration_kolme_fixture_profile_version_missing",
+                )
+                if kolme_fixture_profile_version != KOLME_RUNTIME_COMMIT_PROFILE_VERSION:
+                    fail("local_full_stack_integration_kolme_fixture_profile_version_mismatch")
+
+                kolme_fixture_profile_status = _require_line_value(
+                    run_result.stdout,
+                    "kolme_fixture_profile_status",
+                    "local_full_stack_integration_kolme_fixture_profile_status_missing",
+                )
+                if kolme_fixture_profile_status not in {"planned", "verified"}:
+                    fail("local_full_stack_integration_kolme_fixture_profile_status_mismatch")
+
             artifact_entry["status"] = "verified"
             run_mode_command_count += 1
         else:
@@ -500,6 +600,15 @@ def run_go_no_go_gate_lane(args: argparse.Namespace) -> int:
         "policy_evaluator_status": "verified",
         "manifest_schema_version": manifest_payload["schema_version"],
         "manifest_registry_status": "verified",
+        "combined_reason_taxonomy_version": combined_reason_taxonomy_version,
+        "combined_transport_reason_codes": combined_transport_reason_codes,
+        "combined_kolme_runtime_reason_code": combined_kolme_runtime_reason_code,
+        "kolme_runtime_commit_failure_taxonomy_version": kolme_runtime_commit_failure_taxonomy_version,
+        "kolme_runtime_commit_failure_taxonomy": kolme_runtime_commit_failure_taxonomy,
+        "kolme_fixture_profile": kolme_fixture_profile,
+        "kolme_fixture_profile_version": kolme_fixture_profile_version,
+        "kolme_fixture_profile_status": kolme_fixture_profile_status,
+        "combined_lane_marker_contract_status": "verified",
         "waiver_status": waiver_status,
         "waived_reason_codes": waived_reason_codes,
         "waiver_review_required": waiver_status == "applied",
@@ -549,6 +658,18 @@ def run_go_no_go_gate_lane(args: argparse.Namespace) -> int:
     print(f"manifest_schema_version={manifest_payload['schema_version']}")
     print(f"reason_taxonomy_version={GO_NO_GO_REASON_TAXONOMY_VERSION}")
     print("manifest_registry_status=verified")
+    print(f"combined_reason_taxonomy_version={combined_reason_taxonomy_version}")
+    print(f"combined_transport_reason_codes={','.join(combined_transport_reason_codes)}")
+    print(f"combined_kolme_runtime_reason_code={combined_kolme_runtime_reason_code}")
+    print(
+        "kolme_runtime_commit_failure_taxonomy_version="
+        f"{kolme_runtime_commit_failure_taxonomy_version}"
+    )
+    print(f"kolme_runtime_commit_failure_taxonomy={kolme_runtime_commit_failure_taxonomy}")
+    print(f"kolme_fixture_profile={kolme_fixture_profile}")
+    print(f"kolme_fixture_profile_version={kolme_fixture_profile_version}")
+    print(f"kolme_fixture_profile_status={kolme_fixture_profile_status}")
+    print("combined_lane_marker_contract_status=verified")
     print(f"waiver_status={waiver_status}")
     print(
         "waived_reason_codes="

--- a/scripts/runtime/test_run_go_no_go_gate_lane.sh
+++ b/scripts/runtime/test_run_go_no_go_gate_lane.sh
@@ -106,6 +106,42 @@ if ! printf '%s\n' "$lane_output" | grep -q '^reason_taxonomy_version=kamn.runti
   echo "expected go/no-go gate lane reason taxonomy marker" >&2
   exit 1
 fi
+if ! printf '%s\n' "$lane_output" | grep -q '^combined_reason_taxonomy_version=kamn.runtime.local-full-stack-integration-reason-taxonomy.v1$'; then
+  echo "expected go/no-go gate lane combined reason taxonomy marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$lane_output" | grep -q '^combined_transport_reason_codes=fork_choice_stale_block_height$'; then
+  echo "expected go/no-go gate lane combined transport reason marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$lane_output" | grep -q '^combined_kolme_runtime_reason_code=not_run$'; then
+  echo "expected go/no-go gate lane combined Kolme reason marker in dry-run mode" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$lane_output" | grep -q '^kolme_runtime_commit_failure_taxonomy_version=v1$'; then
+  echo "expected go/no-go gate lane Kolme failure taxonomy version marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$lane_output" | grep -q '^kolme_runtime_commit_failure_taxonomy=not_run$'; then
+  echo "expected go/no-go gate lane Kolme failure taxonomy marker in dry-run mode" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$lane_output" | grep -q '^kolme_fixture_profile=real-node-non-synthetic-v1$'; then
+  echo "expected go/no-go gate lane Kolme fixture profile marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$lane_output" | grep -q '^kolme_fixture_profile_version=v1$'; then
+  echo "expected go/no-go gate lane Kolme fixture profile version marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$lane_output" | grep -q '^kolme_fixture_profile_status=planned$'; then
+  echo "expected go/no-go gate lane Kolme fixture profile status marker in dry-run mode" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$lane_output" | grep -q '^combined_lane_marker_contract_status=verified$'; then
+  echo "expected go/no-go gate lane combined marker contract status marker" >&2
+  exit 1
+fi
 if ! printf '%s\n' "$lane_output" | grep -q '^lane_mode=dry-run$'; then
   echo "expected go/no-go gate lane dry-run mode marker" >&2
   exit 1
@@ -179,6 +215,24 @@ if payload.get("manifest_schema_version") != "kamn.runtime.release-evidence-mani
     raise SystemExit("expected manifest_schema_version marker in go/no-go gate report")
 if payload.get("manifest_registry_status") != "verified":
     raise SystemExit("expected manifest_registry_status=verified")
+if payload.get("combined_reason_taxonomy_version") != "kamn.runtime.local-full-stack-integration-reason-taxonomy.v1":
+    raise SystemExit("expected combined_reason_taxonomy_version marker")
+if payload.get("combined_transport_reason_codes") != ["fork_choice_stale_block_height"]:
+    raise SystemExit("expected combined_transport_reason_codes marker")
+if payload.get("combined_kolme_runtime_reason_code") != "not_run":
+    raise SystemExit("expected combined_kolme_runtime_reason_code=not_run in dry-run mode")
+if payload.get("kolme_runtime_commit_failure_taxonomy_version") != "v1":
+    raise SystemExit("expected kolme_runtime_commit_failure_taxonomy_version marker")
+if payload.get("kolme_runtime_commit_failure_taxonomy") != "not_run":
+    raise SystemExit("expected kolme_runtime_commit_failure_taxonomy=not_run in dry-run mode")
+if payload.get("kolme_fixture_profile") != "real-node-non-synthetic-v1":
+    raise SystemExit("expected kolme_fixture_profile marker")
+if payload.get("kolme_fixture_profile_version") != "v1":
+    raise SystemExit("expected kolme_fixture_profile_version marker")
+if payload.get("kolme_fixture_profile_status") != "planned":
+    raise SystemExit("expected kolme_fixture_profile_status=planned in dry-run mode")
+if payload.get("combined_lane_marker_contract_status") != "verified":
+    raise SystemExit("expected combined_lane_marker_contract_status=verified")
 inventory = payload.get("artifact_inventory")
 if not isinstance(inventory, list) or len(inventory) != 6:
     raise SystemExit("expected deterministic artifact inventory list with six required entries")
@@ -263,6 +317,42 @@ if ! printf '%s\n' "$run_mode_output" | grep -q '^transport_fault_matrix_status=
   echo "expected go/no-go gate lane run-mode transport fault-matrix status marker" >&2
   exit 1
 fi
+if ! printf '%s\n' "$run_mode_output" | grep -q '^combined_reason_taxonomy_version=kamn.runtime.local-full-stack-integration-reason-taxonomy.v1$'; then
+  echo "expected go/no-go gate lane run-mode combined reason taxonomy marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$run_mode_output" | grep -q '^combined_transport_reason_codes=fork_choice_stale_block_height$'; then
+  echo "expected go/no-go gate lane run-mode combined transport reason marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$run_mode_output" | grep -q '^combined_kolme_runtime_reason_code=not_run$'; then
+  echo "expected go/no-go gate lane run-mode combined Kolme reason marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$run_mode_output" | grep -q '^kolme_runtime_commit_failure_taxonomy_version=v1$'; then
+  echo "expected go/no-go gate lane run-mode Kolme failure taxonomy version marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$run_mode_output" | grep -q '^kolme_runtime_commit_failure_taxonomy=not_run$'; then
+  echo "expected go/no-go gate lane run-mode Kolme failure taxonomy marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$run_mode_output" | grep -q '^kolme_fixture_profile=real-node-non-synthetic-v1$'; then
+  echo "expected go/no-go gate lane run-mode Kolme fixture profile marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$run_mode_output" | grep -q '^kolme_fixture_profile_version=v1$'; then
+  echo "expected go/no-go gate lane run-mode Kolme fixture profile version marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$run_mode_output" | grep -q '^kolme_fixture_profile_status=planned$'; then
+  echo "expected go/no-go gate lane run-mode Kolme fixture profile status marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$run_mode_output" | grep -q '^combined_lane_marker_contract_status=verified$'; then
+  echo "expected go/no-go gate lane run-mode combined marker contract status marker" >&2
+  exit 1
+fi
 if ! printf '%s\n' "$run_mode_output" | grep -q '^ci_fast_gate_eligible=false$'; then
   echo "expected go/no-go gate lane run-mode fast-gate exclusion marker" >&2
   exit 1
@@ -314,6 +404,24 @@ if payload.get("local_full_runtime_convergence_status") != "verified":
     raise SystemExit("expected local_full_runtime_convergence_status=verified in run-mode go/no-go gate report")
 if payload.get("transport_fault_matrix_status") != "verified":
     raise SystemExit("expected transport_fault_matrix_status=verified in run-mode go/no-go gate report")
+if payload.get("combined_reason_taxonomy_version") != "kamn.runtime.local-full-stack-integration-reason-taxonomy.v1":
+    raise SystemExit("expected combined_reason_taxonomy_version marker in run-mode go/no-go gate report")
+if payload.get("combined_transport_reason_codes") != ["fork_choice_stale_block_height"]:
+    raise SystemExit("expected combined_transport_reason_codes marker in run-mode go/no-go gate report")
+if payload.get("combined_kolme_runtime_reason_code") != "not_run":
+    raise SystemExit("expected combined_kolme_runtime_reason_code=not_run in run-mode go/no-go gate report")
+if payload.get("kolme_runtime_commit_failure_taxonomy_version") != "v1":
+    raise SystemExit("expected kolme_runtime_commit_failure_taxonomy_version marker in run-mode go/no-go gate report")
+if payload.get("kolme_runtime_commit_failure_taxonomy") != "not_run":
+    raise SystemExit("expected kolme_runtime_commit_failure_taxonomy=not_run in run-mode go/no-go gate report")
+if payload.get("kolme_fixture_profile") != "real-node-non-synthetic-v1":
+    raise SystemExit("expected kolme_fixture_profile marker in run-mode go/no-go gate report")
+if payload.get("kolme_fixture_profile_version") != "v1":
+    raise SystemExit("expected kolme_fixture_profile_version marker in run-mode go/no-go gate report")
+if payload.get("kolme_fixture_profile_status") != "planned":
+    raise SystemExit("expected kolme_fixture_profile_status=planned in run-mode go/no-go gate report")
+if payload.get("combined_lane_marker_contract_status") != "verified":
+    raise SystemExit("expected combined_lane_marker_contract_status=verified in run-mode go/no-go gate report")
 required_ids = payload.get("required_artifact_ids")
 if not isinstance(required_ids, list) or sorted(required_ids) != sorted(
     [


### PR DESCRIPTION
## Summary
Enforces deterministic combined native libp2p+Kolme marker contracts in release go/no-go evidence so milestone promotion fails closed when marker/taxonomy lineage drifts.

Closes #3718

## Changes
- `scripts/runtime/go_no_go_gate_lane_contract.py`: projects combined marker surface into gate reports and validates marker extraction from local full-stack artifact output.
- `scripts/deploy/gonogo_evidence_contract.py`: validates combined marker/taxonomy/profile markers from gate report, adds fail-closed reason codes, and records required contract surface in milestone bundle.
- `scripts/runtime/test_run_go_no_go_gate_lane.sh`: adds dry-run/run assertions for combined marker fields.
- `scripts/deploy/test_generate_gonogo_evidence_bundle.sh`: adds combined marker schema assertions and taxonomy-drift fail-closed regression coverage.
- `scripts/deploy/gonogo_evidence_contract_lane_contract.sh`: updates fixture gate report with required combined markers.
- `scripts/ci/test_kolme_live_integration_architecture_contract.sh`: aligns docs marker contract with current runtime integration marker names and deterministic tamper check.
- Docs updates:
  - `docs/deploy/kolme_devnet_ops.md`
  - `docs/planning/kolme-devnet-ops.md`
  - `docs/plans/2026-02-14-production-service-next-steps.md`

## Risks & Compatibility
- Tightens required marker surface for milestone evidence; older minimal gate fixtures now fail closed until updated.
- No runtime dependency changes.

## Validation
- [x] `python3 -m py_compile scripts/runtime/go_no_go_gate_lane_contract.py scripts/deploy/gonogo_evidence_contract.py`
- [x] `bash scripts/runtime/test_run_go_no_go_gate_lane.sh`
- [x] `bash scripts/deploy/test_generate_gonogo_evidence_bundle.sh`
- [x] `bash scripts/deploy/test_run_gonogo_evidence_contract_lane.sh`
- [x] `bash scripts/ci/test_kolme_live_integration_architecture_contract.sh`
- [x] `bash scripts/ci/test_production_service_next_steps_contract.sh`

## Test Matrix Evidence
| Category     | Status | Notes |
|-------------|--------|-------|
| Unit        | ✅ | Python contract helper behavior validated in script-level checks |
| Functional  | ✅ | go/no-go gate + evidence policy marker contracts validated |
| Integration | ✅ | contract-lane wrappers and docs-contract linkage validated |
| Regression  | ✅ | taxonomy-drift fail-closed test added for milestone evidence bundle |
