### PR TITLE
test(docs): enforce tls runtime behavior contract markers (#4106)

### DIFF
--- a/crates/kamn-core/tests/tls_dependency_governance_docs.rs
+++ b/crates/kamn-core/tests/tls_dependency_governance_docs.rs
@@ -2,6 +2,7 @@ const ADR: &str = include_str!("../../../docs/architecture/adr-kamn-core-live-tl
 const README: &str = include_str!("../../../README.md");
 const RUNTIME_COMMIT_DOC: &str =
     include_str!("../../../docs/foundation/kolme-runtime-commit-client.md");
+const OPS_CONFIGURATION_DOC: &str = include_str!("../../../docs/ops/configuration.md");
 
 #[test]
 fn adr_documents_live_tls_dependency_decision_and_tradeoffs() {
@@ -28,4 +29,14 @@ fn readme_and_foundation_transport_doc_reference_tls_dependency_adr() {
 fn runtime_commit_transport_doc_keeps_in_process_tls_narrative() {
     assert!(RUNTIME_COMMIT_DOC.contains("in-process `rustls` transport wiring"));
     assert!(!RUNTIME_COMMIT_DOC.contains("openssl s_client command wiring"));
+}
+
+#[test]
+fn ops_configuration_doc_tracks_tls_runtime_transport_behavior_contracts() {
+    assert!(OPS_CONFIGURATION_DOC.contains("KAMN_KOLME_TLS_CA_FILE"));
+    assert!(OPS_CONFIGURATION_DOC.contains("tls certificate verification failed"));
+    assert!(OPS_CONFIGURATION_DOC.contains("tls handshake failed"));
+    assert!(OPS_CONFIGURATION_DOC.contains("in-process rustls"));
+    assert!(OPS_CONFIGURATION_DOC.contains("Subprocess fallback is not allowed"));
+    assert!(OPS_CONFIGURATION_DOC.contains("Regression: #4106"));
 }

--- a/docs/ops/configuration.md
+++ b/docs/ops/configuration.md
@@ -65,6 +65,31 @@ Kolme-live keys:
 - `kolme_live_base_url`, `kolme_live_provider_hint`, `kolme_live_signing_profile`
 - `kolme_live_strict_signer_contracts`, `kolme_live_signer_profile`, `kolme_live_signer_key_source`
 
+## TLS Runtime Transport Behavior Contracts
+
+Runtime-commit HTTPS execution in `kolme-live` mode uses an in-process rustls
+client transport. Subprocess fallback is not allowed in runtime request paths.
+
+TLS trust-root override:
+
+- `KAMN_KOLME_TLS_CA_FILE` (optional custom CA bundle for runtime-commit HTTPS)
+
+Deterministic fail-closed TLS reason markers:
+
+- `tls certificate verification failed`
+- `tls handshake failed`
+
+Validation commands:
+
+- `cargo test -p kamn-core --test kolme_runtime_commit_http_transport functional_https_transport_submit_with_trusted_ca_succeeds -- --exact`
+- `cargo test -p kamn-core --test kolme_runtime_commit_http_transport regression_https_transport_maps_certificate_errors_to_unavailable -- --exact`
+- `cargo test -p kamn-core --test kolme_runtime_commit_http_transport regression_https_transport_maps_tls_handshake_failures_to_unavailable -- --exact`
+- `cargo test -p kamn-core --test kolme_runtime_commit_http_transport regression_https_transport_does_not_use_openssl_subprocess -- --exact`
+
+Regression markers:
+
+- `Regression: #4106`
+
 ## Environment Override Contracts
 
 Environment override names map to the same key contracts regardless of config-file usage.


### PR DESCRIPTION
## Summary
Adds explicit docs-contract coverage for TLS runtime behavior governance and updates ops configuration guidance to reflect native rustls transport + deterministic handshake/certificate failure markers. This closes the remaining documentation and traceability gap for the native HTTPS pipeline behavior under `kolme-live`.

## Linked Issues
- Closes #4106
- Refs #4101
- Refs #4099

## Validation
- [x] Relevant local checks passed.
- [x] CI fast-gate checks expected to pass.

## CI Impact Declaration
- [x] No CI scope impact.
- [ ] CI scope impact present (explain below).

CI scope impact details (required when CI scope impact is present):
Workflow(s) touched: N/A
Expected runtime delta: N/A
Expected runner-minute delta: N/A
Rollback plan if CI cost/runtime regresses: N/A

## Changes
- `crates/kamn-core/tests/tls_dependency_governance_docs.rs`
  - Added `ops_configuration_doc_tracks_tls_runtime_transport_behavior_contracts` to require:
    - `KAMN_KOLME_TLS_CA_FILE`
    - deterministic fail-closed markers (`tls certificate verification failed`, `tls handshake failed`)
    - explicit in-process rustls and subprocess-fallback prohibition text
    - regression marker `Regression: #4106`
- `docs/ops/configuration.md`
  - Added `TLS Runtime Transport Behavior Contracts` section with:
    - in-process rustls runtime behavior
    - no subprocess fallback policy
    - TLS trust-root override env var
    - deterministic failure markers
    - validation commands
    - regression marker for #4106

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
cargo test -p kamn-core --test tls_dependency_governance_docs ops_configuration_doc_tracks_tls_runtime_transport_behavior_contracts -- --exact --nocapture
```
Output:
```text
assertion failed: OPS_CONFIGURATION_DOC.contains("KAMN_KOLME_TLS_CA_FILE")
```

### 🟢 Green Phase
Command:
```bash
cargo test -p kamn-core --test tls_dependency_governance_docs ops_configuration_doc_tracks_tls_runtime_transport_behavior_contracts -- --exact --nocapture
```
Output:
```text
test ops_configuration_doc_tracks_tls_runtime_transport_behavior_contracts ... ok
```

### 🔁 Regression
Commands:
```bash
cargo test -p kamn-core --test tls_dependency_governance_docs -- --nocapture
cargo test -p kamn-core --test kolme_runtime_commit_http_transport functional_https_transport_submit_with_trusted_ca_succeeds -- --exact --nocapture
cargo test -p kamn-core --test kolme_runtime_commit_http_transport regression_https_transport_maps_certificate_errors_to_unavailable -- --exact --nocapture
cargo test -p kamn-core --test kolme_runtime_commit_http_transport regression_https_transport_maps_tls_handshake_failures_to_unavailable -- --exact --nocapture
cargo fmt --check
cargo clippy -p kamn-core --all-targets -- -D warnings
```
Result summary:
- `tls_dependency_governance_docs`: 4 passed, 0 failed.
- targeted HTTPS transport success/failure mapping tests: passed.
- `cargo fmt --check`: clean.
- `cargo clippy -p kamn-core --all-targets -- -D warnings`: clean.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | N/A | None | No new Rust unit helper behavior introduced. |
| Functional   | ✅ | TLS runtime behavior docs-contract assertion in `tls_dependency_governance_docs` | N/A |
| Integration  | ✅ | Existing HTTPS transport success/failure mapping integration tests re-validated | N/A |
| Regression   | ✅ | New `Regression: #4106` doc marker contract | N/A |
| Performance  | N/A | None | No throughput behavior change; CI remains bounded smoke. |

## Risks & Rollback
- Risk: low; documentation and contract-test hardening only.
- Rollback: revert this PR commit.

## Documentation Updates
- `docs/ops/configuration.md`

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (scoped: `-p kamn-core --all-targets`)
- [x] TDD Red/Green evidence included above
- [x] Full relevant regression suite passing
- [x] Docs updated
