### PR TITLE
test(deploy): fail closed on rehearsal command and output drift (#4499)

### DIFF
--- a/docs/ops/incident-readiness.md
+++ b/docs/ops/incident-readiness.md
@@ -1,0 +1,26 @@
+# Incident Readiness Runbook
+
+This runbook defines local rehearsal command contracts and drift guards for staged release evidence.
+
+## Staging Rehearsal Commands
+
+- Bundle generation:
+  - `bash scripts/deploy/generate_staging_rehearsal_bundle.sh --output-file /tmp/staging-rehearsal.json --release-candidate v1.1.0-rc.1 --deploy-status PASS --rollback-status PASS --rollback-target-hash state-hash-expected --post-rollback-hash state-hash-expected --recovery-time-seconds 420 --max-allowed-recovery-time-seconds 900 --evidence-complete true --ci-fast-gate PASS`
+- Policy check:
+  - `bash scripts/deploy/check_staging_rehearsal_policy.sh --bundle-file /tmp/staging-rehearsal.json`
+- Contract lane:
+  - `bash scripts/deploy/run_staging_rehearsal_contract_lane.sh`
+- Deep rehearsal lane:
+  - `bash scripts/deploy/run_staging_rehearsal_deep_lane.sh`
+
+## Drift Guards
+
+- Command-surface drift is fail-closed:
+  - `command contract mismatch`
+- Evidence-output contract drift is fail-closed:
+  - `evidence output contract version mismatch`
+
+## Regression Markers
+
+- Rehearsal command and output drift coverage:
+  - `Regression: #4499`

--- a/scripts/deploy/staging_rehearsal_contract.py
+++ b/scripts/deploy/staging_rehearsal_contract.py
@@ -22,9 +22,16 @@ from framework.contract_framework import (  # noqa: E402
 
 SCHEMA_VERSION = "kamn.release.staging-rehearsal.v1"
 STAGED_REHEARSAL_SIGNOFF_SCHEMA_VERSION = "kamn.release.staged-rehearsal-signoff.v1"
+EVIDENCE_OUTPUT_CONTRACT_VERSION = "kamn.release.staging-rehearsal-output-contract.v1"
 GO_DECISION = "GO"
 NO_GO_DECISION = "NO-GO"
 MAX_BPS = 10_000
+COMMAND_CONTRACTS = {
+    "bundle_generator": "scripts/deploy/generate_staging_rehearsal_bundle.sh",
+    "policy_checker": "scripts/deploy/check_staging_rehearsal_policy.sh",
+    "contract_lane": "scripts/deploy/run_staging_rehearsal_contract_lane.sh",
+    "deep_lane": "scripts/deploy/run_staging_rehearsal_deep_lane.sh",
+}
 SIGNOFF_REQUIRED_ARTIFACTS = (
     "deploy_status",
     "rollback_status",
@@ -243,6 +250,8 @@ def generate_bundle(args: argparse.Namespace) -> int:
 
     payload: dict[str, Any] = {
         "schema_version": SCHEMA_VERSION,
+        "evidence_output_contract_version": EVIDENCE_OUTPUT_CONTRACT_VERSION,
+        "command_contracts": dict(COMMAND_CONTRACTS),
         "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
         "release_candidate": args.release_candidate,
         "rehearsal": {
@@ -308,12 +317,30 @@ def check_bundle(args: argparse.Namespace) -> int:
             "schema_version",
             "generated_at",
             "release_candidate",
+            "evidence_output_contract_version",
+            "command_contracts",
             "rehearsal",
             "staged_rehearsal_signoff",
             "decision_reasons",
             "final_decision",
         ),
     )
+
+    evidence_output_contract_version = payload.get("evidence_output_contract_version")
+    if evidence_output_contract_version != EVIDENCE_OUTPUT_CONTRACT_VERSION:
+        fail(
+            "evidence output contract version mismatch: "
+            f"expected {EVIDENCE_OUTPUT_CONTRACT_VERSION}, found {evidence_output_contract_version}"
+        )
+
+    command_contracts = payload.get("command_contracts")
+    if not isinstance(command_contracts, dict):
+        fail("command contract mismatch: command_contracts must be an object")
+    if command_contracts != COMMAND_CONTRACTS:
+        fail(
+            "command contract mismatch: "
+            f"expected {COMMAND_CONTRACTS}, found {command_contracts}"
+        )
 
     rehearsal = payload["rehearsal"]
     if not isinstance(rehearsal, dict):
@@ -599,6 +626,8 @@ def check_bundle(args: argparse.Namespace) -> int:
         "staged_rehearsal_signoff_status="
         f"{expected_signoff_artifact['lineage_status']}"
     )
+    print(f"evidence_output_contract_version={EVIDENCE_OUTPUT_CONTRACT_VERSION}")
+    print("command_contracts_status=verified")
     print(f"reason_codes={','.join(expected_decision_reasons)}")
     print(f"evidence_complete={str(evidence_complete).lower()}")
     return 0

--- a/scripts/deploy/test_generate_staging_rehearsal_bundle.sh
+++ b/scripts/deploy/test_generate_staging_rehearsal_bundle.sh
@@ -66,6 +66,16 @@ payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
 signoff = payload.get("staged_rehearsal_signoff")
 if not isinstance(signoff, dict):
     raise SystemExit("expected staged_rehearsal_signoff object")
+if payload.get("evidence_output_contract_version") != "kamn.release.staging-rehearsal-output-contract.v1":
+    raise SystemExit("expected deterministic staging rehearsal evidence_output_contract_version marker")
+expected_command_contracts = {
+    "bundle_generator": "scripts/deploy/generate_staging_rehearsal_bundle.sh",
+    "policy_checker": "scripts/deploy/check_staging_rehearsal_policy.sh",
+    "contract_lane": "scripts/deploy/run_staging_rehearsal_contract_lane.sh",
+    "deep_lane": "scripts/deploy/run_staging_rehearsal_deep_lane.sh",
+}
+if payload.get("command_contracts") != expected_command_contracts:
+    raise SystemExit("expected deterministic staging rehearsal command contract markers")
 if signoff.get("schema_version") != "kamn.release.staged-rehearsal-signoff.v1":
     raise SystemExit("expected staged_rehearsal_signoff schema marker")
 if signoff.get("lineage_status") != "verified":
@@ -261,6 +271,61 @@ fi
 # Regression: #4574
 if ! printf '%s\n' "$tampered_signer_drift_output" | grep -q "signer_profile_drift_threshold_mismatch"; then
   echo "expected signer drift threshold mismatch reason code for tampered signer drift rehearsal bundle" >&2
+  exit 1
+fi
+
+# Regression: #4499
+tampered_command_contract_bundle="$TMP_DIR/rehearsal-tampered-command-contract.json"
+cp "$go_bundle" "$tampered_command_contract_bundle"
+python3 - "$tampered_command_contract_bundle" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+payload = json.loads(path.read_text())
+payload["command_contracts"]["policy_checker"] = "scripts/deploy/check_staging_rehearsal_policy_drift.sh"
+path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n")
+PY
+
+set +e
+tampered_command_contract_output="$(bash "$POLICY_CHECKER" --bundle-file "$tampered_command_contract_bundle" 2>&1)"
+tampered_command_contract_code=$?
+set -e
+
+if [ "$tampered_command_contract_code" -eq 0 ]; then
+  echo "expected command-contract drift rehearsal bundle to fail policy validation" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$tampered_command_contract_output" | grep -q "command contract mismatch"; then
+  echo "expected explicit command contract mismatch regression guard to be enforced" >&2
+  exit 1
+fi
+
+tampered_output_contract_bundle="$TMP_DIR/rehearsal-tampered-output-contract-version.json"
+cp "$go_bundle" "$tampered_output_contract_bundle"
+python3 - "$tampered_output_contract_bundle" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+payload = json.loads(path.read_text())
+payload["evidence_output_contract_version"] = "kamn.release.staging-rehearsal-output-contract.v0"
+path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n")
+PY
+
+set +e
+tampered_output_contract_output="$(bash "$POLICY_CHECKER" --bundle-file "$tampered_output_contract_bundle" 2>&1)"
+tampered_output_contract_code=$?
+set -e
+
+if [ "$tampered_output_contract_code" -eq 0 ]; then
+  echo "expected evidence-output contract version drift rehearsal bundle to fail policy validation" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$tampered_output_contract_output" | grep -q "evidence output contract version mismatch"; then
+  echo "expected explicit evidence output contract version mismatch regression guard to be enforced" >&2
   exit 1
 fi
 

--- a/scripts/deploy/test_run_staging_rehearsal_contract_lane.sh
+++ b/scripts/deploy/test_run_staging_rehearsal_contract_lane.sh
@@ -5,8 +5,10 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 FAST_SCRIPT="$ROOT_DIR/scripts/deploy/run_staging_rehearsal_contract_lane.sh"
 DEEP_SCRIPT="$ROOT_DIR/scripts/deploy/run_staging_rehearsal_deep_lane.sh"
 SHARED_CONTRACT="$ROOT_DIR/scripts/deploy/staging_rehearsal_contract_lane_contract.sh"
+SHARED_REHEARSAL_CONTRACT_PY="$ROOT_DIR/scripts/deploy/staging_rehearsal_contract.py"
 MANIFEST_FILE="$ROOT_DIR/scripts/framework/manifests/deploy_staging_rehearsal_contract_lane.json"
 DISPATCHER="$ROOT_DIR/scripts/framework/run_non_kolme_contract_lane_dispatch.sh"
+INCIDENT_READINESS_DOC="$ROOT_DIR/docs/ops/incident-readiness.md"
 
 if [ ! -x "$FAST_SCRIPT" ]; then
   echo "expected staging rehearsal fast-lane runner to be executable" >&2
@@ -19,6 +21,11 @@ if [ ! -x "$DEEP_SCRIPT" ]; then
 fi
 if [ ! -x "$SHARED_CONTRACT" ]; then
   echo "expected staging rehearsal shared contract-lane module to be executable" >&2
+  exit 1
+fi
+
+if [ ! -f "$INCIDENT_READINESS_DOC" ]; then
+  echo "expected incident readiness ops doc to exist" >&2
   exit 1
 fi
 
@@ -77,6 +84,16 @@ if ! grep -Fq "staged_rehearsal_signoff_status=verified" "$SHARED_CONTRACT"; the
   exit 1
 fi
 
+if ! grep -Fq "command_contracts" "$SHARED_REHEARSAL_CONTRACT_PY"; then
+  echo "expected staging rehearsal contract generator to emit command contract markers" >&2
+  exit 1
+fi
+
+if ! grep -Fq "evidence_output_contract_version" "$SHARED_REHEARSAL_CONTRACT_PY"; then
+  echo "expected staging rehearsal contract generator to emit evidence output contract version marker" >&2
+  exit 1
+fi
+
 if ! grep -Fq -- "--recovery-time-seconds" "$DEEP_SCRIPT"; then
   echo "expected staging rehearsal deep-lane runner to pass deterministic MTTR evidence markers" >&2
   exit 1
@@ -89,6 +106,41 @@ fi
 
 if ! grep -Fq "staged_rehearsal_signoff_status=fail-closed" "$DEEP_SCRIPT"; then
   echo "expected staging rehearsal deep-lane runner to assert fail-closed staged signoff status" >&2
+  exit 1
+fi
+
+if ! grep -Fq "generate_staging_rehearsal_bundle.sh" "$INCIDENT_READINESS_DOC"; then
+  echo "expected incident readiness ops doc to include rehearsal bundle generator command" >&2
+  exit 1
+fi
+
+if ! grep -Fq "check_staging_rehearsal_policy.sh" "$INCIDENT_READINESS_DOC"; then
+  echo "expected incident readiness ops doc to include rehearsal policy checker command" >&2
+  exit 1
+fi
+
+if ! grep -Fq "run_staging_rehearsal_contract_lane.sh" "$INCIDENT_READINESS_DOC"; then
+  echo "expected incident readiness ops doc to include rehearsal contract lane command" >&2
+  exit 1
+fi
+
+if ! grep -Fq "run_staging_rehearsal_deep_lane.sh" "$INCIDENT_READINESS_DOC"; then
+  echo "expected incident readiness ops doc to include rehearsal deep lane command" >&2
+  exit 1
+fi
+
+if ! grep -Fq "command contract mismatch" "$INCIDENT_READINESS_DOC"; then
+  echo "expected incident readiness ops doc to document command-contract drift guard" >&2
+  exit 1
+fi
+
+if ! grep -Fq "evidence output contract version mismatch" "$INCIDENT_READINESS_DOC"; then
+  echo "expected incident readiness ops doc to document evidence-output contract drift guard" >&2
+  exit 1
+fi
+
+if ! grep -Fq "Regression: #4499" "$INCIDENT_READINESS_DOC"; then
+  echo "expected incident readiness ops doc to include rehearsal drift regression marker" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
Add rehearsal red/green coverage for command-contract drift and evidence-output drift, and enforce those contracts fail-closed in the staging rehearsal policy checker.

## Changes
- `scripts/deploy/test_generate_staging_rehearsal_bundle.sh`
  - Added red/green coverage for:
    - missing/invalid `evidence_output_contract_version`
    - command-contract drift (`command_contracts` mismatch)
- `scripts/deploy/test_run_staging_rehearsal_contract_lane.sh`
  - Added contract/documentation parity checks for incident-readiness rehearsal commands and drift guards.
- `scripts/deploy/staging_rehearsal_contract.py`
  - Added deterministic `evidence_output_contract_version` and `command_contracts` markers in generated bundles.
  - Added fail-closed checker validation for both markers.
- `docs/ops/incident-readiness.md`
  - Added rehearsal command contracts and drift guard runbook markers (`Regression: #4499`).

## TDD Evidence (Mandatory)
### 🔴 Red Phase
```bash
bash scripts/deploy/test_generate_staging_rehearsal_bundle.sh
# expected deterministic staging rehearsal evidence_output_contract_version marker
```

```bash
bash scripts/deploy/test_run_staging_rehearsal_contract_lane.sh
# expected incident readiness ops doc to exist
```

### 🟢 Green Phase
```bash
bash scripts/deploy/test_generate_staging_rehearsal_bundle.sh
# staging rehearsal bundle tests passed.
```

```bash
bash scripts/deploy/test_run_staging_rehearsal_contract_lane.sh
# staging rehearsal contract lane script tests passed.
```

### 🔁 Regression
```bash
bash scripts/ci/test_ci_strategy_contract.sh
# CI strategy contract tests passed.
```

```bash
bash scripts/ci/test_workflow_scope_policy.sh
# workflow scope policy tests passed.
```

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | N/A    | N/A                  | Script-layer contract behavior is validated via functional/integration harnesses in this change. |
| Functional   | ✅     | `scripts/deploy/test_generate_staging_rehearsal_bundle.sh` | |
| Integration  | ✅     | `scripts/deploy/test_run_staging_rehearsal_contract_lane.sh` | |
| Regression   | ✅     | drift vectors for command contract + evidence output contract (`Regression: #4499`) | |
| Performance  | ✅     | bounded local smoke scripts preserved | |

## Risks & Rollback
- Risk: rehearsal bundle/checker now treats command surface and output-version markers as strict contract fields.
- Rollback: revert this PR to restore previous rehearsal bundle/check behavior.

## Documentation Updates
- `docs/ops/incident-readiness.md`

## Validation Checklist
- [ ] `cargo fmt --check` — clean
- [ ] `cargo clippy -- -D warnings` — clean
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)

Closes #4499
