### PR TITLE
feat(runtime): enforce failover evidence convergence and deterministic promotion mapping

### DIFF
--- a/crates/kamn-core/tests/kolme_devnet_ops_docs.rs
+++ b/crates/kamn-core/tests/kolme_devnet_ops_docs.rs
@@ -26,6 +26,25 @@ fn plan_contains_failover_sync_drill_lane_policy() {
     assert!(PLAN.contains("run_failover_sync_drill_deep_lane.sh"));
     assert!(PLAN.contains("run_failover_sync_drill_suite.sh"));
     assert!(PLAN.contains("kamn.runtime.failover-sync-drill-suite-report.v1"));
+    assert!(PLAN.contains(
+        "failover_sync_drill_preflight_contract_lane_contract.sh check-policy --report-file /tmp/failover-sync-preflight-report.json --runbook-file docs/deploy/kolme_devnet_ops.md --expected-final-decision GO --ci-fast-gate PASS --output-json /tmp/failover-sync-preflight-policy.json"
+    ));
+    assert!(PLAN.contains(
+        "failover_sync_drill_preflight_contract_lane_contract.sh check-evidence-convergence --report-file /tmp/failover-sync-preflight-report.json --policy-file /tmp/failover-sync-preflight-policy.json --output-json /tmp/failover-sync-preflight-convergence.json"
+    ));
+    assert!(PLAN.contains(
+        "reason_taxonomy_version=kamn.runtime.failover-evidence-convergence-reason-taxonomy.v1"
+    ));
+    assert!(PLAN.contains(
+        "reason_codes_csv=failover_evidence_link_missing,failover_evidence_payload_tamper_detected,promotion_decision_reason_mapping_mismatch"
+    ));
+    assert!(PLAN.contains(
+        "promotion_decision_reason_taxonomy_version=kamn.runtime.failover-promotion-decision-reason-taxonomy.v1"
+    ));
+    assert!(PLAN.contains("failover_evidence_link_missing:report_file"));
+    assert!(PLAN.contains("promotion_decision_reason_mapping_mismatch"));
+    assert!(PLAN.contains("Regression: #4289"));
+    assert!(PLAN.contains("Regression: #4290"));
 }
 
 #[test]

--- a/crates/kamn-core/tests/release_gonogo_checklist_docs.rs
+++ b/crates/kamn-core/tests/release_gonogo_checklist_docs.rs
@@ -156,6 +156,9 @@ fn checklist_contains_failover_drift_taxonomy_runbook_parity_gate() {
     assert!(CHECKLIST.contains(
         "failover_sync_drill_preflight_contract_lane_contract.sh check-policy --report-file /tmp/failover-sync-preflight-report.json --runbook-file docs/deploy/kolme_devnet_ops.md --expected-final-decision GO --ci-fast-gate PASS --output-json /tmp/failover-sync-preflight-policy.json"
     ));
+    assert!(CHECKLIST.contains(
+        "failover_sync_drill_preflight_contract_lane_contract.sh check-evidence-convergence --report-file /tmp/failover-sync-preflight-report.json --policy-file /tmp/failover-sync-preflight-policy.json --output-json /tmp/failover-sync-preflight-convergence.json"
+    ));
     assert!(CHECKLIST.contains("drift_taxonomy_mapping_status=verified"));
     assert!(CHECKLIST.contains("runbook_marker_parity_status=verified"));
     assert!(CHECKLIST.contains(
@@ -166,8 +169,28 @@ fn checklist_contains_failover_drift_taxonomy_runbook_parity_gate() {
     ));
     assert!(CHECKLIST.contains("drift_taxonomy_mapping_drift_detected"));
     assert!(CHECKLIST.contains("runbook_marker_parity_mismatch"));
+    assert!(CHECKLIST.contains(
+        "promotion_decision_reason_taxonomy_version=kamn.runtime.failover-promotion-decision-reason-taxonomy.v1"
+    ));
+    assert!(CHECKLIST.contains(
+        "promotion_decision_reason_codes_csv=failover_readiness_progress_stalled,live_node_drift_marker_parity_mismatch,ci_local_promotion_budget_boundary_exceeded,drift_taxonomy_mapping_drift_detected,runbook_marker_parity_mismatch,ci_fast_gate_failed,failover_sync_drift_policy_expected_decision_mismatch,failover_sync_drift_policy_violation"
+    ));
+    assert!(CHECKLIST.contains("promotion_decision_reason_code=none|<reason>"));
+    assert!(CHECKLIST.contains("evidence_convergence_status=verified"));
+    assert!(CHECKLIST.contains("promotion_decision_reason_mapping_status=verified"));
+    assert!(CHECKLIST.contains(
+        "reason_taxonomy_version=kamn.runtime.failover-evidence-convergence-reason-taxonomy.v1"
+    ));
+    assert!(CHECKLIST.contains(
+        "reason_codes_csv=failover_evidence_link_missing,failover_evidence_payload_tamper_detected,promotion_decision_reason_mapping_mismatch"
+    ));
+    assert!(CHECKLIST.contains("failover_evidence_link_missing:report_file"));
+    assert!(CHECKLIST.contains("failover_evidence_payload_tamper_detected:<field>"));
+    assert!(CHECKLIST.contains("promotion_decision_reason_mapping_mismatch"));
     assert!(CHECKLIST.contains("Regression: #4287"));
     assert!(CHECKLIST.contains("Regression: #4288"));
+    assert!(CHECKLIST.contains("Regression: #4289"));
+    assert!(CHECKLIST.contains("Regression: #4290"));
 }
 
 #[test]

--- a/docs/foundation/release-gonogo-checklist.md
+++ b/docs/foundation/release-gonogo-checklist.md
@@ -740,19 +740,36 @@ Runtime failover and sync readiness requires deterministic lane routing, budget 
   - `bash scripts/runtime/run_failover_sync_drill_suite.sh --event-name schedule --output-json /tmp/failover-sync-suite-report.json`
 - Drift taxonomy/runbook parity checker:
   - `bash scripts/runtime/failover_sync_drill_preflight_contract_lane_contract.sh check-policy --report-file /tmp/failover-sync-preflight-report.json --runbook-file docs/deploy/kolme_devnet_ops.md --expected-final-decision GO --ci-fast-gate PASS --output-json /tmp/failover-sync-preflight-policy.json`
+- Evidence convergence checker:
+  - `bash scripts/runtime/failover_sync_drill_preflight_contract_lane_contract.sh check-evidence-convergence --report-file /tmp/failover-sync-preflight-report.json --policy-file /tmp/failover-sync-preflight-policy.json --output-json /tmp/failover-sync-preflight-convergence.json`
 - Deterministic taxonomy/runbook markers:
   - `drift_taxonomy_mapping_status=verified`
   - `runbook_marker_parity_status=verified`
   - `drift_taxonomy_runbook_reason_taxonomy_version=kamn.runtime.failover-drift-taxonomy-runbook-reason-taxonomy.v1`
   - `drift_taxonomy_runbook_reason_codes_csv=drift_taxonomy_mapping_drift_detected,runbook_marker_parity_mismatch`
+- Deterministic promotion reason mapping markers:
+  - `promotion_decision_reason_taxonomy_version=kamn.runtime.failover-promotion-decision-reason-taxonomy.v1`
+  - `promotion_decision_reason_codes_csv=failover_readiness_progress_stalled,live_node_drift_marker_parity_mismatch,ci_local_promotion_budget_boundary_exceeded,drift_taxonomy_mapping_drift_detected,runbook_marker_parity_mismatch,ci_fast_gate_failed,failover_sync_drift_policy_expected_decision_mismatch,failover_sync_drift_policy_violation`
+  - `promotion_decision_reason_code=none|<reason>`
+- Deterministic evidence convergence markers:
+  - `evidence_convergence_status=verified`
+  - `promotion_decision_reason_mapping_status=verified`
+  - `reason_taxonomy_version=kamn.runtime.failover-evidence-convergence-reason-taxonomy.v1`
+  - `reason_codes_csv=failover_evidence_link_missing,failover_evidence_payload_tamper_detected,promotion_decision_reason_mapping_mismatch`
 - Fail-closed taxonomy/runbook reasons:
   - `drift_taxonomy_mapping_drift_detected`
   - `runbook_marker_parity_mismatch`
+- Fail-closed convergence reasons:
+  - `failover_evidence_link_missing:report_file`
+  - `failover_evidence_payload_tamper_detected:<field>`
+  - `promotion_decision_reason_mapping_mismatch`
 - Regression policy:
   - preflight runtime budget overruns force lane failure (`Regression: #788`).
   - unscheduled deep-lane execution force-fails via scheduled-only cadence guard (`Regression: #788`).
   - taxonomy-marker drift or runbook marker divergence force `NO-GO` (`Regression: #4287`).
   - taxonomy reason-taxonomy/version mismatch and reason-codes mismatch force `NO-GO` (`Regression: #4288`).
+  - missing evidence-link markers force convergence checker `NO-GO` (`Regression: #4289`).
+  - tampered policy payload and promotion reason mapping drift force convergence checker `NO-GO` (`Regression: #4290`).
 
 ## Peer Adapter Reason Projection and Multi-Process Validation Hooks (Issue #4320)
 Peer adapter retry/timeout evidence must project deterministic reason classes and remain repeatable across process-isolated multi-process validation lanes.

--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -1743,6 +1743,26 @@ Operator checkpoints:
 - CI-oriented suite entrypoint:
   - `bash scripts/runtime/run_failover_sync_drill_suite.sh --event-name schedule --output-json /tmp/failover-sync-suite-report.json`
   - suite report schema: `kamn.runtime.failover-sync-drill-suite-report.v1`.
+- Drift taxonomy/runbook parity checker:
+  - `bash scripts/runtime/failover_sync_drill_preflight_contract_lane_contract.sh check-policy --report-file /tmp/failover-sync-preflight-report.json --runbook-file docs/deploy/kolme_devnet_ops.md --expected-final-decision GO --ci-fast-gate PASS --output-json /tmp/failover-sync-preflight-policy.json`
+- Evidence convergence checker:
+  - `bash scripts/runtime/failover_sync_drill_preflight_contract_lane_contract.sh check-evidence-convergence --report-file /tmp/failover-sync-preflight-report.json --policy-file /tmp/failover-sync-preflight-policy.json --output-json /tmp/failover-sync-preflight-convergence.json`
+- Deterministic failover evidence convergence markers:
+  - `evidence_convergence_status=verified`
+  - `promotion_decision_reason_mapping_status=verified`
+  - `reason_taxonomy_version=kamn.runtime.failover-evidence-convergence-reason-taxonomy.v1`
+  - `reason_codes_csv=failover_evidence_link_missing,failover_evidence_payload_tamper_detected,promotion_decision_reason_mapping_mismatch`
+- Deterministic promotion decision reason mapping markers:
+  - `promotion_decision_reason_taxonomy_version=kamn.runtime.failover-promotion-decision-reason-taxonomy.v1`
+  - `promotion_decision_reason_codes_csv=failover_readiness_progress_stalled,live_node_drift_marker_parity_mismatch,ci_local_promotion_budget_boundary_exceeded,drift_taxonomy_mapping_drift_detected,runbook_marker_parity_mismatch,ci_fast_gate_failed,failover_sync_drift_policy_expected_decision_mismatch,failover_sync_drift_policy_violation`
+  - `promotion_decision_reason_code=none|<reason>`
+- Deterministic fail-closed convergence reasons:
+  - `failover_evidence_link_missing:report_file`
+  - `failover_evidence_payload_tamper_detected:<field>`
+  - `promotion_decision_reason_mapping_mismatch`
+- Regression policy:
+  - missing evidence-link markers force convergence checker `NO-GO` (`Regression: #4289`).
+  - tampered policy payload and promotion reason mapping drift force convergence checker `NO-GO` (`Regression: #4290`).
 
 ## Regression Guard
 

--- a/scripts/runtime/failover_sync_drill_preflight_contract_lane_contract.sh
+++ b/scripts/runtime/failover_sync_drill_preflight_contract_lane_contract.sh
@@ -15,6 +15,10 @@ failover_readiness_reason_taxonomy_version="kamn.runtime.failover-readiness-reas
 failover_readiness_reason_codes_csv="failover_readiness_progress_stalled,live_node_drift_marker_parity_mismatch,ci_local_promotion_budget_boundary_exceeded"
 drift_taxonomy_runbook_reason_taxonomy_version="kamn.runtime.failover-drift-taxonomy-runbook-reason-taxonomy.v1"
 drift_taxonomy_runbook_reason_codes_csv="drift_taxonomy_mapping_drift_detected,runbook_marker_parity_mismatch"
+failover_promotion_decision_reason_taxonomy_version="kamn.runtime.failover-promotion-decision-reason-taxonomy.v1"
+failover_promotion_decision_reason_codes_csv="failover_readiness_progress_stalled,live_node_drift_marker_parity_mismatch,ci_local_promotion_budget_boundary_exceeded,drift_taxonomy_mapping_drift_detected,runbook_marker_parity_mismatch,ci_fast_gate_failed,failover_sync_drift_policy_expected_decision_mismatch,failover_sync_drift_policy_violation"
+failover_evidence_convergence_reason_taxonomy_version="kamn.runtime.failover-evidence-convergence-reason-taxonomy.v1"
+failover_evidence_convergence_reason_codes_csv="failover_evidence_link_missing,failover_evidence_payload_tamper_detected,promotion_decision_reason_mapping_mismatch"
 
 run_policy_check() {
   local report_file=""
@@ -102,6 +106,8 @@ USAGE
     "$failover_readiness_reason_codes_csv" \
     "$drift_taxonomy_runbook_reason_taxonomy_version" \
     "$drift_taxonomy_runbook_reason_codes_csv" \
+    "$failover_promotion_decision_reason_taxonomy_version" \
+    "$failover_promotion_decision_reason_codes_csv" \
     "$runbook_file" \
     <<'PY'
 import json
@@ -117,6 +123,8 @@ import sys
     expected_reason_codes_csv,
     expected_drift_taxonomy_reason_taxonomy_version,
     expected_drift_taxonomy_reason_codes_csv,
+    expected_promotion_reason_taxonomy_version,
+    expected_promotion_reason_codes_csv,
     runbook_file,
 ) = sys.argv[1:]
 
@@ -146,6 +154,24 @@ messages: list[str] = []
 def add_reason(condition: bool, code: str) -> None:
     if condition and code not in reason_codes:
         reason_codes.append(code)
+
+
+def resolve_promotion_reason_code(codes: list[str], pass_status: bool) -> str:
+    if pass_status:
+        return "none"
+    preferred_codes = [
+        "failover_readiness_progress_stalled",
+        "live_node_drift_marker_parity_mismatch",
+        "ci_local_promotion_budget_boundary_exceeded",
+        "drift_taxonomy_mapping_drift_detected",
+        "runbook_marker_parity_mismatch",
+        "ci_fast_gate_failed",
+        "failover_sync_drift_policy_expected_decision_mismatch",
+    ]
+    for code in preferred_codes:
+        if code in codes:
+            return code
+    return "failover_sync_drift_policy_violation"
 
 
 missing_fields = [field for field in required_fields if field not in report]
@@ -238,6 +264,7 @@ final_decision = "GO" if status_pass else "NO-GO"
 policy_status = "verified" if status_pass else "failed"
 status_marker = "ok" if status_pass else "error"
 resolved_reason_codes = ["none"] if status_pass else reason_codes
+promotion_decision_reason_code = resolve_promotion_reason_code(reason_codes, status_pass)
 
 policy_payload = {
     "schema_version": "kamn.runtime.failover-sync-drill-preflight-policy-report.v1",
@@ -251,6 +278,10 @@ policy_payload = {
     "drift_taxonomy_reason_taxonomy_version": expected_drift_taxonomy_reason_taxonomy_version,
     "drift_taxonomy_reason_codes_csv": expected_drift_taxonomy_reason_codes_csv,
     "reason_codes": resolved_reason_codes,
+    "promotion_decision_reason_mapping_status": "verified",
+    "promotion_decision_reason_taxonomy_version": expected_promotion_reason_taxonomy_version,
+    "promotion_decision_reason_codes_csv": expected_promotion_reason_codes_csv,
+    "promotion_decision_reason_code": promotion_decision_reason_code,
     "report_file": str(report_path),
     "runbook_file": str(runbook_path),
 }
@@ -276,7 +307,280 @@ print(
     "reason_codes_value="
     + ("none" if status_pass else ",".join(reason_codes))
 )
+print("promotion_decision_reason_mapping_status=verified")
+print(
+    "promotion_decision_reason_taxonomy_version="
+    + expected_promotion_reason_taxonomy_version
+)
+print(
+    "promotion_decision_reason_codes_csv="
+    + expected_promotion_reason_codes_csv
+)
+print("promotion_decision_reason_code=" + promotion_decision_reason_code)
 print(f"report_file={output_json}")
+
+for message in messages:
+    print(message, file=sys.stderr)
+
+if not status_pass:
+    print(",".join(reason_codes), file=sys.stderr)
+    raise SystemExit(1)
+PY
+}
+
+run_evidence_convergence_check() {
+  local report_file=""
+  local policy_file=""
+  local convergence_output_json="$ROOT_DIR/failover-sync-preflight-convergence-report.json"
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --report-file)
+        report_file="${2:-}"
+        shift 2
+        ;;
+      --policy-file)
+        policy_file="${2:-}"
+        shift 2
+        ;;
+      --output-json)
+        convergence_output_json="${2:-}"
+        shift 2
+        ;;
+      --help|-h)
+        cat <<'USAGE'
+Usage:
+  bash scripts/runtime/failover_sync_drill_preflight_contract_lane_contract.sh check-evidence-convergence \
+    --report-file <path> \
+    --policy-file <path> \
+    [--output-json <path>]
+USAGE
+        exit 0
+        ;;
+      *)
+        echo "unknown argument: $1" >&2
+        exit 1
+        ;;
+    esac
+  done
+
+  if [ -z "$report_file" ]; then
+    echo "--report-file is required in check-evidence-convergence mode" >&2
+    exit 1
+  fi
+  if [ -z "$policy_file" ]; then
+    echo "--policy-file is required in check-evidence-convergence mode" >&2
+    exit 1
+  fi
+  if [ ! -f "$report_file" ]; then
+    echo "report file not found: $report_file" >&2
+    exit 1
+  fi
+  if [ ! -f "$policy_file" ]; then
+    echo "policy file not found: $policy_file" >&2
+    exit 1
+  fi
+
+  mkdir -p "$(dirname "$convergence_output_json")"
+
+  python3 - \
+    "$report_file" \
+    "$policy_file" \
+    "$convergence_output_json" \
+    "$failover_readiness_reason_taxonomy_version" \
+    "$failover_readiness_reason_codes_csv" \
+    "$failover_promotion_decision_reason_taxonomy_version" \
+    "$failover_promotion_decision_reason_codes_csv" \
+    "$failover_evidence_convergence_reason_taxonomy_version" \
+    "$failover_evidence_convergence_reason_codes_csv" \
+    <<'PY'
+import json
+import pathlib
+import sys
+
+(
+    report_file,
+    policy_file,
+    output_json,
+    expected_reason_taxonomy_version,
+    expected_reason_codes_csv,
+    expected_promotion_reason_taxonomy_version,
+    expected_promotion_reason_codes_csv,
+    expected_convergence_reason_taxonomy_version,
+    expected_convergence_reason_codes_csv,
+) = sys.argv[1:]
+
+report_path = pathlib.Path(report_file)
+policy_path = pathlib.Path(policy_file)
+report = json.loads(report_path.read_text(encoding="utf-8"))
+policy = json.loads(policy_path.read_text(encoding="utf-8"))
+
+reason_codes: list[str] = []
+messages: list[str] = []
+
+
+def add_reason(condition: bool, code: str) -> None:
+    if condition and code not in reason_codes:
+        reason_codes.append(code)
+
+
+def resolve_promotion_reason_code(codes: list[str]) -> str:
+    if codes == ["none"]:
+        return "none"
+    preferred_codes = [
+        "failover_readiness_progress_stalled",
+        "live_node_drift_marker_parity_mismatch",
+        "ci_local_promotion_budget_boundary_exceeded",
+        "drift_taxonomy_mapping_drift_detected",
+        "runbook_marker_parity_mismatch",
+        "ci_fast_gate_failed",
+        "failover_sync_drift_policy_expected_decision_mismatch",
+    ]
+    for code in preferred_codes:
+        if code in codes:
+            return code
+    return "failover_sync_drift_policy_violation"
+
+
+add_reason(
+    report.get("schema_version") != "kamn.runtime.failover-sync-drill-report.v1",
+    "failover_evidence_payload_tamper_detected:report_schema_version",
+)
+add_reason(
+    policy.get("schema_version")
+    != "kamn.runtime.failover-sync-drill-preflight-policy-report.v1",
+    "failover_evidence_payload_tamper_detected:policy_schema_version",
+)
+
+required_policy_fields = [
+    "status",
+    "final_decision",
+    "failover_sync_drift_policy_status",
+    "reason_taxonomy_version",
+    "reason_codes_csv",
+    "reason_codes",
+    "report_file",
+    "promotion_decision_reason_mapping_status",
+    "promotion_decision_reason_taxonomy_version",
+    "promotion_decision_reason_codes_csv",
+    "promotion_decision_reason_code",
+]
+for field in required_policy_fields:
+    if field not in policy:
+        add_reason(True, f"failover_evidence_link_missing:{field}")
+        messages.append(f"missing required policy field: {field}")
+
+expected_report_file = str(report_path.resolve())
+policy_report_file = str(pathlib.Path(policy.get("report_file", "")).resolve())
+add_reason(
+    policy_report_file != expected_report_file,
+    "failover_evidence_link_missing:report_file",
+)
+
+add_reason(
+    policy.get("reason_taxonomy_version") != expected_reason_taxonomy_version,
+    "failover_evidence_payload_tamper_detected:reason_taxonomy_version",
+)
+add_reason(
+    policy.get("reason_codes_csv") != expected_reason_codes_csv,
+    "failover_evidence_payload_tamper_detected:reason_codes_csv",
+)
+add_reason(
+    policy.get("promotion_decision_reason_mapping_status") != "verified",
+    "promotion_decision_reason_mapping_mismatch",
+)
+add_reason(
+    policy.get("promotion_decision_reason_taxonomy_version")
+    != expected_promotion_reason_taxonomy_version,
+    "promotion_decision_reason_mapping_mismatch",
+)
+add_reason(
+    policy.get("promotion_decision_reason_codes_csv")
+    != expected_promotion_reason_codes_csv,
+    "promotion_decision_reason_mapping_mismatch",
+)
+
+raw_reason_codes = policy.get("reason_codes")
+if not isinstance(raw_reason_codes, list):
+    add_reason(True, "failover_evidence_payload_tamper_detected:reason_codes_type")
+    normalized_reason_codes = []
+elif len(raw_reason_codes) == 0:
+    add_reason(True, "failover_evidence_payload_tamper_detected:reason_codes_empty")
+    normalized_reason_codes = []
+elif any(not isinstance(code, str) or not code for code in raw_reason_codes):
+    add_reason(True, "failover_evidence_payload_tamper_detected:reason_codes_invalid")
+    normalized_reason_codes = []
+elif "none" in raw_reason_codes and raw_reason_codes != ["none"]:
+    add_reason(
+        True,
+        "failover_evidence_payload_tamper_detected:reason_codes_none_mixed_with_failures",
+    )
+    normalized_reason_codes = []
+else:
+    normalized_reason_codes = raw_reason_codes
+
+if normalized_reason_codes:
+    expected_status = "pass" if normalized_reason_codes == ["none"] else "fail"
+    expected_final_decision = "GO" if normalized_reason_codes == ["none"] else "NO-GO"
+    expected_promotion_reason_code = resolve_promotion_reason_code(normalized_reason_codes)
+else:
+    expected_status = "fail"
+    expected_final_decision = "NO-GO"
+    expected_promotion_reason_code = "failover_sync_drift_policy_violation"
+
+add_reason(
+    policy.get("status") != expected_status,
+    "failover_evidence_payload_tamper_detected:status_decision_mismatch",
+)
+add_reason(
+    policy.get("final_decision") != expected_final_decision,
+    "promotion_decision_reason_mapping_mismatch",
+)
+add_reason(
+    policy.get("promotion_decision_reason_code") != expected_promotion_reason_code,
+    "promotion_decision_reason_mapping_mismatch",
+)
+
+report_reason_code = report.get("reason_code")
+if report_reason_code not in {None, "none"}:
+    add_reason(
+        report_reason_code not in (normalized_reason_codes or []),
+        "failover_evidence_payload_tamper_detected:report_reason_not_projected",
+    )
+
+status_pass = len(reason_codes) == 0
+resolved_reason_codes = ["none"] if status_pass else reason_codes
+status = "pass" if status_pass else "fail"
+final_decision = "GO" if status_pass else "NO-GO"
+
+convergence_payload = {
+    "schema_version": "kamn.runtime.failover-sync-drill-preflight-convergence-report.v1",
+    "status": status,
+    "final_decision": final_decision,
+    "evidence_convergence_status": "verified" if status_pass else "failed",
+    "promotion_decision_reason_mapping_status": "verified" if status_pass else "failed",
+    "reason_taxonomy_version": expected_convergence_reason_taxonomy_version,
+    "reason_codes_csv": expected_convergence_reason_codes_csv,
+    "reason_codes": resolved_reason_codes,
+    "report_file": str(report_path.resolve()),
+    "policy_file": str(policy_path.resolve()),
+}
+pathlib.Path(output_json).write_text(
+    json.dumps(convergence_payload, sort_keys=True, indent=2) + "\n",
+    encoding="utf-8",
+)
+
+print("status=" + ("ok" if status_pass else "error"))
+print("final_decision=" + final_decision)
+print("evidence_convergence_status=" + ("verified" if status_pass else "failed"))
+print(
+    "promotion_decision_reason_mapping_status="
+    + ("verified" if status_pass else "failed")
+)
+print("reason_taxonomy_version=" + expected_convergence_reason_taxonomy_version)
+print("reason_codes_csv=" + expected_convergence_reason_codes_csv)
+print("reason_codes_value=" + ("none" if status_pass else ",".join(reason_codes)))
+print("report_file=" + output_json)
 
 for message in messages:
     print(message, file=sys.stderr)
@@ -290,6 +594,12 @@ PY
 if [ "${1:-}" = "check-policy" ]; then
   shift
   run_policy_check "$@"
+  exit 0
+fi
+
+if [ "${1:-}" = "check-evidence-convergence" ]; then
+  shift
+  run_evidence_convergence_check "$@"
   exit 0
 fi
 

--- a/scripts/runtime/test_run_failover_sync_drill_preflight_contract_lane.sh
+++ b/scripts/runtime/test_run_failover_sync_drill_preflight_contract_lane.sh
@@ -94,6 +94,22 @@ if ! printf '%s\n' "$policy_output" | grep -q '^drift_taxonomy_reason_codes_csv=
   echo "expected deterministic failover/sync preflight drift taxonomy reason codes marker" >&2
   exit 1
 fi
+if ! printf '%s\n' "$policy_output" | grep -q '^promotion_decision_reason_mapping_status=verified$'; then
+  echo "expected failover/sync preflight promotion decision reason mapping status marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$policy_output" | grep -q '^promotion_decision_reason_taxonomy_version=kamn.runtime.failover-promotion-decision-reason-taxonomy.v1$'; then
+  echo "expected deterministic failover/sync preflight promotion decision reason taxonomy marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$policy_output" | grep -q '^promotion_decision_reason_codes_csv=failover_readiness_progress_stalled,live_node_drift_marker_parity_mismatch,ci_local_promotion_budget_boundary_exceeded,drift_taxonomy_mapping_drift_detected,runbook_marker_parity_mismatch,ci_fast_gate_failed,failover_sync_drift_policy_expected_decision_mismatch,failover_sync_drift_policy_violation$'; then
+  echo "expected deterministic failover/sync preflight promotion decision reason codes marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$policy_output" | grep -q '^promotion_decision_reason_code=none$'; then
+  echo "expected deterministic failover/sync preflight promotion decision reason code marker" >&2
+  exit 1
+fi
 
 python3 - "$policy_report" <<'PY'
 import json
@@ -119,7 +135,198 @@ if payload.get("drift_taxonomy_reason_taxonomy_version") != "kamn.runtime.failov
     raise SystemExit("expected deterministic failover/sync preflight drift taxonomy reason taxonomy marker")
 if payload.get("drift_taxonomy_reason_codes_csv") != "drift_taxonomy_mapping_drift_detected,runbook_marker_parity_mismatch":
     raise SystemExit("expected deterministic failover/sync preflight drift taxonomy reason codes marker")
+if payload.get("promotion_decision_reason_mapping_status") != "verified":
+    raise SystemExit("expected failover/sync preflight promotion decision reason mapping status marker")
+if payload.get("promotion_decision_reason_taxonomy_version") != "kamn.runtime.failover-promotion-decision-reason-taxonomy.v1":
+    raise SystemExit("expected deterministic failover/sync preflight promotion decision reason taxonomy marker")
+if payload.get("promotion_decision_reason_codes_csv") != "failover_readiness_progress_stalled,live_node_drift_marker_parity_mismatch,ci_local_promotion_budget_boundary_exceeded,drift_taxonomy_mapping_drift_detected,runbook_marker_parity_mismatch,ci_fast_gate_failed,failover_sync_drift_policy_expected_decision_mismatch,failover_sync_drift_policy_violation":
+    raise SystemExit("expected deterministic failover/sync preflight promotion decision reason codes marker")
+if payload.get("promotion_decision_reason_code") != "none":
+    raise SystemExit("expected deterministic failover/sync preflight promotion decision reason code marker")
 PY
+
+convergence_report="$TMP_DIR/failover-sync-preflight-convergence.json"
+convergence_output="$(
+  bash "$SHARED_CONTRACT" check-evidence-convergence \
+    --report-file "$TMP_REPORT" \
+    --policy-file "$policy_report" \
+    --output-json "$convergence_report"
+)"
+if ! printf '%s\n' "$convergence_output" | grep -q '^status=ok$'; then
+  echo "expected failover/sync preflight convergence checker status=ok marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$convergence_output" | grep -q '^final_decision=GO$'; then
+  echo "expected failover/sync preflight convergence checker final_decision=GO marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$convergence_output" | grep -q '^evidence_convergence_status=verified$'; then
+  echo "expected failover/sync preflight convergence checker evidence status marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$convergence_output" | grep -q '^promotion_decision_reason_mapping_status=verified$'; then
+  echo "expected failover/sync preflight convergence checker promotion mapping status marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$convergence_output" | grep -q '^reason_taxonomy_version=kamn.runtime.failover-evidence-convergence-reason-taxonomy.v1$'; then
+  echo "expected deterministic failover/sync preflight convergence reason taxonomy marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$convergence_output" | grep -q '^reason_codes_csv=failover_evidence_link_missing,failover_evidence_payload_tamper_detected,promotion_decision_reason_mapping_mismatch$'; then
+  echo "expected deterministic failover/sync preflight convergence reason codes marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$convergence_output" | grep -q '^reason_codes_value=none$'; then
+  echo "expected failover/sync preflight convergence checker reason_codes_value=none marker" >&2
+  exit 1
+fi
+
+python3 - "$convergence_report" <<'PY'
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+if payload.get("schema_version") != "kamn.runtime.failover-sync-drill-preflight-convergence-report.v1":
+    raise SystemExit("unexpected failover/sync preflight convergence report schema")
+if payload.get("status") != "pass":
+    raise SystemExit("expected failover/sync preflight convergence report status=pass")
+if payload.get("final_decision") != "GO":
+    raise SystemExit("expected failover/sync preflight convergence report final_decision=GO")
+if payload.get("evidence_convergence_status") != "verified":
+    raise SystemExit("expected failover/sync preflight convergence evidence status marker")
+if payload.get("promotion_decision_reason_mapping_status") != "verified":
+    raise SystemExit("expected failover/sync preflight convergence promotion mapping status marker")
+if payload.get("reason_taxonomy_version") != "kamn.runtime.failover-evidence-convergence-reason-taxonomy.v1":
+    raise SystemExit("expected deterministic failover/sync preflight convergence reason taxonomy marker")
+if payload.get("reason_codes_csv") != "failover_evidence_link_missing,failover_evidence_payload_tamper_detected,promotion_decision_reason_mapping_mismatch":
+    raise SystemExit("expected deterministic failover/sync preflight convergence reason codes marker")
+if payload.get("reason_codes") != ["none"]:
+    raise SystemExit("expected failover/sync preflight convergence success reason code ['none']")
+PY
+
+missing_link_policy="$TMP_DIR/failover-sync-preflight-policy.missing-link.json"
+cp "$policy_report" "$missing_link_policy"
+python3 - "$missing_link_policy" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+payload = json.loads(path.read_text(encoding="utf-8"))
+payload.pop("report_file", None)
+path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+set +e
+missing_link_output_first="$(
+  bash "$SHARED_CONTRACT" check-evidence-convergence \
+    --report-file "$TMP_REPORT" \
+    --policy-file "$missing_link_policy" \
+    --output-json "$TMP_DIR/failover-sync-preflight-convergence.missing-link.first.json" 2>&1
+)"
+missing_link_code_first=$?
+missing_link_output_second="$(
+  bash "$SHARED_CONTRACT" check-evidence-convergence \
+    --report-file "$TMP_REPORT" \
+    --policy-file "$missing_link_policy" \
+    --output-json "$TMP_DIR/failover-sync-preflight-convergence.missing-link.second.json" 2>&1
+)"
+missing_link_code_second=$?
+set -e
+if [ "$missing_link_code_first" -eq 0 ] || [ "$missing_link_code_second" -eq 0 ]; then
+  echo "expected failover/sync preflight convergence checker to reject missing evidence link marker deterministically" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$missing_link_output_first" | grep -q 'failover_evidence_link_missing:report_file'; then
+  echo "expected deterministic failover/sync preflight missing evidence link reason output on first run" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$missing_link_output_second" | grep -q 'failover_evidence_link_missing:report_file'; then
+  echo "expected deterministic failover/sync preflight missing evidence link reason output on second run" >&2
+  exit 1
+fi
+
+python3 - \
+  "$TMP_DIR/failover-sync-preflight-convergence.missing-link.first.json" \
+  "$TMP_DIR/failover-sync-preflight-convergence.missing-link.second.json" <<'PY'
+import json
+import pathlib
+import sys
+
+first_payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+second_payload = json.loads(pathlib.Path(sys.argv[2]).read_text(encoding="utf-8"))
+first_reasons = first_payload.get("reason_codes")
+second_reasons = second_payload.get("reason_codes")
+if not first_reasons:
+    raise SystemExit("expected failover/sync preflight missing-link convergence report to include non-empty reason codes")
+if first_reasons != second_reasons:
+    raise SystemExit("expected deterministic failover/sync preflight convergence reason-code ordering across repeated missing-link checks")
+if "failover_evidence_link_missing:report_file" not in first_reasons:
+    raise SystemExit("expected failover_evidence_link_missing:report_file reason code in failover/sync preflight missing-link convergence reports")
+PY
+
+tampered_mapping_policy="$TMP_DIR/failover-sync-preflight-policy.tampered-mapping.json"
+cp "$policy_report" "$tampered_mapping_policy"
+python3 - "$tampered_mapping_policy" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+payload = json.loads(path.read_text(encoding="utf-8"))
+payload["promotion_decision_reason_code"] = "live_node_drift_marker_parity_mismatch"
+path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+set +e
+tampered_mapping_output="$(
+  bash "$SHARED_CONTRACT" check-evidence-convergence \
+    --report-file "$TMP_REPORT" \
+    --policy-file "$tampered_mapping_policy" \
+    --output-json "$TMP_DIR/failover-sync-preflight-convergence.tampered-mapping.json" 2>&1
+)"
+tampered_mapping_code=$?
+set -e
+if [ "$tampered_mapping_code" -eq 0 ]; then
+  echo "expected failover/sync preflight convergence checker to reject tampered promotion decision reason mapping" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$tampered_mapping_output" | grep -q 'promotion_decision_reason_mapping_mismatch'; then
+  echo "expected deterministic failover/sync preflight promotion reason mapping mismatch marker" >&2
+  exit 1
+fi
+
+tampered_payload_policy="$TMP_DIR/failover-sync-preflight-policy.tampered-payload.json"
+cp "$policy_report" "$tampered_payload_policy"
+python3 - "$tampered_payload_policy" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+payload = json.loads(path.read_text(encoding="utf-8"))
+payload["reason_codes"] = "none"
+path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+set +e
+tampered_payload_output="$(
+  bash "$SHARED_CONTRACT" check-evidence-convergence \
+    --report-file "$TMP_REPORT" \
+    --policy-file "$tampered_payload_policy" \
+    --output-json "$TMP_DIR/failover-sync-preflight-convergence.tampered-payload.json" 2>&1
+)"
+tampered_payload_code=$?
+set -e
+if [ "$tampered_payload_code" -eq 0 ]; then
+  echo "expected failover/sync preflight convergence checker to reject tampered convergence payload" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$tampered_payload_output" | grep -q 'failover_evidence_payload_tamper_detected'; then
+  echo "expected deterministic failover/sync preflight convergence payload tamper marker" >&2
+  exit 1
+fi
 
 missing_marker_report="$TMP_DIR/failover-sync-preflight-summary.missing-marker.json"
 cp "$TMP_REPORT" "$missing_marker_report"

--- a/specs/4283/plan.md
+++ b/specs/4283/plan.md
@@ -1,0 +1,45 @@
+# Plan — #4283
+
+Status: Reviewed
+
+## Approach
+
+- Extend `scripts/runtime/failover_sync_drill_preflight_contract_lane_contract.sh` with a dedicated convergence-check mode that compares:
+  - preflight drift summary report
+  - preflight policy report
+  - promotion decision reason mapping markers
+- Add RED tests first in `scripts/runtime/test_run_failover_sync_drill_preflight_contract_lane.sh` for:
+  - missing evidence-link marker rejection
+  - tampered payload rejection
+  - deterministic repeated mismatch ordering
+- Emit deterministic promotion decision reason mapping fields in policy output.
+- Update docs and docs-contract tests:
+  - `docs/planning/kolme-devnet-ops.md`
+  - `docs/foundation/release-gonogo-checklist.md`
+  - `crates/kamn-core/tests/kolme_devnet_ops_docs.rs`
+  - `crates/kamn-core/tests/release_gonogo_checklist_docs.rs`
+
+## Affected Areas
+
+- `scripts/runtime/failover_sync_drill_preflight_contract_lane_contract.sh`
+- `scripts/runtime/test_run_failover_sync_drill_preflight_contract_lane.sh`
+- `scripts/runtime/test_run_failover_sync_drill_suite.sh`
+- `docs/planning/kolme-devnet-ops.md`
+- `docs/foundation/release-gonogo-checklist.md`
+- `crates/kamn-core/tests/kolme_devnet_ops_docs.rs`
+- `crates/kamn-core/tests/release_gonogo_checklist_docs.rs`
+
+## Risks and Mitigations
+
+- Risk: checker and docs marker drift.
+  - Mitigation: docs-contract assertions for command and marker strings.
+- Risk: nondeterministic failure reason ordering.
+  - Mitigation: centralized deterministic reason insertion order and repeated-run regression assertions.
+
+## Interfaces and Contracts
+
+- New checker mode:
+  - `check-evidence-convergence --report-file <path> --policy-file <path> [--output-json <path>]`
+- Policy output contract extension:
+  - promotion decision reason taxonomy markers
+  - deterministic promotion decision reason code mapping

--- a/specs/4283/spec.md
+++ b/specs/4283/spec.md
@@ -1,0 +1,47 @@
+# Spec — #4283 Task: Build Failover Evidence Convergence Checker
+
+Status: Implemented
+Priority: P1
+Parent: #4280
+Milestone: R27.28 Live-node drift detection and failover-readiness governance
+
+## Problem Statement
+
+Failover-readiness governance currently validates preflight report markers and policy checks, but it does not enforce deterministic evidence convergence between drift-lane outputs and promotion decision artifacts.
+
+## Scope
+
+In scope:
+- Deterministic convergence checker for failover preflight summary and promotion-policy artifacts.
+- Deterministic fail-closed reason mapping when artifact linkage or payload convergence drifts.
+- Regression tests for missing artifact links and tamper scenarios.
+- Docs and docs-contract updates for convergence markers.
+
+Out of scope:
+- Runtime failover orchestration redesign.
+- External promotion orchestrator changes.
+
+## Acceptance Criteria
+
+AC-1: Checker validates required evidence links across failover drift summary and promotion-policy artifacts.
+
+AC-2: Missing or tampered evidence fails closed with deterministic reason markers.
+
+AC-3: Promotion decision reason mapping remains deterministic across repeated runs.
+
+AC-4: Failover ops and release checklist docs include convergence marker contracts and commands.
+
+## Conformance Cases
+
+- C-01 (AC-1, Functional): valid preflight report and policy artifact pass convergence check.
+- C-02 (AC-2, Regression): missing policy artifact linkage marker fails with deterministic link-missing reason.
+- C-03 (AC-2, Regression): tampered policy payload fails with deterministic payload-tamper reason.
+- C-04 (AC-3, Regression): tampered reason mapping fails with deterministic reason-mapping mismatch marker.
+- C-05 (AC-3, Regression): repeated convergence checks over identical drift fixtures preserve deterministic reason ordering.
+- C-06 (AC-4, Conformance): docs-contract tests enforce convergence command and marker references.
+
+## Success Signals
+
+- Convergence checker fails closed on linkage/payload drift.
+- Promotion reason mapping remains deterministic and test-covered.
+- Docs and checker markers stay synchronized via contract tests.

--- a/specs/4283/tasks.md
+++ b/specs/4283/tasks.md
@@ -1,0 +1,15 @@
+# Tasks — #4283
+
+Status: Implemented
+
+T1 (Tests first)
+- Add RED convergence and tamper tests for evidence link completeness and deterministic mismatch ordering (`#4289`).
+
+T2
+- Implement convergence verifier and deterministic promotion decision reason mapping (`#4290`).
+
+T3
+- Update failover docs and docs-contract tests for convergence markers.
+
+T4
+- Run targeted validations, open PR, merge, and close issue chain.

--- a/specs/4289/plan.md
+++ b/specs/4289/plan.md
@@ -1,0 +1,19 @@
+# Plan — #4289
+
+Status: Reviewed
+
+## Approach
+
+- Extend failover preflight contract-lane tests with convergence-specific RED fixtures:
+  - missing evidence-link marker fixture
+  - tampered promotion reason mapping fixture
+  - repeated mismatch-order fixture
+
+## Affected Areas
+
+- `scripts/runtime/test_run_failover_sync_drill_preflight_contract_lane.sh`
+
+## Risks and Mitigations
+
+- Risk: false-positive test failures from unstable output.
+  - Mitigation: assert deterministic reason ordering across repeated checks.

--- a/specs/4289/spec.md
+++ b/specs/4289/spec.md
@@ -1,0 +1,39 @@
+# Spec — #4289 Subtask: RED Tests for Failover Evidence Convergence
+
+Status: Implemented
+Priority: P1
+Parent: #4283
+Milestone: R27.28 Live-node drift detection and failover-readiness governance
+
+## Problem Statement
+
+Failover convergence behavior needs explicit failing tests for missing/tampered artifacts before implementation hardens the checker.
+
+## Scope
+
+In scope:
+- RED tests for missing evidence links.
+- RED tests for tampered convergence payloads.
+- Deterministic repeated mismatch-order tests.
+
+Out of scope:
+- Production checker logic changes beyond what tests require.
+
+## Acceptance Criteria
+
+AC-1: Tests fail when required evidence-link markers are absent.
+
+AC-2: Tests fail when convergence payloads are tampered.
+
+AC-3: Repeated mismatch checks preserve deterministic reason ordering.
+
+## Conformance Cases
+
+- C-01 (AC-1, Regression): missing `report_file` linkage fails closed.
+- C-02 (AC-2, Regression): tampered reason payload fails closed.
+- C-03 (AC-3, Regression): repeated tamper checks emit stable reason ordering.
+
+## Success Signals
+
+- RED tests meaningfully fail prior to implementation.
+- Regression suite captures artifact-link and tamper drift.

--- a/specs/4289/tasks.md
+++ b/specs/4289/tasks.md
@@ -1,0 +1,12 @@
+# Tasks — #4289
+
+Status: Implemented
+
+T1
+- Add missing-link RED test fixture for convergence checker.
+
+T2
+- Add tamper RED test fixture for convergence payload and reason mapping.
+
+T3
+- Add deterministic repeated mismatch-order regression assertions.

--- a/specs/4290/plan.md
+++ b/specs/4290/plan.md
@@ -1,0 +1,22 @@
+# Plan — #4290
+
+Status: Reviewed
+
+## Approach
+
+- Add convergence-check mode to the failover preflight shared contract script.
+- Extend policy output with deterministic promotion reason mapping markers.
+- Emit convergence checker report markers for success/failure classification.
+- Keep reason ordering deterministic by fixed insertion order and normalized payload checks.
+
+## Affected Areas
+
+- `scripts/runtime/failover_sync_drill_preflight_contract_lane_contract.sh`
+- `scripts/runtime/test_run_failover_sync_drill_preflight_contract_lane.sh`
+
+## Risks and Mitigations
+
+- Risk: accidental nondeterminism in reason ordering.
+  - Mitigation: append-only, ordered reason checks and repeated-run test assertions.
+- Risk: marker drift across docs.
+  - Mitigation: docs-contract tests updated in same PR.

--- a/specs/4290/spec.md
+++ b/specs/4290/spec.md
@@ -1,0 +1,41 @@
+# Spec — #4290 Subtask: Implement Convergence Verifier and Deterministic Promotion Reason Mapping
+
+Status: Implemented
+Priority: P1
+Parent: #4283
+Milestone: R27.28 Live-node drift detection and failover-readiness governance
+
+## Problem Statement
+
+Failover promotion decisions need deterministic, auditable reason mapping tied to converged drift evidence artifacts.
+
+## Scope
+
+In scope:
+- Convergence verifier implementation for drift summary + policy artifacts.
+- Deterministic promotion decision reason mapping fields in policy output.
+- Fail-closed deterministic reason codes for link mismatch and payload drift.
+
+Out of scope:
+- Promotion orchestration engine redesign.
+
+## Acceptance Criteria
+
+AC-1: Verifier rejects invalid convergence artifacts deterministically.
+
+AC-2: Promotion reason mapping is deterministic for both GO and NO-GO outcomes.
+
+AC-3: Integration tests validate convergence-to-promotion decision linkage.
+
+## Conformance Cases
+
+- C-01 (AC-1, Functional): valid summary/policy artifacts verify convergence.
+- C-02 (AC-1, Regression): missing linkage marker fails with deterministic reason.
+- C-03 (AC-1, Regression): tampered payload fails with deterministic reason.
+- C-04 (AC-2, Regression): promotion reason mapping mismatch fails with deterministic marker.
+- C-05 (AC-3, Integration): suite contracts retain preflight pass markers with convergence signals.
+
+## Success Signals
+
+- Deterministic convergence verification and reason mapping are emitted in policy/checker outputs.
+- Integration and regression tests pass with stable reason ordering.

--- a/specs/4290/tasks.md
+++ b/specs/4290/tasks.md
@@ -1,0 +1,15 @@
+# Tasks — #4290
+
+Status: Implemented
+
+T1
+- Implement convergence checker mode for report/policy artifact linkage.
+
+T2
+- Add deterministic promotion decision reason mapping markers to policy output.
+
+T3
+- Ensure fail-closed deterministic reason taxonomy for missing links and tamper drift.
+
+T4
+- Validate with focused runtime script tests and regression assertions.


### PR DESCRIPTION
## Summary
Implements the `#4283` task chain by adding a failover evidence convergence checker and deterministic promotion-decision reason mapping to the preflight shared contract module. Adds RED/REGRESSION coverage for missing-link and tamper scenarios, then updates failover docs and docs-contract tests to keep marker contracts synchronized. All targeted runtime and docs tests are green.

## Links
- Milestone: R27.28 Live-node drift detection and failover-readiness governance
- Closes #4283
- Closes #4289
- Closes #4290
- Spec: `specs/4283/spec.md`
- Plan: `specs/4283/plan.md`
- Tasks: `specs/4283/tasks.md`
- Spec: `specs/4289/spec.md`
- Plan: `specs/4289/plan.md`
- Tasks: `specs/4289/tasks.md`
- Spec: `specs/4290/spec.md`
- Plan: `specs/4290/plan.md`
- Tasks: `specs/4290/tasks.md`

## Spec Verification (AC → tests)
| AC | ✅/❌ | Test(s) |
|---|---|---|
| AC-1: convergence checker validates evidence links across drift summary and policy artifacts | ✅ | `scripts/runtime/test_run_failover_sync_drill_preflight_contract_lane.sh` (success path + `check-evidence-convergence`) |
| AC-2: missing/tampered evidence fails closed deterministically | ✅ | `scripts/runtime/test_run_failover_sync_drill_preflight_contract_lane.sh` (missing `report_file`, tampered reason payload, tampered promotion mapping) |
| AC-3: promotion decision reason mapping is deterministic | ✅ | `scripts/runtime/test_run_failover_sync_drill_preflight_contract_lane.sh` (promotion mapping markers + repeated mismatch-order checks) |
| AC-4: docs/checker marker contracts are synchronized | ✅ | `cargo test -p kamn-core --test kolme_devnet_ops_docs`; `cargo test -p kamn-core --test release_gonogo_checklist_docs` |

## TDD Evidence
- RED command+evidence:
  - `bash scripts/runtime/test_run_failover_sync_drill_preflight_contract_lane.sh`
  - Negative-path assertions executed in-script and verified deterministic fail-closed markers for:
    - `failover_evidence_link_missing:report_file`
    - `failover_evidence_payload_tamper_detected:*`
    - `promotion_decision_reason_mapping_mismatch`
- GREEN command+output:
  - `bash scripts/runtime/test_run_failover_sync_drill_preflight_contract_lane.sh`
  - Output: `failover/sync preflight contract lane script tests passed.`
- REGRESSION summary:
  - `bash scripts/runtime/test_run_failover_sync_drill_suite.sh`
  - `cargo test -p kamn-core --test kolme_devnet_ops_docs`
  - `cargo test -p kamn-core --test release_gonogo_checklist_docs`

## Test Tiers
| Tier | ✅/❌/N/A | Tests | N/A Why |
|---|---|---|---|
| Unit | ✅ | Python assertions in `test_run_failover_sync_drill_preflight_contract_lane.sh` for policy/convergence payload fields | |
| Property | N/A | | Shell contract checker path; no property-based harness in this lane |
| Contract/DbC | N/A | | Rust DbC macros not used in this shell contract-lane scope |
| Snapshot | N/A | | No snapshot fixtures or stable golden snapshots introduced |
| Functional | ✅ | `bash scripts/runtime/test_run_failover_sync_drill_preflight_contract_lane.sh` | |
| Conformance | ✅ | AC-mapped failover convergence/tamper cases in preflight test script | |
| Integration | ✅ | `bash scripts/runtime/test_run_failover_sync_drill_suite.sh` | |
| Fuzz | N/A | | No untrusted parser/fuzzer surface added in this task scope |
| Mutation | N/A | | Change is shell contract-lane governance logic; no critical Rust mutation target introduced |
| Regression | ✅ | Repeated-order checks + docs-contract tests | |
| Performance | N/A | | Existing bounded smoke budget contract reused; no new hotspot benchmark target |

## Mutation
- N/A for this shell-only governance change; no new Rust critical-path mutation target was introduced.

## Risks/Rollback
- Risks: Low. Scope is failover contract script + tests/docs.
- Rollback: Revert this PR to restore previous failover policy behavior.

## Docs/ADR
- Updated docs:
  - `docs/planning/kolme-devnet-ops.md`
  - `docs/foundation/release-gonogo-checklist.md`
- Updated docs-contract tests:
  - `crates/kamn-core/tests/kolme_devnet_ops_docs.rs`
  - `crates/kamn-core/tests/release_gonogo_checklist_docs.rs`
- ADR: Not required (no dependency/protocol architecture decision change).
