### PR TITLE
feat(kamn-node): emit bounded retry decision markers (#4110)

### DIFF
--- a/crates/kamn-core/tests/kolme_devnet_ops_docs.rs
+++ b/crates/kamn-core/tests/kolme_devnet_ops_docs.rs
@@ -210,8 +210,20 @@ fn plan_contains_local_runtime_commit_live_lane() {
     assert!(PLAN.contains("run_local_runtime_commit_live_finality_evidence_contract_lane.sh"));
     assert!(PLAN.contains("submit_evidence_marker_present"));
     assert!(PLAN.contains("finality_evidence_marker_present"));
+    assert!(PLAN.contains("kolme.live.submit.retry"));
+    assert!(PLAN.contains("kolme.live.finality.retry"));
+    assert!(PLAN.contains("kolme.live.submit.retry.terminal"));
+    assert!(PLAN.contains("kolme.live.finality.retry.terminal"));
+    assert!(PLAN.contains("decision=retry"));
+    assert!(PLAN.contains("jitter_seed"));
+    assert!(PLAN.contains("terminal_decision=attempt_ceiling_reached"));
+    assert!(PLAN.contains("terminal_decision=malformed_response_fail_fast"));
+    assert!(PLAN.contains("submit_retry_terminal_decision"));
+    assert!(PLAN.contains("finality_retry_terminal_decision"));
+    assert!(PLAN.contains("retry_jitter_seed"));
     assert!(PLAN.contains("kamn.kolme.local-runtime-commit-live-summary.v1"));
     assert!(PLAN.contains("`Regression: #2099`"));
+    assert!(PLAN.contains("`Regression: #4110`"));
 }
 
 #[test]

--- a/crates/kamn-node/src/main_tests/runtime_tests.rs
+++ b/crates/kamn-node/src/main_tests/runtime_tests.rs
@@ -578,8 +578,8 @@ fn functional_kolme_live_retry_emits_structured_retry_markers() {
         Some("unavailable")
     );
     assert_eq!(
-        extract_json_string_field(submit_retry_line, "backoff_ms").as_deref(),
-        Some("10")
+        extract_json_string_field(submit_retry_line, "decision").as_deref(),
+        Some("retry")
     );
     assert_eq!(
         extract_json_string_field(submit_retry_line, "max_attempts").as_deref(),
@@ -590,12 +590,44 @@ fn functional_kolme_live_retry_emits_structured_retry_markers() {
         Some("unavailable")
     );
     assert_eq!(
-        extract_json_string_field(finality_retry_line, "backoff_ms").as_deref(),
-        Some("10")
+        extract_json_string_field(finality_retry_line, "decision").as_deref(),
+        Some("retry")
     );
     assert_eq!(
         extract_json_string_field(finality_retry_line, "max_attempts").as_deref(),
         Some("3")
+    );
+    let submit_jitter_seed = extract_json_string_field(submit_retry_line, "jitter_seed")
+        .expect("submit retry marker should include deterministic jitter seed");
+    let finality_jitter_seed = extract_json_string_field(finality_retry_line, "jitter_seed")
+        .expect("finality retry marker should include deterministic jitter seed");
+    assert_eq!(
+        submit_jitter_seed, finality_jitter_seed,
+        "submit/finality retry markers should project the same jitter seed for one correlation id"
+    );
+    assert!(
+        !submit_jitter_seed.is_empty(),
+        "retry jitter seed must not be empty"
+    );
+    let submit_backoff_ms = extract_json_string_field(submit_retry_line, "backoff_ms")
+        .expect("submit retry marker should include backoff")
+        .parse::<u64>()
+        .expect("submit retry backoff should parse as u64");
+    let finality_backoff_ms = extract_json_string_field(finality_retry_line, "backoff_ms")
+        .expect("finality retry marker should include backoff")
+        .parse::<u64>()
+        .expect("finality retry backoff should parse as u64");
+    assert!(
+        (10..=40).contains(&submit_backoff_ms),
+        "submit retry backoff must stay bounded"
+    );
+    assert!(
+        (10..=40).contains(&finality_backoff_ms),
+        "finality retry backoff must stay bounded"
+    );
+    assert_eq!(
+        submit_backoff_ms, finality_backoff_ms,
+        "submit/finality retry backoff should match for same attempt and jitter seed"
     );
 }
 
@@ -1937,6 +1969,185 @@ fn regression_runtime_kolme_live_submit_malformed_response_fails_fast_without_re
         recorded_requests.len(),
         2,
         "malformed submit response should fail without retrying submit requests"
+    );
+}
+
+#[test]
+fn regression_runtime_kolme_live_submit_retry_exhaustion_emits_terminal_decision_marker() {
+    // Regression: #4110
+    let _lock = signer_env_lock()
+        .lock()
+        .expect("signer env lock should guard test mutation");
+    let _profile_env_guard =
+        EnvVarGuard::set("KAMN_KOLME_LIVE_SIGNER_PROFILE", Some("ops-primary"));
+    let _env_guard = EnvVarGuard::set(
+        "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX",
+        Some(TEST_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX),
+    );
+    let _level_guard = EnvVarGuard::set("KAMN_NODE_LOG_LEVEL", Some("info"));
+    let _format_guard = EnvVarGuard::set("KAMN_NODE_LOG_FORMAT", Some("json"));
+    let (base_url, requests) = spawn_kolme_live_mock_server(vec![
+        MockHttpReply::ok(r#"{"next_nonce":17,"account_id":"acct-live-processor"}"#),
+        MockHttpReply {
+            status_line: "HTTP/1.1 503 Service Unavailable",
+            body: "{\"error\":\"submit unavailable\"}".to_owned(),
+        },
+        MockHttpReply {
+            status_line: "HTTP/1.1 503 Service Unavailable",
+            body: "{\"error\":\"submit unavailable\"}".to_owned(),
+        },
+        MockHttpReply {
+            status_line: "HTTP/1.1 503 Service Unavailable",
+            body: "{\"error\":\"submit unavailable\"}".to_owned(),
+        },
+    ]);
+    let parsed = parse_args(vec![
+        "kamn-node".to_owned(),
+        "--role".to_owned(),
+        "processor".to_owned(),
+        "--runtime-mode".to_owned(),
+        "kolme-live".to_owned(),
+        "--kolme-live-base-url".to_owned(),
+        base_url,
+        "--kolme-live-provider-hint".to_owned(),
+        "kolme-fork-local".to_owned(),
+        "--kolme-live-signing-profile".to_owned(),
+        "kolme-fork-secp256k1-v1".to_owned(),
+        "--kolme-live-signer-key-source".to_owned(),
+        "env-local".to_owned(),
+    ])
+    .expect("kolme-live args should parse");
+
+    let (report_result, captured_logs) = capture_test_logs(|| execute(parsed));
+    let error = report_result.expect_err("submit retry exhaustion must fail closed");
+    assert!(
+        matches!(error, ConfigError::RuntimeKolmeLive(message) if message.contains("submit retries exhausted")),
+        "submit retry exhaustion should preserve deterministic fail-closed message"
+    );
+
+    let terminal_retry_line = captured_logs
+        .iter()
+        .find(|line| line.contains("\"event\":\"kolme.live.submit.retry.terminal\""))
+        .expect("submit retry exhaustion should emit terminal retry decision marker");
+    assert_eq!(
+        extract_json_string_field(terminal_retry_line, "decision").as_deref(),
+        Some("stop")
+    );
+    assert_eq!(
+        extract_json_string_field(terminal_retry_line, "terminal_decision").as_deref(),
+        Some("attempt_ceiling_reached")
+    );
+    assert_eq!(
+        extract_json_string_field(terminal_retry_line, "reason").as_deref(),
+        Some("unavailable")
+    );
+    assert_eq!(
+        extract_json_string_field(terminal_retry_line, "attempt").as_deref(),
+        Some("3")
+    );
+    assert_eq!(
+        extract_json_string_field(terminal_retry_line, "max_attempts").as_deref(),
+        Some("3")
+    );
+
+    let recorded_requests = requests.lock().expect("request mutex should lock");
+    assert_eq!(
+        recorded_requests.len(),
+        4,
+        "submit retry exhaustion should issue nonce plus three submit attempts"
+    );
+}
+
+#[test]
+fn functional_kolme_live_finality_retry_exhaustion_emits_terminal_decision_marker() {
+    let _lock = signer_env_lock()
+        .lock()
+        .expect("signer env lock should guard test mutation");
+    let _profile_env_guard =
+        EnvVarGuard::set("KAMN_KOLME_LIVE_SIGNER_PROFILE", Some("ops-primary"));
+    let _env_guard = EnvVarGuard::set(
+        "KAMN_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX",
+        Some(TEST_KOLME_LIVE_SIGNER_PRIVATE_KEY_HEX),
+    );
+    let _level_guard = EnvVarGuard::set("KAMN_NODE_LOG_LEVEL", Some("info"));
+    let _format_guard = EnvVarGuard::set("KAMN_NODE_LOG_FORMAT", Some("json"));
+    let (base_url, requests) = spawn_kolme_live_mock_server(vec![
+        MockHttpReply::ok(r#"{"next_nonce":17,"account_id":"acct-live-processor"}"#),
+        MockHttpReply::ok(
+            r#"{"status":"submitted","provider":"kolme-fork-local","commit_id":"kolme-commit:ab12cd34","finality":"pending"}"#,
+        ),
+        MockHttpReply {
+            status_line: "HTTP/1.1 503 Service Unavailable",
+            body: "{\"error\":\"finality unavailable\"}".to_owned(),
+        },
+        MockHttpReply {
+            status_line: "HTTP/1.1 503 Service Unavailable",
+            body: "{\"error\":\"finality unavailable\"}".to_owned(),
+        },
+        MockHttpReply {
+            status_line: "HTTP/1.1 503 Service Unavailable",
+            body: "{\"error\":\"finality unavailable\"}".to_owned(),
+        },
+    ]);
+    let parsed = parse_args(vec![
+        "kamn-node".to_owned(),
+        "--role".to_owned(),
+        "processor".to_owned(),
+        "--runtime-mode".to_owned(),
+        "kolme-live".to_owned(),
+        "--kolme-live-base-url".to_owned(),
+        base_url,
+        "--kolme-live-provider-hint".to_owned(),
+        "kolme-fork-local".to_owned(),
+        "--kolme-live-signing-profile".to_owned(),
+        "kolme-fork-secp256k1-v1".to_owned(),
+        "--kolme-live-signer-key-source".to_owned(),
+        "env-local".to_owned(),
+        "--output".to_owned(),
+        "json".to_owned(),
+    ])
+    .expect("kolme-live args should parse");
+
+    let (report_result, captured_logs) = capture_test_logs(|| execute(parsed));
+    let report = report_result.expect("finality retry exhaustion should resolve gracefully");
+    assert_eq!(report.runtime_mode, "kolme-live");
+
+    let terminal_retry_line = captured_logs
+        .iter()
+        .find(|line| line.contains("\"event\":\"kolme.live.finality.retry.terminal\""))
+        .expect("finality retry exhaustion should emit terminal retry decision marker");
+    assert_eq!(
+        extract_json_string_field(terminal_retry_line, "decision").as_deref(),
+        Some("stop")
+    );
+    assert_eq!(
+        extract_json_string_field(terminal_retry_line, "terminal_decision").as_deref(),
+        Some("attempt_ceiling_reached")
+    );
+    assert_eq!(
+        extract_json_string_field(terminal_retry_line, "reason").as_deref(),
+        Some("unavailable")
+    );
+    assert_eq!(
+        extract_json_string_field(terminal_retry_line, "attempt").as_deref(),
+        Some("3")
+    );
+    assert_eq!(
+        extract_json_string_field(terminal_retry_line, "max_attempts").as_deref(),
+        Some("3")
+    );
+
+    let rendered = render_bootstrap_report(&report, OutputMode::json());
+    assert!(rendered.contains("resolution=finality-unavailable"));
+    assert!(rendered.contains("finality_retry_attempts=3"));
+    assert!(rendered.contains("finality_retry_terminal_decision=attempt_ceiling_reached"));
+    assert!(rendered.contains("retry_jitter_seed="));
+
+    let recorded_requests = requests.lock().expect("request mutex should lock");
+    assert_eq!(
+        recorded_requests.len(),
+        5,
+        "finality retry exhaustion should issue nonce, submit, and three finality attempts"
     );
 }
 

--- a/crates/kamn-node/src/runtime_kolme_live.rs
+++ b/crates/kamn-node/src/runtime_kolme_live.rs
@@ -90,14 +90,12 @@ fn classify_retry_category(error: &KolmeRuntimeCommitProviderError) -> Option<&'
     }
 }
 
-#[cfg(test)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum RetryDecision {
     Retry { reason_code: &'static str },
     Stop { reason_code: &'static str },
 }
 
-#[cfg(test)]
 fn retry_decision_for_attempt(
     error: &KolmeRuntimeCommitProviderError,
     attempt: u32,
@@ -120,7 +118,6 @@ fn deterministic_retry_backoff_millis(retry_attempt: u32) -> u64 {
     (KOLME_LIVE_RETRY_BASE_BACKOFF_MILLIS * multiplier).min(KOLME_LIVE_RETRY_MAX_BACKOFF_MILLIS)
 }
 
-#[cfg(test)]
 fn deterministic_retry_jitter_seed(correlation_id: &str) -> u64 {
     correlation_id
         .bytes()
@@ -129,7 +126,6 @@ fn deterministic_retry_jitter_seed(correlation_id: &str) -> u64 {
         })
 }
 
-#[cfg(test)]
 fn deterministic_retry_backoff_millis_with_jitter(retry_attempt: u32, jitter_seed: u64) -> u64 {
     let backoff = deterministic_retry_backoff_millis(retry_attempt);
     let rotate_by = retry_attempt.saturating_sub(1) % 63;
@@ -161,6 +157,7 @@ pub(crate) fn execute_kolme_live_runtime(
         .map_err(|error| ConfigError::RuntimeKolmeLive(error.to_string()))?;
     let request = build_kolme_live_request(plan)?;
     let correlation_id = request.idempotency_key().to_owned();
+    let retry_jitter_seed = deterministic_retry_jitter_seed(correlation_id.as_str());
     log_info(
         "kolme.live.submit.start",
         &[
@@ -185,6 +182,7 @@ pub(crate) fn execute_kolme_live_runtime(
     .map_err(|error| ConfigError::RuntimeKolmeLive(error.to_string()))?;
     let mut submit_attempts = 0_u32;
     let mut submit_retry_reason = "none";
+    let mut submit_retry_terminal_decision = "none";
     let submit_outcome = loop {
         submit_attempts += 1;
         match provider
@@ -192,13 +190,21 @@ pub(crate) fn execute_kolme_live_runtime(
         {
             Ok(outcome) => break outcome,
             Err(error) => {
-                if let Some(reason_code) = classify_retry_category(&error) {
-                    if submit_attempts < KOLME_LIVE_SUBMIT_RETRY_MAX_ATTEMPTS {
+                match retry_decision_for_attempt(
+                    &error,
+                    submit_attempts,
+                    KOLME_LIVE_SUBMIT_RETRY_MAX_ATTEMPTS,
+                ) {
+                    RetryDecision::Retry { reason_code } => {
                         submit_retry_reason = reason_code;
                         let attempt_label = submit_attempts.to_string();
                         let max_attempts_label = KOLME_LIVE_SUBMIT_RETRY_MAX_ATTEMPTS.to_string();
-                        let backoff_ms = deterministic_retry_backoff_millis(submit_attempts);
+                        let backoff_ms = deterministic_retry_backoff_millis_with_jitter(
+                            submit_attempts,
+                            retry_jitter_seed,
+                        );
                         let backoff_ms_label = backoff_ms.to_string();
+                        let jitter_seed_label = retry_jitter_seed.to_string();
                         log_warn(
                             "kolme.live.submit.retry",
                             &[
@@ -206,17 +212,59 @@ pub(crate) fn execute_kolme_live_runtime(
                                 ("attempt", attempt_label.as_str()),
                                 ("max_attempts", max_attempts_label.as_str()),
                                 ("reason", reason_code),
+                                ("decision", "retry"),
+                                ("jitter_seed", jitter_seed_label.as_str()),
                                 ("backoff_ms", backoff_ms_label.as_str()),
                             ],
                         )?;
                         thread::sleep(Duration::from_millis(backoff_ms));
                         continue;
                     }
-                    return Err(ConfigError::RuntimeKolmeLive(format!(
-                        "submit retries exhausted after {submit_attempts} attempts ({reason_code}): {error}"
-                    )));
+                    RetryDecision::Stop {
+                        reason_code: "attempt_ceiling_reached",
+                    } => {
+                        submit_retry_terminal_decision = "attempt_ceiling_reached";
+                        let terminal_reason = classify_retry_category(&error).unwrap_or("unknown");
+                        let attempt_label = submit_attempts.to_string();
+                        let max_attempts_label = KOLME_LIVE_SUBMIT_RETRY_MAX_ATTEMPTS.to_string();
+                        log_warn(
+                            "kolme.live.submit.retry.terminal",
+                            &[
+                                ("correlation_id", correlation_id.as_str()),
+                                ("attempt", attempt_label.as_str()),
+                                ("max_attempts", max_attempts_label.as_str()),
+                                ("reason", terminal_reason),
+                                ("decision", "stop"),
+                                ("terminal_decision", submit_retry_terminal_decision),
+                            ],
+                        )?;
+                        return Err(ConfigError::RuntimeKolmeLive(format!(
+                            "submit retries exhausted after {submit_attempts} attempts ({terminal_reason}): {error}"
+                        )));
+                    }
+                    RetryDecision::Stop {
+                        reason_code: "malformed_response_fail_fast",
+                    } => {
+                        submit_retry_terminal_decision = "malformed_response_fail_fast";
+                        let attempt_label = submit_attempts.to_string();
+                        let max_attempts_label = KOLME_LIVE_SUBMIT_RETRY_MAX_ATTEMPTS.to_string();
+                        log_warn(
+                            "kolme.live.submit.retry.terminal",
+                            &[
+                                ("correlation_id", correlation_id.as_str()),
+                                ("attempt", attempt_label.as_str()),
+                                ("max_attempts", max_attempts_label.as_str()),
+                                ("reason", "malformed"),
+                                ("decision", "fail-fast"),
+                                ("terminal_decision", submit_retry_terminal_decision),
+                            ],
+                        )?;
+                        return Err(ConfigError::RuntimeKolmeLive(error.to_string()));
+                    }
+                    RetryDecision::Stop { .. } => {
+                        return Err(ConfigError::RuntimeKolmeLive(error.to_string()));
+                    }
                 }
-                return Err(ConfigError::RuntimeKolmeLive(error.to_string()));
             }
         }
     };
@@ -234,6 +282,7 @@ pub(crate) fn execute_kolme_live_runtime(
     let mut resolution = "submit-receipt".to_owned();
     let mut finality_retry_attempts = 0_u32;
     let mut finality_retry_reason = "none";
+    let mut finality_retry_terminal_decision = "none";
 
     if matches!(receipt.finality, KolmeCommitReceiptFinality::Pending) {
         log_info(
@@ -264,15 +313,22 @@ pub(crate) fn execute_kolme_live_runtime(
                     break;
                 }
                 Err(error) => {
-                    if let Some(reason_code) = classify_retry_category(&error) {
-                        if finality_retry_attempts < KOLME_LIVE_FINALITY_RETRY_MAX_ATTEMPTS {
+                    match retry_decision_for_attempt(
+                        &error,
+                        finality_retry_attempts,
+                        KOLME_LIVE_FINALITY_RETRY_MAX_ATTEMPTS,
+                    ) {
+                        RetryDecision::Retry { reason_code } => {
                             finality_retry_reason = reason_code;
                             let attempt_label = finality_retry_attempts.to_string();
                             let max_attempts_label =
                                 KOLME_LIVE_FINALITY_RETRY_MAX_ATTEMPTS.to_string();
-                            let backoff_ms =
-                                deterministic_retry_backoff_millis(finality_retry_attempts);
+                            let backoff_ms = deterministic_retry_backoff_millis_with_jitter(
+                                finality_retry_attempts,
+                                retry_jitter_seed,
+                            );
                             let backoff_ms_label = backoff_ms.to_string();
+                            let jitter_seed_label = retry_jitter_seed.to_string();
                             log_warn(
                                 "kolme.live.finality.retry",
                                 &[
@@ -281,25 +337,74 @@ pub(crate) fn execute_kolme_live_runtime(
                                     ("attempt", attempt_label.as_str()),
                                     ("max_attempts", max_attempts_label.as_str()),
                                     ("reason", reason_code),
+                                    ("decision", "retry"),
+                                    ("jitter_seed", jitter_seed_label.as_str()),
                                     ("backoff_ms", backoff_ms_label.as_str()),
                                 ],
                             )?;
                             thread::sleep(Duration::from_millis(backoff_ms));
                             continue;
                         }
-                        resolution = if reason_code == "timeout" {
-                            "finality-timeout".to_owned()
-                        } else {
-                            "finality-unavailable".to_owned()
-                        };
-                        break;
+                        RetryDecision::Stop {
+                            reason_code: "attempt_ceiling_reached",
+                        } => {
+                            finality_retry_terminal_decision = "attempt_ceiling_reached";
+                            let terminal_reason =
+                                classify_retry_category(&error).unwrap_or("unavailable");
+                            let attempt_label = finality_retry_attempts.to_string();
+                            let max_attempts_label =
+                                KOLME_LIVE_FINALITY_RETRY_MAX_ATTEMPTS.to_string();
+                            log_warn(
+                                "kolme.live.finality.retry.terminal",
+                                &[
+                                    ("correlation_id", correlation_id.as_str()),
+                                    ("commit_id", receipt.commit_id.as_str()),
+                                    ("attempt", attempt_label.as_str()),
+                                    ("max_attempts", max_attempts_label.as_str()),
+                                    ("reason", terminal_reason),
+                                    ("decision", "stop"),
+                                    ("terminal_decision", finality_retry_terminal_decision),
+                                ],
+                            )?;
+                            resolution = if terminal_reason == "timeout" {
+                                "finality-timeout".to_owned()
+                            } else {
+                                "finality-unavailable".to_owned()
+                            };
+                            break;
+                        }
+                        RetryDecision::Stop {
+                            reason_code: "malformed_response_fail_fast",
+                        } => {
+                            finality_retry_terminal_decision = "malformed_response_fail_fast";
+                            let attempt_label = finality_retry_attempts.to_string();
+                            let max_attempts_label =
+                                KOLME_LIVE_FINALITY_RETRY_MAX_ATTEMPTS.to_string();
+                            log_warn(
+                                "kolme.live.finality.retry.terminal",
+                                &[
+                                    ("correlation_id", correlation_id.as_str()),
+                                    ("commit_id", receipt.commit_id.as_str()),
+                                    ("attempt", attempt_label.as_str()),
+                                    ("max_attempts", max_attempts_label.as_str()),
+                                    ("reason", "malformed"),
+                                    ("decision", "fail-fast"),
+                                    ("terminal_decision", finality_retry_terminal_decision),
+                                ],
+                            )?;
+                            if let KolmeRuntimeCommitProviderError::MalformedResponse { reason } =
+                                error
+                            {
+                                return Err(ConfigError::RuntimeKolmeLive(format!(
+                                    "finality response malformed: {reason}"
+                                )));
+                            }
+                            return Err(ConfigError::RuntimeKolmeLive(error.to_string()));
+                        }
+                        RetryDecision::Stop { .. } => {
+                            return Err(ConfigError::RuntimeKolmeLive(error.to_string()));
+                        }
                     }
-                    if let KolmeRuntimeCommitProviderError::MalformedResponse { reason } = error {
-                        return Err(ConfigError::RuntimeKolmeLive(format!(
-                            "finality response malformed: {reason}"
-                        )));
-                    }
-                    return Err(ConfigError::RuntimeKolmeLive(error.to_string()));
                 }
             }
         }
@@ -330,8 +435,9 @@ pub(crate) fn execute_kolme_live_runtime(
     let finality_retry_max_attempts = KOLME_LIVE_FINALITY_RETRY_MAX_ATTEMPTS;
     let retry_backoff_base_ms = KOLME_LIVE_RETRY_BASE_BACKOFF_MILLIS;
     let retry_backoff_cap_ms = KOLME_LIVE_RETRY_MAX_BACKOFF_MILLIS;
+    let retry_jitter_seed_label = retry_jitter_seed.to_string();
     let execution_status = format!(
-        "{submit_status};commit_id={};finality={finality};resolution={resolution};submit_attempts={submit_attempts};submit_retry_reason={submit_retry_reason};submit_retry_max_attempts={submit_retry_max_attempts};finality_retry_attempts={finality_retry_attempts};finality_retry_reason={finality_retry_reason};finality_retry_max_attempts={finality_retry_max_attempts};retry_backoff_base_ms={retry_backoff_base_ms};retry_backoff_cap_ms={retry_backoff_cap_ms};signer_previous_profile={};signer_failover_active={};signer_rotation_epoch={};signer_previous_rotation_epoch={};signer_quorum_linkage_contract_version={};signer_quorum_required_approvals={};signer_quorum_approved_signers_count={};signer_quorum_profile_linked={};signer_quorum_satisfied={};signer_quorum_linked={}",
+        "{submit_status};commit_id={};finality={finality};resolution={resolution};submit_attempts={submit_attempts};submit_retry_reason={submit_retry_reason};submit_retry_terminal_decision={submit_retry_terminal_decision};submit_retry_max_attempts={submit_retry_max_attempts};finality_retry_attempts={finality_retry_attempts};finality_retry_reason={finality_retry_reason};finality_retry_terminal_decision={finality_retry_terminal_decision};finality_retry_max_attempts={finality_retry_max_attempts};retry_backoff_base_ms={retry_backoff_base_ms};retry_backoff_cap_ms={retry_backoff_cap_ms};retry_jitter_seed={retry_jitter_seed_label};signer_previous_profile={};signer_failover_active={};signer_rotation_epoch={};signer_previous_rotation_epoch={};signer_quorum_linkage_contract_version={};signer_quorum_required_approvals={};signer_quorum_approved_signers_count={};signer_quorum_profile_linked={};signer_quorum_satisfied={};signer_quorum_linked={}",
         receipt.commit_id
         ,
         signer_preflight.previous_profile,

--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -1481,6 +1481,15 @@ Operator checkpoints:
   - replay marker contract field (`replay_evidence_contract_version`) remains fail-closed in policy checks
   - request/finality linkage markers (`request_payload_evidence_marker_present`, `request_payload_evidence_artifact_path`, `submit_evidence_artifact_path`, `finality_evidence_artifact_path`, `request_finality_evidence_contract_version`, `request_finality_evidence_linked`) remain fail-closed in policy checks
   - finality retry evidence markers (`finality_retry_contract_version`, `finality_retry_max_attempts`, `finality_retry_backoff_seconds`, `finality_retry_attempts_used`, `finality_retry_exhausted`, `finality_retry_failure_class`) remain fail-closed in policy checks
+  - runtime retry marker emissions remain deterministic and bounded:
+    - retry events: `kolme.live.submit.retry`, `kolme.live.finality.retry`
+    - terminal events: `kolme.live.submit.retry.terminal`, `kolme.live.finality.retry.terminal`
+    - retry events include marker fields `attempt`, `max_attempts`, `reason`, `decision=retry`, `jitter_seed`, `backoff_ms`
+    - terminal events include marker fields `attempt`, `max_attempts`, `reason`, `decision=stop|fail-fast`
+    - deterministic terminal decision marker values:
+      - `terminal_decision=attempt_ceiling_reached`
+      - `terminal_decision=malformed_response_fail_fast`
+    - execution status includes `submit_retry_terminal_decision`, `finality_retry_terminal_decision`, and `retry_jitter_seed`
   - live-provider marker contracts (`provider_contract_enforcement_mode`, `provider_live_contract_marker`, `provider_live_contract_marker_present`, `provider_in_memory_reference_detected`) remain fail-closed in policy checks
   - real-signing marker contracts (`provider_signer_adapter_contract=KolmeForkSecp256k1SignerAdapter`, `provider_signing_curve_contract=secp256k1`, `provider_signing_profile_contract_version=v1`) remain fail-closed in policy checks
   - provider mismatch remains fail-closed with deterministic reason `provider_client_contract_mismatch`.
@@ -1493,6 +1502,7 @@ Operator checkpoints:
   - request/finality linkage drift fails closed with deterministic reasons (`request_payload_evidence_marker_missing`, `replay_evidence_marker_missing`, `finality_evidence_artifact_path_missing`, `request_finality_evidence_linkage_missing`).
   - provider drift fails closed when in-memory provider usage is detected in summary marker surfaces (`provider_in_memory_reference_detected`).
   - finality retry exhaustion reasons are deterministic (`live_finality_retry_exhausted_timeout`, `live_finality_retry_exhausted_failed`) and drift fails closed with checker reasons (`finality_retry_failure_class_mismatch_for_timeout_reason`, `finality_retry_attempts_used_mismatch_for_timeout_reason`).
+  - runtime retry marker decision/jitter taxonomy remains deterministic and fail-closed (`Regression: #4110`).
   - submit/finality success-reason taxonomy remains deterministic in policy outputs:
     - `submit_finality_reason_taxonomy_version=kamn.kolme.local-runtime-commit-submit-finality-reason-taxonomy.v1`
     - `submit_finality_reason_codes_csv=submit_finality_reason_mismatch_for_finality_enabled_run,submit_finality_reason_mismatch_for_submit_only_run`


### PR DESCRIPTION
## Summary
- Wire bounded retry decision-matrix helpers into `runtime_kolme_live` retry loops for submit/finality paths.
- Emit deterministic retry marker fields (`decision`, `jitter_seed`) and terminal decision markers (`*.retry.terminal`) with bounded attempt ceilings.
- Extend runtime tests and planning/docs contracts to validate marker semantics, including `Regression: #4110`.

## Linked Issues
- Closes #4110
- Refs #4103

## Validation
- [x] Relevant local checks passed.
- [x] CI fast-gate checks expected to pass.

## CI Impact Declaration
- [x] No CI scope impact.
- [ ] CI scope impact present (explain below).

CI scope impact details (required when CI scope impact is present):
- Workflow(s) touched: N/A
- Expected runtime delta: N/A
- Expected runner-minute delta: N/A
- Rollback plan if CI cost/runtime regresses: N/A

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
```bash
cargo test -p kamn-node main_tests::runtime_tests::functional_kolme_live_retry_emits_structured_retry_markers -- --exact --nocapture
```
Failure excerpt:
```text
assertion `left == right` failed
  left: None
 right: Some("retry")
```

### 🟢 Green Phase
Command:
```bash
cargo test -p kamn-node main_tests::runtime_tests::functional_kolme_live_retry_emits_structured_retry_markers -- --exact --nocapture
```
Pass excerpt:
```text
... "event":"kolme.live.submit.retry" ... "decision":"retry" ... "jitter_seed":"..."
... "event":"kolme.live.finality.retry" ... "decision":"retry" ... "jitter_seed":"..."
test ...functional_kolme_live_retry_emits_structured_retry_markers ... ok
```

### 🔁 Regression
Commands:
```bash
cargo test -p kamn-node main_tests::runtime_tests::functional_kolme_live_retry_emits_structured_retry_markers -- --exact --nocapture
cargo test -p kamn-node main_tests::runtime_tests::regression_runtime_kolme_live_submit_malformed_response_fails_fast_without_retry -- --exact --nocapture
cargo test -p kamn-node main_tests::runtime_tests::regression_runtime_kolme_live_submit_retry_exhaustion_emits_terminal_decision_marker -- --exact --nocapture
cargo test -p kamn-node main_tests::runtime_tests::functional_kolme_live_finality_retry_exhaustion_emits_terminal_decision_marker -- --exact --nocapture
cargo test -p kamn-node main_tests::runtime_tests::performance_runtime_kolme_live_retry_recovery_stays_within_budget -- --exact --nocapture
cargo test -p kamn-node runtime_kolme_live::tests:: -- --nocapture
cargo test -p kamn-core --test kolme_devnet_ops_docs plan_contains_local_runtime_commit_live_lane -- --exact --nocapture
cargo fmt --check
cargo clippy -p kamn-node --all-targets -- -D warnings
cargo clippy -p kamn-core --tests -- -D warnings
```
All commands passed locally.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `runtime_kolme_live::tests` decision/backoff/jitter helper contracts | |
| Functional   | ✅     | Updated `functional_kolme_live_retry_emits_structured_retry_markers`; added finality terminal marker functional test | |
| Integration  | ✅     | Runtime execution path coverage through main runtime tests with mock server fault scenarios | |
| Regression   | ✅     | Added submit retry exhaustion terminal marker regression + docs regression marker `#4110` | |
| Performance  | ✅     | Re-ran `performance_runtime_kolme_live_retry_recovery_stays_within_budget` | |

## Risks & Rollback
- Risk: Low-medium. Runtime retry marker payloads changed (new fields/events) and jitter-based backoff is now used for retry delays.
- Rollback plan: Revert commit `d2b83723`.

## Documentation Updates
- `docs/planning/kolme-devnet-ops.md`
- `crates/kamn-core/tests/kolme_devnet_ops_docs.rs`
