### PR TITLE
docs(spec): mark #4269 websocket-session specs implemented

### DIFF
--- a/specs/4269/spec.md
+++ b/specs/4269/spec.md
@@ -1,6 +1,6 @@
 # Spec — #4269 Task: CI Smoke Governance for Websocket-Session Marker Integrity
 
-Status: Reviewed
+Status: Implemented
 Priority: P1
 Parent: #4265
 Milestone: R27.27 API protocol compliance and websocket-session governance

--- a/specs/4269/tasks.md
+++ b/specs/4269/tasks.md
@@ -1,6 +1,6 @@
 # Tasks — #4269
 
-Status: Reviewed
+Status: Implemented
 
 T1 (Tests first)
 - Add RED checker fixtures for websocket-session marker drift and heavy session drill leakage (`#4276`).

--- a/specs/4276/spec.md
+++ b/specs/4276/spec.md
@@ -1,6 +1,6 @@
 # Spec — #4276 Subtask: Websocket-Session CI Smoke Checker and Heavy-Lane Exclusion
 
-Status: Reviewed
+Status: Implemented
 Priority: P1
 Parent: #4269
 Milestone: R27.27 API protocol compliance and websocket-session governance

--- a/specs/4276/tasks.md
+++ b/specs/4276/tasks.md
@@ -1,6 +1,6 @@
 # Tasks — #4276
 
-Status: Reviewed
+Status: Implemented
 
 T1: Write fixture-driven RED checks for missing marker and heavy-lane leakage cases.
 

--- a/specs/4277/spec.md
+++ b/specs/4277/spec.md
@@ -1,6 +1,6 @@
 # Spec — #4277 Subtask: Websocket-Session Governance Docs and Drift-Contract Sync
 
-Status: Reviewed
+Status: Implemented
 Priority: P1
 Parent: #4269
 Milestone: R27.27 API protocol compliance and websocket-session governance

--- a/specs/4277/tasks.md
+++ b/specs/4277/tasks.md
@@ -1,6 +1,6 @@
 # Tasks — #4277
 
-Status: Reviewed
+Status: Implemented
 
 T1: Update strategy + next-steps docs with websocket-session governance markers.
 


### PR DESCRIPTION
## Summary
Updates `spec.md` and `tasks.md` status fields for `#4269/#4276/#4277` from `Reviewed` to `Implemented` after merge of `#4776`.

## Links
- Follow-up to PR #4776
- Related issues: #4269, #4276, #4277

## Validation
- [x] Status fields now reflect implemented state in merged issue chain.
