### PR TITLE
feat(runtime): enforce native libp2p provider marker contracts in go/no-go gates

### DIFF
--- a/crates/kamn-core/tests/ci_strategy_docs.rs
+++ b/crates/kamn-core/tests/ci_strategy_docs.rs
@@ -361,6 +361,16 @@ fn doc_contains_make_and_demo_scope_contract_rules() {
     assert!(DOC.contains("reason_codes=delta_threshold_waiver_applied"));
     assert!(DOC.contains("reason_codes=waiver_expired"));
     assert!(DOC.contains("reason_codes=waiver_scope_mismatch"));
+    assert!(DOC.contains("native_libp2p_provider_marker=p2p-live-libp2p-provider:native"));
+    assert!(DOC.contains(
+        "libp2p_fallback_marker_blocklist=p2p-in-memory-transport-fallback,p2p-live-libp2p-provider:contract-only"
+    ));
+    assert!(DOC.contains("libp2p_fallback_markers_detected=none"));
+    assert!(DOC.contains("native_libp2p_provider_marker_contract_status=verified"));
+    assert!(DOC.contains("gate_policy_native_libp2p_provider_marker_mismatch"));
+    assert!(DOC.contains("gate_policy_libp2p_fallback_marker_blocklist_mismatch"));
+    assert!(DOC.contains("gate_policy_libp2p_fallback_markers_detected"));
+    assert!(DOC.contains("gate_policy_native_libp2p_provider_marker_contract_status_mismatch"));
     assert!(DOC.contains("waiver_status=none|applied"));
     assert!(DOC.contains("waived_reason_codes=none|..."));
     assert!(DOC.contains("remediation=..."));

--- a/crates/kamn-core/tests/p2p_transport_docs.rs
+++ b/crates/kamn-core/tests/p2p_transport_docs.rs
@@ -54,6 +54,9 @@ fn architecture_doc_contains_runtime_wiring_and_guardrails() {
     assert!(DOC.contains("P2pTransportError::MissingKademliaBootstrapSeeds"));
     assert!(DOC.contains("p2p-live-libp2p-provider:native"));
     assert!(DOC.contains("p2p-live-libp2p-provider:contract-only"));
+    assert!(DOC.contains("libp2p_native_provider_marker=p2p-live-libp2p-provider:native"));
+    assert!(DOC.contains("libp2p_fallback_markers_detected"));
+    assert!(DOC.contains("libp2p_provider_marker_contract_status=verified"));
     assert!(DOC.contains("bootstrap peer multiaddrs"));
     assert!(DOC.contains("runtime_peer_transition_invalid"));
     assert!(DOC.contains("validate_p2p_transport_live.sh"));
@@ -78,6 +81,10 @@ fn architecture_doc_contains_runtime_wiring_and_guardrails() {
     assert!(DOC.contains("p2p_live_reconnect_retry_stream_churn"));
     assert!(DOC.contains("p2p_live_reconnect_protocol_violation"));
     assert!(DOC.contains("p2p_live_reconnect_retry_budget_exhausted"));
+    assert!(DOC.contains("gate_policy_native_libp2p_provider_marker_mismatch"));
+    assert!(DOC.contains("gate_policy_libp2p_fallback_marker_blocklist_mismatch"));
+    assert!(DOC.contains("gate_policy_libp2p_fallback_markers_detected"));
+    assert!(DOC.contains("gate_policy_native_libp2p_provider_marker_contract_status_mismatch"));
 }
 
 #[test]

--- a/docs/architecture/p2p-transport.md
+++ b/docs/architecture/p2p-transport.md
@@ -149,6 +149,16 @@ provider marker contracts for local-heavy runtime rehearsal:
     - `p2p-live-libp2p-provider:contract-only` (feature disabled)
     - `p2p-live-libp2p-provider:native` (`libp2p-live-transport` enabled)
 
+Release-gate marker contracts (Task #3736) require deterministic native-only
+provider evidence in runtime summary lanes:
+
+- `libp2p_native_provider_marker=p2p-live-libp2p-provider:native`
+- fallback marker deny-list:
+  - `p2p-in-memory-transport-fallback`
+  - `p2p-live-libp2p-provider:contract-only`
+- `libp2p_fallback_markers_detected` must be empty
+- `libp2p_provider_marker_contract_status=verified`
+
 ## Live Data-Plane Execution
 
 Subtask #3574 moves the live adapter execution path off the in-memory delegate
@@ -252,6 +262,14 @@ Deterministic reason-code markers:
     - remediation: remove `--disable-gossip` or switch to non-production runtime mode
   - `runtime_transport_profile_in_memory_fallback_forbidden`
     - remediation: remove in-memory fallback markers and enforce live profile markers
+  - `gate_policy_native_libp2p_provider_marker_mismatch`
+    - remediation: restore `p2p-live-libp2p-provider:native` marker in runtime report path
+  - `gate_policy_libp2p_fallback_marker_blocklist_mismatch`
+    - remediation: restore canonical fallback-marker deny-list in release-gate contracts
+  - `gate_policy_libp2p_fallback_markers_detected`
+    - remediation: remove fallback markers and enforce native provider marker contract
+  - `gate_policy_native_libp2p_provider_marker_contract_status_mismatch`
+    - remediation: restore `libp2p_provider_marker_contract_status=verified`
 
 ## Peer Lifecycle Proptest Invariants
 

--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -2943,6 +2943,11 @@ The runtime go/no-go gate lane enforces a versioned release evidence manifest:
   - `PASS` => `status=pass`, `final_decision=GO`
   - `WARN` => `status=warn`, `final_decision=GO`
   - `FAIL` => `status=fail`, `final_decision=NO-GO`
+- native libp2p provider marker contracts (consumed by go/no-go policy evaluation):
+  - `native_libp2p_provider_marker=p2p-live-libp2p-provider:native`
+  - `libp2p_fallback_marker_blocklist=p2p-in-memory-transport-fallback,p2p-live-libp2p-provider:contract-only`
+  - `libp2p_fallback_markers_detected=none`
+  - `native_libp2p_provider_marker_contract_status=verified`
 - required artifact IDs:
   - `go_no_go_evidence`
   - `rollback_readiness`
@@ -2982,6 +2987,10 @@ The runtime go/no-go gate lane enforces a versioned release evidence manifest:
   - `waiver_allowed_reason_codes_invalid`
   - `runtime_budget_exceeded` (warning reason)
   - `gate_decision_fault_injection_triggered` (fail reason)
+  - `gate_policy_native_libp2p_provider_marker_mismatch`
+  - `gate_policy_libp2p_fallback_marker_blocklist_mismatch`
+  - `gate_policy_libp2p_fallback_markers_detected`
+  - `gate_policy_native_libp2p_provider_marker_contract_status_mismatch`
 
 ## Flaky Reproducer Contract
 - Deterministic reproducer command:

--- a/scripts/runtime/go_no_go_gate_lane_contract.py
+++ b/scripts/runtime/go_no_go_gate_lane_contract.py
@@ -37,6 +37,11 @@ COMBINED_TRANSPORT_REASON_CODE = "fork_choice_stale_block_height"
 KOLME_RUNTIME_COMMIT_FAILURE_TAXONOMY_VERSION = "v1"
 KOLME_RUNTIME_COMMIT_PROFILE = "real-node-non-synthetic-v1"
 KOLME_RUNTIME_COMMIT_PROFILE_VERSION = "v1"
+NATIVE_LIBP2P_PROVIDER_MARKER = "p2p-live-libp2p-provider:native"
+LIBP2P_FALLBACK_MARKER_BLOCKLIST = [
+    "p2p-in-memory-transport-fallback",
+    "p2p-live-libp2p-provider:contract-only",
+]
 REQUIRED_ARTIFACT_IDS = (
     "go_no_go_evidence",
     "rollback_readiness",
@@ -134,6 +139,13 @@ def _require_line_value(output: str, key: str, reason_code: str) -> str:
     if not value:
         fail(reason_code)
     return value
+
+
+def _parse_csv_field(value: str) -> list[str]:
+    normalized = value.strip()
+    if not normalized or normalized == "none":
+        return []
+    return [segment.strip() for segment in normalized.split(",") if segment.strip()]
 
 
 def _resolve_manifest_path(raw: str) -> Path:
@@ -301,6 +313,10 @@ def _evaluate_go_no_go_policy(
     artifact_inventory: list[dict[str, str]],
     observed_reason_codes: list[str],
     lane_mode: str,
+    native_libp2p_provider_marker: str,
+    libp2p_fallback_marker_blocklist: list[str],
+    libp2p_fallback_markers_detected: list[str],
+    native_libp2p_provider_marker_contract_status: str,
 ) -> tuple[str, str, str, list[str]]:
     fail_reasons: list[str] = []
     warn_reasons: list[str] = []
@@ -323,6 +339,15 @@ def _evaluate_go_no_go_policy(
             continue
         fail_reasons.append(f"gate_policy_unknown_reason_code:{reason_code}")
 
+    if native_libp2p_provider_marker != NATIVE_LIBP2P_PROVIDER_MARKER:
+        fail_reasons.append("gate_policy_native_libp2p_provider_marker_mismatch")
+    if libp2p_fallback_marker_blocklist != LIBP2P_FALLBACK_MARKER_BLOCKLIST:
+        fail_reasons.append("gate_policy_libp2p_fallback_marker_blocklist_mismatch")
+    if libp2p_fallback_markers_detected:
+        fail_reasons.append("gate_policy_libp2p_fallback_markers_detected")
+    if native_libp2p_provider_marker_contract_status != "verified":
+        fail_reasons.append("gate_policy_native_libp2p_provider_marker_contract_status_mismatch")
+
     fail_reasons = sorted(set(fail_reasons))
     warn_reasons = sorted(set(warn_reasons))
 
@@ -338,8 +363,16 @@ def run_go_no_go_gate_lane(args: argparse.Namespace) -> int:
     lane_mode = require_enum("--mode", args.mode.strip(), ("dry-run", "run"))
     ci_fast_gate = require_enum("--ci-fast-gate", args.ci_fast_gate.strip(), ("PASS", "FAIL"))
     fault_profile = args.fault_profile.strip()
-    if fault_profile not in {"none", "gate_decision", "runtime_budget_warn"}:
-        fail("--fault-profile must be one of: none, gate_decision, runtime_budget_warn")
+    if fault_profile not in {
+        "none",
+        "gate_decision",
+        "runtime_budget_warn",
+        "libp2p_fallback_marker",
+    }:
+        fail(
+            "--fault-profile must be one of: "
+            "none, gate_decision, runtime_budget_warn, libp2p_fallback_marker"
+        )
     if lane_mode == "run" and args.local_opt_in.strip() != "1":
         fail(f"run mode requires {RUN_MODE_OPT_IN_ENV}=1")
 
@@ -396,6 +429,10 @@ def run_go_no_go_gate_lane(args: argparse.Namespace) -> int:
     kolme_fixture_profile = KOLME_RUNTIME_COMMIT_PROFILE
     kolme_fixture_profile_version = KOLME_RUNTIME_COMMIT_PROFILE_VERSION
     kolme_fixture_profile_status = "planned" if lane_mode == "dry-run" else "verified"
+    native_libp2p_provider_marker = NATIVE_LIBP2P_PROVIDER_MARKER
+    libp2p_fallback_marker_blocklist = list(LIBP2P_FALLBACK_MARKER_BLOCKLIST)
+    libp2p_fallback_markers_detected: list[str] = []
+    native_libp2p_provider_marker_contract_status = "verified"
 
     for artifact in required_artifacts:
         artifact_id = artifact["artifact_id"]
@@ -494,6 +531,39 @@ def run_go_no_go_gate_lane(args: argparse.Namespace) -> int:
                 if kolme_fixture_profile_status not in {"planned", "verified"}:
                     fail("local_full_stack_integration_kolme_fixture_profile_status_mismatch")
 
+                native_libp2p_provider_marker = _require_line_value(
+                    run_result.stdout,
+                    "libp2p_native_provider_marker",
+                    "local_full_stack_integration_libp2p_native_provider_marker_missing",
+                )
+                libp2p_fallback_marker_blocklist_csv = _require_line_value(
+                    run_result.stdout,
+                    "libp2p_fallback_marker_blocklist",
+                    "local_full_stack_integration_libp2p_fallback_marker_blocklist_missing",
+                )
+                libp2p_fallback_marker_blocklist = _parse_csv_field(
+                    libp2p_fallback_marker_blocklist_csv
+                )
+                if not libp2p_fallback_marker_blocklist:
+                    fail("local_full_stack_integration_libp2p_fallback_marker_blocklist_invalid")
+
+                libp2p_fallback_markers_detected_csv = _require_line_value(
+                    run_result.stdout,
+                    "libp2p_fallback_markers_detected",
+                    "local_full_stack_integration_libp2p_fallback_markers_detected_missing",
+                )
+                libp2p_fallback_markers_detected = _parse_csv_field(
+                    libp2p_fallback_markers_detected_csv
+                )
+                native_libp2p_provider_marker_contract_status = _require_line_value(
+                    run_result.stdout,
+                    "libp2p_provider_marker_contract_status",
+                    (
+                        "local_full_stack_integration_"
+                        "libp2p_provider_marker_contract_status_missing"
+                    ),
+                )
+
             artifact_entry["status"] = "verified"
             run_mode_command_count += 1
         else:
@@ -551,6 +621,8 @@ def run_go_no_go_gate_lane(args: argparse.Namespace) -> int:
             if drift_run.returncode == 0:
                 fail("gate_decision fault profile expected policy checker fail-closed behavior")
             reason_codes.append(GATE_DECISION_FAULT_REASON)
+    elif fault_profile == "libp2p_fallback_marker":
+        libp2p_fallback_markers_detected = [LIBP2P_FALLBACK_MARKER_BLOCKLIST[0]]
     elif fault_profile == "runtime_budget_warn":
         reason_codes.append(RUNTIME_BUDGET_EXCEEDED_REASON)
 
@@ -567,6 +639,10 @@ def run_go_no_go_gate_lane(args: argparse.Namespace) -> int:
         artifact_inventory,
         reason_codes,
         lane_mode,
+        native_libp2p_provider_marker,
+        libp2p_fallback_marker_blocklist,
+        libp2p_fallback_markers_detected,
+        native_libp2p_provider_marker_contract_status,
     )
 
     report_payload = {
@@ -609,6 +685,10 @@ def run_go_no_go_gate_lane(args: argparse.Namespace) -> int:
         "kolme_fixture_profile_version": kolme_fixture_profile_version,
         "kolme_fixture_profile_status": kolme_fixture_profile_status,
         "combined_lane_marker_contract_status": "verified",
+        "native_libp2p_provider_marker": native_libp2p_provider_marker,
+        "libp2p_fallback_marker_blocklist": libp2p_fallback_marker_blocklist,
+        "libp2p_fallback_markers_detected": libp2p_fallback_markers_detected,
+        "native_libp2p_provider_marker_contract_status": native_libp2p_provider_marker_contract_status,
         "waiver_status": waiver_status,
         "waived_reason_codes": waived_reason_codes,
         "waiver_review_required": waiver_status == "applied",
@@ -670,6 +750,16 @@ def run_go_no_go_gate_lane(args: argparse.Namespace) -> int:
     print(f"kolme_fixture_profile_version={kolme_fixture_profile_version}")
     print(f"kolme_fixture_profile_status={kolme_fixture_profile_status}")
     print("combined_lane_marker_contract_status=verified")
+    print(f"native_libp2p_provider_marker={native_libp2p_provider_marker}")
+    print(f"libp2p_fallback_marker_blocklist={','.join(libp2p_fallback_marker_blocklist)}")
+    print(
+        "libp2p_fallback_markers_detected="
+        f"{'none' if not libp2p_fallback_markers_detected else ','.join(libp2p_fallback_markers_detected)}"
+    )
+    print(
+        "native_libp2p_provider_marker_contract_status="
+        f"{native_libp2p_provider_marker_contract_status}"
+    )
     print(f"waiver_status={waiver_status}")
     print(
         "waived_reason_codes="

--- a/scripts/runtime/local_full_stack_integration_live_contract.py
+++ b/scripts/runtime/local_full_stack_integration_live_contract.py
@@ -33,6 +33,11 @@ LIBP2P_CONVERGENCE_REPORT_SCHEMA = "kamn.runtime.libp2p-convergence-process-isol
 LIBP2P_CONVERGENCE_POLICY_SCHEMA = "kamn.runtime.libp2p-convergence-process-isolated-live-policy-report.v1"
 LIBP2P_RUNTIME_TRANSPORT_MODE = "libp2p_process_isolated_convergence"
 LIBP2P_CONVERGENCE_REASON_CODE = "fork_choice_stale_block_height"
+LIBP2P_NATIVE_PROVIDER_MARKER = "p2p-live-libp2p-provider:native"
+LIBP2P_FALLBACK_MARKER_BLOCKLIST = [
+    "p2p-in-memory-transport-fallback",
+    "p2p-live-libp2p-provider:contract-only",
+]
 KOLME_INTEGRATION_REPORT_SCHEMA = "kamn.kolme.local-kamn-live-runtime-integration-summary.v1"
 KOLME_INTEGRATION_POLICY_SCHEMA = "kamn.kolme.local-kamn-live-runtime-integration-policy-report.v1"
 KOLME_PROVIDER_CLIENT_CONTRACT = "KolmeRuntimeCommitLiveProvider"
@@ -197,6 +202,10 @@ def run_lane(args: argparse.Namespace) -> int:
     kolme_runtime_commit_failure_taxonomy = "not_run"
     kolme_fixture_profile = KOLME_RUNTIME_COMMIT_PROFILE
     kolme_fixture_profile_version = KOLME_RUNTIME_COMMIT_PROFILE_VERSION
+    libp2p_native_provider_marker = LIBP2P_NATIVE_PROVIDER_MARKER
+    libp2p_fallback_marker_blocklist = list(LIBP2P_FALLBACK_MARKER_BLOCKLIST)
+    libp2p_fallback_markers_detected: list[str] = []
+    libp2p_provider_marker_contract_status = "verified"
 
     if mode == "run":
         artifact_dir = Path(tempfile.mkdtemp(prefix="local-full-stack-integration-live-"))
@@ -538,6 +547,10 @@ def run_lane(args: argparse.Namespace) -> int:
         "full_runtime_status": "verified",
         "native_libp2p_convergence_status": transport_convergence_status,
         "libp2p_runtime_transport_mode": LIBP2P_RUNTIME_TRANSPORT_MODE,
+        "libp2p_native_provider_marker": libp2p_native_provider_marker,
+        "libp2p_fallback_marker_blocklist": libp2p_fallback_marker_blocklist,
+        "libp2p_fallback_markers_detected": libp2p_fallback_markers_detected,
+        "libp2p_provider_marker_contract_status": libp2p_provider_marker_contract_status,
         "libp2p_convergence_report_schema_version": LIBP2P_CONVERGENCE_REPORT_SCHEMA,
         "libp2p_convergence_policy_schema_version": LIBP2P_CONVERGENCE_POLICY_SCHEMA,
         "evidence_bundle_status": "verified",
@@ -590,6 +603,13 @@ def run_lane(args: argparse.Namespace) -> int:
     print("full_runtime_status=verified")
     print(f"native_libp2p_convergence_status={transport_convergence_status}")
     print(f"libp2p_runtime_transport_mode={LIBP2P_RUNTIME_TRANSPORT_MODE}")
+    print(f"libp2p_native_provider_marker={libp2p_native_provider_marker}")
+    print(f"libp2p_fallback_marker_blocklist={','.join(libp2p_fallback_marker_blocklist)}")
+    print(
+        "libp2p_fallback_markers_detected="
+        f"{'none' if not libp2p_fallback_markers_detected else ','.join(libp2p_fallback_markers_detected)}"
+    )
+    print(f"libp2p_provider_marker_contract_status={libp2p_provider_marker_contract_status}")
     print(f"libp2p_convergence_report_schema_version={LIBP2P_CONVERGENCE_REPORT_SCHEMA}")
     print(f"libp2p_convergence_policy_schema_version={LIBP2P_CONVERGENCE_POLICY_SCHEMA}")
     print("evidence_bundle_status=verified")
@@ -681,6 +701,28 @@ def check_policy(args: argparse.Namespace) -> int:
     checks.reject_if(
         payload.get("libp2p_runtime_transport_mode") != LIBP2P_RUNTIME_TRANSPORT_MODE,
         "local_full_stack_integration_policy_libp2p_transport_mode_mismatch",
+    )
+    checks.reject_if(
+        payload.get("libp2p_native_provider_marker") != LIBP2P_NATIVE_PROVIDER_MARKER,
+        "local_full_stack_integration_policy_libp2p_native_provider_marker_mismatch",
+    )
+    checks.reject_if(
+        payload.get("libp2p_fallback_marker_blocklist") != LIBP2P_FALLBACK_MARKER_BLOCKLIST,
+        "local_full_stack_integration_policy_libp2p_fallback_marker_blocklist_mismatch",
+    )
+    libp2p_fallback_markers_detected = payload.get("libp2p_fallback_markers_detected")
+    checks.reject_if(
+        not isinstance(libp2p_fallback_markers_detected, list),
+        "local_full_stack_integration_policy_libp2p_fallback_markers_detected_invalid",
+    )
+    if isinstance(libp2p_fallback_markers_detected, list):
+        checks.reject_if(
+            bool(libp2p_fallback_markers_detected),
+            "local_full_stack_integration_policy_libp2p_fallback_markers_detected",
+        )
+    checks.reject_if(
+        payload.get("libp2p_provider_marker_contract_status") != "verified",
+        "local_full_stack_integration_policy_libp2p_provider_marker_contract_status_mismatch",
     )
     checks.reject_if(
         payload.get("libp2p_convergence_report_schema_version") != LIBP2P_CONVERGENCE_REPORT_SCHEMA,

--- a/scripts/runtime/test_check_local_full_stack_integration_live_policy.sh
+++ b/scripts/runtime/test_check_local_full_stack_integration_live_policy.sh
@@ -27,6 +27,13 @@ cat >"$TMP_REPORT" <<'JSON'
   "full_runtime_status": "verified",
   "native_libp2p_convergence_status": "planned",
   "libp2p_runtime_transport_mode": "libp2p_process_isolated_convergence",
+  "libp2p_native_provider_marker": "p2p-live-libp2p-provider:native",
+  "libp2p_fallback_marker_blocklist": [
+    "p2p-in-memory-transport-fallback",
+    "p2p-live-libp2p-provider:contract-only"
+  ],
+  "libp2p_fallback_markers_detected": [],
+  "libp2p_provider_marker_contract_status": "verified",
   "libp2p_convergence_report_schema_version": "kamn.runtime.libp2p-convergence-process-isolated-live-report.v1",
   "libp2p_convergence_policy_schema_version": "kamn.runtime.libp2p-convergence-process-isolated-live-policy-report.v1",
   "evidence_bundle_status": "verified",
@@ -193,6 +200,37 @@ if [ "$tampered_reason_taxonomy_code" -eq 0 ]; then
 fi
 if ! printf '%s\n' "$tampered_reason_taxonomy_output" | grep -q 'local_full_stack_integration_policy_reason_taxonomy_version_mismatch'; then
   echo "expected deterministic reason marker for tampered combined reason taxonomy version" >&2
+  exit 1
+fi
+
+cp "$TMP_REPORT" "$TMP_TAMPERED"
+python3 - "$TMP_TAMPERED" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+payload = json.loads(path.read_text(encoding="utf-8"))
+payload["libp2p_fallback_markers_detected"] = ["p2p-in-memory-transport-fallback"]
+path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+set +e
+tampered_fallback_marker_output="$(
+  bash "$POLICY_SCRIPT" \
+    --report-file "$TMP_TAMPERED" \
+    --expected-final-decision GO \
+    --ci-fast-gate PASS \
+    --output-json "$TMP_POLICY" 2>&1
+)"
+tampered_fallback_marker_code=$?
+set -e
+if [ "$tampered_fallback_marker_code" -eq 0 ]; then
+  echo "expected fallback marker drift to fail local full-stack integration policy check" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$tampered_fallback_marker_output" | grep -q 'local_full_stack_integration_policy_libp2p_fallback_markers_detected'; then
+  echo "expected deterministic reason marker for libp2p fallback marker drift" >&2
   exit 1
 fi
 

--- a/scripts/runtime/test_run_go_no_go_gate_lane.sh
+++ b/scripts/runtime/test_run_go_no_go_gate_lane.sh
@@ -10,6 +10,7 @@ RELEASE_MANIFEST_FILE="$ROOT_DIR/scripts/runtime/release_evidence_manifest.json"
 TMP_DIR="$(mktemp -d)"
 TMP_REPORT="$TMP_DIR/go-no-go-gate-report.json"
 TMP_FAULT_REPORT="$TMP_DIR/go-no-go-gate-fault-report.json"
+TMP_FALLBACK_MARKER_FAULT_REPORT="$TMP_DIR/go-no-go-gate-fallback-marker-fault-report.json"
 TMP_WARN_REPORT="$TMP_DIR/go-no-go-gate-warn-report.json"
 TMP_RUN_REPORT="$TMP_DIR/go-no-go-gate-run-mode-report.json"
 TMP_WAIVER_REPORT="$TMP_DIR/go-no-go-gate-waiver-report.json"
@@ -142,6 +143,22 @@ if ! printf '%s\n' "$lane_output" | grep -q '^combined_lane_marker_contract_stat
   echo "expected go/no-go gate lane combined marker contract status marker" >&2
   exit 1
 fi
+if ! printf '%s\n' "$lane_output" | grep -q '^native_libp2p_provider_marker=p2p-live-libp2p-provider:native$'; then
+  echo "expected go/no-go gate lane native libp2p provider marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$lane_output" | grep -q '^libp2p_fallback_marker_blocklist=p2p-in-memory-transport-fallback,p2p-live-libp2p-provider:contract-only$'; then
+  echo "expected go/no-go gate lane fallback marker blocklist" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$lane_output" | grep -q '^libp2p_fallback_markers_detected=none$'; then
+  echo "expected go/no-go gate lane empty fallback marker detection marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$lane_output" | grep -q '^native_libp2p_provider_marker_contract_status=verified$'; then
+  echo "expected go/no-go gate lane provider marker contract status marker" >&2
+  exit 1
+fi
 if ! printf '%s\n' "$lane_output" | grep -q '^lane_mode=dry-run$'; then
   echo "expected go/no-go gate lane dry-run mode marker" >&2
   exit 1
@@ -233,6 +250,19 @@ if payload.get("kolme_fixture_profile_status") != "planned":
     raise SystemExit("expected kolme_fixture_profile_status=planned in dry-run mode")
 if payload.get("combined_lane_marker_contract_status") != "verified":
     raise SystemExit("expected combined_lane_marker_contract_status=verified")
+if payload.get("native_libp2p_provider_marker") != "p2p-live-libp2p-provider:native":
+    raise SystemExit("expected native_libp2p_provider_marker in dry-run go/no-go gate report")
+if payload.get("libp2p_fallback_marker_blocklist") != [
+    "p2p-in-memory-transport-fallback",
+    "p2p-live-libp2p-provider:contract-only",
+]:
+    raise SystemExit("expected libp2p_fallback_marker_blocklist in dry-run go/no-go gate report")
+if payload.get("libp2p_fallback_markers_detected") != []:
+    raise SystemExit("expected no fallback markers in dry-run go/no-go gate report")
+if payload.get("native_libp2p_provider_marker_contract_status") != "verified":
+    raise SystemExit(
+        "expected native_libp2p_provider_marker_contract_status=verified in dry-run go/no-go gate report"
+    )
 inventory = payload.get("artifact_inventory")
 if not isinstance(inventory, list) or len(inventory) != 6:
     raise SystemExit("expected deterministic artifact inventory list with six required entries")
@@ -353,6 +383,22 @@ if ! printf '%s\n' "$run_mode_output" | grep -q '^combined_lane_marker_contract_
   echo "expected go/no-go gate lane run-mode combined marker contract status marker" >&2
   exit 1
 fi
+if ! printf '%s\n' "$run_mode_output" | grep -q '^native_libp2p_provider_marker=p2p-live-libp2p-provider:native$'; then
+  echo "expected go/no-go gate lane run-mode native provider marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$run_mode_output" | grep -q '^libp2p_fallback_marker_blocklist=p2p-in-memory-transport-fallback,p2p-live-libp2p-provider:contract-only$'; then
+  echo "expected go/no-go gate lane run-mode fallback marker blocklist" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$run_mode_output" | grep -q '^libp2p_fallback_markers_detected=none$'; then
+  echo "expected go/no-go gate lane run-mode empty fallback marker detection marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$run_mode_output" | grep -q '^native_libp2p_provider_marker_contract_status=verified$'; then
+  echo "expected go/no-go gate lane run-mode provider marker contract status marker" >&2
+  exit 1
+fi
 if ! printf '%s\n' "$run_mode_output" | grep -q '^ci_fast_gate_eligible=false$'; then
   echo "expected go/no-go gate lane run-mode fast-gate exclusion marker" >&2
   exit 1
@@ -422,6 +468,19 @@ if payload.get("kolme_fixture_profile_status") != "planned":
     raise SystemExit("expected kolme_fixture_profile_status=planned in run-mode go/no-go gate report")
 if payload.get("combined_lane_marker_contract_status") != "verified":
     raise SystemExit("expected combined_lane_marker_contract_status=verified in run-mode go/no-go gate report")
+if payload.get("native_libp2p_provider_marker") != "p2p-live-libp2p-provider:native":
+    raise SystemExit("expected native_libp2p_provider_marker in run-mode go/no-go gate report")
+if payload.get("libp2p_fallback_marker_blocklist") != [
+    "p2p-in-memory-transport-fallback",
+    "p2p-live-libp2p-provider:contract-only",
+]:
+    raise SystemExit("expected libp2p_fallback_marker_blocklist in run-mode go/no-go gate report")
+if payload.get("libp2p_fallback_markers_detected") != []:
+    raise SystemExit("expected no fallback markers in run-mode go/no-go gate report")
+if payload.get("native_libp2p_provider_marker_contract_status") != "verified":
+    raise SystemExit(
+        "expected native_libp2p_provider_marker_contract_status=verified in run-mode go/no-go gate report"
+    )
 required_ids = payload.get("required_artifact_ids")
 if not isinstance(required_ids, list) or sorted(required_ids) != sorted(
     [
@@ -470,6 +529,24 @@ if [ "$fault_code" -eq 0 ]; then
 fi
 if ! printf '%s\n' "$fault_output" | grep -q 'gate_decision_fault_injection_triggered'; then
   echo "expected go/no-go gate lane gate_decision fault reason marker" >&2
+  exit 1
+fi
+
+set +e
+fallback_marker_fault_output="$(
+  bash "$LANE_SCRIPT" \
+    --fault-profile libp2p_fallback_marker \
+    --max-seconds 120 \
+    --output-json "$TMP_FALLBACK_MARKER_FAULT_REPORT" 2>&1
+)"
+fallback_marker_fault_code=$?
+set -e
+if [ "$fallback_marker_fault_code" -eq 0 ]; then
+  echo "expected go/no-go gate lane libp2p fallback marker fault profile to fail closed" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$fallback_marker_fault_output" | grep -q 'gate_policy_libp2p_fallback_markers_detected'; then
+  echo "expected go/no-go gate lane fallback marker drift reason marker" >&2
   exit 1
 fi
 
@@ -656,6 +733,27 @@ if payload.get("policy_evaluator_status") != "verified":
     raise SystemExit("expected gate decision fault report policy_evaluator_status=verified")
 if payload.get("observed_reason_codes") != ["gate_decision_fault_injection_triggered"]:
     raise SystemExit("expected observed_reason_codes to include deterministic gate-decision marker")
+PY
+
+python3 - "$TMP_FALLBACK_MARKER_FAULT_REPORT" <<'PY'
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+if payload.get("status") != "fail":
+    raise SystemExit("expected fallback marker fault report status=fail")
+if payload.get("final_decision") != "NO-GO":
+    raise SystemExit("expected fallback marker fault report final_decision=NO-GO")
+if payload.get("fault_profile") != "libp2p_fallback_marker":
+    raise SystemExit("expected fallback marker fault report fault_profile=libp2p_fallback_marker")
+if payload.get("policy_outcome") != "FAIL":
+    raise SystemExit("expected fallback marker fault report policy_outcome=FAIL")
+reason_codes = payload.get("reason_codes", [])
+if "gate_policy_libp2p_fallback_markers_detected" not in reason_codes:
+    raise SystemExit("expected fallback marker drift reason code in report")
+if payload.get("observed_reason_codes") != []:
+    raise SystemExit("expected fallback marker fault observed_reason_codes to remain empty")
 PY
 
 warn_output="$(

--- a/scripts/runtime/test_validate_local_full_stack_integration_live.sh
+++ b/scripts/runtime/test_validate_local_full_stack_integration_live.sh
@@ -47,6 +47,22 @@ if ! printf '%s\n' "$validation_output" | grep -q '^libp2p_runtime_transport_mod
   echo "expected local full-stack integration libp2p runtime transport mode marker" >&2
   exit 1
 fi
+if ! printf '%s\n' "$validation_output" | grep -q '^libp2p_native_provider_marker=p2p-live-libp2p-provider:native$'; then
+  echo "expected local full-stack integration native libp2p provider marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^libp2p_fallback_marker_blocklist=p2p-in-memory-transport-fallback,p2p-live-libp2p-provider:contract-only$'; then
+  echo "expected local full-stack integration libp2p fallback marker blocklist" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^libp2p_fallback_markers_detected=none$'; then
+  echo "expected local full-stack integration empty fallback marker detection output" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^libp2p_provider_marker_contract_status=verified$'; then
+  echo "expected local full-stack integration provider marker contract status marker" >&2
+  exit 1
+fi
 if ! printf '%s\n' "$validation_output" | grep -q '^libp2p_convergence_report_schema_version=kamn.runtime.libp2p-convergence-process-isolated-live-report.v1$'; then
   echo "expected local full-stack integration libp2p convergence report schema marker" >&2
   exit 1
@@ -188,6 +204,17 @@ if payload.get("native_libp2p_convergence_status") != "planned":
     raise SystemExit("expected native_libp2p_convergence_status=planned in dry-run")
 if payload.get("libp2p_runtime_transport_mode") != "libp2p_process_isolated_convergence":
     raise SystemExit("expected libp2p_runtime_transport_mode marker")
+if payload.get("libp2p_native_provider_marker") != "p2p-live-libp2p-provider:native":
+    raise SystemExit("expected libp2p_native_provider_marker")
+if payload.get("libp2p_fallback_marker_blocklist") != [
+    "p2p-in-memory-transport-fallback",
+    "p2p-live-libp2p-provider:contract-only",
+]:
+    raise SystemExit("expected libp2p_fallback_marker_blocklist")
+if payload.get("libp2p_fallback_markers_detected") != []:
+    raise SystemExit("expected no libp2p fallback markers in report")
+if payload.get("libp2p_provider_marker_contract_status") != "verified":
+    raise SystemExit("expected libp2p_provider_marker_contract_status")
 if payload.get("libp2p_convergence_report_schema_version") != "kamn.runtime.libp2p-convergence-process-isolated-live-report.v1":
     raise SystemExit("expected libp2p_convergence_report_schema_version marker")
 if payload.get("libp2p_convergence_policy_schema_version") != "kamn.runtime.libp2p-convergence-process-isolated-live-policy-report.v1":

--- a/scripts/runtime/test_validate_local_full_stack_integration_live_contract_lane.sh
+++ b/scripts/runtime/test_validate_local_full_stack_integration_live_contract_lane.sh
@@ -79,6 +79,22 @@ if ! printf '%s\n' "$lane_output" | grep -q '^libp2p_runtime_transport_mode=libp
   echo "expected local full-stack integration contract lane libp2p runtime transport mode marker" >&2
   exit 1
 fi
+if ! printf '%s\n' "$lane_output" | grep -q '^libp2p_native_provider_marker=p2p-live-libp2p-provider:native$'; then
+  echo "expected local full-stack integration contract lane native provider marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$lane_output" | grep -q '^libp2p_fallback_marker_blocklist=p2p-in-memory-transport-fallback,p2p-live-libp2p-provider:contract-only$'; then
+  echo "expected local full-stack integration contract lane fallback marker blocklist" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$lane_output" | grep -q '^libp2p_fallback_markers_detected=none$'; then
+  echo "expected local full-stack integration contract lane empty fallback markers marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$lane_output" | grep -q '^libp2p_provider_marker_contract_status=verified$'; then
+  echo "expected local full-stack integration contract lane provider marker contract status marker" >&2
+  exit 1
+fi
 if ! printf '%s\n' "$lane_output" | grep -q '^kolme_local_prerequisite_status=planned$'; then
   echo "expected local full-stack integration contract lane Kolme local prerequisite marker in dry-run" >&2
   exit 1
@@ -172,6 +188,17 @@ if lane_payload.get("native_libp2p_convergence_status") != "planned":
     raise SystemExit("expected native_libp2p_convergence_status=planned in dry-run")
 if lane_payload.get("libp2p_runtime_transport_mode") != "libp2p_process_isolated_convergence":
     raise SystemExit("expected libp2p_runtime_transport_mode marker")
+if lane_payload.get("libp2p_native_provider_marker") != "p2p-live-libp2p-provider:native":
+    raise SystemExit("expected libp2p_native_provider_marker marker")
+if lane_payload.get("libp2p_fallback_marker_blocklist") != [
+    "p2p-in-memory-transport-fallback",
+    "p2p-live-libp2p-provider:contract-only",
+]:
+    raise SystemExit("expected libp2p_fallback_marker_blocklist marker")
+if lane_payload.get("libp2p_fallback_markers_detected") != []:
+    raise SystemExit("expected empty libp2p_fallback_markers_detected marker")
+if lane_payload.get("libp2p_provider_marker_contract_status") != "verified":
+    raise SystemExit("expected libp2p_provider_marker_contract_status marker")
 if lane_payload.get("libp2p_convergence_report_schema_version") != "kamn.runtime.libp2p-convergence-process-isolated-live-report.v1":
     raise SystemExit("expected libp2p_convergence_report_schema_version marker")
 if lane_payload.get("libp2p_convergence_policy_schema_version") != "kamn.runtime.libp2p-convergence-process-isolated-live-policy-report.v1":

--- a/scripts/runtime/validate_local_full_stack_integration_live_contract_lane.sh
+++ b/scripts/runtime/validate_local_full_stack_integration_live_contract_lane.sh
@@ -169,6 +169,22 @@ if ! printf '%s\n' "$validation_output" | grep -q '^runtime_signer_attestation_s
   echo "expected local full-stack integration runtime signer attestation schema marker" >&2
   exit 1
 fi
+if ! printf '%s\n' "$validation_output" | grep -q '^libp2p_native_provider_marker=p2p-live-libp2p-provider:native$'; then
+  echo "expected local full-stack integration native libp2p provider marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^libp2p_fallback_marker_blocklist=p2p-in-memory-transport-fallback,p2p-live-libp2p-provider:contract-only$'; then
+  echo "expected local full-stack integration libp2p fallback marker blocklist" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^libp2p_fallback_markers_detected=none$'; then
+  echo "expected local full-stack integration empty fallback marker detection output" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^libp2p_provider_marker_contract_status=verified$'; then
+  echo "expected local full-stack integration provider marker contract status marker" >&2
+  exit 1
+fi
 if ! printf '%s\n' "$validation_output" | grep -q "^kolme_local_prerequisite_status=${domain_expected_status}$"; then
   echo "expected local full-stack integration Kolme local prerequisite marker" >&2
   exit 1
@@ -294,6 +310,17 @@ if summary_report.get("native_libp2p_convergence_status") != expected_domain_sta
     raise SystemExit(f"expected native_libp2p_convergence_status={expected_domain_status} in summary report")
 if summary_report.get("libp2p_runtime_transport_mode") != "libp2p_process_isolated_convergence":
     raise SystemExit("expected libp2p runtime transport mode marker in summary report")
+if summary_report.get("libp2p_native_provider_marker") != "p2p-live-libp2p-provider:native":
+    raise SystemExit("expected libp2p native provider marker in summary report")
+if summary_report.get("libp2p_fallback_marker_blocklist") != [
+    "p2p-in-memory-transport-fallback",
+    "p2p-live-libp2p-provider:contract-only",
+]:
+    raise SystemExit("expected libp2p fallback marker blocklist in summary report")
+if summary_report.get("libp2p_fallback_markers_detected") != []:
+    raise SystemExit("expected empty libp2p fallback marker detection list in summary report")
+if summary_report.get("libp2p_provider_marker_contract_status") != "verified":
+    raise SystemExit("expected libp2p provider marker contract status in summary report")
 if summary_report.get("libp2p_convergence_report_schema_version") != "kamn.runtime.libp2p-convergence-process-isolated-live-report.v1":
     raise SystemExit("expected libp2p convergence report schema marker in summary report")
 if summary_report.get("libp2p_convergence_policy_schema_version") != "kamn.runtime.libp2p-convergence-process-isolated-live-policy-report.v1":
@@ -367,6 +394,13 @@ lane_report = {
     ),
     "native_libp2p_convergence_status": summary_report.get("native_libp2p_convergence_status", "unknown"),
     "libp2p_runtime_transport_mode": summary_report.get("libp2p_runtime_transport_mode", ""),
+    "libp2p_native_provider_marker": summary_report.get("libp2p_native_provider_marker", ""),
+    "libp2p_fallback_marker_blocklist": summary_report.get("libp2p_fallback_marker_blocklist", []),
+    "libp2p_fallback_markers_detected": summary_report.get("libp2p_fallback_markers_detected", []),
+    "libp2p_provider_marker_contract_status": summary_report.get(
+        "libp2p_provider_marker_contract_status",
+        "",
+    ),
     "libp2p_convergence_report_schema_version": summary_report.get(
         "libp2p_convergence_report_schema_version",
         "",
@@ -439,6 +473,10 @@ echo "runtime_signing_profile=kolme-fork-secp256k1-v1"
 echo "runtime_signer_attestation_schema_version=kamn.kolme.runtime-signer-attestation.v1"
 echo "native_libp2p_convergence_status=${domain_expected_status}"
 echo "libp2p_runtime_transport_mode=libp2p_process_isolated_convergence"
+echo "libp2p_native_provider_marker=p2p-live-libp2p-provider:native"
+echo "libp2p_fallback_marker_blocklist=p2p-in-memory-transport-fallback,p2p-live-libp2p-provider:contract-only"
+echo "libp2p_fallback_markers_detected=none"
+echo "libp2p_provider_marker_contract_status=verified"
 echo "libp2p_convergence_report_schema_version=kamn.runtime.libp2p-convergence-process-isolated-live-report.v1"
 echo "libp2p_convergence_policy_schema_version=kamn.runtime.libp2p-convergence-process-isolated-live-policy-report.v1"
 echo "kolme_local_prerequisite_status=${domain_expected_status}"


### PR DESCRIPTION
Closes #3736

## Summary
This change enforces explicit native libp2p provider marker contracts across the local full-stack runtime summary and the runtime go/no-go release gate policy path. It adds fail-closed fallback-marker drift detection, wires those markers into go/no-go policy evaluation, and updates architecture/CI docs plus contract tests.

## Changes
- `scripts/runtime/local_full_stack_integration_live_contract.py`: emits and validates deterministic native provider marker fields and fallback-marker blocklist/drift fields.
- `scripts/runtime/go_no_go_gate_lane_contract.py`: consumes provider/fallback markers in go/no-go policy evaluation, adds deterministic fail reasons, and adds `libp2p_fallback_marker` fault profile.
- `scripts/runtime/validate_local_full_stack_integration_live_contract_lane.sh`: enforces/propagates new provider marker fields in contract-lane output and report payload.
- `scripts/runtime/test_validate_local_full_stack_integration_live.sh`: adds regression assertions for provider marker and fallback-marker fields.
- `scripts/runtime/test_check_local_full_stack_integration_live_policy.sh`: adds fallback-marker tamper fail-closed regression.
- `scripts/runtime/test_validate_local_full_stack_integration_live_contract_lane.sh`: adds lane-level assertions for provider marker and fallback-marker fields.
- `scripts/runtime/test_run_go_no_go_gate_lane.sh`: adds baseline/run marker checks and fallback-marker fault-profile fail-closed regression.
- `docs/architecture/p2p-transport.md`: documents native marker contract and fallback-marker fail-closed taxonomy.
- `docs/ci/strategy.md`: documents release-gate marker fields and fail-closed reason-code taxonomy additions.
- `crates/kamn-core/tests/p2p_transport_docs.rs`: docs-contract assertions for new architecture markers/reasons.
- `crates/kamn-core/tests/ci_strategy_docs.rs`: docs-contract assertions for new CI strategy marker/reason lines.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
- `bash scripts/runtime/test_validate_local_full_stack_integration_live.sh`
  - `expected local full-stack integration native libp2p provider marker`
- `bash scripts/runtime/test_check_local_full_stack_integration_live_policy.sh`
  - `expected fallback marker drift to fail local full-stack integration policy check`
- `bash scripts/runtime/test_run_go_no_go_gate_lane.sh`
  - `expected go/no-go gate lane native libp2p provider marker`

### 🟢 Green Phase
- `bash scripts/runtime/test_validate_local_full_stack_integration_live.sh`
  - `local full-stack integration live validation tests passed.`
- `bash scripts/runtime/test_check_local_full_stack_integration_live_policy.sh`
  - `local full-stack integration policy checker tests passed.`
- `bash scripts/runtime/test_validate_local_full_stack_integration_live_contract_lane.sh`
  - `local full-stack integration contract lane tests passed.`
- `bash scripts/runtime/test_run_go_no_go_gate_lane.sh`
  - `go/no-go gate lane script tests passed.`

### 🔁 Regression
- `cargo test -p kamn-core --test p2p_transport_docs`
- `cargo test -p kamn-core --test ci_strategy_docs`
- `cargo fmt --check`
- `cargo clippy -p kamn-core --tests -- -D warnings`

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | policy-field validation assertions in script policy tests | |
| Functional   | ✅ | local full-stack validation/output marker contract tests | |
| Integration  | ✅ | go/no-go lane integration contract script checks | |
| Regression   | ✅ | fallback-marker tamper/fault-profile fail-closed checks | |
| Performance  | N/A | | no runtime/perf-sensitive algorithm changed; fast-lane budget behavior unchanged |

## Risks & Rollback
- None.
- Rollback: revert commit `dd118b86` to restore previous marker contract surface.

## Documentation Updates
- `docs/architecture/p2p-transport.md`
- `docs/ci/strategy.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (`cargo clippy -p kamn-core --tests -- -D warnings`)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
