### PR TITLE
test(docs): add architecture navigation index contract checks (#3976)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1242,6 +1242,7 @@ Canonical contributor rules are in `.github/CONTRIBUTING.md` (`AGENTS.md` remain
 - `.github/CONTRIBUTING.md`: mandatory execution contract (issue hierarchy, TDD, PR standards).
 - `AGENTS.md`: compatibility redirect for agent tooling.
 - `PRD.md`: product requirements and phase scope baseline.
+- `docs/architecture/README.md`: canonical architecture navigation index and diagram catalog.
 - `docs/planning/engineering-hardening-wave.md#commands`: baseline hardening and missing-doc policy command surface.
 - `docs/architecture/kamn-core-module-map.md#ownership-matrix`: `kamn-core` domain ownership map.
 - `docs/architecture/kamn-core-module-map.md#contributor-entrypoint-matrix`: contributor entrypoints by architecture/workflow need.

--- a/crates/kamn-node/tests/architecture_navigation_docs.rs
+++ b/crates/kamn-node/tests/architecture_navigation_docs.rs
@@ -1,0 +1,37 @@
+const ARCH_NAV_INDEX: &str = include_str!("../../../docs/architecture/README.md");
+const REPO_README: &str = include_str!("../../../README.md");
+const CI_STRATEGY_DOC: &str = include_str!("../../../docs/ci/strategy.md");
+
+#[test]
+fn architecture_navigation_index_declares_schema_and_diagram_catalog_markers() {
+    assert!(ARCH_NAV_INDEX.contains("schema_version=kamn.docs.architecture-navigation-index.v1"));
+    assert!(ARCH_NAV_INDEX.contains("diagram_catalog_status=active"));
+    assert!(ARCH_NAV_INDEX.contains("diagram:runtime-layout"));
+    assert!(ARCH_NAV_INDEX.contains("diagram:service-runtime"));
+    assert!(ARCH_NAV_INDEX.contains("diagram:block-pipeline"));
+    assert!(ARCH_NAV_INDEX.contains("diagram:p2p-transport"));
+    assert!(ARCH_NAV_INDEX.contains("diagram:kolme-live-integration"));
+    assert!(ARCH_NAV_INDEX.contains("diagram:signer-lifecycle"));
+}
+
+#[test]
+fn architecture_navigation_index_links_required_artifacts() {
+    assert!(ARCH_NAV_INDEX.contains("docs/architecture/kamn-core-module-map.md"));
+    assert!(ARCH_NAV_INDEX.contains("docs/architecture/kamn-node-module-map.md"));
+    assert!(ARCH_NAV_INDEX.contains("docs/architecture/runtime-layout.md"));
+    assert!(ARCH_NAV_INDEX.contains("docs/architecture/service-runtime.md"));
+    assert!(ARCH_NAV_INDEX.contains("docs/architecture/block-pipeline.md"));
+    assert!(ARCH_NAV_INDEX.contains("docs/architecture/p2p-transport.md"));
+    assert!(ARCH_NAV_INDEX.contains("docs/architecture/kolme-live-integration.md"));
+    assert!(ARCH_NAV_INDEX.contains("docs/architecture/kolme-runtime-commit.md"));
+    assert!(ARCH_NAV_INDEX.contains("docs/architecture/persistence-backends.md"));
+    assert!(ARCH_NAV_INDEX.contains("docs/architecture/did-chain-adapter.md"));
+    assert!(ARCH_NAV_INDEX.contains("docs/architecture/adr-kamn-core-live-tls-transport.md"));
+}
+
+#[test]
+fn readme_and_ci_strategy_reference_architecture_navigation_guard() {
+    assert!(REPO_README.contains("docs/architecture/README.md"));
+    assert!(CI_STRATEGY_DOC.contains("architecture navigation index guard"));
+    assert!(CI_STRATEGY_DOC.contains("cargo test -p kamn-node --test architecture_navigation_docs"));
+}

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,38 @@
+# Architecture Navigation Index
+
+schema_version=kamn.docs.architecture-navigation-index.v1
+diagram_catalog_status=active
+index_last_reviewed=2026-02-16
+
+This index is the canonical navigation entrypoint for architecture artifacts and
+diagram references.
+
+## Module Maps
+
+- `docs/architecture/kamn-core-module-map.md`
+- `docs/architecture/kamn-node-module-map.md`
+
+## Runtime And Service Flows
+
+- `docs/architecture/runtime-layout.md`
+- `docs/architecture/service-runtime.md`
+- `docs/architecture/block-pipeline.md`
+- `docs/architecture/p2p-transport.md`
+- `docs/architecture/kolme-live-integration.md`
+- `docs/architecture/kolme-runtime-commit.md`
+- `docs/architecture/signer-lifecycle.md`
+- `docs/architecture/persistence-backends.md`
+- `docs/architecture/did-chain-adapter.md`
+
+## Decision Records
+
+- `docs/architecture/adr-kamn-core-live-tls-transport.md`
+
+## Diagram Catalog
+
+- `diagram:runtime-layout` => `docs/architecture/runtime-layout.md`
+- `diagram:service-runtime` => `docs/architecture/service-runtime.md`
+- `diagram:block-pipeline` => `docs/architecture/block-pipeline.md`
+- `diagram:p2p-transport` => `docs/architecture/p2p-transport.md`
+- `diagram:kolme-live-integration` => `docs/architecture/kolme-live-integration.md`
+- `diagram:signer-lifecycle` => `docs/architecture/signer-lifecycle.md`

--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -1154,6 +1154,17 @@ Versioned thresholds are defined in `.ci/ci-budget.env`.
     - `impl_contract_status_marker_missing:scripts/runtime/validate_service_api_graceful_shutdown_drain_live_contract_lane_impl.sh`
     - `fallback_reason_code=dispatcher_unknown_wrapper`
 
+## Architecture Navigation Index Contract
+- architecture navigation index guard stays on PR fast gate:
+  - `cargo test -p kamn-node --test architecture_navigation_docs`
+- index artifact and marker contract:
+  - `docs/architecture/README.md`
+  - `schema_version=kamn.docs.architecture-navigation-index.v1`
+  - `diagram_catalog_status=active`
+- required cross-doc references remain fail-closed:
+  - `README.md` must reference `docs/architecture/README.md`.
+  - architecture index must include core map/runtime/service/Kolme/TLS ADR paths.
+
 ## Kolme HTTPS Native Transport Contract
 - Runtime-commit HTTPS transport uses an in-process native TLS client path.
 - `openssl s_client` subprocess execution is prohibited in transport code paths (`Regression: #2671`).


### PR DESCRIPTION
## Summary
Adds a canonical architecture navigation index and a deterministic docs-contract test that fails closed when architecture links/diagram markers drift.

Closes #3976
Refs #3969

## CI Impact Declaration
- [ ] No CI scope impact.
- [x] CI scope impact present (explain below).

CI scope impact details (required when CI scope impact is present):
Workflow(s) touched: ci-fast-gate Rust test lane (`kamn-node` docs-contract test target)
Expected runtime delta: +1s to +5s
Expected runner-minute delta: negligible (<0.1 runner-minutes)
Rollback plan if CI cost/runtime regresses: revert commit 124cc927 and re-land with a slimmer marker set.

## Changes
- Added `docs/architecture/README.md` as the architecture navigation index and diagram catalog.
- Added `crates/kamn-node/tests/architecture_navigation_docs.rs` for fail-closed marker checks.
- Updated `README.md` key links to include the architecture navigation index.
- Updated `docs/ci/strategy.md` with the architecture navigation index guard command and required markers.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
`cargo test -p kamn-node --test architecture_navigation_docs`
- failed with compile-time include error (missing `docs/architecture/README.md`).

### 🟢 Green Phase
`cargo test -p kamn-node --test architecture_navigation_docs`
- passed (`3 passed; 0 failed`).

### 🔁 Regression
`cargo test -p kamn-node --all-features --no-fail-fast`
- passed.

`bash scripts/ci/test_ci_strategy_contract.sh`
- passed.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `architecture_navigation_docs` marker checks |                      |
| Functional   | ✅     | docs artifact link/marker contract behavior via test assertions |                      |
| Integration  | ✅     | `cargo test -p kamn-node --all-features --no-fail-fast` |                      |
| Regression   | ✅     | Red/green replay for missing index + drift guard markers |                      |
| Performance  | N/A    | Docs-contract scope only; no runtime hot-path change | Not applicable        |

## Risks & Rollback
- Risk: low (documentation + docs-contract test only).
- Rollback: revert this PR if marker policy is too strict.

## Documentation Updates
- `docs/architecture/README.md`
- `docs/ci/strategy.md`
- `README.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (no new warnings introduced in touched code paths)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing for touched surface
- [x] Docs updated
