### PR TITLE
feat(logging): enforce bootstrap default field projection (#4120)

### DIFF
--- a/crates/kamn-node/src/logging.rs
+++ b/crates/kamn-node/src/logging.rs
@@ -4,6 +4,10 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 pub(crate) const KAMN_NODE_LOG_LEVEL_ENV: &str = "KAMN_NODE_LOG_LEVEL";
 pub(crate) const KAMN_NODE_LOG_FORMAT_ENV: &str = "KAMN_NODE_LOG_FORMAT";
+const LOG_FIELD_CORRELATION_ID: &str = "correlation_id";
+const LOG_FIELD_REASON_CODE: &str = "reason_code";
+const LOG_DEFAULT_CORRELATION_ID: &str = "none";
+const LOG_DEFAULT_REASON_CODE: &str = "none";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) enum NodeLogLevel {
@@ -162,12 +166,13 @@ fn render_text_log_event_line(
     event: &str,
     fields: &[(&str, &str)],
 ) -> String {
+    let normalized_fields = normalize_log_fields(fields);
     let mut line = format!(
         "ts_unix_ms={timestamp_ms} level={} event={}",
         level.as_str(),
         render_text_field_value(event)
     );
-    for (key, value) in fields {
+    for &(key, value) in &normalized_fields {
         line.push(' ');
         line.push_str(key);
         line.push('=');
@@ -182,17 +187,18 @@ fn render_json_log_event_line(
     event: &str,
     fields: &[(&str, &str)],
 ) -> String {
+    let normalized_fields = normalize_log_fields(fields);
     let mut line = format!(
         "{{\"ts_unix_ms\":{timestamp_ms},\"level\":\"{}\",\"event\":\"{}\"",
         level.as_str(),
         escape_json_string(event)
     );
-    if fields.is_empty() {
+    if normalized_fields.is_empty() {
         line.push('}');
         return line;
     }
     line.push_str(",\"fields\":{");
-    for (index, (key, value)) in fields.iter().enumerate() {
+    for (index, (key, value)) in normalized_fields.iter().enumerate() {
         if index > 0 {
             line.push(',');
         }
@@ -204,6 +210,41 @@ fn render_json_log_event_line(
     }
     line.push_str("}}");
     line
+}
+
+fn normalize_log_fields<'a>(fields: &'a [(&'a str, &'a str)]) -> Vec<(&'a str, &'a str)> {
+    let mut normalized = Vec::with_capacity(fields.len() + 2);
+    let mut has_correlation_id = false;
+    let mut has_reason_code = false;
+
+    for &(key, value) in fields {
+        if key == LOG_FIELD_CORRELATION_ID {
+            if value.trim().is_empty() {
+                continue;
+            }
+            has_correlation_id = true;
+            normalized.push((key, value));
+            continue;
+        }
+        if key == LOG_FIELD_REASON_CODE {
+            if value.trim().is_empty() {
+                continue;
+            }
+            has_reason_code = true;
+            normalized.push((key, value));
+            continue;
+        }
+        normalized.push((key, value));
+    }
+
+    if !has_correlation_id {
+        normalized.push((LOG_FIELD_CORRELATION_ID, LOG_DEFAULT_CORRELATION_ID));
+    }
+    if !has_reason_code {
+        normalized.push((LOG_FIELD_REASON_CODE, LOG_DEFAULT_REASON_CODE));
+    }
+
+    normalized
 }
 
 fn render_text_field_value(value: &str) -> String {

--- a/crates/kamn-node/src/main_tests/runtime_tests.rs
+++ b/crates/kamn-node/src/main_tests/runtime_tests.rs
@@ -383,6 +383,19 @@ fn unit_log_config_parses_level_and_format_inputs() {
 }
 
 #[test]
+fn unit_log_config_parses_bootstrap_level_with_whitespace_and_case_insensitive_inputs() {
+    let config = resolve_log_config_from_inputs(Some(" WARN "), Some(" JSON "))
+        .expect("bootstrap log config inputs should parse after trim/lowercase normalization");
+    assert_eq!(
+        config,
+        NodeLogConfig {
+            level: NodeLogLevel::Warn,
+            format: NodeLogFormat::Json,
+        }
+    );
+}
+
+#[test]
 fn unit_log_renderer_renders_json_event_fields() {
     let line = render_log_event_line(
         NodeLogConfig {
@@ -400,6 +413,52 @@ fn unit_log_renderer_renders_json_event_fields() {
     assert!(line.contains("\"event\":\"kolme.live.submit.start\""));
     assert!(line.contains("\"correlation_id\":\"runtime-commit:abc\""));
     assert!(line.contains("\"provider_hint\":\"local\""));
+}
+
+#[test]
+fn regression_log_renderer_projects_default_correlation_and_reason_fields_when_missing() {
+    // Regression: #4120
+    let line = render_log_event_line(
+        NodeLogConfig {
+            level: NodeLogLevel::Info,
+            format: NodeLogFormat::Json,
+        },
+        NodeLogLevel::Info,
+        "node.runtime.bootstrap.plan.ready",
+        &[("component", "planner")],
+    );
+    assert_eq!(
+        extract_json_string_field(&line, "correlation_id").as_deref(),
+        Some("none"),
+        "structured events must project deterministic fallback correlation marker"
+    );
+    assert_eq!(
+        extract_json_string_field(&line, "reason_code").as_deref(),
+        Some("none"),
+        "structured events must project deterministic fallback reason marker"
+    );
+}
+
+#[test]
+fn regression_log_renderer_text_projects_default_correlation_and_reason_fields_when_missing() {
+    // Regression: #4120
+    let line = render_log_event_line(
+        NodeLogConfig {
+            level: NodeLogLevel::Info,
+            format: NodeLogFormat::Text,
+        },
+        NodeLogLevel::Info,
+        "node.runtime.bootstrap.plan.ready",
+        &[("component", "planner")],
+    );
+    assert!(
+        line.contains("correlation_id=none"),
+        "text events must project deterministic fallback correlation marker"
+    );
+    assert!(
+        line.contains("reason_code=none"),
+        "text events must project deterministic fallback reason marker"
+    );
 }
 
 #[test]

--- a/docs/ops/configuration.md
+++ b/docs/ops/configuration.md
@@ -90,6 +90,33 @@ Regression markers:
 
 - `Regression: #4106`
 
+## Structured Logging Bootstrap Contracts
+
+`kamn-node` logging bootstrap remains deterministic for all runtime modes.
+
+Environment controls:
+
+- `KAMN_NODE_LOG_LEVEL` -> `error|warn|info|debug|trace` (trimmed, case-insensitive)
+- `KAMN_NODE_LOG_FORMAT` -> `text|json` (trimmed, case-insensitive)
+
+Deterministic defaults:
+
+- Level defaults to `info` when unset.
+- Format defaults to `text` when unset.
+- Structured event fields project fallback markers when omitted:
+  - `correlation_id=none`
+  - `reason_code=none`
+
+Validation commands:
+
+- `cargo test -p kamn-node regression_log_renderer_projects_default_correlation_and_reason_fields_when_missing -- --nocapture`
+- `cargo test -p kamn-node regression_log_renderer_text_projects_default_correlation_and_reason_fields_when_missing -- --nocapture`
+- `cargo test -p kamn-node unit_log_config_parses_bootstrap_level_with_whitespace_and_case_insensitive_inputs -- --nocapture`
+
+Regression marker:
+
+- `Regression: #4120`
+
 ## Environment Override Contracts
 
 Environment override names map to the same key contracts regardless of config-file usage.


### PR DESCRIPTION
## Summary
This change closes #4120 by adding deterministic logging bootstrap contract tests and minimal logger normalization so missing `correlation_id`/`reason_code` fields are projected as `none` across text/json outputs.

## Changes
- `crates/kamn-node/src/main_tests/runtime_tests.rs`
  - Added level parsing stability test for whitespace/case-insensitive bootstrap inputs.
  - Added regression tests asserting fallback `correlation_id` and `reason_code` projection for JSON and text renderers.
- `crates/kamn-node/src/logging.rs`
  - Added normalized log-field projection that injects deterministic fallback markers when correlation/reason fields are missing or blank.
- `docs/ops/configuration.md`
  - Documented structured logging bootstrap contracts, env controls, fallback field semantics, and validation commands.

## Linked Issues
- Closes #4120

## TDD Evidence (Mandatory)
### 🔴 Red Phase
Command:
`cargo test -p kamn-node regression_log_renderer_projects_default_correlation_and_reason_fields_when_missing -- --nocapture`

Observed failure before implementation:
```text
thread '...regression_log_renderer_projects_default_correlation_and_reason_fields_when_missing' panicked
assertion `left == right` failed
left: None
right: Some("none")
```

### 🟢 Green Phase
Commands:
- `cargo test -p kamn-node regression_log_renderer_projects_default_correlation_and_reason_fields_when_missing -- --nocapture`
- `cargo test -p kamn-node regression_log_renderer_text_projects_default_correlation_and_reason_fields_when_missing -- --nocapture`
- `cargo test -p kamn-node unit_log_config_parses_bootstrap_level_with_whitespace_and_case_insensitive_inputs -- --nocapture`

Result: all pass.

### 🔁 Regression
Command:
`cargo test -p kamn-node main_tests::runtime_tests:: -- --test-threads=1`

Result:
- 64 passed, 0 failed.

Additional focused checks:
- `cargo test -p kamn-node integration_runtime_kolme_live_renders_secondary_signer_selection_markers -- --nocapture`
- `cargo test -p kamn-node integration_service_api_endpoint_websocket_upgrade_streams_state_transition_event -- --nocapture`

Both pass.

## Test Matrix (Mandatory)
| Category      | Status | Tests Added/Modified | Justification if N/A |
|--------------|--------|----------------------|----------------------|
| Unit         | ✅     | `unit_log_config_parses_bootstrap_level_with_whitespace_and_case_insensitive_inputs` | |
| Functional   | ✅     | `unit_log_renderer_renders_json_event_fields` (covered unchanged behavior with new defaults in place) | |
| Integration  | ✅     | `integration_bootstrap_runtime_emits_structured_marker` (within runtime regression suite) | |
| Regression   | ✅     | `regression_log_renderer_projects_default_correlation_and_reason_fields_when_missing`, `regression_log_renderer_text_projects_default_correlation_and_reason_fields_when_missing` | |
| Performance  | ✅     | `performance_structured_logging_rendering_stays_bounded` (included in runtime suite) | |

## Risks & Rollback
- Risk: log lines now always include fallback `correlation_id`/`reason_code` markers when not explicitly provided.
- Rollback: revert this PR commit to restore previous field projection behavior.

## Documentation Updates
- Updated `docs/ops/configuration.md` structured logging bootstrap contract section.

## Validation Checklist
- [x] `cargo fmt --check` — clean
- [ ] `cargo clippy -- -D warnings` — not run in this PR scope (localized logging/test change)
- [x] TDD Red/Green evidence included above
- [x] Full regression suite passing
- [x] Docs updated (or justified why not)

## Validation
- [x] Relevant local checks passed.
- [x] CI fast-gate checks expected to pass.

## CI Impact Declaration
- [x] No CI scope impact.
- [ ] CI scope impact present (explain below).

CI scope impact details (required when CI scope impact is present):
- Workflow(s) touched: None
- Expected runtime delta: None
- Expected runner-minute delta: None
- Rollback plan if CI cost/runtime regresses: Revert this PR.
