### PR TITLE
docs(specs): mark runtime parity issue specs implemented

### DIFF
--- a/specs/4329/spec.md
+++ b/specs/4329/spec.md
@@ -1,6 +1,6 @@
 # Spec — #4329 Task: Runtime Decomposition Checkpoints with Deterministic Parity Checker Governance
 
-Status: Reviewed
+Status: Implemented
 Priority: P1
 Parent: #4325
 Milestone: R27.31 Signal-safe daemon lifecycle, streaming observability, and runtime-decomposition governance

--- a/specs/4336/spec.md
+++ b/specs/4336/spec.md
@@ -1,6 +1,6 @@
 # Spec — #4336 Subtask: RED Tests for Runtime Extraction Parity Drift Across Module Boundaries
 
-Status: Reviewed
+Status: Implemented
 Priority: P1
 Parent: #4329
 Milestone: R27.31 Signal-safe daemon lifecycle, streaming observability, and runtime-decomposition governance

--- a/specs/4337/spec.md
+++ b/specs/4337/spec.md
@@ -1,6 +1,6 @@
 # Spec — #4337 Subtask: Runtime Module-Boundary Checker with CI Smoke Parity Governance
 
-Status: Reviewed
+Status: Implemented
 Priority: P1
 Parent: #4329
 Milestone: R27.31 Signal-safe daemon lifecycle, streaming observability, and runtime-decomposition governance


### PR DESCRIPTION
## Summary
- Marks `specs/4329/spec.md`, `specs/4336/spec.md`, and `specs/4337/spec.md` as `Status: Implemented` after merge of runtime module-boundary parity work.

## Linked Issues
- Refs #4329
- Refs #4336
- Refs #4337

## Validation
- [x] Relevant local checks passed.
- [x] CI fast-gate checks expected to pass.

## CI Impact Declaration
- [x] No CI scope impact.
- [ ] CI scope impact present (explain below).
