### PR TITLE
feat(kolme): normalize startup reason taxonomy outputs (#4496)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1059,7 +1059,7 @@ bash scripts/kolme/run_managed_signer_startup_live_validation_contract_lane.sh \
 ```
 
 Live Provider Operator Runbook (Issue #2114): `docs/planning/kolme-devnet-ops.md`
-Local Demo Startup Drift Runbook (Issue #4495): `docs/ops/runbook_demo.md`
+Local Demo Startup Drift Runbook (Issues #4495 / #4496): `docs/ops/runbook_demo.md`
 
 ### Run Local Live-Node Validation Bundle Lane
 

--- a/docs/ops/runbook_demo.md
+++ b/docs/ops/runbook_demo.md
@@ -38,6 +38,33 @@ The checker must fail closed when orchestration evidence becomes unstable:
 - non-deterministic phase ordering across the primary orchestration chain:
   - `check_sequence_mismatch`
 
+## Reason Taxonomy and Evidence Normalization
+
+Lifecycle summaries now include deterministic reason taxonomy and normalized
+evidence sections:
+
+- `reason_taxonomy.schema_version=kamn.kolme.local-fork-process-lifecycle.reason-taxonomy.v1`
+  - `overall`
+  - `startup`
+  - `readiness`
+  - `integration`
+  - `teardown`
+- `normalized_evidence.schema_version=kamn.kolme.local-fork-process-lifecycle.evidence-normalization.v1`
+  - `primary_check_order`
+  - `checks_by_id`
+
+Fail-closed mismatch markers include:
+
+- `reason_taxonomy_overall_mismatch`
+- `reason_taxonomy_startup_mismatch`
+- `reason_taxonomy_readiness_mismatch`
+- `reason_taxonomy_integration_mismatch`
+- `reason_taxonomy_teardown_mismatch`
+- `normalized_evidence_primary_check_order_mismatch`
+- `normalized_evidence_status_mismatch:<check-id>`
+- `normalized_evidence_reason_code_mismatch:<check-id>`
+- `normalized_evidence_command_mismatch:<check-id>`
+
 ## Local Validation Commands
 
 ```bash

--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -1751,6 +1751,7 @@ Operator checkpoints:
 - local fork process lifecycle integration lane propagates rollback/recovery evidence linkage options and deterministic artifact markers in summary/policy contracts (`Regression: #2107`).
 - local fork process lifecycle policy rejects startup dependency drift acceptance and duplicate orchestration check identifiers (`Regression: #4495`).
 - demo startup drift and orchestration instability response runbook: `docs/ops/runbook_demo.md` (`Regression: #4495`).
+- local fork process lifecycle summary emits deterministic reason taxonomy and normalized evidence outputs; policy checker fails closed on reason-output mapping drift (`Regression: #4496`).
 - local fork profile preflight lane fails closed for local opt-in, checkout/profile contract drift, probe command failures, and runtime budget overruns (`Regression: #1648`).
 - local fork profile preflight policy and contract-lane command/report drift remains fail-closed (`Regression: #1697`).
 - local fork self-test lane fails closed for local opt-in, nested matrix/policy checkpoint failures, and runtime budget overruns (`Regression: #1652`).

--- a/scripts/kolme/check_local_kolme_fork_process_lifecycle_policy.py
+++ b/scripts/kolme/check_local_kolme_fork_process_lifecycle_policy.py
@@ -5,6 +5,84 @@ import argparse
 import json
 from pathlib import Path
 
+EXPECTED_PRIMARY_CHECK_ORDER = [
+    "process_start",
+    "readiness_probe",
+    "kamn_live_integration",
+    "process_teardown",
+    "rollback_evidence",
+    "recovery_evidence",
+]
+
+
+def classify_overall_reason(status_value: str, reason_value: str) -> str:
+    if status_value == "ok" and reason_value == "dry_run_no_commands_executed":
+        return "lifecycle.not_run"
+    if status_value == "ok":
+        return "lifecycle.success"
+    if reason_value in (
+        "local_opt_in_missing",
+        "serve_command_missing",
+        "process_start_failed",
+        "process_readiness_failed",
+    ):
+        return "lifecycle.startup_failed"
+    if reason_value == "kamn_live_integration_failed":
+        return "lifecycle.integration_failed"
+    if reason_value == "process_teardown_failed":
+        return "lifecycle.teardown_failed"
+    if reason_value == "process_lifecycle_budget_exceeded":
+        return "lifecycle.budget_exceeded"
+    return "lifecycle.failed"
+
+
+def classify_start_reason(reason_value: str) -> str:
+    mapping = {
+        "not_run": "startup.not_run",
+        "process_started": "startup.process_started",
+        "local_opt_in_missing": "startup.local_opt_in_missing",
+        "serve_command_missing": "startup.serve_command_missing",
+        "process_start_failed": "startup.process_start_failed",
+    }
+    return mapping.get(reason_value, "startup.other")
+
+
+def classify_readiness_reason(reason_value: str) -> str:
+    mapping = {
+        "not_run": "readiness.not_run",
+        "readiness_checks_passed": "readiness.checks_passed",
+        "process_readiness_failed": "readiness.checks_failed",
+        "local_opt_in_missing": "readiness.prerequisite_failed",
+        "serve_command_missing": "readiness.prerequisite_failed",
+        "process_start_failed": "readiness.prerequisite_failed",
+    }
+    return mapping.get(reason_value, "readiness.other")
+
+
+def classify_integration_reason(reason_value: str) -> str:
+    mapping = {
+        "not_run": "integration.not_run",
+        "kamn_live_integration_passed": "integration.passed",
+        "kamn_live_integration_timeout": "integration.timeout",
+        "process_readiness_failed": "integration.prerequisite_failed",
+        "local_opt_in_missing": "integration.prerequisite_failed",
+        "serve_command_missing": "integration.prerequisite_failed",
+        "process_start_failed": "integration.prerequisite_failed",
+    }
+    return mapping.get(reason_value, "integration.failed")
+
+
+def classify_teardown_reason(reason_value: str) -> str:
+    mapping = {
+        "not_run": "teardown.not_run",
+        "process_teardown_passed": "teardown.passed",
+        "process_teardown_forced": "teardown.forced",
+        "local_opt_in_missing": "teardown.skipped_prerequisite_failed",
+        "serve_command_missing": "teardown.skipped_prerequisite_failed",
+        "process_start_failed": "teardown.skipped_prerequisite_failed",
+    }
+    return mapping.get(reason_value, "teardown.other")
+
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
@@ -123,6 +201,68 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
     if not isinstance(teardown_reason_code, str) or not teardown_reason_code.strip():
         reason_codes.append("teardown_reason_code_missing")
 
+    reason_taxonomy = report.get("reason_taxonomy")
+    if not isinstance(reason_taxonomy, dict):
+        reason_codes.append("reason_taxonomy_missing")
+    else:
+        if reason_taxonomy.get("schema_version") != "kamn.kolme.local-fork-process-lifecycle.reason-taxonomy.v1":
+            reason_codes.append("reason_taxonomy_schema_mismatch")
+        expected_overall_taxonomy = classify_overall_reason(
+            str(status) if isinstance(status, str) else "",
+            reason_code if isinstance(reason_code, str) else "",
+        )
+        if reason_taxonomy.get("overall") != expected_overall_taxonomy:
+            reason_codes.append("reason_taxonomy_overall_mismatch")
+        expected_start_taxonomy = classify_start_reason(
+            start_reason_code if isinstance(start_reason_code, str) else ""
+        )
+        if reason_taxonomy.get("startup") != expected_start_taxonomy:
+            reason_codes.append("reason_taxonomy_startup_mismatch")
+        expected_readiness_taxonomy = classify_readiness_reason(
+            readiness_reason_code if isinstance(readiness_reason_code, str) else ""
+        )
+        if reason_taxonomy.get("readiness") != expected_readiness_taxonomy:
+            reason_codes.append("reason_taxonomy_readiness_mismatch")
+        expected_integration_taxonomy = classify_integration_reason(
+            integration_reason_code if isinstance(integration_reason_code, str) else ""
+        )
+        if reason_taxonomy.get("integration") != expected_integration_taxonomy:
+            reason_codes.append("reason_taxonomy_integration_mismatch")
+        expected_teardown_taxonomy = classify_teardown_reason(
+            teardown_reason_code if isinstance(teardown_reason_code, str) else ""
+        )
+        if reason_taxonomy.get("teardown") != expected_teardown_taxonomy:
+            reason_codes.append("reason_taxonomy_teardown_mismatch")
+
+    normalized_evidence = report.get("normalized_evidence")
+    normalized_checks_by_id: dict[str, object] = {}
+    if not isinstance(normalized_evidence, dict):
+        reason_codes.append("normalized_evidence_missing")
+    else:
+        if normalized_evidence.get("schema_version") != "kamn.kolme.local-fork-process-lifecycle.evidence-normalization.v1":
+            reason_codes.append("normalized_evidence_schema_mismatch")
+        if normalized_evidence.get("primary_check_order") != EXPECTED_PRIMARY_CHECK_ORDER:
+            reason_codes.append("normalized_evidence_primary_check_order_mismatch")
+        checks_by_id = normalized_evidence.get("checks_by_id")
+        if not isinstance(checks_by_id, dict):
+            reason_codes.append("normalized_evidence_checks_by_id_missing")
+        else:
+            normalized_checks_by_id = checks_by_id
+            for check_id in EXPECTED_PRIMARY_CHECK_ORDER:
+                check_entry = checks_by_id.get(check_id)
+                if not isinstance(check_entry, dict):
+                    reason_codes.append(f"normalized_evidence_check_missing:{check_id}")
+                    continue
+                if not isinstance(check_entry.get("status"), str) or not check_entry.get("status"):
+                    reason_codes.append(f"normalized_evidence_status_invalid:{check_id}")
+                if (
+                    not isinstance(check_entry.get("reason_code"), str)
+                    or not check_entry.get("reason_code")
+                ):
+                    reason_codes.append(f"normalized_evidence_reason_code_invalid:{check_id}")
+                if not isinstance(check_entry.get("command"), str):
+                    reason_codes.append(f"normalized_evidence_command_invalid:{check_id}")
+
     artifact_paths = report.get("artifact_paths")
     if not isinstance(artifact_paths, list) or not artifact_paths:
         reason_codes.append("artifact_paths_missing")
@@ -153,14 +293,7 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
     if not isinstance(checks, list) or not checks:
         reason_codes.append("checks_missing")
     else:
-        expected_order = [
-            "process_start",
-            "readiness_probe",
-            "kamn_live_integration",
-            "process_teardown",
-            "rollback_evidence",
-            "recovery_evidence",
-        ]
+        expected_order = EXPECTED_PRIMARY_CHECK_ORDER
         expected_ids = set(expected_order)
         observed_ids: set[str] = set()
         for entry in checks:
@@ -222,6 +355,19 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
         missing_ids = sorted(expected_ids - observed_ids)
         for missing_id in missing_ids:
             reason_codes.append(f"check_missing:{missing_id}")
+
+        if normalized_checks_by_id and expected_ids.issubset(set(check_entries_by_id.keys())):
+            for check_id in expected_order:
+                normalized_entry = normalized_checks_by_id.get(check_id)
+                if not isinstance(normalized_entry, dict):
+                    continue
+                first_entry = check_entries_by_id[check_id][0]
+                if normalized_entry.get("status") != first_entry["status"]:
+                    reason_codes.append(f"normalized_evidence_status_mismatch:{check_id}")
+                if normalized_entry.get("reason_code") != first_entry["reason_code"]:
+                    reason_codes.append(f"normalized_evidence_reason_code_mismatch:{check_id}")
+                if normalized_entry.get("command") != first_entry["command"]:
+                    reason_codes.append(f"normalized_evidence_command_mismatch:{check_id}")
 
         for check_id, entries in check_entries_by_id.items():
             if len(entries) > 1:

--- a/scripts/kolme/contracts/local_kolme_fork_process_lifecycle_contract_lane.py
+++ b/scripts/kolme/contracts/local_kolme_fork_process_lifecycle_contract_lane.py
@@ -231,12 +231,20 @@ def main() -> int:
 
     doc_text = DOC_FILE.read_text(encoding="utf-8")
     readme_text = README_FILE.read_text(encoding="utf-8")
+    runbook_text = RUNBOOK_FILE.read_text(encoding="utf-8")
     if "run_local_kolme_fork_process_lifecycle_lane.sh" not in doc_text:
         print("expected Kolme devnet ops doc to reference local Kolme fork process lifecycle runner", file=sys.stderr)
         return 1
     # Regression: #4495
     if "docs/ops/runbook_demo.md" not in doc_text:
         print("expected Kolme devnet ops doc to reference demo startup drift runbook", file=sys.stderr)
+        return 1
+    # Regression: #4496
+    if "Regression: #4496" not in doc_text:
+        print(
+            "expected Kolme devnet ops doc to include reason taxonomy and normalized evidence regression marker",
+            file=sys.stderr,
+        )
         return 1
     if "check_local_kolme_fork_process_lifecycle_policy.py" not in doc_text:
         print("expected Kolme devnet ops doc to reference local Kolme fork process lifecycle policy checker", file=sys.stderr)
@@ -288,6 +296,15 @@ def main() -> int:
         return 1
     if "docs/ops/runbook_demo.md" not in readme_text:
         print("expected README to reference demo startup drift runbook", file=sys.stderr)
+        return 1
+    if "kamn.kolme.local-fork-process-lifecycle.reason-taxonomy.v1" not in runbook_text:
+        print("expected runbook to document reason taxonomy schema marker", file=sys.stderr)
+        return 1
+    if "kamn.kolme.local-fork-process-lifecycle.evidence-normalization.v1" not in runbook_text:
+        print("expected runbook to document normalized evidence schema marker", file=sys.stderr)
+        return 1
+    if "reason_taxonomy_readiness_mismatch" not in runbook_text:
+        print("expected runbook to document reason taxonomy mismatch marker", file=sys.stderr)
         return 1
     if "--integration-runtime-commit-finality-command" not in readme_text:
         print(

--- a/scripts/kolme/contracts/local_kolme_fork_process_lifecycle_summary.py
+++ b/scripts/kolme/contracts/local_kolme_fork_process_lifecycle_summary.py
@@ -5,6 +5,103 @@ import json
 import pathlib
 import sys
 
+PRIMARY_CHECK_ORDER = [
+    "process_start",
+    "readiness_probe",
+    "kamn_live_integration",
+    "process_teardown",
+    "rollback_evidence",
+    "recovery_evidence",
+]
+
+
+def classify_overall_reason(status_value: str, reason_value: str) -> str:
+    if status_value == "ok" and reason_value == "dry_run_no_commands_executed":
+        return "lifecycle.not_run"
+    if status_value == "ok":
+        return "lifecycle.success"
+    if reason_value in (
+        "local_opt_in_missing",
+        "serve_command_missing",
+        "process_start_failed",
+        "process_readiness_failed",
+    ):
+        return "lifecycle.startup_failed"
+    if reason_value == "kamn_live_integration_failed":
+        return "lifecycle.integration_failed"
+    if reason_value == "process_teardown_failed":
+        return "lifecycle.teardown_failed"
+    if reason_value == "process_lifecycle_budget_exceeded":
+        return "lifecycle.budget_exceeded"
+    return "lifecycle.failed"
+
+
+def classify_start_reason(reason_value: str) -> str:
+    mapping = {
+        "not_run": "startup.not_run",
+        "process_started": "startup.process_started",
+        "local_opt_in_missing": "startup.local_opt_in_missing",
+        "serve_command_missing": "startup.serve_command_missing",
+        "process_start_failed": "startup.process_start_failed",
+    }
+    return mapping.get(reason_value, "startup.other")
+
+
+def classify_readiness_reason(reason_value: str) -> str:
+    mapping = {
+        "not_run": "readiness.not_run",
+        "readiness_checks_passed": "readiness.checks_passed",
+        "process_readiness_failed": "readiness.checks_failed",
+        "local_opt_in_missing": "readiness.prerequisite_failed",
+        "serve_command_missing": "readiness.prerequisite_failed",
+        "process_start_failed": "readiness.prerequisite_failed",
+    }
+    return mapping.get(reason_value, "readiness.other")
+
+
+def classify_integration_reason(reason_value: str) -> str:
+    mapping = {
+        "not_run": "integration.not_run",
+        "kamn_live_integration_passed": "integration.passed",
+        "kamn_live_integration_timeout": "integration.timeout",
+        "process_readiness_failed": "integration.prerequisite_failed",
+        "local_opt_in_missing": "integration.prerequisite_failed",
+        "serve_command_missing": "integration.prerequisite_failed",
+        "process_start_failed": "integration.prerequisite_failed",
+    }
+    return mapping.get(reason_value, "integration.failed")
+
+
+def classify_teardown_reason(reason_value: str) -> str:
+    mapping = {
+        "not_run": "teardown.not_run",
+        "process_teardown_passed": "teardown.passed",
+        "process_teardown_forced": "teardown.forced",
+        "local_opt_in_missing": "teardown.skipped_prerequisite_failed",
+        "serve_command_missing": "teardown.skipped_prerequisite_failed",
+        "process_start_failed": "teardown.skipped_prerequisite_failed",
+    }
+    return mapping.get(reason_value, "teardown.other")
+
+
+def build_normalized_checks(checks: list[dict[str, str]]) -> dict[str, dict[str, str]]:
+    normalized: dict[str, dict[str, str]] = {}
+    for check_id in PRIMARY_CHECK_ORDER:
+        first_match = next(
+            (entry for entry in checks if entry.get("id") == check_id),
+            None,
+        )
+        if first_match is None:
+            normalized[check_id] = {"status": "missing", "reason_code": "missing", "command": ""}
+            continue
+        normalized[check_id] = {
+            "status": str(first_match.get("status", "")),
+            "reason_code": str(first_match.get("reason_code", "")),
+            "command": str(first_match.get("command", "")),
+        }
+    return normalized
+
+
 output_path = pathlib.Path(sys.argv[1]).resolve()
 mode = sys.argv[2]
 status = sys.argv[3]
@@ -89,6 +186,19 @@ summary = {
     "readiness_reason_code": readiness_reason_code,
     "integration_reason_code": integration_reason_code,
     "teardown_reason_code": teardown_reason_code,
+    "reason_taxonomy": {
+        "schema_version": "kamn.kolme.local-fork-process-lifecycle.reason-taxonomy.v1",
+        "overall": classify_overall_reason(status, reason_code),
+        "startup": classify_start_reason(start_reason_code),
+        "readiness": classify_readiness_reason(readiness_reason_code),
+        "integration": classify_integration_reason(integration_reason_code),
+        "teardown": classify_teardown_reason(teardown_reason_code),
+    },
+    "normalized_evidence": {
+        "schema_version": "kamn.kolme.local-fork-process-lifecycle.evidence-normalization.v1",
+        "primary_check_order": PRIMARY_CHECK_ORDER,
+        "checks_by_id": build_normalized_checks(checks),
+    },
     "contracts": {
         "healthz_path": "/healthz",
         "fork_info_path": "/fork-info",

--- a/scripts/kolme/test_run_local_kolme_fork_process_lifecycle_contract_lane.sh
+++ b/scripts/kolme/test_run_local_kolme_fork_process_lifecycle_contract_lane.sh
@@ -137,6 +137,7 @@ required_coverage_markers=(
   "Regression: #2104"
   "Regression: #2107"
   "Regression: #4495"
+  "Regression: #4496"
 )
 for marker in "${required_coverage_markers[@]}"; do
   if ! grep -q "$marker" "$CONTRACT_IMPL"; then
@@ -260,6 +261,16 @@ if ! grep -q "check_id_duplicate:<check-id>" "$RUNBOOK_FILE"; then
   exit 1
 fi
 
+if ! grep -q "kamn.kolme.local-fork-process-lifecycle.reason-taxonomy.v1" "$RUNBOOK_FILE"; then
+  echo "expected runbook to document reason taxonomy schema marker" >&2
+  exit 1
+fi
+
+if ! grep -q "kamn.kolme.local-fork-process-lifecycle.evidence-normalization.v1" "$RUNBOOK_FILE"; then
+  echo "expected runbook to document normalized evidence schema marker" >&2
+  exit 1
+fi
+
 if ! grep -q "Regression: #2104" "$DOC_FILE"; then
   echo "expected Kolme devnet ops doc to include process lifecycle runtime policy pass-through regression marker" >&2
   exit 1
@@ -378,14 +389,54 @@ if str(rollback_evidence_path) not in summary.get("artifact_paths", []):
     raise SystemExit("expected process lifecycle summary artifact paths to include rollback evidence file path")
 if str(recovery_evidence_path) not in summary.get("artifact_paths", []):
     raise SystemExit("expected process lifecycle summary artifact paths to include recovery evidence file path")
+reason_taxonomy = summary.get("reason_taxonomy")
+if not isinstance(reason_taxonomy, dict):
+    raise SystemExit("expected process lifecycle summary reason taxonomy object")
+if reason_taxonomy.get("schema_version") != "kamn.kolme.local-fork-process-lifecycle.reason-taxonomy.v1":
+    raise SystemExit("expected process lifecycle summary reason taxonomy schema")
+if reason_taxonomy.get("overall") != "lifecycle.not_run":
+    raise SystemExit("expected process lifecycle summary overall reason taxonomy for dry-run")
+if reason_taxonomy.get("startup") != "startup.not_run":
+    raise SystemExit("expected process lifecycle summary startup reason taxonomy for dry-run")
+if reason_taxonomy.get("readiness") != "readiness.not_run":
+    raise SystemExit("expected process lifecycle summary readiness reason taxonomy for dry-run")
+if reason_taxonomy.get("integration") != "integration.not_run":
+    raise SystemExit("expected process lifecycle summary integration reason taxonomy for dry-run")
+if reason_taxonomy.get("teardown") != "teardown.not_run":
+    raise SystemExit("expected process lifecycle summary teardown reason taxonomy for dry-run")
+normalized_evidence = summary.get("normalized_evidence")
+if not isinstance(normalized_evidence, dict):
+    raise SystemExit("expected process lifecycle summary normalized evidence object")
+if normalized_evidence.get("schema_version") != "kamn.kolme.local-fork-process-lifecycle.evidence-normalization.v1":
+    raise SystemExit("expected process lifecycle summary normalized evidence schema")
+expected_order = [
+    "process_start",
+    "readiness_probe",
+    "kamn_live_integration",
+    "process_teardown",
+    "rollback_evidence",
+    "recovery_evidence",
+]
+if normalized_evidence.get("primary_check_order") != expected_order:
+    raise SystemExit("expected process lifecycle summary normalized evidence primary check order")
+checks_by_id = normalized_evidence.get("checks_by_id")
+if not isinstance(checks_by_id, dict):
+    raise SystemExit("expected process lifecycle summary normalized checks_by_id object")
+for check_id in expected_order:
+    check_entry = checks_by_id.get(check_id)
+    if not isinstance(check_entry, dict):
+        raise SystemExit(f"expected normalized check entry for {check_id}")
+    if check_entry.get("status") != "planned":
+        raise SystemExit(f"expected normalized check entry status=planned for dry-run: {check_id}")
 PY
 
 # Regression: #4495
 TMP_STARTUP_DRIFT_SUMMARY="$(mktemp)"
 TMP_ORCHESTRATION_DRIFT_SUMMARY="$(mktemp)"
+TMP_REASON_TAXONOMY_DRIFT_SUMMARY="$(mktemp)"
 TMP_POLICY_OUTPUT="$(mktemp)"
 TMP_POLICY_ERR="$(mktemp)"
-trap 'rm -f "$TMP_REPORT" "$TMP_POLICY_REPORT" "$TMP_DIRECT_SUMMARY" "$TMP_DIRECT_PROCESS_OUTPUT" "$TMP_DIRECT_INTEGRATION_REPORT" "$TMP_DIRECT_FINALITY_OUTPUT" "$TMP_DIRECT_RUNTIME_POLICY_REPORT" "$TMP_DIRECT_ROLLBACK_EVIDENCE_FILE" "$TMP_DIRECT_RECOVERY_EVIDENCE_FILE" "$TMP_STARTUP_DRIFT_SUMMARY" "$TMP_ORCHESTRATION_DRIFT_SUMMARY" "$TMP_POLICY_OUTPUT" "$TMP_POLICY_ERR"' EXIT
+trap 'rm -f "$TMP_REPORT" "$TMP_POLICY_REPORT" "$TMP_DIRECT_SUMMARY" "$TMP_DIRECT_PROCESS_OUTPUT" "$TMP_DIRECT_INTEGRATION_REPORT" "$TMP_DIRECT_FINALITY_OUTPUT" "$TMP_DIRECT_RUNTIME_POLICY_REPORT" "$TMP_DIRECT_ROLLBACK_EVIDENCE_FILE" "$TMP_DIRECT_RECOVERY_EVIDENCE_FILE" "$TMP_STARTUP_DRIFT_SUMMARY" "$TMP_ORCHESTRATION_DRIFT_SUMMARY" "$TMP_REASON_TAXONOMY_DRIFT_SUMMARY" "$TMP_POLICY_OUTPUT" "$TMP_POLICY_ERR"' EXIT
 
 python3 - "$TMP_REPORT" "$TMP_STARTUP_DRIFT_SUMMARY" <<'PY'
 from __future__ import annotations
@@ -490,6 +541,42 @@ if [ "$orchestration_drift_code" -eq 0 ]; then
 fi
 if ! grep -q "check_id_duplicate:readiness_probe" "$TMP_POLICY_ERR"; then
   echo "expected duplicate orchestration check-id reason marker" >&2
+  exit 1
+fi
+
+# Regression: #4496
+python3 - "$TMP_REPORT" "$TMP_REASON_TAXONOMY_DRIFT_SUMMARY" <<'PY'
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+summary = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+reason_taxonomy = summary.get("reason_taxonomy", {})
+if isinstance(reason_taxonomy, dict):
+    reason_taxonomy["readiness"] = "readiness.checks_passed"
+summary["reason_taxonomy"] = reason_taxonomy
+pathlib.Path(sys.argv[2]).write_text(
+    json.dumps(summary, sort_keys=True, indent=2) + "\n",
+    encoding="utf-8",
+)
+PY
+
+set +e
+python3 "$CHECKER" \
+  --report-file "$TMP_REASON_TAXONOMY_DRIFT_SUMMARY" \
+  --expected-final-decision NO-GO \
+  --ci-fast-gate PASS \
+  --output-json "$TMP_POLICY_OUTPUT" >"$TMP_POLICY_ERR" 2>&1
+reason_taxonomy_drift_code=$?
+set -e
+if [ "$reason_taxonomy_drift_code" -eq 0 ]; then
+  echo "expected checker to fail when reason taxonomy readiness mapping drifts" >&2
+  exit 1
+fi
+if ! grep -q "reason_taxonomy_readiness_mismatch" "$TMP_POLICY_ERR"; then
+  echo "expected reason taxonomy readiness mismatch reason marker" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
Implemented deterministic startup reason taxonomy and normalized orchestration evidence outputs for the local Kolme fork process-lifecycle summary/policy contracts, with fail-closed mapping drift validation.

Closes #4496

## Changes
- `scripts/kolme/contracts/local_kolme_fork_process_lifecycle_summary.py`
  - Added deterministic `reason_taxonomy` output (`kamn.kolme.local-fork-process-lifecycle.reason-taxonomy.v1`).
  - Added deterministic `normalized_evidence` output (`kamn.kolme.local-fork-process-lifecycle.evidence-normalization.v1`) with `primary_check_order` and `checks_by_id`.
- `scripts/kolme/check_local_kolme_fork_process_lifecycle_policy.py`
  - Added fail-closed validation for reason-taxonomy mapping drift (`reason_taxonomy_*_mismatch`).
  - Added normalized evidence schema/order/content validation and per-check mismatch detection.
- `scripts/kolme/test_run_local_kolme_fork_process_lifecycle_contract_lane.sh`
  - Added red/green assertions for taxonomy + normalized evidence presence/shape.
  - Added regression proof for readiness taxonomy drift (`reason_taxonomy_readiness_mismatch`).
  - Added runbook taxonomy/evidence marker parity checks.
- `scripts/kolme/contracts/local_kolme_fork_process_lifecycle_contract_lane.py`
  - Added doc/runbook parity checks for `Regression: #4496` markers.
- `docs/ops/runbook_demo.md`
  - Added startup reason taxonomy and normalized evidence contract sections + mismatch markers.
- `docs/planning/kolme-devnet-ops.md`
  - Added `Regression: #4496` marker for taxonomy/evidence normalization behavior.
- `README.md`
  - Updated runbook reference to include `#4496`.

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
bash scripts/kolme/test_run_local_kolme_fork_process_lifecycle_contract_lane.sh
```
Observed failing output:
```text
expected process lifecycle summary reason taxonomy object
```

### 🟢 Green Phase
Command:
```bash
bash scripts/kolme/test_run_local_kolme_fork_process_lifecycle_contract_lane.sh
```
Passing output:
```text
local fork process lifecycle contract lane tests passed.
```

### 🔁 Regression
Commands:
```bash
bash scripts/kolme/test_run_local_kolme_fork_real_process_contract_lane.sh
bash scripts/kolme/test_run_local_signed_to_kolme_demo_contract_lane.sh
bash scripts/ci/test_ci_strategy_contract.sh
```
Passing output summary:
```text
local fork real-process contract lane tests passed.
local signed-to-Kolme demo contract lane tests passed.
CI strategy contract tests passed.
```

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | N/A    | N/A                  | Python/bash contract logic is validated in functional/contract-lane harnesses for this slice. |
| Functional   | ✅     | `scripts/kolme/test_run_local_kolme_fork_process_lifecycle_contract_lane.sh` | Added taxonomy/evidence shape and drift checks. |
| Integration  | ✅     | `scripts/kolme/test_run_local_kolme_fork_real_process_contract_lane.sh`, `scripts/kolme/test_run_local_signed_to_kolme_demo_contract_lane.sh` | Verified adjacent contract lanes remain stable with new taxonomy/evidence constraints. |
| Regression   | ✅     | `scripts/kolme/test_run_local_kolme_fork_process_lifecycle_contract_lane.sh` | Added explicit readiness taxonomy drift fail-closed proof. |
| Performance  | ✅     | existing bounded lane budgets preserved | Dry-run-first local contract-lane path remains bounded and local-only. |

## Risks & Rollback
- Risk: stricter taxonomy/evidence checks can reject legacy synthetic summaries missing normalized structures.
- Rollback plan: revert this PR commit to restore prior checker tolerance.

## Documentation Updates
- `docs/ops/runbook_demo.md`
- `docs/planning/kolme-devnet-ops.md`
- `README.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean (N/A: no Rust source touched)
- [x] `cargo clippy -- -D warnings` — clean (N/A: no Rust source touched)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing (targeted affected-lane regression set)
- [x] Docs updated
