### PR TITLE
feat(kolme): harden startup drift and orchestration policy contracts (#4495)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1019,6 +1019,7 @@ bash scripts/kolme/run_managed_signer_startup_live_validation_contract_lane.sh \
 ```
 
 Live Provider Operator Runbook (Issue #2114): `docs/planning/kolme-devnet-ops.md`
+Local Demo Startup Drift Runbook (Issue #4495): `docs/ops/runbook_demo.md`
 
 ### Run Local Live-Node Validation Bundle Lane
 

--- a/docs/ops/runbook_demo.md
+++ b/docs/ops/runbook_demo.md
@@ -1,0 +1,59 @@
+# Local Demo Startup Drift Runbook
+
+This runbook documents fail-closed handling for local multi-process demo startup
+dependency drift and orchestration instability in the Kolme process lifecycle lane.
+
+## Scope
+
+- Lane under governance:
+  - `bash scripts/kolme/run_local_kolme_fork_process_lifecycle_lane.sh`
+- Policy checker:
+  - `python3 scripts/kolme/check_local_kolme_fork_process_lifecycle_policy.py`
+- Contract-lane regression test:
+  - `bash scripts/kolme/test_run_local_kolme_fork_process_lifecycle_contract_lane.sh`
+
+## Startup Dependency Drift
+
+The checker must fail closed when downstream startup phases report success while
+upstream prerequisites are not satisfied.
+
+Required fail-closed markers include:
+
+- `startup_dependency_drift:readiness_without_process_start`
+- `startup_dependency_drift:integration_without_readiness`
+- `startup_dependency_drift:integration_without_process_start`
+
+These markers cover:
+
+- readiness success accepted after process start failure,
+- integration success accepted before readiness success, and
+- integration success accepted while process start is not successful.
+
+## Orchestration Instability
+
+The checker must fail closed when orchestration evidence becomes unstable:
+
+- duplicate check IDs in the same report:
+  - `check_id_duplicate:<check-id>`
+- non-deterministic phase ordering across the primary orchestration chain:
+  - `check_sequence_mismatch`
+
+## Local Validation Commands
+
+```bash
+# Run full contract-lane regression (dry-run safe path by default)
+bash scripts/kolme/test_run_local_kolme_fork_process_lifecycle_contract_lane.sh
+
+# Validate a generated lifecycle summary directly
+python3 scripts/kolme/check_local_kolme_fork_process_lifecycle_policy.py \
+  --report-file /tmp/kolme-local-fork-process-lifecycle-summary.json \
+  --expected-final-decision GO \
+  --ci-fast-gate PASS \
+  --output-json /tmp/kolme-local-fork-process-lifecycle-policy.json
+```
+
+## CI Cost Boundary
+
+- Keep startup drift and orchestration instability checks in dry-run contract lanes.
+- Reserve local heavy run-mode execution for explicit opt-in:
+  - `KAMN_KOLME_LOCAL_HEAVY=1`

--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -1675,6 +1675,8 @@ Operator checkpoints:
 - local fork process lifecycle integration lane propagates integration runtime finality pass-through options and artifacts to nested integration command composition (`Regression: #1973`).
 - local fork process lifecycle integration lane propagates runtime policy report linkage to nested integration command composition and summary artifact lineage (`Regression: #2104`).
 - local fork process lifecycle integration lane propagates rollback/recovery evidence linkage options and deterministic artifact markers in summary/policy contracts (`Regression: #2107`).
+- local fork process lifecycle policy rejects startup dependency drift acceptance and duplicate orchestration check identifiers (`Regression: #4495`).
+- demo startup drift and orchestration instability response runbook: `docs/ops/runbook_demo.md` (`Regression: #4495`).
 - local fork profile preflight lane fails closed for local opt-in, checkout/profile contract drift, probe command failures, and runtime budget overruns (`Regression: #1648`).
 - local fork profile preflight policy and contract-lane command/report drift remains fail-closed (`Regression: #1697`).
 - local fork self-test lane fails closed for local opt-in, nested matrix/policy checkpoint failures, and runtime budget overruns (`Regression: #1652`).

--- a/scripts/kolme/check_local_kolme_fork_process_lifecycle_policy.py
+++ b/scripts/kolme/check_local_kolme_fork_process_lifecycle_policy.py
@@ -110,6 +110,18 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
     recovery_evidence_reason_code = report.get("recovery_evidence_reason_code")
     if not isinstance(recovery_evidence_reason_code, str) or not recovery_evidence_reason_code.strip():
         reason_codes.append("recovery_evidence_reason_code_missing")
+    start_reason_code = report.get("start_reason_code")
+    if not isinstance(start_reason_code, str) or not start_reason_code.strip():
+        reason_codes.append("start_reason_code_missing")
+    readiness_reason_code = report.get("readiness_reason_code")
+    if not isinstance(readiness_reason_code, str) or not readiness_reason_code.strip():
+        reason_codes.append("readiness_reason_code_missing")
+    integration_reason_code = report.get("integration_reason_code")
+    if not isinstance(integration_reason_code, str) or not integration_reason_code.strip():
+        reason_codes.append("integration_reason_code_missing")
+    teardown_reason_code = report.get("teardown_reason_code")
+    if not isinstance(teardown_reason_code, str) or not teardown_reason_code.strip():
+        reason_codes.append("teardown_reason_code_missing")
 
     artifact_paths = report.get("artifact_paths")
     if not isinstance(artifact_paths, list) or not artifact_paths:
@@ -136,17 +148,20 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
         reason_codes.append("recovery_evidence_artifact_missing")
 
     checks = report.get("checks")
+    check_entries_by_id: dict[str, list[dict[str, str]]] = {}
+    check_order: list[str] = []
     if not isinstance(checks, list) or not checks:
         reason_codes.append("checks_missing")
     else:
-        expected_ids = {
+        expected_order = [
             "process_start",
             "readiness_probe",
             "kamn_live_integration",
             "process_teardown",
             "rollback_evidence",
             "recovery_evidence",
-        }
+        ]
+        expected_ids = set(expected_order)
         observed_ids: set[str] = set()
         for entry in checks:
             if not isinstance(entry, dict):
@@ -160,12 +175,20 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
                 reason_codes.append("check_id_invalid")
                 continue
             observed_ids.add(check_id)
+            check_order.append(check_id)
             if not isinstance(command, str) or not command.strip():
                 reason_codes.append(f"check_command_invalid:{check_id}")
             if check_status not in ("planned", "pass", "fail", "skipped"):
                 reason_codes.append(f"check_status_invalid:{check_id}")
             if not isinstance(check_reason_code, str) or not check_reason_code.strip():
                 reason_codes.append(f"check_reason_code_invalid:{check_id}")
+            check_entries_by_id.setdefault(check_id, []).append(
+                {
+                    "status": str(check_status),
+                    "reason_code": str(check_reason_code),
+                    "command": str(command),
+                }
+            )
             if (
                 check_id == "kamn_live_integration"
                 and isinstance(command, str)
@@ -199,6 +222,62 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
         missing_ids = sorted(expected_ids - observed_ids)
         for missing_id in missing_ids:
             reason_codes.append(f"check_missing:{missing_id}")
+
+        for check_id, entries in check_entries_by_id.items():
+            if len(entries) > 1:
+                reason_codes.append(f"check_id_duplicate:{check_id}")
+
+        observed_primary_order: list[str] = []
+        seen_primary_ids: set[str] = set()
+        for check_id in check_order:
+            if check_id in expected_ids and check_id not in seen_primary_ids:
+                observed_primary_order.append(check_id)
+                seen_primary_ids.add(check_id)
+        if len(observed_primary_order) == len(expected_order) and observed_primary_order != expected_order:
+            reason_codes.append("check_sequence_mismatch")
+
+        if expected_ids.issubset(set(check_entries_by_id.keys())):
+            process_start_status = check_entries_by_id["process_start"][0]["status"]
+            readiness_status = check_entries_by_id["readiness_probe"][0]["status"]
+            integration_status = check_entries_by_id["kamn_live_integration"][0]["status"]
+            teardown_status = check_entries_by_id["process_teardown"][0]["status"]
+
+            if readiness_status == "pass" and process_start_status != "pass":
+                reason_codes.append("startup_dependency_drift:readiness_without_process_start")
+            if integration_status == "pass" and readiness_status != "pass":
+                reason_codes.append("startup_dependency_drift:integration_without_readiness")
+            if integration_status == "pass" and process_start_status != "pass":
+                reason_codes.append("startup_dependency_drift:integration_without_process_start")
+            if teardown_status == "pass" and integration_status not in ("pass", "fail"):
+                reason_codes.append("startup_dependency_drift:teardown_without_integration_outcome")
+
+            if mode == "dry-run":
+                if start_reason_code != "not_run":
+                    reason_codes.append("dry_run_start_reason_code_mismatch")
+                if readiness_reason_code != "not_run":
+                    reason_codes.append("dry_run_readiness_reason_code_mismatch")
+                if integration_reason_code != "not_run":
+                    reason_codes.append("dry_run_integration_reason_code_mismatch")
+                if teardown_reason_code != "not_run":
+                    reason_codes.append("dry_run_teardown_reason_code_mismatch")
+
+            if mode == "run" and status == "ok":
+                if process_start_status != "pass":
+                    reason_codes.append("run_ok_process_start_status_mismatch")
+                if readiness_status != "pass":
+                    reason_codes.append("run_ok_readiness_status_mismatch")
+                if integration_status != "pass":
+                    reason_codes.append("run_ok_integration_status_mismatch")
+                if teardown_status != "pass":
+                    reason_codes.append("run_ok_teardown_status_mismatch")
+                if start_reason_code != "process_started":
+                    reason_codes.append("run_ok_start_reason_code_mismatch")
+                if readiness_reason_code != "readiness_checks_passed":
+                    reason_codes.append("run_ok_readiness_reason_code_mismatch")
+                if integration_reason_code != "kamn_live_integration_passed":
+                    reason_codes.append("run_ok_integration_reason_code_mismatch")
+                if teardown_reason_code != "process_teardown_passed":
+                    reason_codes.append("run_ok_teardown_reason_code_mismatch")
 
     if args.ci_fast_gate != "PASS":
         reason_codes.append("ci_fast_gate_failed")

--- a/scripts/kolme/contracts/local_kolme_fork_process_lifecycle_contract_lane.py
+++ b/scripts/kolme/contracts/local_kolme_fork_process_lifecycle_contract_lane.py
@@ -16,6 +16,7 @@ RUNNER = ROOT_DIR / "scripts/kolme/run_local_kolme_fork_process_lifecycle_lane.s
 CHECKER = ROOT_DIR / "scripts/kolme/check_local_kolme_fork_process_lifecycle_policy.py"
 DOC_FILE = ROOT_DIR / "docs/planning/kolme-devnet-ops.md"
 README_FILE = ROOT_DIR / "README.md"
+RUNBOOK_FILE = ROOT_DIR / "docs/ops/runbook_demo.md"
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -64,6 +65,9 @@ def main() -> int:
         return 1
     if not README_FILE.is_file():
         print("expected README to exist", file=sys.stderr)
+        return 1
+    if not RUNBOOK_FILE.is_file():
+        print("expected demo startup drift runbook to exist", file=sys.stderr)
         return 1
 
     start_epoch = time.monotonic()
@@ -230,6 +234,10 @@ def main() -> int:
     if "run_local_kolme_fork_process_lifecycle_lane.sh" not in doc_text:
         print("expected Kolme devnet ops doc to reference local Kolme fork process lifecycle runner", file=sys.stderr)
         return 1
+    # Regression: #4495
+    if "docs/ops/runbook_demo.md" not in doc_text:
+        print("expected Kolme devnet ops doc to reference demo startup drift runbook", file=sys.stderr)
+        return 1
     if "check_local_kolme_fork_process_lifecycle_policy.py" not in doc_text:
         print("expected Kolme devnet ops doc to reference local Kolme fork process lifecycle policy checker", file=sys.stderr)
         return 1
@@ -277,6 +285,9 @@ def main() -> int:
         return 1
     if "run_local_kolme_fork_process_lifecycle_contract_lane.sh" not in readme_text:
         print("expected README to reference local Kolme fork process lifecycle contract lane", file=sys.stderr)
+        return 1
+    if "docs/ops/runbook_demo.md" not in readme_text:
+        print("expected README to reference demo startup drift runbook", file=sys.stderr)
         return 1
     if "--integration-runtime-commit-finality-command" not in readme_text:
         print(

--- a/scripts/kolme/test_run_local_kolme_fork_process_lifecycle_contract_lane.sh
+++ b/scripts/kolme/test_run_local_kolme_fork_process_lifecycle_contract_lane.sh
@@ -12,6 +12,7 @@ RUN_MANIFEST="$ROOT_DIR/scripts/framework/manifests/kolme_local_kolme_fork_proce
 DISPATCHER="$ROOT_DIR/scripts/kolme/run_lane_dispatch.sh"
 DOC_FILE="$ROOT_DIR/docs/planning/kolme-devnet-ops.md"
 README_FILE="$ROOT_DIR/README.md"
+RUNBOOK_FILE="$ROOT_DIR/docs/ops/runbook_demo.md"
 TMP_REPORT="$(mktemp)"
 TMP_POLICY_REPORT="$(mktemp)"
 trap 'rm -f "$TMP_REPORT" "$TMP_POLICY_REPORT"' EXIT
@@ -135,6 +136,7 @@ required_coverage_markers=(
   "Regression: #1973"
   "Regression: #2104"
   "Regression: #2107"
+  "Regression: #4495"
 )
 for marker in "${required_coverage_markers[@]}"; do
   if ! grep -q "$marker" "$CONTRACT_IMPL"; then
@@ -188,6 +190,11 @@ if ! grep -q -- "--recovery-evidence-file" "$DOC_FILE"; then
   exit 1
 fi
 
+if ! grep -q "docs/ops/runbook_demo.md" "$DOC_FILE"; then
+  echo "expected Kolme devnet ops doc to reference demo startup drift runbook" >&2
+  exit 1
+fi
+
 if ! grep -q "check_local_kolme_fork_process_lifecycle_policy.py" "$README_FILE"; then
   echo "expected README to reference local fork process lifecycle policy checker" >&2
   exit 1
@@ -230,6 +237,26 @@ fi
 
 if ! grep -q -- "--recovery-evidence-file" "$README_FILE"; then
   echo "expected README to document process lifecycle recovery evidence option" >&2
+  exit 1
+fi
+
+if ! grep -q "docs/ops/runbook_demo.md" "$README_FILE"; then
+  echo "expected README to reference demo startup drift runbook" >&2
+  exit 1
+fi
+
+if [ ! -f "$RUNBOOK_FILE" ]; then
+  echo "expected demo startup drift runbook to exist" >&2
+  exit 1
+fi
+
+if ! grep -q "startup_dependency_drift:readiness_without_process_start" "$RUNBOOK_FILE"; then
+  echo "expected runbook to document startup dependency drift reason marker" >&2
+  exit 1
+fi
+
+if ! grep -q "check_id_duplicate:<check-id>" "$RUNBOOK_FILE"; then
+  echo "expected runbook to document duplicate orchestration check-id reason marker" >&2
   exit 1
 fi
 
@@ -352,5 +379,118 @@ if str(rollback_evidence_path) not in summary.get("artifact_paths", []):
 if str(recovery_evidence_path) not in summary.get("artifact_paths", []):
     raise SystemExit("expected process lifecycle summary artifact paths to include recovery evidence file path")
 PY
+
+# Regression: #4495
+TMP_STARTUP_DRIFT_SUMMARY="$(mktemp)"
+TMP_ORCHESTRATION_DRIFT_SUMMARY="$(mktemp)"
+TMP_POLICY_OUTPUT="$(mktemp)"
+TMP_POLICY_ERR="$(mktemp)"
+trap 'rm -f "$TMP_REPORT" "$TMP_POLICY_REPORT" "$TMP_DIRECT_SUMMARY" "$TMP_DIRECT_PROCESS_OUTPUT" "$TMP_DIRECT_INTEGRATION_REPORT" "$TMP_DIRECT_FINALITY_OUTPUT" "$TMP_DIRECT_RUNTIME_POLICY_REPORT" "$TMP_DIRECT_ROLLBACK_EVIDENCE_FILE" "$TMP_DIRECT_RECOVERY_EVIDENCE_FILE" "$TMP_STARTUP_DRIFT_SUMMARY" "$TMP_ORCHESTRATION_DRIFT_SUMMARY" "$TMP_POLICY_OUTPUT" "$TMP_POLICY_ERR"' EXIT
+
+python3 - "$TMP_REPORT" "$TMP_STARTUP_DRIFT_SUMMARY" <<'PY'
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+summary = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+summary["mode"] = "run"
+summary["status"] = "ok"
+summary["reason_code"] = "process_lifecycle_integration_passed"
+summary["budget_status"] = "within_budget"
+summary["start_reason_code"] = "process_start_failed"
+summary["readiness_reason_code"] = "readiness_checks_passed"
+summary["integration_reason_code"] = "kamn_live_integration_passed"
+summary["teardown_reason_code"] = "process_teardown_passed"
+summary["rollback_evidence_status"] = "not_required"
+summary["rollback_evidence_reason_code"] = "no_failure_detected"
+summary["recovery_evidence_status"] = "validated"
+summary["recovery_evidence_reason_code"] = "teardown_path_validated"
+for check in summary.get("checks", []):
+    if not isinstance(check, dict):
+        continue
+    check_id = check.get("id")
+    if check_id == "process_start":
+        check["status"] = "fail"
+        check["reason_code"] = "process_start_failed"
+    elif check_id == "readiness_probe":
+        check["status"] = "pass"
+        check["reason_code"] = "readiness_checks_passed"
+    elif check_id == "kamn_live_integration":
+        check["status"] = "pass"
+        check["reason_code"] = "kamn_live_integration_passed"
+    elif check_id == "process_teardown":
+        check["status"] = "pass"
+        check["reason_code"] = "process_teardown_passed"
+    elif check_id == "rollback_evidence":
+        check["status"] = "pass"
+        check["reason_code"] = "no_failure_detected"
+    elif check_id == "recovery_evidence":
+        check["status"] = "pass"
+        check["reason_code"] = "teardown_path_validated"
+pathlib.Path(sys.argv[2]).write_text(
+    json.dumps(summary, sort_keys=True, indent=2) + "\n",
+    encoding="utf-8",
+)
+PY
+
+set +e
+python3 "$CHECKER" \
+  --report-file "$TMP_STARTUP_DRIFT_SUMMARY" \
+  --expected-final-decision NO-GO \
+  --ci-fast-gate PASS \
+  --output-json "$TMP_POLICY_OUTPUT" >"$TMP_POLICY_ERR" 2>&1
+startup_drift_code=$?
+set -e
+if [ "$startup_drift_code" -eq 0 ]; then
+  echo "expected checker to fail when startup dependency drift is accepted in run mode" >&2
+  exit 1
+fi
+if ! grep -q "startup_dependency_drift:readiness_without_process_start" "$TMP_POLICY_ERR"; then
+  echo "expected startup dependency drift reason marker for readiness without process-start pass" >&2
+  exit 1
+fi
+
+python3 - "$TMP_REPORT" "$TMP_ORCHESTRATION_DRIFT_SUMMARY" <<'PY'
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+summary = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+checks = summary.get("checks", [])
+checks.append(
+    {
+        "id": "readiness_probe",
+        "command": "curl --silent --show-error --fail http://127.0.0.1:3000/healthz",
+        "status": "fail",
+        "reason_code": "process_readiness_failed",
+    }
+)
+summary["checks"] = checks
+pathlib.Path(sys.argv[2]).write_text(
+    json.dumps(summary, sort_keys=True, indent=2) + "\n",
+    encoding="utf-8",
+)
+PY
+
+set +e
+python3 "$CHECKER" \
+  --report-file "$TMP_ORCHESTRATION_DRIFT_SUMMARY" \
+  --expected-final-decision NO-GO \
+  --ci-fast-gate PASS \
+  --output-json "$TMP_POLICY_OUTPUT" >"$TMP_POLICY_ERR" 2>&1
+orchestration_drift_code=$?
+set -e
+if [ "$orchestration_drift_code" -eq 0 ]; then
+  echo "expected checker to fail when duplicate orchestration check ids are accepted" >&2
+  exit 1
+fi
+if ! grep -q "check_id_duplicate:readiness_probe" "$TMP_POLICY_ERR"; then
+  echo "expected duplicate orchestration check-id reason marker" >&2
+  exit 1
+fi
 
 echo "local fork process lifecycle contract lane tests passed."


### PR DESCRIPTION
## Summary
Hardened local demo process-lifecycle policy contracts to fail closed on startup dependency drift and orchestration instability. Added explicit regression tests and documented operator response in a dedicated runbook.

Closes #4495

## Changes
- `scripts/kolme/test_run_local_kolme_fork_process_lifecycle_contract_lane.sh`: added red/green regression proofs for:
  - startup dependency drift acceptance (`startup_dependency_drift:readiness_without_process_start`)
  - duplicate orchestration check-id acceptance (`check_id_duplicate:readiness_probe`)
  - runbook/reference parity guards.
- `scripts/kolme/check_local_kolme_fork_process_lifecycle_policy.py`:
  - validates phase reason-code fields (`start/readiness/integration/teardown_reason_code`),
  - rejects duplicate check ids and unstable primary sequence,
  - enforces startup dependency ordering across process start/readiness/integration/teardown,
  - tightens mode/status coherence for run/dry-run contracts.
- `scripts/kolme/contracts/local_kolme_fork_process_lifecycle_contract_lane.py`: added runbook existence/reference checks (`Regression: #4495`).
- `docs/ops/runbook_demo.md`: new runbook for startup drift and orchestration instability handling.
- `docs/planning/kolme-devnet-ops.md`: added regression markers and runbook linkage (`Regression: #4495`).
- `README.md`: added runbook link.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
bash scripts/kolme/test_run_local_kolme_fork_process_lifecycle_contract_lane.sh
```
Observed failing output:
```text
expected startup dependency drift reason marker for readiness without process-start pass
```

### 🟢 Green Phase
Command:
```bash
bash scripts/kolme/test_run_local_kolme_fork_process_lifecycle_contract_lane.sh
```
Passing output:
```text
local fork process lifecycle contract lane tests passed.
```

### 🔁 Regression
Commands:
```bash
bash scripts/kolme/test_run_local_kolme_fork_real_process_contract_lane.sh
bash scripts/kolme/test_run_local_signed_to_kolme_demo_contract_lane.sh
bash scripts/ci/test_ci_strategy_contract.sh
```
Passing output summary:
```text
local fork real-process contract lane tests passed.
local signed-to-Kolme demo contract lane tests passed.
CI strategy contract tests passed.
```

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | N/A    | N/A                  | Script policy contracts are validated via functional/contract-lane harnesses in this slice. |
| Functional   | ✅     | `scripts/kolme/test_run_local_kolme_fork_process_lifecycle_contract_lane.sh` | Added startup drift + duplicate orchestration fail-closed assertions. |
| Integration  | ✅     | `scripts/kolme/test_run_local_kolme_fork_real_process_contract_lane.sh`, `scripts/kolme/test_run_local_signed_to_kolme_demo_contract_lane.sh` | Verified adjacent lane composition and docs parity after policy hardening. |
| Regression   | ✅     | `scripts/kolme/test_run_local_kolme_fork_process_lifecycle_contract_lane.sh` | Added explicit regression cases for drift/instability acceptance gaps. |
| Performance  | ✅     | existing bounded lane budgets preserved | Dry-run-first local contract-lane path remains bounded and local-only. |

## Risks & Rollback
- Risk: stricter policy checks can surface latent drift in existing synthetic reports.
- Rollback plan: revert this PR commit to restore previous policy tolerance.

## Documentation Updates
- `docs/ops/runbook_demo.md` (new)
- `docs/planning/kolme-devnet-ops.md`
- `README.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean (N/A: no Rust source touched)
- [x] `cargo clippy -- -D warnings` — clean (N/A: no Rust source touched)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (targeted affected-lane regression set)
- [x] Docs updated
