### PR TITLE
feat(runtime): enforce process-isolated full-stack marker contracts (#3737)

### DIFF
--- a/crates/kamn-core/tests/kolme_live_integration_docs.rs
+++ b/crates/kamn-core/tests/kolme_live_integration_docs.rs
@@ -1,0 +1,29 @@
+const DOC: &str = include_str!("../../../docs/architecture/kolme-live-integration.md");
+
+#[test]
+fn doc_contains_process_isolation_marker_contracts() {
+    assert!(DOC.contains("transport_convergence_status"));
+    assert!(DOC.contains("libp2p_process_isolation_status"));
+    assert!(DOC.contains("libp2p_two_node_process_isolated_status"));
+    assert!(DOC.contains("libp2p_three_node_process_isolated_status"));
+    assert!(DOC.contains("runtime_provider_client_contract=KolmeRuntimeCommitLiveProvider"));
+}
+
+#[test]
+fn doc_contains_process_isolation_fail_closed_reasons() {
+    assert!(DOC.contains("local_full_stack_integration_policy_reason_taxonomy_version_mismatch"));
+    assert!(DOC
+        .contains("local_full_stack_integration_policy_libp2p_process_isolation_status_mismatch"));
+    assert!(DOC.contains(
+        "local_full_stack_integration_policy_libp2p_two_node_process_isolated_status_mismatch"
+    ));
+    assert!(DOC.contains(
+        "local_full_stack_integration_policy_libp2p_three_node_process_isolated_status_mismatch"
+    ));
+    assert!(DOC.contains(
+        "local_full_stack_integration_policy_libp2p_summary_three_node_partition_rejoin_status_mismatch"
+    ));
+    assert!(DOC.contains(
+        "local_full_stack_integration_policy_libp2p_summary_three_node_publish_drop_status_mismatch"
+    ));
+}

--- a/docs/architecture/kolme-live-integration.md
+++ b/docs/architecture/kolme-live-integration.md
@@ -20,6 +20,9 @@ runtime signing and `njfio/kolme_fork` compatibility expectations.
   - release manifest linkage: `scripts/runtime/release_evidence_manifest.json` requires artifact id `local_full_stack_integration`.
 - Marker taxonomy (top-level fail-closed contract):
   - `transport_convergence_status`
+  - `libp2p_process_isolation_status`
+  - `libp2p_two_node_process_isolated_status`
+  - `libp2p_three_node_process_isolated_status`
   - `signer_provenance_status`
   - `runtime_commit_submission_status`
   - `runtime_commit_finality_status`
@@ -37,6 +40,11 @@ runtime signing and `njfio/kolme_fork` compatibility expectations.
   - `runtime_signer_attestation_schema_version=kamn.kolme.runtime-signer-attestation.v1`
 - Deterministic fail-closed reasons:
   - `local_full_stack_integration_policy_reason_taxonomy_version_mismatch`
+  - `local_full_stack_integration_policy_libp2p_process_isolation_status_mismatch`
+  - `local_full_stack_integration_policy_libp2p_two_node_process_isolated_status_mismatch`
+  - `local_full_stack_integration_policy_libp2p_three_node_process_isolated_status_mismatch`
+  - `local_full_stack_integration_policy_libp2p_summary_three_node_partition_rejoin_status_mismatch`
+  - `local_full_stack_integration_policy_libp2p_summary_three_node_publish_drop_status_mismatch`
   - `local_full_stack_integration_policy_kolme_summary_schema_mismatch`
   - `local_full_stack_integration_policy_kolme_policy_final_decision_mismatch`
   - `release_manifest_missing_required_artifact:local_full_stack_integration`

--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -475,6 +475,9 @@ Versioned thresholds are defined in `.ci/ci-budget.env`.
   - composes Kolme runtime integration lane (`run_local_kamn_live_runtime_integration_lane.sh`) in run mode.
   - enforces top-level marker domains for:
     - transport convergence
+    - process-isolated libp2p execution (`libp2p_process_isolation_status`)
+    - two-node process-isolated proof (`libp2p_two_node_process_isolated_status`)
+    - three-node process-isolated proof (`libp2p_three_node_process_isolated_status`)
     - signer provenance
     - runtime commit submission
     - runtime commit finality
@@ -497,6 +500,9 @@ Versioned thresholds are defined in `.ci/ci-budget.env`.
   - local full-stack integration run-mode commands remain excluded from ci-fast-gate and ci-tools fast mode.
 - Deterministic fail-closed marker for policy tamper drills:
   - `local_full_stack_integration_policy_reason_taxonomy_version_mismatch`
+  - `local_full_stack_integration_policy_libp2p_process_isolation_status_mismatch`
+  - `local_full_stack_integration_policy_libp2p_two_node_process_isolated_status_mismatch`
+  - `local_full_stack_integration_policy_libp2p_three_node_process_isolated_status_mismatch`
 
 ## Deploy Compose Topology Contract Lane
 - Entry commands:

--- a/scripts/runtime/local_full_stack_integration_live_contract.py
+++ b/scripts/runtime/local_full_stack_integration_live_contract.py
@@ -187,6 +187,9 @@ def run_lane(args: argparse.Namespace) -> int:
     commands_executed = 0
     artifact_paths: dict[str, str] = {}
     transport_convergence_status = "planned" if mode == "dry-run" else "verified"
+    libp2p_process_isolation_status = "planned" if mode == "dry-run" else "verified"
+    libp2p_two_node_process_isolated_status = "planned" if mode == "dry-run" else "verified"
+    libp2p_three_node_process_isolated_status = "planned" if mode == "dry-run" else "verified"
     signer_provenance_status = "planned" if mode == "dry-run" else "verified"
     runtime_commit_submission_status = "planned" if mode == "dry-run" else "verified"
     runtime_commit_finality_status = "planned" if mode == "dry-run" else "verified"
@@ -383,6 +386,14 @@ def run_lane(args: argparse.Namespace) -> int:
             != [LIBP2P_CONVERGENCE_REASON_CODE]
         ):
             fail("native libp2p convergence report reason taxonomy mismatch")
+        if libp2p_convergence_payload.get("two_node_disconnected_fail_closed_status") != "verified":
+            fail("native libp2p convergence report two-node disconnected marker mismatch")
+        if libp2p_convergence_payload.get("two_node_connected_delivery_status") != "verified":
+            fail("native libp2p convergence report two-node connected marker mismatch")
+        if libp2p_convergence_payload.get("three_node_partition_rejoin_status") != "verified":
+            fail("native libp2p convergence report three-node partition/rejoin marker mismatch")
+        if libp2p_convergence_payload.get("three_node_publish_drop_recovery_status") != "verified":
+            fail("native libp2p convergence report three-node publish-drop marker mismatch")
         if libp2p_policy_payload.get("schema_version") != LIBP2P_CONVERGENCE_POLICY_SCHEMA:
             fail("native libp2p convergence policy schema mismatch")
         if libp2p_policy_payload.get("final_decision") != "GO":
@@ -485,6 +496,9 @@ def run_lane(args: argparse.Namespace) -> int:
             "kolme_runtime_integration_report_file": str(kolme_integration_report),
             "kolme_runtime_integration_policy_report_file": str(kolme_integration_policy_report),
             "transport_convergence_status": transport_convergence_status,
+            "libp2p_process_isolation_status": libp2p_process_isolation_status,
+            "libp2p_two_node_process_isolated_status": libp2p_two_node_process_isolated_status,
+            "libp2p_three_node_process_isolated_status": libp2p_three_node_process_isolated_status,
             "signer_provenance_status": signer_provenance_status,
             "runtime_commit_submission_status": runtime_commit_submission_status,
             "runtime_commit_finality_status": runtime_commit_finality_status,
@@ -555,6 +569,9 @@ def run_lane(args: argparse.Namespace) -> int:
         "libp2p_convergence_policy_schema_version": LIBP2P_CONVERGENCE_POLICY_SCHEMA,
         "evidence_bundle_status": "verified",
         "transport_convergence_status": transport_convergence_status,
+        "libp2p_process_isolation_status": libp2p_process_isolation_status,
+        "libp2p_two_node_process_isolated_status": libp2p_two_node_process_isolated_status,
+        "libp2p_three_node_process_isolated_status": libp2p_three_node_process_isolated_status,
         "signer_provenance_status": signer_provenance_status,
         "runtime_commit_submission_status": runtime_commit_submission_status,
         "runtime_commit_finality_status": runtime_commit_finality_status,
@@ -614,6 +631,12 @@ def run_lane(args: argparse.Namespace) -> int:
     print(f"libp2p_convergence_policy_schema_version={LIBP2P_CONVERGENCE_POLICY_SCHEMA}")
     print("evidence_bundle_status=verified")
     print(f"transport_convergence_status={transport_convergence_status}")
+    print(f"libp2p_process_isolation_status={libp2p_process_isolation_status}")
+    print(f"libp2p_two_node_process_isolated_status={libp2p_two_node_process_isolated_status}")
+    print(
+        "libp2p_three_node_process_isolated_status="
+        f"{libp2p_three_node_process_isolated_status}"
+    )
     print(f"signer_provenance_status={signer_provenance_status}")
     print(f"runtime_commit_submission_status={runtime_commit_submission_status}")
     print(f"runtime_commit_finality_status={runtime_commit_finality_status}")
@@ -806,6 +829,18 @@ def check_policy(args: argparse.Namespace) -> int:
     checks.reject_if(
         payload.get("transport_convergence_status") != expected_domain_status,
         "local_full_stack_integration_policy_transport_convergence_status_mismatch",
+    )
+    checks.reject_if(
+        payload.get("libp2p_process_isolation_status") != expected_domain_status,
+        "local_full_stack_integration_policy_libp2p_process_isolation_status_mismatch",
+    )
+    checks.reject_if(
+        payload.get("libp2p_two_node_process_isolated_status") != expected_domain_status,
+        "local_full_stack_integration_policy_libp2p_two_node_process_isolated_status_mismatch",
+    )
+    checks.reject_if(
+        payload.get("libp2p_three_node_process_isolated_status") != expected_domain_status,
+        "local_full_stack_integration_policy_libp2p_three_node_process_isolated_status_mismatch",
     )
     checks.reject_if(
         payload.get("signer_provenance_status") != expected_domain_status,
@@ -1002,6 +1037,36 @@ def check_policy(args: argparse.Namespace) -> int:
                 libp2p_summary_payload.get("convergence_reason_codes")
                 != [LIBP2P_CONVERGENCE_REASON_CODE],
                 "local_full_stack_integration_policy_libp2p_summary_reason_taxonomy_mismatch",
+            )
+            checks.reject_if(
+                libp2p_summary_payload.get("two_node_disconnected_fail_closed_status")
+                != "verified",
+                (
+                    "local_full_stack_integration_policy_libp2p_summary_two_node_"
+                    "disconnected_status_mismatch"
+                ),
+            )
+            checks.reject_if(
+                libp2p_summary_payload.get("two_node_connected_delivery_status") != "verified",
+                (
+                    "local_full_stack_integration_policy_libp2p_summary_two_node_"
+                    "connected_status_mismatch"
+                ),
+            )
+            checks.reject_if(
+                libp2p_summary_payload.get("three_node_partition_rejoin_status") != "verified",
+                (
+                    "local_full_stack_integration_policy_libp2p_summary_three_node_"
+                    "partition_rejoin_status_mismatch"
+                ),
+            )
+            checks.reject_if(
+                libp2p_summary_payload.get("three_node_publish_drop_recovery_status")
+                != "verified",
+                (
+                    "local_full_stack_integration_policy_libp2p_summary_three_node_"
+                    "publish_drop_status_mismatch"
+                ),
             )
 
         if libp2p_policy_report_path:

--- a/scripts/runtime/test_check_local_full_stack_integration_live_policy.sh
+++ b/scripts/runtime/test_check_local_full_stack_integration_live_policy.sh
@@ -34,6 +34,9 @@ cat >"$TMP_REPORT" <<'JSON'
   ],
   "libp2p_fallback_markers_detected": [],
   "libp2p_provider_marker_contract_status": "verified",
+  "libp2p_process_isolation_status": "planned",
+  "libp2p_two_node_process_isolated_status": "planned",
+  "libp2p_three_node_process_isolated_status": "planned",
   "libp2p_convergence_report_schema_version": "kamn.runtime.libp2p-convergence-process-isolated-live-report.v1",
   "libp2p_convergence_policy_schema_version": "kamn.runtime.libp2p-convergence-process-isolated-live-policy-report.v1",
   "evidence_bundle_status": "verified",
@@ -169,6 +172,37 @@ if [ "$tampered_kolme_marker_code" -eq 0 ]; then
 fi
 if ! printf '%s\n' "$tampered_kolme_marker_output" | grep -q 'local_full_stack_integration_policy_kolme_local_prerequisite_status_mismatch'; then
   echo "expected deterministic reason marker for tampered Kolme local prerequisite status" >&2
+  exit 1
+fi
+
+cp "$TMP_REPORT" "$TMP_TAMPERED"
+python3 - "$TMP_TAMPERED" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+payload = json.loads(path.read_text(encoding="utf-8"))
+payload["libp2p_three_node_process_isolated_status"] = "missing"
+path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+set +e
+tampered_three_node_marker_output="$(
+  bash "$POLICY_SCRIPT" \
+    --report-file "$TMP_TAMPERED" \
+    --expected-final-decision GO \
+    --ci-fast-gate PASS \
+    --output-json "$TMP_POLICY" 2>&1
+)"
+tampered_three_node_marker_code=$?
+set -e
+if [ "$tampered_three_node_marker_code" -eq 0 ]; then
+  echo "expected tampered three-node process-isolated marker to fail policy check" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$tampered_three_node_marker_output" | grep -q 'local_full_stack_integration_policy_libp2p_three_node_process_isolated_status_mismatch'; then
+  echo "expected deterministic reason marker for tampered three-node process-isolated status" >&2
   exit 1
 fi
 

--- a/scripts/runtime/test_validate_local_full_stack_integration_live.sh
+++ b/scripts/runtime/test_validate_local_full_stack_integration_live.sh
@@ -63,6 +63,18 @@ if ! printf '%s\n' "$validation_output" | grep -q '^libp2p_provider_marker_contr
   echo "expected local full-stack integration provider marker contract status marker" >&2
   exit 1
 fi
+if ! printf '%s\n' "$validation_output" | grep -q '^libp2p_process_isolation_status=planned$'; then
+  echo "expected local full-stack integration process-isolation marker in dry-run" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^libp2p_two_node_process_isolated_status=planned$'; then
+  echo "expected local full-stack integration two-node process-isolated marker in dry-run" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q '^libp2p_three_node_process_isolated_status=planned$'; then
+  echo "expected local full-stack integration three-node process-isolated marker in dry-run" >&2
+  exit 1
+fi
 if ! printf '%s\n' "$validation_output" | grep -q '^libp2p_convergence_report_schema_version=kamn.runtime.libp2p-convergence-process-isolated-live-report.v1$'; then
   echo "expected local full-stack integration libp2p convergence report schema marker" >&2
   exit 1
@@ -215,6 +227,12 @@ if payload.get("libp2p_fallback_markers_detected") != []:
     raise SystemExit("expected no libp2p fallback markers in report")
 if payload.get("libp2p_provider_marker_contract_status") != "verified":
     raise SystemExit("expected libp2p_provider_marker_contract_status")
+if payload.get("libp2p_process_isolation_status") != "planned":
+    raise SystemExit("expected libp2p_process_isolation_status=planned")
+if payload.get("libp2p_two_node_process_isolated_status") != "planned":
+    raise SystemExit("expected libp2p_two_node_process_isolated_status=planned")
+if payload.get("libp2p_three_node_process_isolated_status") != "planned":
+    raise SystemExit("expected libp2p_three_node_process_isolated_status=planned")
 if payload.get("libp2p_convergence_report_schema_version") != "kamn.runtime.libp2p-convergence-process-isolated-live-report.v1":
     raise SystemExit("expected libp2p_convergence_report_schema_version marker")
 if payload.get("libp2p_convergence_policy_schema_version") != "kamn.runtime.libp2p-convergence-process-isolated-live-policy-report.v1":

--- a/scripts/runtime/test_validate_local_full_stack_integration_live_contract_lane.sh
+++ b/scripts/runtime/test_validate_local_full_stack_integration_live_contract_lane.sh
@@ -95,6 +95,18 @@ if ! printf '%s\n' "$lane_output" | grep -q '^libp2p_provider_marker_contract_st
   echo "expected local full-stack integration contract lane provider marker contract status marker" >&2
   exit 1
 fi
+if ! printf '%s\n' "$lane_output" | grep -q '^libp2p_process_isolation_status=planned$'; then
+  echo "expected local full-stack integration contract lane process-isolation marker in dry-run" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$lane_output" | grep -q '^libp2p_two_node_process_isolated_status=planned$'; then
+  echo "expected local full-stack integration contract lane two-node process-isolated marker in dry-run" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$lane_output" | grep -q '^libp2p_three_node_process_isolated_status=planned$'; then
+  echo "expected local full-stack integration contract lane three-node process-isolated marker in dry-run" >&2
+  exit 1
+fi
 if ! printf '%s\n' "$lane_output" | grep -q '^kolme_local_prerequisite_status=planned$'; then
   echo "expected local full-stack integration contract lane Kolme local prerequisite marker in dry-run" >&2
   exit 1
@@ -199,6 +211,12 @@ if lane_payload.get("libp2p_fallback_markers_detected") != []:
     raise SystemExit("expected empty libp2p_fallback_markers_detected marker")
 if lane_payload.get("libp2p_provider_marker_contract_status") != "verified":
     raise SystemExit("expected libp2p_provider_marker_contract_status marker")
+if lane_payload.get("libp2p_process_isolation_status") != "planned":
+    raise SystemExit("expected libp2p_process_isolation_status=planned in dry-run")
+if lane_payload.get("libp2p_two_node_process_isolated_status") != "planned":
+    raise SystemExit("expected libp2p_two_node_process_isolated_status=planned in dry-run")
+if lane_payload.get("libp2p_three_node_process_isolated_status") != "planned":
+    raise SystemExit("expected libp2p_three_node_process_isolated_status=planned in dry-run")
 if lane_payload.get("libp2p_convergence_report_schema_version") != "kamn.runtime.libp2p-convergence-process-isolated-live-report.v1":
     raise SystemExit("expected libp2p_convergence_report_schema_version marker")
 if lane_payload.get("libp2p_convergence_policy_schema_version") != "kamn.runtime.libp2p-convergence-process-isolated-live-policy-report.v1":

--- a/scripts/runtime/validate_local_full_stack_integration_live_contract_lane.sh
+++ b/scripts/runtime/validate_local_full_stack_integration_live_contract_lane.sh
@@ -141,6 +141,18 @@ if ! printf '%s\n' "$validation_output" | grep -q "^transport_convergence_status
   echo "expected local full-stack integration transport convergence marker" >&2
   exit 1
 fi
+if ! printf '%s\n' "$validation_output" | grep -q "^libp2p_process_isolation_status=${domain_expected_status}$"; then
+  echo "expected local full-stack integration process-isolation marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q "^libp2p_two_node_process_isolated_status=${domain_expected_status}$"; then
+  echo "expected local full-stack integration two-node process-isolated marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$validation_output" | grep -q "^libp2p_three_node_process_isolated_status=${domain_expected_status}$"; then
+  echo "expected local full-stack integration three-node process-isolated marker" >&2
+  exit 1
+fi
 if ! printf '%s\n' "$validation_output" | grep -q "^signer_provenance_status=${domain_expected_status}$"; then
   echo "expected local full-stack integration signer provenance marker" >&2
   exit 1
@@ -360,6 +372,9 @@ if summary_report.get("kolme_fork_chain_version") != sys.argv[11]:
 
 for marker in (
     "transport_convergence_status",
+    "libp2p_process_isolation_status",
+    "libp2p_two_node_process_isolated_status",
+    "libp2p_three_node_process_isolated_status",
     "signer_provenance_status",
     "runtime_commit_submission_status",
     "runtime_commit_finality_status",
@@ -382,6 +397,18 @@ lane_report = {
         "local_full_stack_integration_policy_status", "unknown"
     ),
     "transport_convergence_status": summary_report.get("transport_convergence_status", "unknown"),
+    "libp2p_process_isolation_status": summary_report.get(
+        "libp2p_process_isolation_status",
+        "unknown",
+    ),
+    "libp2p_two_node_process_isolated_status": summary_report.get(
+        "libp2p_two_node_process_isolated_status",
+        "unknown",
+    ),
+    "libp2p_three_node_process_isolated_status": summary_report.get(
+        "libp2p_three_node_process_isolated_status",
+        "unknown",
+    ),
     "signer_provenance_status": summary_report.get("signer_provenance_status", "unknown"),
     "runtime_commit_submission_status": summary_report.get("runtime_commit_submission_status", "unknown"),
     "runtime_commit_finality_status": summary_report.get("runtime_commit_finality_status", "unknown"),
@@ -464,6 +491,9 @@ echo "lane_mode=${mode}"
 echo "local_full_stack_integration_contract_status=verified"
 echo "local_full_stack_integration_policy_status=verified"
 echo "transport_convergence_status=${domain_expected_status}"
+echo "libp2p_process_isolation_status=${domain_expected_status}"
+echo "libp2p_two_node_process_isolated_status=${domain_expected_status}"
+echo "libp2p_three_node_process_isolated_status=${domain_expected_status}"
 echo "signer_provenance_status=${domain_expected_status}"
 echo "runtime_commit_submission_status=${domain_expected_status}"
 echo "runtime_commit_finality_status=${domain_expected_status}"


### PR DESCRIPTION
## Summary
Enforces explicit process-isolated marker domains for the composed local full-stack runtime lane and fails closed when marker drift is detected. This hardens the native libp2p + Kolme live evidence contract required for release go/no-go.

Closes #3737

## Changes
- `scripts/runtime/local_full_stack_integration_live_contract.py`: added process-isolated top-level markers and policy checks; added nested libp2p summary checks for two-node and three-node process-isolated outcomes.
- `scripts/runtime/validate_local_full_stack_integration_live_contract_lane.sh`: enforced new markers in lane output and lane report schema.
- `scripts/runtime/test_validate_local_full_stack_integration_live.sh`: added dry-run marker assertions and JSON marker checks.
- `scripts/runtime/test_check_local_full_stack_integration_live_policy.sh`: added fail-closed tamper regression for three-node process-isolated marker drift.
- `scripts/runtime/test_validate_local_full_stack_integration_live_contract_lane.sh`: added lane-level marker assertions and JSON checks.
- `docs/architecture/kolme-live-integration.md`: documented new marker taxonomy and deterministic fail-closed reasons.
- `docs/ci/strategy.md`: documented local full-stack process-isolated marker domains and policy drift reasons.
- `crates/kamn-core/tests/kolme_live_integration_docs.rs`: added docs-contract tests for process-isolated markers and reason taxonomy.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command (intentional tamper):
```bash
python3 scripts/runtime/local_full_stack_integration_live_contract.py run-lane --mode dry-run --output-json /tmp/local-full-stack-3737-red.json
# mutate libp2p_three_node_process_isolated_status -> missing
python3 scripts/runtime/local_full_stack_integration_live_contract.py check-policy --report-file /tmp/local-full-stack-3737-red.json --expected-final-decision GO --ci-fast-gate PASS --output-json /tmp/local-full-stack-3737-red-policy.json
```
Output:
```text
exit_code=1
local_full_stack_integration_policy_libp2p_three_node_process_isolated_status_mismatch,local_full_stack_integration_policy_expected_decision_mismatch
status=fail
final_decision=NO-GO
```

### 🟢 Green Phase
Commands:
```bash
bash scripts/runtime/test_validate_local_full_stack_integration_live.sh
bash scripts/runtime/test_check_local_full_stack_integration_live_policy.sh
bash scripts/runtime/test_validate_local_full_stack_integration_live_contract_lane.sh
```
Output:
```text
local full-stack integration live validation tests passed.
local full-stack integration policy checker tests passed.
local full-stack integration contract lane tests passed.
```

### 🔁 Regression
Commands:
```bash
bash scripts/runtime/test_run_go_no_go_gate_lane.sh
bash scripts/runtime/test_validate_libp2p_convergence_process_isolated_live.sh
bash scripts/runtime/test_check_libp2p_convergence_process_isolated_live_policy.sh
bash scripts/runtime/test_validate_libp2p_convergence_process_isolated_live_contract_lane.sh
cargo test -p kamn-core --test kolme_live_integration_docs
cargo test -p kamn-core --test ci_strategy_docs
cargo fmt --check
cargo clippy -p kamn-core --tests -- -D warnings
```
Result:
```text
All commands passed.
```

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅ | `crates/kamn-core/tests/kolme_live_integration_docs.rs` | |
| Functional   | ✅ | `scripts/runtime/test_validate_local_full_stack_integration_live.sh` | |
| Integration  | ✅ | `scripts/runtime/test_validate_local_full_stack_integration_live_contract_lane.sh`, `scripts/runtime/test_run_go_no_go_gate_lane.sh` | |
| Regression   | ✅ | `scripts/runtime/test_check_local_full_stack_integration_live_policy.sh` (tampered marker NO-GO) | |
| Performance  | N/A | | No runtime budget constants changed in this task; existing lane budget policy remains unchanged. |

## Risks & Rollback
- No breaking API changes.
- Rollback: revert this PR to restore previous marker surface and policy behavior.

## Documentation Updates
- `docs/architecture/kolme-live-integration.md`
- `docs/ci/strategy.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (executed as `cargo clippy -p kamn-core --tests -- -D warnings`)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)
