### PR TITLE
test(kamn-node): add retry matrix and jitter seed contracts (#4109)

### DIFF
--- a/crates/kamn-node/src/runtime_kolme_live.rs
+++ b/crates/kamn-node/src/runtime_kolme_live.rs
@@ -90,10 +90,56 @@ fn classify_retry_category(error: &KolmeRuntimeCommitProviderError) -> Option<&'
     }
 }
 
+#[cfg(test)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RetryDecision {
+    Retry { reason_code: &'static str },
+    Stop { reason_code: &'static str },
+}
+
+#[cfg(test)]
+fn retry_decision_for_attempt(
+    error: &KolmeRuntimeCommitProviderError,
+    attempt: u32,
+    max_attempts: u32,
+) -> RetryDecision {
+    match classify_retry_category(error) {
+        Some(reason_code) if attempt < max_attempts => RetryDecision::Retry { reason_code },
+        Some(_) => RetryDecision::Stop {
+            reason_code: "attempt_ceiling_reached",
+        },
+        None => RetryDecision::Stop {
+            reason_code: "malformed_response_fail_fast",
+        },
+    }
+}
+
 fn deterministic_retry_backoff_millis(retry_attempt: u32) -> u64 {
     let exponent = retry_attempt.saturating_sub(1).min(4);
     let multiplier = 1_u64 << exponent;
     (KOLME_LIVE_RETRY_BASE_BACKOFF_MILLIS * multiplier).min(KOLME_LIVE_RETRY_MAX_BACKOFF_MILLIS)
+}
+
+#[cfg(test)]
+fn deterministic_retry_jitter_seed(correlation_id: &str) -> u64 {
+    correlation_id
+        .bytes()
+        .fold(0xcbf2_9ce4_8422_2325_u64, |acc, byte| {
+            (acc ^ u64::from(byte)).wrapping_mul(0x1000_0000_01b3)
+        })
+}
+
+#[cfg(test)]
+fn deterministic_retry_backoff_millis_with_jitter(retry_attempt: u32, jitter_seed: u64) -> u64 {
+    let backoff = deterministic_retry_backoff_millis(retry_attempt);
+    let rotate_by = retry_attempt.saturating_sub(1) % 63;
+    let jitter = jitter_seed
+        .rotate_left(rotate_by)
+        .wrapping_add(u64::from(retry_attempt))
+        % 4;
+    backoff
+        .saturating_add(jitter)
+        .min(KOLME_LIVE_RETRY_MAX_BACKOFF_MILLIS)
 }
 
 pub(crate) fn execute_kolme_live_runtime(
@@ -391,10 +437,11 @@ pub(crate) fn execute_kolme_live_runtime_continuous(
 mod tests {
     use super::{
         classify_retry_category, deterministic_retry_backoff_millis,
+        deterministic_retry_backoff_millis_with_jitter, deterministic_retry_jitter_seed,
         ensure_kolme_live_provider_marker, kolme_live_finality_label,
-        map_kolme_live_submit_outcome, ConfigError, KolmeCommitReceiptFinality,
-        KolmeRuntimeCommitProviderError, KolmeRuntimeCommitProviderOutcome,
-        KolmeRuntimeCommitProviderReceipt,
+        map_kolme_live_submit_outcome, retry_decision_for_attempt, ConfigError,
+        KolmeCommitReceiptFinality, KolmeRuntimeCommitProviderError,
+        KolmeRuntimeCommitProviderOutcome, KolmeRuntimeCommitProviderReceipt, RetryDecision,
     };
 
     #[test]
@@ -423,6 +470,77 @@ mod tests {
         assert_eq!(deterministic_retry_backoff_millis(2), 20);
         assert_eq!(deterministic_retry_backoff_millis(3), 40);
         assert_eq!(deterministic_retry_backoff_millis(8), 40);
+    }
+
+    #[test]
+    fn unit_retry_decision_matrix_respects_attempt_ceiling_contract() {
+        assert_eq!(
+            retry_decision_for_attempt(&KolmeRuntimeCommitProviderError::Timeout, 1, 3),
+            RetryDecision::Retry {
+                reason_code: "timeout",
+            }
+        );
+        assert_eq!(
+            retry_decision_for_attempt(
+                &KolmeRuntimeCommitProviderError::Unavailable {
+                    reason: "temporary network fault".to_owned(),
+                },
+                2,
+                3,
+            ),
+            RetryDecision::Retry {
+                reason_code: "unavailable",
+            }
+        );
+        assert_eq!(
+            retry_decision_for_attempt(&KolmeRuntimeCommitProviderError::Timeout, 3, 3),
+            RetryDecision::Stop {
+                reason_code: "attempt_ceiling_reached",
+            }
+        );
+        assert_eq!(
+            retry_decision_for_attempt(
+                &KolmeRuntimeCommitProviderError::MalformedResponse {
+                    reason: "invalid json".to_owned(),
+                },
+                1,
+                3,
+            ),
+            RetryDecision::Stop {
+                reason_code: "malformed_response_fail_fast",
+            }
+        );
+    }
+
+    #[test]
+    fn unit_retry_jitter_seed_contract_is_deterministic() {
+        // Regression: #4109
+        let correlation_id = "kolme:retry:seed:deterministic";
+        assert_eq!(
+            deterministic_retry_jitter_seed(correlation_id),
+            deterministic_retry_jitter_seed(correlation_id)
+        );
+        assert_ne!(
+            deterministic_retry_jitter_seed(correlation_id),
+            deterministic_retry_jitter_seed("kolme:retry:seed:deterministic:alt")
+        );
+    }
+
+    #[test]
+    fn unit_retry_backoff_with_jitter_stays_bounded_and_deterministic() {
+        let seed = deterministic_retry_jitter_seed("kolme:retry:jitter:bounded");
+        assert_eq!(
+            deterministic_retry_backoff_millis_with_jitter(1, seed),
+            deterministic_retry_backoff_millis_with_jitter(1, seed)
+        );
+        assert_eq!(
+            deterministic_retry_backoff_millis_with_jitter(2, seed),
+            deterministic_retry_backoff_millis_with_jitter(2, seed)
+        );
+        assert!(
+            deterministic_retry_backoff_millis_with_jitter(8, seed) <= 40,
+            "retry backoff must remain capped at configured max"
+        );
     }
 
     #[test]

--- a/docs/ops/configuration.md
+++ b/docs/ops/configuration.md
@@ -110,6 +110,31 @@ Fail-closed mismatch reasons:
 - `submit_finality_reason_mismatch_for_finality_enabled_run`
 - `submit_finality_reason_mismatch_for_submit_only_run`
 
+### Retry Decision Matrix and Jitter Seed Contracts
+
+`kamn-node` keeps retry behavior deterministic and bounded for live runtime submit/finality paths.
+
+Contract helpers and invariants:
+
+- `retry_decision_for_attempt(error, attempt, max_attempts)`:
+  - returns `Retry` only for transient classes (`timeout`, `unavailable`) with `attempt < max_attempts`
+  - returns `Stop` with `attempt_ceiling_reached` when transient classes hit the configured ceiling
+  - returns `Stop` with `malformed_response_fail_fast` for malformed payload classes
+- `deterministic_retry_jitter_seed(correlation_id)`:
+  - produces a stable seed for a given correlation ID
+  - different correlation IDs produce different seeds in contract tests
+- `deterministic_retry_backoff_millis_with_jitter(attempt, seed)`:
+  - remains deterministic for the same input pair
+  - remains bounded by `retry_backoff_cap_ms`
+
+Operational note:
+
+- Active runtime marker emission remains on the deterministic non-jitter schedule (`deterministic_retry_backoff_millis`) until rollout issue `#4110` wires jitter into runtime retry markers.
+
+Regression marker:
+
+- `Regression: #4109`
+
 ## Validation Evidence
 
 Implemented and validated by `kamn-node` tests:


### PR DESCRIPTION
## Summary
- Add retry decision-matrix contract tests for attempt ceilings and fail-fast malformed responses in `runtime_kolme_live`.
- Add deterministic jitter-seed/backoff contract tests (bounded, deterministic) without changing active runtime retry marker behavior.
- Update `docs/ops/configuration.md` with retry decision-matrix/jitter seed contract details and `Regression: #4109` marker.

## Linked Issues
- Closes #4109
- Refs #4103

## Changes
- `crates/kamn-node/src/runtime_kolme_live.rs`
  - Added test-only retry contract helpers:
    - `RetryDecision`
    - `retry_decision_for_attempt`
    - `deterministic_retry_jitter_seed`
    - `deterministic_retry_backoff_millis_with_jitter`
  - Added tests:
    - `unit_retry_decision_matrix_respects_attempt_ceiling_contract`
    - `unit_retry_jitter_seed_contract_is_deterministic`
    - `unit_retry_backoff_with_jitter_stays_bounded_and_deterministic`
- `docs/ops/configuration.md`
  - Added section: `Retry Decision Matrix and Jitter Seed Contracts`
  - Added regression marker for #4109

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
cargo test -p kamn-node runtime_kolme_live::tests::unit_retry_decision_matrix_respects_attempt_ceiling_contract -- --exact --nocapture
```
Failure excerpt:
```text
error[E0432]: unresolved imports ...
no `deterministic_retry_backoff_millis_with_jitter` in `runtime_kolme_live`
no `deterministic_retry_jitter_seed` in `runtime_kolme_live`
no `retry_decision_for_attempt` in `runtime_kolme_live`
no `RetryDecision` in `runtime_kolme_live`
```

### 🟢 Green Phase
Command:
```bash
cargo test -p kamn-node runtime_kolme_live::tests::unit_retry_decision_matrix_respects_attempt_ceiling_contract -- --exact --nocapture
```
Pass excerpt:
```text
test runtime_kolme_live::tests::unit_retry_decision_matrix_respects_attempt_ceiling_contract ... ok
```

### 🔁 Regression
Commands:
```bash
cargo test -p kamn-node runtime_kolme_live::tests:: -- --nocapture
cargo test -p kamn-node main_tests::runtime_tests::functional_kolme_live_retry_emits_structured_retry_markers -- --exact --nocapture
cargo fmt --check
cargo clippy -p kamn-node --all-targets -- -D warnings
```
Results:
- All listed commands passed locally.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | Added retry decision matrix + jitter seed/backoff contract tests in `runtime_kolme_live` | |
| Functional   | ✅     | Re-ran `functional_kolme_live_retry_emits_structured_retry_markers` | |
| Integration  | ✅     | Existing runtime flow coverage exercised through main runtime test path | |
| Regression   | ✅     | Added `Regression: #4109` contract marker in docs and preserved retry marker regression behavior | |
| Performance  | N/A    | No high-throughput path changes; CI remains fast-gate bounded | No new performance hotspot introduced |

## Risks & Rollback
- Risk: Low. Changes are test-only runtime helpers + docs; active retry marker behavior intentionally preserved.
- Rollback plan: Revert commit `e0a0111c` if any unexpected test/doc contract regression appears.

## Documentation Updates
- Updated `docs/ops/configuration.md` with retry matrix/jitter-seed contract section and regression marker.

## Validation
- [x] Relevant local checks passed.
- [x] CI fast-gate checks expected to pass.

## CI Impact Declaration
- [x] No CI scope impact.
- [ ] CI scope impact present (explain below).

CI scope impact details (required when CI scope impact is present):
- Workflow(s) touched: N/A
- Expected runtime delta: N/A
- Expected runner-minute delta: N/A
- Rollback plan if CI cost/runtime regresses: N/A
