### PR TITLE
refactor(runtime): extract daemon phase orchestration module

### DIFF
--- a/crates/kamn-node/src/runtime_orchestration.rs
+++ b/crates/kamn-node/src/runtime_orchestration.rs
@@ -1,24 +1,12 @@
 use super::*;
 
-fn daemon_lifecycle_event_as_str(event: PeerLifecycleEvent) -> &'static str {
-    match event {
-        PeerLifecycleEvent::StartConnect => "start-connect",
-        PeerLifecycleEvent::HandshakeSucceeded => "handshake-succeeded",
-        PeerLifecycleEvent::HeartbeatMissed => "heartbeat-missed",
-        PeerLifecycleEvent::HeartbeatRestored => "heartbeat-restored",
-        PeerLifecycleEvent::Disconnect => "disconnect",
-        PeerLifecycleEvent::Rejoin => "rejoin",
-    }
-}
+mod daemon_phase;
 
-fn peer_lifecycle_state_as_str(state: PeerLifecycleState) -> &'static str {
-    match state {
-        PeerLifecycleState::Disconnected => "disconnected",
-        PeerLifecycleState::Connecting => "connecting",
-        PeerLifecycleState::Active => "active",
-        PeerLifecycleState::Degraded => "degraded",
-    }
-}
+use daemon_phase::execute_daemon_runtime;
+use daemon_phase::{
+    daemon_shutdown_drain_status, daemon_shutdown_reason_field, daemon_shutdown_signal_tick,
+    daemon_shutdown_snapshot_flush_status,
+};
 
 pub(crate) fn build_runtime_execution_id(
     runtime_mode: RuntimeMode,
@@ -169,46 +157,6 @@ fn enforce_production_transport_profile_policy(
     Ok(())
 }
 
-pub(crate) fn daemon_shutdown_drain_status(completion_reason: &str) -> &'static str {
-    if completion_reason.starts_with("graceful-shutdown:signal@") {
-        "completed"
-    } else if completion_reason.starts_with("graceful-shutdown-timeout:signal@") {
-        "timeout"
-    } else {
-        "not-signaled"
-    }
-}
-
-pub(crate) fn daemon_shutdown_snapshot_flush_status(completion_reason: &str) -> &'static str {
-    if completion_reason.starts_with("graceful-shutdown:signal@") {
-        "snapshot-flushed"
-    } else if completion_reason.starts_with("graceful-shutdown-timeout:signal@") {
-        "snapshot-flush-timeout"
-    } else {
-        "snapshot-not-requested"
-    }
-}
-
-pub(crate) fn daemon_shutdown_signal_tick(completion_reason: &str) -> Option<&str> {
-    completion_reason
-        .strip_prefix("graceful-shutdown:signal@")
-        .or_else(|| completion_reason.strip_prefix("graceful-shutdown-timeout:signal@"))
-        .map(|value| value.split(';').next().unwrap_or(value))
-}
-
-pub(crate) fn daemon_shutdown_reason_field<'a>(
-    completion_reason: &'a str,
-    key: &str,
-) -> Option<&'a str> {
-    completion_reason.split(';').find_map(|segment| {
-        let (field, value) = segment.split_once('=')?;
-        if field == key {
-            return Some(value);
-        }
-        None
-    })
-}
-
 pub(crate) fn classify_full_bootstrap_component_contract_violation(
     components: &[&str],
 ) -> Option<&'static str> {
@@ -325,146 +273,6 @@ pub(crate) fn validate_full_supervisor_stop_contract(
         )));
     }
     Ok(())
-}
-
-fn execute_daemon_runtime(
-    runtime_mode: RuntimeMode,
-    execution_id: &str,
-    options: DaemonRuntimeOptions,
-) -> Result<DaemonExecution, ConfigError> {
-    let DaemonRuntimeOptions {
-        daemon_max_ticks,
-        daemon_tick_interval_ms,
-        daemon_shutdown_signal_ticks,
-        daemon_shutdown_os_signals,
-        daemon_shutdown_drain_ticks,
-        daemon_shutdown_timeout_ticks,
-        daemon_peer_id,
-        daemon_lifecycle_events,
-    } = options;
-    let max_ticks =
-        daemon_max_ticks.ok_or(ConfigError::MissingArgumentValue("--daemon-max-ticks"))?;
-    let tick_interval_ms = daemon_tick_interval_ms.ok_or(ConfigError::MissingArgumentValue(
-        "--daemon-tick-interval-ms",
-    ))?;
-    let max_ticks_label = max_ticks.to_string();
-    let tick_interval_ms_label = tick_interval_ms.to_string();
-    log_info(
-        "node.runtime.daemon.execute.start",
-        &[
-            ("runtime_mode", runtime_mode.as_str()),
-            ("max_ticks", max_ticks_label.as_str()),
-            ("tick_interval_ms", tick_interval_ms_label.as_str()),
-            ("execution_id", execution_id),
-        ],
-    )?;
-    let (peer_id, peer_lifecycle_final_state, peer_lifecycle_applied_events) = match daemon_peer_id
-    {
-        Some(peer_id) => {
-            let mut lifecycle = PeerLifecycle::new(&peer_id)
-                .map_err(|error| ConfigError::RuntimeDaemonLifecycle(error.to_string()))?;
-            let mut applied_events = Vec::with_capacity(daemon_lifecycle_events.len());
-            for event in daemon_lifecycle_events {
-                lifecycle
-                    .transition(event)
-                    .map_err(|error| ConfigError::RuntimeDaemonLifecycle(error.to_string()))?;
-                applied_events.push(daemon_lifecycle_event_as_str(event).to_owned());
-            }
-            (
-                Some(peer_id),
-                Some(peer_lifecycle_state_as_str(lifecycle.state()).to_owned()),
-                Some(applied_events),
-            )
-        }
-        None => (None, None, None),
-    };
-    let daemon_completion = if should_use_os_signal_shutdown(
-        runtime_mode,
-        daemon_shutdown_os_signals,
-        daemon_shutdown_signal_ticks.as_slice(),
-    ) {
-        evaluate_daemon_completion_with_os_signals(
-            max_ticks,
-            tick_interval_ms,
-            daemon_shutdown_drain_ticks,
-            daemon_shutdown_timeout_ticks,
-        )
-        .map_err(|error| ConfigError::RuntimeDaemonLifecycle(error.to_string()))?
-    } else {
-        evaluate_daemon_completion(
-            max_ticks,
-            daemon_shutdown_signal_ticks.as_slice(),
-            daemon_shutdown_drain_ticks,
-            daemon_shutdown_timeout_ticks,
-        )
-    };
-    let daemon_observability = build_daemon_observability_telemetry(
-        tick_interval_ms,
-        daemon_completion.completion_reason.as_str(),
-    )
-    .map_err(|error| ConfigError::RuntimeDaemonLifecycle(error.to_string()))?;
-    let shutdown_drain_status =
-        daemon_shutdown_drain_status(daemon_completion.completion_reason.as_str());
-    let shutdown_snapshot_flush_status =
-        daemon_shutdown_snapshot_flush_status(daemon_completion.completion_reason.as_str());
-    let shutdown_signal_tick =
-        daemon_shutdown_signal_tick(daemon_completion.completion_reason.as_str()).unwrap_or("none");
-    let shutdown_drain_ticks =
-        daemon_shutdown_reason_field(daemon_completion.completion_reason.as_str(), "drain_ticks")
-            .unwrap_or("0");
-    let shutdown_timeout_ticks = daemon_shutdown_reason_field(
-        daemon_completion.completion_reason.as_str(),
-        "timeout_ticks",
-    )
-    .unwrap_or("0");
-    let shutdown_ignored_signals = daemon_shutdown_reason_field(
-        daemon_completion.completion_reason.as_str(),
-        "ignored_signals",
-    )
-    .unwrap_or("0");
-    let executed_ticks_label = daemon_completion.executed_ticks.to_string();
-    log_info(
-        "node.runtime.daemon.execute.complete",
-        &[
-            ("runtime_mode", runtime_mode.as_str()),
-            ("executed_ticks", executed_ticks_label.as_str()),
-            (
-                "completion_reason",
-                daemon_completion.completion_reason.as_str(),
-            ),
-            ("shutdown_drain_status", shutdown_drain_status),
-            (
-                "shutdown_snapshot_flush_status",
-                shutdown_snapshot_flush_status,
-            ),
-            ("shutdown_signal_tick", shutdown_signal_tick),
-            ("shutdown_drain_ticks", shutdown_drain_ticks),
-            ("shutdown_timeout_ticks", shutdown_timeout_ticks),
-            ("shutdown_ignored_signals", shutdown_ignored_signals),
-            ("execution_id", execution_id),
-        ],
-    )?;
-    Ok(DaemonExecution {
-        max_ticks,
-        tick_interval_ms,
-        executed_ticks: daemon_completion.executed_ticks,
-        completion_reason: daemon_completion.completion_reason,
-        observability_latency_p50_ms: daemon_observability.latency_p50_ms,
-        observability_latency_p99_ms: daemon_observability.latency_p99_ms,
-        observability_throughput_tps: daemon_observability.throughput_tps,
-        observability_error_rate_bps: daemon_observability.error_rate_bps,
-        observability_availability_bps: daemon_observability.availability_bps,
-        observability_health: daemon_observability.health,
-        observability_alert_count: daemon_observability.alert_count,
-        observability_reason_code: daemon_observability.reason_code,
-        observability_transport_checkpoint_failures: daemon_observability
-            .transport_checkpoint_failures,
-        observability_signer_checkpoint_failures: daemon_observability.signer_checkpoint_failures,
-        observability_commit_checkpoint_failures: daemon_observability.commit_checkpoint_failures,
-        peer_id,
-        peer_lifecycle_final_state,
-        peer_lifecycle_applied_events,
-    })
 }
 
 pub(crate) fn resolve_kolme_live_allow_local_signer_testing_override() -> Result<bool, ConfigError>

--- a/crates/kamn-node/src/runtime_orchestration/daemon_phase.rs
+++ b/crates/kamn-node/src/runtime_orchestration/daemon_phase.rs
@@ -1,0 +1,201 @@
+use super::*;
+
+fn daemon_lifecycle_event_as_str(event: PeerLifecycleEvent) -> &'static str {
+    match event {
+        PeerLifecycleEvent::StartConnect => "start-connect",
+        PeerLifecycleEvent::HandshakeSucceeded => "handshake-succeeded",
+        PeerLifecycleEvent::HeartbeatMissed => "heartbeat-missed",
+        PeerLifecycleEvent::HeartbeatRestored => "heartbeat-restored",
+        PeerLifecycleEvent::Disconnect => "disconnect",
+        PeerLifecycleEvent::Rejoin => "rejoin",
+    }
+}
+
+fn peer_lifecycle_state_as_str(state: PeerLifecycleState) -> &'static str {
+    match state {
+        PeerLifecycleState::Disconnected => "disconnected",
+        PeerLifecycleState::Connecting => "connecting",
+        PeerLifecycleState::Active => "active",
+        PeerLifecycleState::Degraded => "degraded",
+    }
+}
+
+pub(super) fn daemon_shutdown_drain_status(completion_reason: &str) -> &'static str {
+    if completion_reason.starts_with("graceful-shutdown:signal@") {
+        "completed"
+    } else if completion_reason.starts_with("graceful-shutdown-timeout:signal@") {
+        "timeout"
+    } else {
+        "not-signaled"
+    }
+}
+
+pub(super) fn daemon_shutdown_snapshot_flush_status(completion_reason: &str) -> &'static str {
+    if completion_reason.starts_with("graceful-shutdown:signal@") {
+        "snapshot-flushed"
+    } else if completion_reason.starts_with("graceful-shutdown-timeout:signal@") {
+        "snapshot-flush-timeout"
+    } else {
+        "snapshot-not-requested"
+    }
+}
+
+pub(super) fn daemon_shutdown_signal_tick(completion_reason: &str) -> Option<&str> {
+    completion_reason
+        .strip_prefix("graceful-shutdown:signal@")
+        .or_else(|| completion_reason.strip_prefix("graceful-shutdown-timeout:signal@"))
+        .map(|value| value.split(';').next().unwrap_or(value))
+}
+
+pub(super) fn daemon_shutdown_reason_field<'a>(
+    completion_reason: &'a str,
+    key: &str,
+) -> Option<&'a str> {
+    completion_reason.split(';').find_map(|segment| {
+        let (field, value) = segment.split_once('=')?;
+        if field == key {
+            return Some(value);
+        }
+        None
+    })
+}
+
+pub(super) fn execute_daemon_runtime(
+    runtime_mode: RuntimeMode,
+    execution_id: &str,
+    options: DaemonRuntimeOptions,
+) -> Result<DaemonExecution, ConfigError> {
+    let DaemonRuntimeOptions {
+        daemon_max_ticks,
+        daemon_tick_interval_ms,
+        daemon_shutdown_signal_ticks,
+        daemon_shutdown_os_signals,
+        daemon_shutdown_drain_ticks,
+        daemon_shutdown_timeout_ticks,
+        daemon_peer_id,
+        daemon_lifecycle_events,
+    } = options;
+    let max_ticks =
+        daemon_max_ticks.ok_or(ConfigError::MissingArgumentValue("--daemon-max-ticks"))?;
+    let tick_interval_ms = daemon_tick_interval_ms.ok_or(ConfigError::MissingArgumentValue(
+        "--daemon-tick-interval-ms",
+    ))?;
+    let max_ticks_label = max_ticks.to_string();
+    let tick_interval_ms_label = tick_interval_ms.to_string();
+    log_info(
+        "node.runtime.daemon.execute.start",
+        &[
+            ("runtime_mode", runtime_mode.as_str()),
+            ("max_ticks", max_ticks_label.as_str()),
+            ("tick_interval_ms", tick_interval_ms_label.as_str()),
+            ("execution_id", execution_id),
+        ],
+    )?;
+    let (peer_id, peer_lifecycle_final_state, peer_lifecycle_applied_events) = match daemon_peer_id
+    {
+        Some(peer_id) => {
+            let mut lifecycle = PeerLifecycle::new(&peer_id)
+                .map_err(|error| ConfigError::RuntimeDaemonLifecycle(error.to_string()))?;
+            let mut applied_events = Vec::with_capacity(daemon_lifecycle_events.len());
+            for event in daemon_lifecycle_events {
+                lifecycle
+                    .transition(event)
+                    .map_err(|error| ConfigError::RuntimeDaemonLifecycle(error.to_string()))?;
+                applied_events.push(daemon_lifecycle_event_as_str(event).to_owned());
+            }
+            (
+                Some(peer_id),
+                Some(peer_lifecycle_state_as_str(lifecycle.state()).to_owned()),
+                Some(applied_events),
+            )
+        }
+        None => (None, None, None),
+    };
+    let daemon_completion = if should_use_os_signal_shutdown(
+        runtime_mode,
+        daemon_shutdown_os_signals,
+        daemon_shutdown_signal_ticks.as_slice(),
+    ) {
+        evaluate_daemon_completion_with_os_signals(
+            max_ticks,
+            tick_interval_ms,
+            daemon_shutdown_drain_ticks,
+            daemon_shutdown_timeout_ticks,
+        )
+        .map_err(|error| ConfigError::RuntimeDaemonLifecycle(error.to_string()))?
+    } else {
+        evaluate_daemon_completion(
+            max_ticks,
+            daemon_shutdown_signal_ticks.as_slice(),
+            daemon_shutdown_drain_ticks,
+            daemon_shutdown_timeout_ticks,
+        )
+    };
+    let daemon_observability = build_daemon_observability_telemetry(
+        tick_interval_ms,
+        daemon_completion.completion_reason.as_str(),
+    )
+    .map_err(|error| ConfigError::RuntimeDaemonLifecycle(error.to_string()))?;
+    let shutdown_drain_status =
+        daemon_shutdown_drain_status(daemon_completion.completion_reason.as_str());
+    let shutdown_snapshot_flush_status =
+        daemon_shutdown_snapshot_flush_status(daemon_completion.completion_reason.as_str());
+    let shutdown_signal_tick =
+        daemon_shutdown_signal_tick(daemon_completion.completion_reason.as_str()).unwrap_or("none");
+    let shutdown_drain_ticks =
+        daemon_shutdown_reason_field(daemon_completion.completion_reason.as_str(), "drain_ticks")
+            .unwrap_or("0");
+    let shutdown_timeout_ticks = daemon_shutdown_reason_field(
+        daemon_completion.completion_reason.as_str(),
+        "timeout_ticks",
+    )
+    .unwrap_or("0");
+    let shutdown_ignored_signals = daemon_shutdown_reason_field(
+        daemon_completion.completion_reason.as_str(),
+        "ignored_signals",
+    )
+    .unwrap_or("0");
+    let executed_ticks_label = daemon_completion.executed_ticks.to_string();
+    log_info(
+        "node.runtime.daemon.execute.complete",
+        &[
+            ("runtime_mode", runtime_mode.as_str()),
+            ("executed_ticks", executed_ticks_label.as_str()),
+            (
+                "completion_reason",
+                daemon_completion.completion_reason.as_str(),
+            ),
+            ("shutdown_drain_status", shutdown_drain_status),
+            (
+                "shutdown_snapshot_flush_status",
+                shutdown_snapshot_flush_status,
+            ),
+            ("shutdown_signal_tick", shutdown_signal_tick),
+            ("shutdown_drain_ticks", shutdown_drain_ticks),
+            ("shutdown_timeout_ticks", shutdown_timeout_ticks),
+            ("shutdown_ignored_signals", shutdown_ignored_signals),
+            ("execution_id", execution_id),
+        ],
+    )?;
+    Ok(DaemonExecution {
+        max_ticks,
+        tick_interval_ms,
+        executed_ticks: daemon_completion.executed_ticks,
+        completion_reason: daemon_completion.completion_reason,
+        observability_latency_p50_ms: daemon_observability.latency_p50_ms,
+        observability_latency_p99_ms: daemon_observability.latency_p99_ms,
+        observability_throughput_tps: daemon_observability.throughput_tps,
+        observability_error_rate_bps: daemon_observability.error_rate_bps,
+        observability_availability_bps: daemon_observability.availability_bps,
+        observability_health: daemon_observability.health,
+        observability_alert_count: daemon_observability.alert_count,
+        observability_reason_code: daemon_observability.reason_code,
+        observability_transport_checkpoint_failures: daemon_observability
+            .transport_checkpoint_failures,
+        observability_signer_checkpoint_failures: daemon_observability.signer_checkpoint_failures,
+        observability_commit_checkpoint_failures: daemon_observability.commit_checkpoint_failures,
+        peer_id,
+        peer_lifecycle_final_state,
+        peer_lifecycle_applied_events,
+    })
+}

--- a/crates/kamn-node/tests/main_module_extraction_contract.rs
+++ b/crates/kamn-node/tests/main_module_extraction_contract.rs
@@ -157,6 +157,28 @@ fn main_module_extraction_contract_removes_inline_runtime_orchestration_impls() 
 }
 
 #[test]
+fn runtime_orchestration_module_extraction_contract_declares_daemon_phase_module() {
+    let runtime_orchestration_rs = read_repo_file("src/runtime_orchestration.rs");
+    let daemon_phase_rs = read_repo_file("src/runtime_orchestration/daemon_phase.rs");
+    assert!(
+        runtime_orchestration_rs.contains("mod daemon_phase;"),
+        "runtime_orchestration.rs should declare daemon phase submodule"
+    );
+    assert!(
+        !runtime_orchestration_rs.contains("fn execute_daemon_runtime("),
+        "runtime_orchestration.rs should not keep inline daemon runtime executor"
+    );
+    assert!(
+        daemon_phase_rs.contains("pub(super) fn execute_daemon_runtime("),
+        "daemon phase module should own daemon runtime execution"
+    );
+    assert!(
+        daemon_phase_rs.contains("pub(super) fn daemon_shutdown_drain_status("),
+        "daemon phase module should own shutdown drain status derivation"
+    );
+}
+
+#[test]
 fn main_module_extraction_contract_keeps_impls_in_new_modules() {
     let signer_rs = read_repo_file("src/signer.rs");
     let report_builder_rs = read_repo_file("src/report_builder.rs");

--- a/docs/architecture/service-runtime.md
+++ b/docs/architecture/service-runtime.md
@@ -12,6 +12,17 @@ full runtime execution paths.
 - explicit OS-signal override flag (`--daemon-shutdown-os-signals`) remains
   supported for policy clarity and cross-platform fail-closed checks
 
+## Runtime Phase Module Map
+
+- `crates/kamn-node/src/runtime_orchestration.rs`
+  - owns runtime mode dispatch, production transport profile policy checks, full
+    supervisor stop-contract validation, and signer policy enforcement.
+- `crates/kamn-node/src/runtime_orchestration/daemon_phase.rs`
+  - owns daemon/full daemon-phase execution, peer lifecycle transition
+    projection, and shutdown marker parsing/projection.
+- Extraction contract lane:
+  - `cargo test -p kamn-node --test main_module_extraction_contract`
+
 ## Drain Marker Contract
 
 `shutdown_drain_status` is emitted on daemon completion and full-supervisor stop


### PR DESCRIPTION
## Summary
This extracts daemon-phase orchestration into a dedicated runtime phase module while preserving runtime behavior. `runtime_orchestration.rs` now focuses on dispatch/policy contracts, and daemon execution + shutdown marker helpers live in `runtime_orchestration/daemon_phase.rs`.

Closes #3735.

## Changes
- `crates/kamn-node/src/runtime_orchestration/daemon_phase.rs` (new):
  - moved daemon-phase execution path (`execute_daemon_runtime`)
  - moved daemon lifecycle transition helpers
  - moved shutdown marker helper parsing/projection functions
- `crates/kamn-node/src/runtime_orchestration.rs`:
  - declared/imported `mod daemon_phase;`
  - removed inline daemon-phase execution/helper implementations
  - preserved existing public runtime orchestration behavior/contracts
- `crates/kamn-node/tests/main_module_extraction_contract.rs`:
  - added `runtime_orchestration_module_extraction_contract_declares_daemon_phase_module`
  - enforces module declaration and ownership of `execute_daemon_runtime`
- `docs/architecture/service-runtime.md`:
  - added runtime phase module map section with ownership boundaries and extraction contract lane

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Initial extraction wiring failed as expected before visibility/import cleanup:
- `cargo test -p kamn-node --test main_module_extraction_contract`
- compile errors included:
  - `E0364: daemon_shutdown_* is private, and cannot be re-exported`

This established the failing state for module boundary wiring.

### 🟢 Green Phase
After fixing module imports/visibility usage and finalizing extraction:
- `cargo test -p kamn-node --test main_module_extraction_contract`
- `cargo test -p kamn-node -- main_tests::runtime_tests`
- `cargo test -p kamn-node -- main_tests::daemon_tests`
- `cargo test -p kamn-node --test node_module_map_docs`

Results:
- extraction contract: `7 passed; 0 failed`
- runtime suite: `59 passed; 0 failed`
- daemon suite: `13 passed; 0 failed`
- node module map docs: `2 passed; 0 failed`

### 🔁 Regression
- `cargo fmt --check`
- `cargo clippy -p kamn-node -- -D warnings`
- `cargo test -p kamn-node --test main_module_extraction_contract`
- `cargo test -p kamn-node -- main_tests::runtime_tests`
- `cargo test -p kamn-node -- main_tests::daemon_tests`

Result:
- all commands pass clean.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | module-ownership assertions in `main_module_extraction_contract` | |
| Functional   | ✅ | runtime mode dispatch parity via `main_tests::runtime_tests` | |
| Integration  | ✅ | daemon/full runtime orchestration path parity via runtime+daemon suites | |
| Regression   | ✅ | new daemon-phase module extraction contract assertion | |
| Performance  | ✅ | existing bounded startup/retry performance tests in runtime suite remain green | |

## Risks & Rollback
- Low-to-medium risk: structural refactor of runtime orchestration internals.
- Rollback plan: revert this PR to restore inline daemon-phase implementation if behavior drift is detected.

## Documentation Updates
- `docs/architecture/service-runtime.md` updated with runtime phase module map and extraction contract lane.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (run as `cargo clippy -p kamn-node -- -D warnings`)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (relevant scope)
- [x] Docs updated
