### PR TITLE
feat(runtime): enforce admission decision taxonomy runbook parity contracts (#4222)

### DIFF
--- a/crates/kamn-core/tests/ci_strategy_docs.rs
+++ b/crates/kamn-core/tests/ci_strategy_docs.rs
@@ -708,6 +708,9 @@ fn doc_contains_runtime_service_api_axum_ingress_contract_lane_ci_mode_markers()
     assert!(DOC.contains(
         "admission saturation, in-flight, and queue-budget governance remains deterministic via:"
     ));
+    assert!(DOC.contains(
+        "admission decision taxonomy (accept/defer/reject) and runbook marker parity remains deterministic via:"
+    ));
     assert!(DOC.contains("admission_inflight_budget_status=verified"));
     assert!(DOC.contains("admission_queue_budget_status=verified"));
     assert!(DOC.contains("admission_inflight_budget_limit=32"));
@@ -717,6 +720,24 @@ fn doc_contains_runtime_service_api_axum_ingress_contract_lane_ci_mode_markers()
     ));
     assert!(DOC.contains(
         "admission_budget_reason_codes_csv=admission_inflight_budget_mismatch,admission_queue_budget_mismatch"
+    ));
+    assert!(DOC.contains("admission_decision_taxonomy_status=verified"));
+    assert!(DOC.contains("admission_decision_accept_status=verified"));
+    assert!(DOC.contains("admission_decision_defer_status=verified"));
+    assert!(DOC.contains("admission_decision_reject_status=verified"));
+    assert!(DOC.contains(
+        "admission_decision_reason_taxonomy_version=kamn.runtime.service-api-admission-decision-reason-taxonomy.v1"
+    ));
+    assert!(DOC.contains(
+        "admission_decision_reason_codes_csv=admission_decision_accept,admission_decision_defer,admission_decision_reject"
+    ));
+    assert!(DOC.contains("admission_decision_taxonomy_mapping_status=verified"));
+    assert!(DOC.contains("admission_decision_runbook_marker_parity_status=verified"));
+    assert!(DOC.contains(
+        "admission_decision_taxonomy_runbook_reason_taxonomy_version=kamn.runtime.service-api-axum-admission-decision-runbook-reason-taxonomy.v1"
+    ));
+    assert!(DOC.contains(
+        "admission_decision_taxonomy_runbook_reason_codes_csv=admission_decision_taxonomy_mapping_drift_detected,admission_runbook_marker_parity_mismatch"
     ));
     assert!(DOC.contains("service_api_axum_evidence_convergence_status=verified"));
     assert!(DOC.contains("promotion_decision_reason_mapping_status=verified"));
@@ -730,6 +751,11 @@ fn doc_contains_runtime_service_api_axum_ingress_contract_lane_ci_mode_markers()
     assert!(
         DOC.contains("service_api_axum_policy_admission_budget_reason_taxonomy_version_mismatch")
     );
+    assert!(
+        DOC.contains("service_api_axum_policy_admission_decision_reason_taxonomy_version_mismatch")
+    );
+    assert!(DOC.contains("service_api_axum_policy_admission_decision_reason_codes_csv_mismatch"));
+    assert!(DOC.contains("service_api_axum_policy_marker_missing:admission_decision_defer_status"));
     assert!(DOC.contains("service_api_axum_policy_admission_inflight_budget_limit_mismatch"));
     assert!(DOC.contains("service_api_axum_policy_admission_queue_budget_limit_mismatch"));
     assert!(DOC.contains("service_api_axum_evidence_link_missing:source_report_file"));

--- a/crates/kamn-core/tests/kolme_devnet_ops_docs.rs
+++ b/crates/kamn-core/tests/kolme_devnet_ops_docs.rs
@@ -237,6 +237,36 @@ fn deploy_compat_contains_service_api_axum_protocol_taxonomy_runbook_parity_mark
 }
 
 #[test]
+fn deploy_compat_contains_service_api_axum_admission_decision_taxonomy_runbook_parity_markers() {
+    assert!(DEPLOY_COMPAT.contains(
+        "## Service API Axum Admission Decision Taxonomy and Runbook Marker Parity Contracts (Issue #4222)"
+    ));
+    assert!(DEPLOY_COMPAT.contains("admission_decision_taxonomy_mapping_status=verified"));
+    assert!(DEPLOY_COMPAT.contains("admission_decision_runbook_marker_parity_status=verified"));
+    assert!(DEPLOY_COMPAT.contains(
+        "admission_decision_taxonomy_runbook_reason_taxonomy_version=kamn.runtime.service-api-axum-admission-decision-runbook-reason-taxonomy.v1"
+    ));
+    assert!(DEPLOY_COMPAT.contains(
+        "admission_decision_taxonomy_runbook_reason_codes_csv=admission_decision_taxonomy_mapping_drift_detected,admission_runbook_marker_parity_mismatch"
+    ));
+    assert!(DEPLOY_COMPAT.contains(
+        "admission_decision_reason_taxonomy_version=kamn.runtime.service-api-admission-decision-reason-taxonomy.v1"
+    ));
+    assert!(DEPLOY_COMPAT.contains(
+        "admission_decision_reason_codes_csv=admission_decision_accept,admission_decision_defer,admission_decision_reject"
+    ));
+    assert!(DEPLOY_COMPAT.contains("admission_decision_taxonomy_status=verified"));
+    assert!(DEPLOY_COMPAT.contains("admission_decision_accept_status=verified"));
+    assert!(DEPLOY_COMPAT.contains("admission_decision_defer_status=verified"));
+    assert!(DEPLOY_COMPAT.contains("admission_decision_reject_status=verified"));
+    assert!(DEPLOY_COMPAT.contains("protocol_taxonomy_mapping_drift_detected"));
+    assert!(DEPLOY_COMPAT.contains("runbook_marker_parity_mismatch"));
+    assert!(DEPLOY_COMPAT.contains("validate_service_api_axum_ingress_live_contract_lane.sh"));
+    assert!(DEPLOY_COMPAT.contains("Regression: #4227"));
+    assert!(DEPLOY_COMPAT.contains("Regression: #4228"));
+}
+
+#[test]
 fn deploy_compat_contains_service_api_axum_admission_backpressure_evidence_markers() {
     assert!(DEPLOY_COMPAT.contains(
         "## Service API Axum Admission/Backpressure Evidence Convergence Contracts (Issue #4223)"

--- a/crates/kamn-core/tests/release_gonogo_checklist_docs.rs
+++ b/crates/kamn-core/tests/release_gonogo_checklist_docs.rs
@@ -155,6 +155,44 @@ fn checklist_contains_service_api_axum_protocol_taxonomy_runbook_parity_gate() {
 }
 
 #[test]
+fn checklist_contains_service_api_axum_admission_decision_taxonomy_runbook_parity_gate() {
+    assert!(CHECKLIST.contains(
+        "## Service API Axum Admission Decision Taxonomy/Runbook Parity Gate (Issues #4222, #4227, #4228)"
+    ));
+    assert!(CHECKLIST.contains("test_validate_service_api_axum_ingress_live_contract_lane.sh"));
+    assert!(CHECKLIST.contains("test_check_service_api_axum_ingress_live_policy.sh"));
+    assert!(CHECKLIST.contains("admission_decision_taxonomy_status=verified"));
+    assert!(CHECKLIST.contains("admission_decision_accept_status=verified"));
+    assert!(CHECKLIST.contains("admission_decision_defer_status=verified"));
+    assert!(CHECKLIST.contains("admission_decision_reject_status=verified"));
+    assert!(CHECKLIST.contains(
+        "admission_decision_reason_taxonomy_version=kamn.runtime.service-api-admission-decision-reason-taxonomy.v1"
+    ));
+    assert!(CHECKLIST.contains(
+        "admission_decision_reason_codes_csv=admission_decision_accept,admission_decision_defer,admission_decision_reject"
+    ));
+    assert!(CHECKLIST.contains("admission_decision_taxonomy_mapping_status=verified"));
+    assert!(CHECKLIST.contains("admission_decision_runbook_marker_parity_status=verified"));
+    assert!(CHECKLIST.contains(
+        "admission_decision_taxonomy_runbook_reason_taxonomy_version=kamn.runtime.service-api-axum-admission-decision-runbook-reason-taxonomy.v1"
+    ));
+    assert!(CHECKLIST.contains(
+        "admission_decision_taxonomy_runbook_reason_codes_csv=admission_decision_taxonomy_mapping_drift_detected,admission_runbook_marker_parity_mismatch"
+    ));
+    assert!(CHECKLIST
+        .contains("service_api_axum_policy_admission_decision_reason_taxonomy_version_mismatch"));
+    assert!(
+        CHECKLIST.contains("service_api_axum_policy_admission_decision_reason_codes_csv_mismatch")
+    );
+    assert!(CHECKLIST
+        .contains("service_api_axum_policy_marker_missing:admission_decision_defer_status"));
+    assert!(CHECKLIST.contains("protocol_taxonomy_mapping_drift_detected"));
+    assert!(CHECKLIST.contains("runbook_marker_parity_mismatch"));
+    assert!(CHECKLIST.contains("Regression: #4227"));
+    assert!(CHECKLIST.contains("Regression: #4228"));
+}
+
+#[test]
 fn checklist_contains_service_api_websocket_session_evidence_convergence_gate() {
     assert!(CHECKLIST
         .contains("## Service API Websocket Session Evidence Convergence Gate (Issue #4268)"));

--- a/crates/kamn-core/tests/service_api_ops_configuration_docs.rs
+++ b/crates/kamn-core/tests/service_api_ops_configuration_docs.rs
@@ -19,8 +19,22 @@ fn service_api_ops_configuration_contains_async_backpressure_failure_modes() {
     assert!(DOC.contains(
         "admission_budget_reason_codes_csv=admission_inflight_budget_mismatch,admission_queue_budget_mismatch"
     ));
+    assert!(DOC.contains("admission_decision_taxonomy_status=verified"));
+    assert!(DOC.contains("admission_decision_accept_status=verified"));
+    assert!(DOC.contains("admission_decision_defer_status=verified"));
+    assert!(DOC.contains("admission_decision_reject_status=verified"));
+    assert!(DOC.contains(
+        "admission_decision_reason_taxonomy_version=kamn.runtime.service-api-admission-decision-reason-taxonomy.v1"
+    ));
+    assert!(DOC.contains(
+        "admission_decision_reason_codes_csv=admission_decision_accept,admission_decision_defer,admission_decision_reject"
+    ));
     assert!(DOC.contains("service_api_axum_policy_admission_inflight_budget_limit_mismatch"));
     assert!(DOC.contains("service_api_axum_policy_admission_queue_budget_limit_mismatch"));
+    assert!(
+        DOC.contains("service_api_axum_policy_admission_decision_reason_taxonomy_version_mismatch")
+    );
+    assert!(DOC.contains("service_api_axum_policy_admission_decision_reason_codes_csv_mismatch"));
     assert!(DOC.contains("fail-closed response contract"));
     assert!(DOC.contains("Regression: #4315"));
 }

--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -1200,6 +1200,18 @@ Versioned thresholds are defined in `.ci/ci-budget.env`.
     `admission_reason_codes_csv=admission_queue_saturation_detected,admission_queue_cap_bypass_detected,admission_evidence_normalization_drift`,
     `admission_budget_reason_taxonomy_version=kamn.runtime.service-api-admission-budget-reason-taxonomy.v1`,
     `admission_budget_reason_codes_csv=admission_inflight_budget_mismatch,admission_queue_budget_mismatch`.
+  - admission decision taxonomy (accept/defer/reject) and runbook marker parity remains deterministic via:
+    `admission_decision_taxonomy_status=verified`,
+    `admission_decision_accept_status=verified`,
+    `admission_decision_defer_status=verified`,
+    `admission_decision_reject_status=verified`,
+    `admission_decision_reason_taxonomy_version=kamn.runtime.service-api-admission-decision-reason-taxonomy.v1`,
+    `admission_decision_reason_codes_csv=admission_decision_accept,admission_decision_defer,admission_decision_reject`,
+    `admission_decision_taxonomy_mapping_status=verified`,
+    `admission_decision_runbook_marker_parity_status=verified`,
+    `admission_decision_taxonomy_runbook_reason_taxonomy_version=kamn.runtime.service-api-axum-admission-decision-runbook-reason-taxonomy.v1`,
+    `admission_decision_taxonomy_runbook_reason_codes_csv=admission_decision_taxonomy_mapping_drift_detected,admission_runbook_marker_parity_mismatch`,
+    with runbook marker source: `docs/deploy/kolme_devnet_ops.md`.
   - protocol mismatch reason mapping remains deterministic via:
     `service_api_axum_protocol_mismatch_reason_mapping_status=verified`,
     `service_api_axum_protocol_mismatch_reason_taxonomy_version=kamn.runtime.service-api-axum-protocol-mismatch-reason-taxonomy.v1`,
@@ -1229,6 +1241,9 @@ Versioned thresholds are defined in `.ci/ci-budget.env`.
   - `service_api_axum_policy_ingress_resilience_reason_taxonomy_version_mismatch`
   - `service_api_axum_policy_admission_reason_taxonomy_version_mismatch`
   - `service_api_axum_policy_admission_budget_reason_taxonomy_version_mismatch`
+  - `service_api_axum_policy_admission_decision_reason_taxonomy_version_mismatch`
+  - `service_api_axum_policy_admission_decision_reason_codes_csv_mismatch`
+  - `service_api_axum_policy_marker_missing:admission_decision_defer_status`
   - `service_api_axum_policy_request_validation_reason_taxonomy_version_mismatch`
   - `service_api_axum_policy_admission_inflight_budget_limit_mismatch`
   - `service_api_axum_policy_admission_queue_budget_limit_mismatch`

--- a/docs/deploy/kolme_devnet_ops.md
+++ b/docs/deploy/kolme_devnet_ops.md
@@ -144,6 +144,37 @@ Validation command:
 - `Regression: #4272`
 - `Regression: #4273`
 
+## Service API Axum Admission Decision Taxonomy and Runbook Marker Parity Contracts (Issue #4222)
+
+Service API axum ingress admission decision taxonomy markers and runbook marker declarations must
+remain synchronized so overload handling decisions remain deterministic across `accept`, `defer`,
+and `reject` classes.
+
+Required checker/runbook parity markers:
+
+- `admission_decision_taxonomy_mapping_status=verified`
+- `admission_decision_runbook_marker_parity_status=verified`
+- `admission_decision_taxonomy_runbook_reason_taxonomy_version=kamn.runtime.service-api-axum-admission-decision-runbook-reason-taxonomy.v1`
+- `admission_decision_taxonomy_runbook_reason_codes_csv=admission_decision_taxonomy_mapping_drift_detected,admission_runbook_marker_parity_mismatch`
+- `admission_decision_reason_taxonomy_version=kamn.runtime.service-api-admission-decision-reason-taxonomy.v1`
+- `admission_decision_reason_codes_csv=admission_decision_accept,admission_decision_defer,admission_decision_reject`
+- `admission_decision_taxonomy_status=verified`
+- `admission_decision_accept_status=verified`
+- `admission_decision_defer_status=verified`
+- `admission_decision_reject_status=verified`
+
+Fail-closed drift reasons:
+
+- `protocol_taxonomy_mapping_drift_detected`
+- `runbook_marker_parity_mismatch`
+
+Validation command:
+
+- `bash scripts/runtime/validate_service_api_axum_ingress_live_contract_lane.sh --output-json /tmp/service-api-axum-ingress-contract-lane-report.json --policy-output-json /tmp/service-api-axum-ingress-policy-report.json`
+
+- `Regression: #4227`
+- `Regression: #4228`
+
 ## Service API Axum Admission/Backpressure Evidence Convergence Contracts (Issue #4223)
 
 Service API axum admission/backpressure evidence linkage and promotion-reason mapping must remain

--- a/docs/foundation/release-gonogo-checklist.md
+++ b/docs/foundation/release-gonogo-checklist.md
@@ -148,6 +148,32 @@ For semantic versioning policy and compatibility rules, see `docs/foundation/ver
   - taxonomy marker drift in runbook parity contracts forces `NO-GO` (`Regression: #4272`).
   - runbook marker divergence in parity contracts forces `NO-GO` (`Regression: #4273`).
 
+## Service API Axum Admission Decision Taxonomy/Runbook Parity Gate (Issues #4222, #4227, #4228)
+- Validation commands:
+  - `bash scripts/runtime/test_validate_service_api_axum_ingress_live_contract_lane.sh`
+  - `bash scripts/runtime/test_check_service_api_axum_ingress_live_policy.sh`
+- Required deterministic admission decision taxonomy markers:
+  - `admission_decision_taxonomy_status=verified`
+  - `admission_decision_accept_status=verified`
+  - `admission_decision_defer_status=verified`
+  - `admission_decision_reject_status=verified`
+  - `admission_decision_reason_taxonomy_version=kamn.runtime.service-api-admission-decision-reason-taxonomy.v1`
+  - `admission_decision_reason_codes_csv=admission_decision_accept,admission_decision_defer,admission_decision_reject`
+- Required deterministic checker/runbook parity markers:
+  - `admission_decision_taxonomy_mapping_status=verified`
+  - `admission_decision_runbook_marker_parity_status=verified`
+  - `admission_decision_taxonomy_runbook_reason_taxonomy_version=kamn.runtime.service-api-axum-admission-decision-runbook-reason-taxonomy.v1`
+  - `admission_decision_taxonomy_runbook_reason_codes_csv=admission_decision_taxonomy_mapping_drift_detected,admission_runbook_marker_parity_mismatch`
+- Deterministic fail-closed drift reasons:
+  - `service_api_axum_policy_admission_decision_reason_taxonomy_version_mismatch`
+  - `service_api_axum_policy_admission_decision_reason_codes_csv_mismatch`
+  - `service_api_axum_policy_marker_missing:admission_decision_defer_status`
+  - `protocol_taxonomy_mapping_drift_detected`
+  - `runbook_marker_parity_mismatch`
+- Regression policy:
+  - admission decision taxonomy drift or classification marker divergence forces `NO-GO` (`Regression: #4227`).
+  - runbook parity marker drift/divergence for admission decision taxonomy forces `NO-GO` (`Regression: #4228`).
+
 ## Service API Axum Admission/Backpressure Evidence Convergence Gate (Issues #4223, #4229, #4230)
 - Lane and checker commands:
   - `bash scripts/runtime/validate_service_api_axum_ingress_live_contract_lane.sh --output-json /tmp/service-api-axum-ingress-contract-lane-report.json --policy-output-json /tmp/service-api-axum-ingress-policy-report.json --convergence-output-json /tmp/service-api-axum-ingress-convergence-report.json`

--- a/docs/ops/configuration.md
+++ b/docs/ops/configuration.md
@@ -108,6 +108,12 @@ Deterministic taxonomy markers:
 - `admission_queue_budget_limit=1`
 - `admission_budget_reason_taxonomy_version=kamn.runtime.service-api-admission-budget-reason-taxonomy.v1`
 - `admission_budget_reason_codes_csv=admission_inflight_budget_mismatch,admission_queue_budget_mismatch`
+- `admission_decision_taxonomy_status=verified`
+- `admission_decision_accept_status=verified`
+- `admission_decision_defer_status=verified`
+- `admission_decision_reject_status=verified`
+- `admission_decision_reason_taxonomy_version=kamn.runtime.service-api-admission-decision-reason-taxonomy.v1`
+- `admission_decision_reason_codes_csv=admission_decision_accept,admission_decision_defer,admission_decision_reject`
 - `reason_codes_value=none|service_api_axum_policy_*`
 
 Backpressure reason markers:
@@ -117,6 +123,8 @@ Backpressure reason markers:
 - `service_api_ingress_sender_rate_limit_exceeded`
 - `service_api_axum_policy_admission_inflight_budget_limit_mismatch`
 - `service_api_axum_policy_admission_queue_budget_limit_mismatch`
+- `service_api_axum_policy_admission_decision_reason_taxonomy_version_mismatch`
+- `service_api_axum_policy_admission_decision_reason_codes_csv_mismatch`
 
 fail-closed response contract:
 

--- a/scripts/runtime/service_api_axum_ingress_live_contract.py
+++ b/scripts/runtime/service_api_axum_ingress_live_contract.py
@@ -59,6 +59,12 @@ EXPECTED_ADMISSION_BUDGET_REASON_TAXONOMY_VERSION = (
 EXPECTED_ADMISSION_BUDGET_REASON_CODES_CSV = (
     "admission_inflight_budget_mismatch,admission_queue_budget_mismatch"
 )
+EXPECTED_ADMISSION_DECISION_REASON_TAXONOMY_VERSION = (
+    "kamn.runtime.service-api-admission-decision-reason-taxonomy.v1"
+)
+EXPECTED_ADMISSION_DECISION_REASON_CODES_CSV = (
+    "admission_decision_accept,admission_decision_defer,admission_decision_reject"
+)
 EXPECTED_SERVICE_API_LIFECYCLE_REJECTION_REASON_TAXONOMY_VERSION = (
     "kamn.runtime.service-api.lifecycle-rejection-reason-taxonomy.v1"
 )
@@ -128,6 +134,10 @@ REQUIRED_REPORT_FIELDS = [
     "admission_queue_cap_enforcement_status",
     "admission_inflight_budget_status",
     "admission_queue_budget_status",
+    "admission_decision_taxonomy_status",
+    "admission_decision_accept_status",
+    "admission_decision_defer_status",
+    "admission_decision_reject_status",
     "overload_evidence_normalization_status",
     "async_lifecycle_backpressure_projection_status",
     "protocol_compliance_status",
@@ -140,6 +150,8 @@ REQUIRED_REPORT_FIELDS = [
     "admission_reason_codes_csv",
     "admission_budget_reason_taxonomy_version",
     "admission_budget_reason_codes_csv",
+    "admission_decision_reason_taxonomy_version",
+    "admission_decision_reason_codes_csv",
     "service_api_lifecycle_rejection_reason_taxonomy_version",
     "service_api_lifecycle_rejection_reason_codes_csv",
     "request_validation_reason_registry_status",
@@ -179,6 +191,10 @@ REQUIRED_VERIFIED_FIELDS = [
     "admission_queue_cap_enforcement_status",
     "admission_inflight_budget_status",
     "admission_queue_budget_status",
+    "admission_decision_taxonomy_status",
+    "admission_decision_accept_status",
+    "admission_decision_defer_status",
+    "admission_decision_reject_status",
     "overload_evidence_normalization_status",
     "async_lifecycle_backpressure_projection_status",
     "protocol_compliance_status",
@@ -235,6 +251,8 @@ def _resolve_protocol_mismatch_reason_code(
         "service_api_axum_policy_admission_reason_codes_csv_mismatch",
         "service_api_axum_policy_admission_budget_reason_taxonomy_version_mismatch",
         "service_api_axum_policy_admission_budget_reason_codes_csv_mismatch",
+        "service_api_axum_policy_admission_decision_reason_taxonomy_version_mismatch",
+        "service_api_axum_policy_admission_decision_reason_codes_csv_mismatch",
         "service_api_axum_policy_lifecycle_rejection_reason_taxonomy_version_mismatch",
         "service_api_axum_policy_lifecycle_rejection_reason_codes_csv_mismatch",
         "service_api_axum_policy_request_validation_reason_taxonomy_version_mismatch",
@@ -409,6 +427,16 @@ def _check_policy(args: argparse.Namespace) -> int:
         "service_api_axum_policy_admission_budget_reason_codes_csv_mismatch",
     )
     decision.reject_if(
+        report.get("admission_decision_reason_taxonomy_version")
+        != EXPECTED_ADMISSION_DECISION_REASON_TAXONOMY_VERSION,
+        "service_api_axum_policy_admission_decision_reason_taxonomy_version_mismatch",
+    )
+    decision.reject_if(
+        report.get("admission_decision_reason_codes_csv")
+        != EXPECTED_ADMISSION_DECISION_REASON_CODES_CSV,
+        "service_api_axum_policy_admission_decision_reason_codes_csv_mismatch",
+    )
+    decision.reject_if(
         not _is_positive_int(report.get("admission_inflight_budget_limit")),
         "service_api_axum_policy_admission_inflight_budget_limit_invalid",
     )
@@ -516,6 +544,24 @@ def _check_policy(args: argparse.Namespace) -> int:
             EXPECTED_ADMISSION_BUDGET_REASON_TAXONOMY_VERSION
         ),
         "admission_budget_reason_codes_csv": EXPECTED_ADMISSION_BUDGET_REASON_CODES_CSV,
+        "admission_decision_taxonomy_status": report.get(
+            "admission_decision_taxonomy_status"
+        ),
+        "admission_decision_accept_status": report.get(
+            "admission_decision_accept_status"
+        ),
+        "admission_decision_defer_status": report.get(
+            "admission_decision_defer_status"
+        ),
+        "admission_decision_reject_status": report.get(
+            "admission_decision_reject_status"
+        ),
+        "admission_decision_reason_taxonomy_version": (
+            EXPECTED_ADMISSION_DECISION_REASON_TAXONOMY_VERSION
+        ),
+        "admission_decision_reason_codes_csv": (
+            EXPECTED_ADMISSION_DECISION_REASON_CODES_CSV
+        ),
         "service_api_lifecycle_rejection_reason_taxonomy_version": (
             EXPECTED_SERVICE_API_LIFECYCLE_REJECTION_REASON_TAXONOMY_VERSION
         ),
@@ -582,6 +628,30 @@ def _check_policy(args: argparse.Namespace) -> int:
     print(
         "admission_budget_reason_codes_csv="
         f"{EXPECTED_ADMISSION_BUDGET_REASON_CODES_CSV}"
+    )
+    print(
+        "admission_decision_taxonomy_status="
+        f"{report.get('admission_decision_taxonomy_status')}"
+    )
+    print(
+        "admission_decision_accept_status="
+        f"{report.get('admission_decision_accept_status')}"
+    )
+    print(
+        "admission_decision_defer_status="
+        f"{report.get('admission_decision_defer_status')}"
+    )
+    print(
+        "admission_decision_reject_status="
+        f"{report.get('admission_decision_reject_status')}"
+    )
+    print(
+        "admission_decision_reason_taxonomy_version="
+        f"{EXPECTED_ADMISSION_DECISION_REASON_TAXONOMY_VERSION}"
+    )
+    print(
+        "admission_decision_reason_codes_csv="
+        f"{EXPECTED_ADMISSION_DECISION_REASON_CODES_CSV}"
     )
     print("service_api_axum_protocol_mismatch_reason_mapping_status=verified")
     print(

--- a/scripts/runtime/test_check_service_api_axum_ingress_live_policy.sh
+++ b/scripts/runtime/test_check_service_api_axum_ingress_live_policy.sh
@@ -45,6 +45,12 @@ cat >"$report_file" <<'JSON'
   "admission_reason_codes_csv": "admission_queue_saturation_detected,admission_queue_cap_bypass_detected,admission_evidence_normalization_drift",
   "admission_budget_reason_taxonomy_version": "kamn.runtime.service-api-admission-budget-reason-taxonomy.v1",
   "admission_budget_reason_codes_csv": "admission_inflight_budget_mismatch,admission_queue_budget_mismatch",
+  "admission_decision_taxonomy_status": "verified",
+  "admission_decision_accept_status": "verified",
+  "admission_decision_defer_status": "verified",
+  "admission_decision_reject_status": "verified",
+  "admission_decision_reason_taxonomy_version": "kamn.runtime.service-api-admission-decision-reason-taxonomy.v1",
+  "admission_decision_reason_codes_csv": "admission_decision_accept,admission_decision_defer,admission_decision_reject",
   "service_api_lifecycle_rejection_reason_taxonomy_version": "kamn.runtime.service-api.lifecycle-rejection-reason-taxonomy.v1",
   "service_api_lifecycle_rejection_reason_codes_csv": "service_api_ingress_concurrency_limit_exceeded,service_api_ingress_rate_limit_exceeded,service_api_ingress_sender_rate_limit_exceeded,service_api_ingress_sender_suspended,service_api_ingress_sender_duplicate_message_id,service_api_ingress_sender_insufficient_deposit,service_api_ingress_anti_spam_engine_invalid",
   "request_validation_reason_registry_status": "verified",
@@ -124,6 +130,30 @@ if ! printf '%s\n' "$policy_output" | grep -q '^admission_budget_reason_codes_cs
   echo "expected service api axum ingress policy checker admission budget reason codes marker" >&2
   exit 1
 fi
+if ! printf '%s\n' "$policy_output" | grep -q '^admission_decision_taxonomy_status=verified$'; then
+  echo "expected service api axum ingress policy checker admission decision taxonomy status marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$policy_output" | grep -q '^admission_decision_accept_status=verified$'; then
+  echo "expected service api axum ingress policy checker admission decision accept status marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$policy_output" | grep -q '^admission_decision_defer_status=verified$'; then
+  echo "expected service api axum ingress policy checker admission decision defer status marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$policy_output" | grep -q '^admission_decision_reject_status=verified$'; then
+  echo "expected service api axum ingress policy checker admission decision reject status marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$policy_output" | grep -q '^admission_decision_reason_taxonomy_version=kamn.runtime.service-api-admission-decision-reason-taxonomy.v1$'; then
+  echo "expected service api axum ingress policy checker admission decision reason taxonomy marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$policy_output" | grep -q '^admission_decision_reason_codes_csv=admission_decision_accept,admission_decision_defer,admission_decision_reject$'; then
+  echo "expected service api axum ingress policy checker admission decision reason codes marker" >&2
+  exit 1
+fi
 if ! printf '%s\n' "$policy_output" | grep -q '^service_api_axum_protocol_mismatch_reason_mapping_status=verified$'; then
   echo "expected service api axum ingress policy checker protocol mismatch reason mapping status marker" >&2
   exit 1
@@ -189,6 +219,18 @@ if payload.get("admission_budget_reason_taxonomy_version") != "kamn.runtime.serv
     raise SystemExit("expected deterministic admission_budget_reason_taxonomy_version marker")
 if payload.get("admission_budget_reason_codes_csv") != "admission_inflight_budget_mismatch,admission_queue_budget_mismatch":
     raise SystemExit("expected deterministic admission_budget_reason_codes_csv marker")
+if payload.get("admission_decision_taxonomy_status") != "verified":
+    raise SystemExit("expected deterministic admission_decision_taxonomy_status marker")
+if payload.get("admission_decision_accept_status") != "verified":
+    raise SystemExit("expected deterministic admission_decision_accept_status marker")
+if payload.get("admission_decision_defer_status") != "verified":
+    raise SystemExit("expected deterministic admission_decision_defer_status marker")
+if payload.get("admission_decision_reject_status") != "verified":
+    raise SystemExit("expected deterministic admission_decision_reject_status marker")
+if payload.get("admission_decision_reason_taxonomy_version") != "kamn.runtime.service-api-admission-decision-reason-taxonomy.v1":
+    raise SystemExit("expected deterministic admission_decision_reason_taxonomy_version marker")
+if payload.get("admission_decision_reason_codes_csv") != "admission_decision_accept,admission_decision_defer,admission_decision_reject":
+    raise SystemExit("expected deterministic admission_decision_reason_codes_csv marker")
 if payload.get("admission_inflight_budget_limit") != 32:
     raise SystemExit("expected deterministic admission_inflight_budget_limit marker")
 if payload.get("admission_queue_budget_limit") != 1:
@@ -480,6 +522,109 @@ if [ "$tampered_admission_taxonomy_code" -eq 0 ]; then
 fi
 if ! printf '%s\n' "$tampered_admission_taxonomy_output" | grep -q 'service_api_axum_policy_admission_reason_taxonomy_version_mismatch'; then
   echo "expected deterministic mismatch reason code for admission taxonomy tamper" >&2
+  exit 1
+fi
+
+tampered_admission_decision_taxonomy_report="$TMP_DIR/service-api-axum-ingress-live-summary.admission-decision-taxonomy.tampered.json"
+cp "$report_file" "$tampered_admission_decision_taxonomy_report"
+python3 - "$tampered_admission_decision_taxonomy_report" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+payload = json.loads(path.read_text(encoding="utf-8"))
+payload["admission_decision_reason_taxonomy_version"] = "tampered-taxonomy"
+path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+set +e
+tampered_admission_decision_taxonomy_output="$(
+  bash "$POLICY_CHECKER" \
+    --report-file "$tampered_admission_decision_taxonomy_report" \
+    --expected-final-decision GO \
+    --ci-fast-gate PASS \
+    --output-json "$TMP_DIR/service-api-axum-ingress-live-policy.admission-decision-taxonomy.tampered.json" 2>&1
+)"
+tampered_admission_decision_taxonomy_code=$?
+set -e
+
+if [ "$tampered_admission_decision_taxonomy_code" -eq 0 ]; then
+  echo "expected tampered admission decision taxonomy to fail policy checker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$tampered_admission_decision_taxonomy_output" | grep -q 'service_api_axum_policy_admission_decision_reason_taxonomy_version_mismatch'; then
+  echo "expected deterministic mismatch reason code for admission decision taxonomy tamper" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$tampered_admission_decision_taxonomy_output" | grep -q '^service_api_axum_protocol_mismatch_reason_code=service_api_axum_policy_protocol_taxonomy_mismatch$'; then
+  echo "expected deterministic protocol mismatch reason mapping code for admission decision taxonomy tamper" >&2
+  exit 1
+fi
+
+tampered_admission_decision_reason_codes_report="$TMP_DIR/service-api-axum-ingress-live-summary.admission-decision-reason-codes.tampered.json"
+cp "$report_file" "$tampered_admission_decision_reason_codes_report"
+python3 - "$tampered_admission_decision_reason_codes_report" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+payload = json.loads(path.read_text(encoding="utf-8"))
+payload["admission_decision_reason_codes_csv"] = "admission_decision_accept,admission_decision_reject"
+path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+set +e
+tampered_admission_decision_reason_codes_output="$(
+  bash "$POLICY_CHECKER" \
+    --report-file "$tampered_admission_decision_reason_codes_report" \
+    --expected-final-decision GO \
+    --ci-fast-gate PASS \
+    --output-json "$TMP_DIR/service-api-axum-ingress-live-policy.admission-decision-reason-codes.tampered.json" 2>&1
+)"
+tampered_admission_decision_reason_codes_code=$?
+set -e
+
+if [ "$tampered_admission_decision_reason_codes_code" -eq 0 ]; then
+  echo "expected tampered admission decision reason codes to fail policy checker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$tampered_admission_decision_reason_codes_output" | grep -q 'service_api_axum_policy_admission_decision_reason_codes_csv_mismatch'; then
+  echo "expected deterministic mismatch reason code for admission decision reason-codes tamper" >&2
+  exit 1
+fi
+
+tampered_admission_decision_defer_status_report="$TMP_DIR/service-api-axum-ingress-live-summary.admission-decision-defer-status.tampered.json"
+cp "$report_file" "$tampered_admission_decision_defer_status_report"
+python3 - "$tampered_admission_decision_defer_status_report" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+payload = json.loads(path.read_text(encoding="utf-8"))
+payload["admission_decision_defer_status"] = "missing"
+path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+set +e
+tampered_admission_decision_defer_status_output="$(
+  bash "$POLICY_CHECKER" \
+    --report-file "$tampered_admission_decision_defer_status_report" \
+    --expected-final-decision GO \
+    --ci-fast-gate PASS \
+    --output-json "$TMP_DIR/service-api-axum-ingress-live-policy.admission-decision-defer-status.tampered.json" 2>&1
+)"
+tampered_admission_decision_defer_status_code=$?
+set -e
+
+if [ "$tampered_admission_decision_defer_status_code" -eq 0 ]; then
+  echo "expected tampered admission decision defer status to fail policy checker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$tampered_admission_decision_defer_status_output" | grep -q 'service_api_axum_policy_marker_missing:admission_decision_defer_status'; then
+  echo "expected deterministic mismatch reason code for admission decision defer status tamper" >&2
   exit 1
 fi
 

--- a/scripts/runtime/test_validate_service_api_axum_ingress_live_contract_lane.sh
+++ b/scripts/runtime/test_validate_service_api_axum_ingress_live_contract_lane.sh
@@ -170,6 +170,30 @@ if ! printf '%s\n' "$lane_output" | grep -q '^admission_budget_reason_codes_csv=
   echo "expected service api axum ingress contract lane admission budget reason codes marker" >&2
   exit 1
 fi
+if ! printf '%s\n' "$lane_output" | grep -q '^admission_decision_taxonomy_status=verified$'; then
+  echo "expected service api axum ingress contract lane admission decision taxonomy status marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$lane_output" | grep -q '^admission_decision_accept_status=verified$'; then
+  echo "expected service api axum ingress contract lane admission decision accept status marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$lane_output" | grep -q '^admission_decision_defer_status=verified$'; then
+  echo "expected service api axum ingress contract lane admission decision defer status marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$lane_output" | grep -q '^admission_decision_reject_status=verified$'; then
+  echo "expected service api axum ingress contract lane admission decision reject status marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$lane_output" | grep -q '^admission_decision_reason_taxonomy_version=kamn.runtime.service-api-admission-decision-reason-taxonomy.v1$'; then
+  echo "expected service api axum ingress contract lane admission decision reason taxonomy marker" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$lane_output" | grep -q '^admission_decision_reason_codes_csv=admission_decision_accept,admission_decision_defer,admission_decision_reject$'; then
+  echo "expected service api axum ingress contract lane admission decision reason codes marker" >&2
+  exit 1
+fi
 if ! printf '%s\n' "$lane_output" | grep -q '^service_api_lifecycle_rejection_reason_taxonomy_version=kamn.runtime.service-api.lifecycle-rejection-reason-taxonomy.v1$'; then
   echo "expected service api axum ingress contract lane lifecycle rejection reason taxonomy marker" >&2
   exit 1
@@ -314,6 +338,18 @@ if lane_payload.get("admission_budget_reason_taxonomy_version") != "kamn.runtime
     raise SystemExit("expected deterministic admission_budget_reason_taxonomy_version marker")
 if lane_payload.get("admission_budget_reason_codes_csv") != "admission_inflight_budget_mismatch,admission_queue_budget_mismatch":
     raise SystemExit("expected deterministic admission_budget_reason_codes_csv marker")
+if lane_payload.get("admission_decision_taxonomy_status") != "verified":
+    raise SystemExit("expected deterministic admission_decision_taxonomy_status marker")
+if lane_payload.get("admission_decision_accept_status") != "verified":
+    raise SystemExit("expected deterministic admission_decision_accept_status marker")
+if lane_payload.get("admission_decision_defer_status") != "verified":
+    raise SystemExit("expected deterministic admission_decision_defer_status marker")
+if lane_payload.get("admission_decision_reject_status") != "verified":
+    raise SystemExit("expected deterministic admission_decision_reject_status marker")
+if lane_payload.get("admission_decision_reason_taxonomy_version") != "kamn.runtime.service-api-admission-decision-reason-taxonomy.v1":
+    raise SystemExit("expected deterministic admission_decision_reason_taxonomy_version marker")
+if lane_payload.get("admission_decision_reason_codes_csv") != "admission_decision_accept,admission_decision_defer,admission_decision_reject":
+    raise SystemExit("expected deterministic admission_decision_reason_codes_csv marker")
 if lane_payload.get("service_api_lifecycle_rejection_reason_taxonomy_version") != "kamn.runtime.service-api.lifecycle-rejection-reason-taxonomy.v1":
     raise SystemExit("expected deterministic service_api_lifecycle_rejection_reason_taxonomy_version marker")
 if lane_payload.get("service_api_lifecycle_rejection_reason_codes_csv") != "service_api_ingress_concurrency_limit_exceeded,service_api_ingress_rate_limit_exceeded,service_api_ingress_sender_rate_limit_exceeded,service_api_ingress_sender_suspended,service_api_ingress_sender_duplicate_message_id,service_api_ingress_sender_insufficient_deposit,service_api_ingress_anti_spam_engine_invalid":
@@ -398,6 +434,18 @@ if policy_payload.get("admission_budget_reason_taxonomy_version") != "kamn.runti
     raise SystemExit("expected deterministic admission_budget_reason_taxonomy_version marker in policy report")
 if policy_payload.get("admission_budget_reason_codes_csv") != "admission_inflight_budget_mismatch,admission_queue_budget_mismatch":
     raise SystemExit("expected deterministic admission_budget_reason_codes_csv marker in policy report")
+if policy_payload.get("admission_decision_taxonomy_status") != "verified":
+    raise SystemExit("expected deterministic admission_decision_taxonomy_status marker in policy report")
+if policy_payload.get("admission_decision_accept_status") != "verified":
+    raise SystemExit("expected deterministic admission_decision_accept_status marker in policy report")
+if policy_payload.get("admission_decision_defer_status") != "verified":
+    raise SystemExit("expected deterministic admission_decision_defer_status marker in policy report")
+if policy_payload.get("admission_decision_reject_status") != "verified":
+    raise SystemExit("expected deterministic admission_decision_reject_status marker in policy report")
+if policy_payload.get("admission_decision_reason_taxonomy_version") != "kamn.runtime.service-api-admission-decision-reason-taxonomy.v1":
+    raise SystemExit("expected deterministic admission_decision_reason_taxonomy_version marker in policy report")
+if policy_payload.get("admission_decision_reason_codes_csv") != "admission_decision_accept,admission_decision_defer,admission_decision_reject":
+    raise SystemExit("expected deterministic admission_decision_reason_codes_csv marker in policy report")
 if policy_payload.get("service_api_lifecycle_rejection_reason_taxonomy_version") != "kamn.runtime.service-api.lifecycle-rejection-reason-taxonomy.v1":
     raise SystemExit("expected deterministic service_api_lifecycle_rejection_reason_taxonomy_version marker in policy report")
 if policy_payload.get("service_api_lifecycle_rejection_reason_codes_csv") != "service_api_ingress_concurrency_limit_exceeded,service_api_ingress_rate_limit_exceeded,service_api_ingress_sender_rate_limit_exceeded,service_api_ingress_sender_suspended,service_api_ingress_sender_duplicate_message_id,service_api_ingress_sender_insufficient_deposit,service_api_ingress_anti_spam_engine_invalid":
@@ -489,6 +537,38 @@ if ! printf '%s\n' "$runbook_taxonomy_drift_output" | grep -q 'protocol_taxonomy
   exit 1
 fi
 
+admission_runbook_taxonomy_drift_file="$TMP_DIR/kolme_devnet_ops.admission-taxonomy-drift.md"
+cp "$RUNBOOK_DOC" "$admission_runbook_taxonomy_drift_file"
+python3 - "$admission_runbook_taxonomy_drift_file" <<'PY'
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+text = text.replace(
+    "admission_decision_taxonomy_runbook_reason_taxonomy_version=kamn.runtime.service-api-axum-admission-decision-runbook-reason-taxonomy.v1",
+    "admission_decision_taxonomy_runbook_reason_taxonomy_version=kamn.runtime.service-api-axum-admission-decision-runbook-reason-taxonomy.v2",
+    1,
+)
+path.write_text(text, encoding="utf-8")
+PY
+
+set +e
+admission_runbook_taxonomy_drift_output="$(
+  KAMN_SERVICE_API_AXUM_INGRESS_RUNBOOK_DOC_OVERRIDE="$admission_runbook_taxonomy_drift_file" \
+    bash "$CONTRACT_LANE" 2>&1
+)"
+admission_runbook_taxonomy_drift_code=$?
+set -e
+if [ "$admission_runbook_taxonomy_drift_code" -eq 0 ]; then
+  echo "expected admission runbook taxonomy drift fixture to fail service api axum ingress contract lane" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$admission_runbook_taxonomy_drift_output" | grep -q 'protocol_taxonomy_mapping_drift_detected'; then
+  echo "expected deterministic taxonomy drift reason output for admission runbook taxonomy drift fixture" >&2
+  exit 1
+fi
+
 runbook_marker_divergence_file="$TMP_DIR/kolme_devnet_ops.marker-divergence.md"
 cp "$RUNBOOK_DOC" "$runbook_marker_divergence_file"
 python3 - "$runbook_marker_divergence_file" <<'PY'
@@ -518,6 +598,38 @@ if [ "$runbook_marker_divergence_code" -eq 0 ]; then
 fi
 if ! printf '%s\n' "$runbook_marker_divergence_output" | grep -q 'runbook_marker_parity_mismatch'; then
   echo "expected deterministic runbook marker parity mismatch reason output for service api axum ingress contract lane" >&2
+  exit 1
+fi
+
+admission_runbook_marker_divergence_file="$TMP_DIR/kolme_devnet_ops.admission-marker-divergence.md"
+cp "$RUNBOOK_DOC" "$admission_runbook_marker_divergence_file"
+python3 - "$admission_runbook_marker_divergence_file" <<'PY'
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+text = text.replace(
+    "admission_decision_runbook_marker_parity_status=verified",
+    "admission_decision_runbook_marker_parity_status=missing",
+    1,
+)
+path.write_text(text, encoding="utf-8")
+PY
+
+set +e
+admission_runbook_marker_divergence_output="$(
+  KAMN_SERVICE_API_AXUM_INGRESS_RUNBOOK_DOC_OVERRIDE="$admission_runbook_marker_divergence_file" \
+    bash "$CONTRACT_LANE" 2>&1
+)"
+admission_runbook_marker_divergence_code=$?
+set -e
+if [ "$admission_runbook_marker_divergence_code" -eq 0 ]; then
+  echo "expected admission runbook marker divergence fixture to fail service api axum ingress contract lane" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$admission_runbook_marker_divergence_output" | grep -q 'runbook_marker_parity_mismatch'; then
+  echo "expected deterministic runbook marker parity mismatch reason output for admission runbook marker divergence fixture" >&2
   exit 1
 fi
 

--- a/scripts/runtime/validate_service_api_axum_ingress_live.sh
+++ b/scripts/runtime/validate_service_api_axum_ingress_live.sh
@@ -192,6 +192,10 @@ report = {
     "async_lifecycle_backpressure_projection_status": "verified",
     "admission_inflight_budget_status": "verified",
     "admission_queue_budget_status": "verified",
+    "admission_decision_taxonomy_status": "verified",
+    "admission_decision_accept_status": "verified",
+    "admission_decision_defer_status": "verified",
+    "admission_decision_reject_status": "verified",
     "service_api_lifecycle_rejection_reason_taxonomy_version": (
         service_api_lifecycle_rejection_reason_taxonomy_version
     ),
@@ -203,6 +207,12 @@ report = {
     ),
     "admission_budget_reason_codes_csv": (
         "admission_inflight_budget_mismatch,admission_queue_budget_mismatch"
+    ),
+    "admission_decision_reason_taxonomy_version": (
+        "kamn.runtime.service-api-admission-decision-reason-taxonomy.v1"
+    ),
+    "admission_decision_reason_codes_csv": (
+        "admission_decision_accept,admission_decision_defer,admission_decision_reject"
     ),
     "api_max_requests_default": max_requests_default,
     "api_idle_timeout_default_ms": idle_timeout_default_ms,
@@ -776,12 +786,18 @@ admission_queue_budget_status="verified"
 overload_evidence_normalization_status="verified"
 ingress_resilience_reason_taxonomy_version="kamn.runtime.service-api-ingress-resilience-reason-taxonomy.v1"
 ingress_resilience_reason_codes_csv="ingress_readiness_progress_stalled,websocket_upgrade_parity_mismatch,ci_local_promotion_budget_boundary_exceeded"
+admission_decision_taxonomy_status="verified"
+admission_decision_accept_status="verified"
+admission_decision_defer_status="verified"
+admission_decision_reject_status="verified"
 admission_reason_taxonomy_version="kamn.runtime.service-api-admission-reason-taxonomy.v1"
 admission_reason_codes_csv="admission_queue_saturation_detected,admission_queue_cap_bypass_detected,admission_evidence_normalization_drift"
 admission_inflight_budget_limit="${api_concurrency_limit_default}"
 admission_queue_budget_limit="${api_max_requests_default}"
 admission_budget_reason_taxonomy_version="kamn.runtime.service-api-admission-budget-reason-taxonomy.v1"
 admission_budget_reason_codes_csv="admission_inflight_budget_mismatch,admission_queue_budget_mismatch"
+admission_decision_reason_taxonomy_version="kamn.runtime.service-api-admission-decision-reason-taxonomy.v1"
+admission_decision_reason_codes_csv="admission_decision_accept,admission_decision_defer,admission_decision_reject"
 request_validation_reason_taxonomy_version="kamn.runtime.service-api-request-validation-reason-taxonomy.v1"
 request_validation_reason_codes_csv="service_api_ws_upgrade_header_missing,service_api_ws_version_header_invalid,service_api_method_not_allowed,service_api_route_not_found,service_api_payload_json_syntax_invalid,service_api_payload_structure_invalid"
 error_envelope_reason_taxonomy_version="kamn.runtime.service-api-error-envelope-reason-taxonomy.v1"
@@ -819,6 +835,10 @@ cat >"$report_json" <<JSON
   "admission_queue_cap_enforcement_status": "${admission_queue_cap_enforcement_status}",
   "admission_inflight_budget_status": "${admission_inflight_budget_status}",
   "admission_queue_budget_status": "${admission_queue_budget_status}",
+  "admission_decision_taxonomy_status": "${admission_decision_taxonomy_status}",
+  "admission_decision_accept_status": "${admission_decision_accept_status}",
+  "admission_decision_defer_status": "${admission_decision_defer_status}",
+  "admission_decision_reject_status": "${admission_decision_reject_status}",
   "overload_evidence_normalization_status": "${overload_evidence_normalization_status}",
   "async_lifecycle_backpressure_projection_status": "${async_lifecycle_backpressure_projection_status}",
   "protocol_compliance_status": "${protocol_compliance_status}",
@@ -831,6 +851,8 @@ cat >"$report_json" <<JSON
   "admission_reason_codes_csv": "${admission_reason_codes_csv}",
   "admission_budget_reason_taxonomy_version": "${admission_budget_reason_taxonomy_version}",
   "admission_budget_reason_codes_csv": "${admission_budget_reason_codes_csv}",
+  "admission_decision_reason_taxonomy_version": "${admission_decision_reason_taxonomy_version}",
+  "admission_decision_reason_codes_csv": "${admission_decision_reason_codes_csv}",
   "service_api_lifecycle_rejection_reason_taxonomy_version": "${service_api_lifecycle_rejection_reason_taxonomy_version}",
   "service_api_lifecycle_rejection_reason_codes_csv": "${service_api_lifecycle_rejection_reason_codes_csv}",
   "request_validation_reason_registry_status": "${request_validation_reason_registry_status}",
@@ -877,6 +899,10 @@ echo "admission_saturation_status=${admission_saturation_status}"
 echo "admission_queue_cap_enforcement_status=${admission_queue_cap_enforcement_status}"
 echo "admission_inflight_budget_status=${admission_inflight_budget_status}"
 echo "admission_queue_budget_status=${admission_queue_budget_status}"
+echo "admission_decision_taxonomy_status=${admission_decision_taxonomy_status}"
+echo "admission_decision_accept_status=${admission_decision_accept_status}"
+echo "admission_decision_defer_status=${admission_decision_defer_status}"
+echo "admission_decision_reject_status=${admission_decision_reject_status}"
 echo "overload_evidence_normalization_status=${overload_evidence_normalization_status}"
 echo "async_lifecycle_backpressure_projection_status=${async_lifecycle_backpressure_projection_status}"
 echo "protocol_compliance_status=${protocol_compliance_status}"
@@ -889,6 +915,8 @@ echo "admission_reason_taxonomy_version=${admission_reason_taxonomy_version}"
 echo "admission_reason_codes_csv=${admission_reason_codes_csv}"
 echo "admission_budget_reason_taxonomy_version=${admission_budget_reason_taxonomy_version}"
 echo "admission_budget_reason_codes_csv=${admission_budget_reason_codes_csv}"
+echo "admission_decision_reason_taxonomy_version=${admission_decision_reason_taxonomy_version}"
+echo "admission_decision_reason_codes_csv=${admission_decision_reason_codes_csv}"
 echo "service_api_lifecycle_rejection_reason_taxonomy_version=${service_api_lifecycle_rejection_reason_taxonomy_version}"
 echo "service_api_lifecycle_rejection_reason_codes_csv=${service_api_lifecycle_rejection_reason_codes_csv}"
 echo "request_validation_reason_registry_status=${request_validation_reason_registry_status}"

--- a/scripts/runtime/validate_service_api_axum_ingress_live_contract_lane.sh
+++ b/scripts/runtime/validate_service_api_axum_ingress_live_contract_lane.sh
@@ -57,6 +57,10 @@ VALIDATION_REQUIRED_MARKERS=(
   "admission_queue_cap_enforcement_status=verified"
   "admission_inflight_budget_status=verified"
   "admission_queue_budget_status=verified"
+  "admission_decision_taxonomy_status=verified"
+  "admission_decision_accept_status=verified"
+  "admission_decision_defer_status=verified"
+  "admission_decision_reject_status=verified"
   "overload_evidence_normalization_status=verified"
   "async_lifecycle_backpressure_projection_status=verified"
   "protocol_compliance_status=verified"
@@ -69,6 +73,8 @@ VALIDATION_REQUIRED_MARKERS=(
   "admission_reason_codes_csv=admission_queue_saturation_detected,admission_queue_cap_bypass_detected,admission_evidence_normalization_drift"
   "admission_budget_reason_taxonomy_version=kamn.runtime.service-api-admission-budget-reason-taxonomy.v1"
   "admission_budget_reason_codes_csv=admission_inflight_budget_mismatch,admission_queue_budget_mismatch"
+  "admission_decision_reason_taxonomy_version=kamn.runtime.service-api-admission-decision-reason-taxonomy.v1"
+  "admission_decision_reason_codes_csv=admission_decision_accept,admission_decision_defer,admission_decision_reject"
   "service_api_lifecycle_rejection_reason_taxonomy_version=kamn.runtime.service-api.lifecycle-rejection-reason-taxonomy.v1"
   "service_api_lifecycle_rejection_reason_codes_csv=service_api_ingress_concurrency_limit_exceeded,service_api_ingress_rate_limit_exceeded,service_api_ingress_sender_rate_limit_exceeded,service_api_ingress_sender_suspended,service_api_ingress_sender_duplicate_message_id,service_api_ingress_sender_insufficient_deposit,service_api_ingress_anti_spam_engine_invalid"
   "request_validation_reason_registry_status=verified"
@@ -100,6 +106,12 @@ POLICY_REQUIRED_MARKERS=(
   "admission_queue_budget_limit=1"
   "admission_budget_reason_taxonomy_version=kamn.runtime.service-api-admission-budget-reason-taxonomy.v1"
   "admission_budget_reason_codes_csv=admission_inflight_budget_mismatch,admission_queue_budget_mismatch"
+  "admission_decision_taxonomy_status=verified"
+  "admission_decision_accept_status=verified"
+  "admission_decision_defer_status=verified"
+  "admission_decision_reject_status=verified"
+  "admission_decision_reason_taxonomy_version=kamn.runtime.service-api-admission-decision-reason-taxonomy.v1"
+  "admission_decision_reason_codes_csv=admission_decision_accept,admission_decision_defer,admission_decision_reject"
   "service_api_axum_protocol_mismatch_reason_mapping_status=verified"
   "service_api_axum_protocol_mismatch_reason_taxonomy_version=kamn.runtime.service-api-axum-protocol-mismatch-reason-taxonomy.v1"
   "service_api_axum_protocol_mismatch_reason_codes_csv=service_api_axum_policy_required_field_missing,service_api_axum_policy_marker_missing,service_api_axum_policy_protocol_taxonomy_mismatch,service_api_axum_policy_limit_contract_mismatch,ci_fast_gate_failed,service_api_axum_policy_expected_decision_mismatch,service_api_axum_policy_violation"
@@ -120,6 +132,7 @@ STRATEGY_REQUIRED_MARKERS=(
   "request-validation and error-envelope taxonomy parity remains deterministic via:"
   "ingress resilience governance remains deterministic via:"
   "admission saturation, in-flight, and queue-budget governance remains deterministic via:"
+  "admission decision taxonomy (accept/defer/reject) and runbook marker parity remains deterministic via:"
   "protocol mismatch reason mapping remains deterministic via:"
   "admission backpressure evidence convergence governance remains deterministic via:"
   "protocol taxonomy and runbook-marker parity remains deterministic via:"
@@ -138,6 +151,13 @@ RUNBOOK_REQUIRED_MARKERS=(
   "error_envelope_reason_codes_csv=service_api_ws_upgrade_header_missing,service_api_method_not_allowed,service_api_route_not_found"
   "service_api_axum_protocol_mismatch_reason_taxonomy_version=kamn.runtime.service-api-axum-protocol-mismatch-reason-taxonomy.v1"
   "service_api_axum_protocol_mismatch_reason_codes_csv=service_api_axum_policy_required_field_missing,service_api_axum_policy_marker_missing,service_api_axum_policy_protocol_taxonomy_mismatch,service_api_axum_policy_limit_contract_mismatch,ci_fast_gate_failed,service_api_axum_policy_expected_decision_mismatch,service_api_axum_policy_violation"
+  "## Service API Axum Admission Decision Taxonomy and Runbook Marker Parity Contracts (Issue #4222)"
+  "admission_decision_taxonomy_mapping_status=verified"
+  "admission_decision_runbook_marker_parity_status=verified"
+  "admission_decision_taxonomy_runbook_reason_taxonomy_version=kamn.runtime.service-api-axum-admission-decision-runbook-reason-taxonomy.v1"
+  "admission_decision_taxonomy_runbook_reason_codes_csv=admission_decision_taxonomy_mapping_drift_detected,admission_runbook_marker_parity_mismatch"
+  "admission_decision_reason_taxonomy_version=kamn.runtime.service-api-admission-decision-reason-taxonomy.v1"
+  "admission_decision_reason_codes_csv=admission_decision_accept,admission_decision_defer,admission_decision_reject"
 )
 LANE_REPORT_SUMMARY_FIELDS=(
   ingress_limit_config_status
@@ -152,6 +172,10 @@ LANE_REPORT_SUMMARY_FIELDS=(
   admission_queue_cap_enforcement_status
   admission_inflight_budget_status
   admission_queue_budget_status
+  admission_decision_taxonomy_status
+  admission_decision_accept_status
+  admission_decision_defer_status
+  admission_decision_reject_status
   overload_evidence_normalization_status
   async_lifecycle_backpressure_projection_status
   protocol_compliance_status
@@ -164,6 +188,8 @@ LANE_REPORT_SUMMARY_FIELDS=(
   admission_reason_codes_csv
   admission_budget_reason_taxonomy_version
   admission_budget_reason_codes_csv
+  admission_decision_reason_taxonomy_version
+  admission_decision_reason_codes_csv
   service_api_lifecycle_rejection_reason_taxonomy_version
   service_api_lifecycle_rejection_reason_codes_csv
   request_validation_reason_registry_status
@@ -193,6 +219,10 @@ OUTPUT_SUMMARY_FIELDS=(
   admission_queue_cap_enforcement_status
   admission_inflight_budget_status
   admission_queue_budget_status
+  admission_decision_taxonomy_status
+  admission_decision_accept_status
+  admission_decision_defer_status
+  admission_decision_reject_status
   overload_evidence_normalization_status
   async_lifecycle_backpressure_projection_status
   protocol_compliance_status
@@ -205,6 +235,8 @@ OUTPUT_SUMMARY_FIELDS=(
   admission_reason_codes_csv
   admission_budget_reason_taxonomy_version
   admission_budget_reason_codes_csv
+  admission_decision_reason_taxonomy_version
+  admission_decision_reason_codes_csv
   service_api_lifecycle_rejection_reason_taxonomy_version
   service_api_lifecycle_rejection_reason_codes_csv
   request_validation_reason_registry_status

--- a/specs/4222/plan.md
+++ b/specs/4222/plan.md
@@ -1,0 +1,52 @@
+# Plan — #4222 Admission Decision Taxonomy + Runbook Marker Parity
+
+Status: Implemented
+
+## Approach
+1. Add red tests first for admission decision taxonomy marker assertions and tamper paths in:
+   - `scripts/runtime/test_check_service_api_axum_ingress_live_policy.sh`
+   - `scripts/runtime/test_validate_service_api_axum_ingress_live_contract_lane.sh`
+2. Emit admission decision taxonomy markers from validation summary in:
+   - `scripts/runtime/validate_service_api_axum_ingress_live.sh`
+3. Enforce policy fail-closed checks and deterministic mismatch reasons in:
+   - `scripts/runtime/service_api_axum_ingress_live_contract.py`
+4. Wire lane required markers and runbook parity requirements in:
+   - `scripts/runtime/validate_service_api_axum_ingress_live_contract_lane.sh`
+5. Update docs and docs-contract tests:
+   - `docs/ci/strategy.md`
+   - `docs/foundation/release-gonogo-checklist.md`
+   - `docs/deploy/kolme_devnet_ops.md`
+   - `docs/ops/configuration.md` (if marker surface is documented there)
+   - Rust docs tests under `crates/kamn-core/tests/*`
+6. Run targeted verification commands for shell scripts and docs-contract tests.
+
+## Affected Modules
+- Runtime shell contracts: `scripts/runtime/*service_api_axum_ingress*`
+- Runtime policy checker: `scripts/runtime/service_api_axum_ingress_live_contract.py`
+- Operator/CI docs: runbook, strategy, release checklist, ops configuration.
+- Rust docs-contract tests in `crates/kamn-core/tests`.
+
+## Risks and Mitigations
+- Risk: marker-name drift across script/docs/test surfaces.
+  - Mitigation: define one canonical marker set and reuse exact literals in all assertions.
+- Risk: reason-code taxonomy changes breaking existing gate expectations.
+  - Mitigation: add new admission-decision-specific markers without removing existing protocol mismatch taxonomy markers.
+- Risk: unintended CI cost increase.
+  - Mitigation: keep contract-lane command surface unchanged; only marker validation is extended.
+
+## Interfaces / Contracts
+New summary/policy markers:
+- `admission_decision_taxonomy_status=verified`
+- `admission_decision_accept_status=verified`
+- `admission_decision_defer_status=verified`
+- `admission_decision_reject_status=verified`
+- `admission_decision_reason_taxonomy_version=kamn.runtime.service-api-admission-decision-reason-taxonomy.v1`
+- `admission_decision_reason_codes_csv=admission_decision_accept,admission_decision_defer,admission_decision_reject`
+
+Runbook parity markers:
+- `admission_decision_taxonomy_mapping_status=verified`
+- `admission_decision_runbook_marker_parity_status=verified`
+- `admission_decision_taxonomy_runbook_reason_taxonomy_version=kamn.runtime.service-api-axum-admission-decision-runbook-reason-taxonomy.v1`
+- `admission_decision_taxonomy_runbook_reason_codes_csv=admission_decision_taxonomy_mapping_drift_detected,admission_runbook_marker_parity_mismatch`
+
+No dependency changes.

--- a/specs/4222/spec.md
+++ b/specs/4222/spec.md
@@ -1,0 +1,56 @@
+# Spec — #4222 Task: Enforce Admission Decision Taxonomy and Runbook Marker Parity Under Overload
+
+Status: Implemented
+Priority: P1
+Parent: #4219
+Milestone: R27.24 Async API concurrency and admission-backpressure governance
+
+## Problem Statement
+Service API axum ingress contracts currently verify admission saturation and budget markers but do not expose an explicit admission decision taxonomy contract for `accept`/`defer`/`reject` with runbook parity validation. This creates drift risk between checker output and operator runbook guidance during overload handling.
+
+## Scope
+In scope:
+- Add deterministic admission decision taxonomy markers (`accept`, `defer`, `reject`) to service-api axum validation/policy outputs.
+- Enforce policy fail-closed behavior for admission decision taxonomy drift.
+- Extend contract-lane runbook parity requirements to include admission decision taxonomy markers.
+- Update release/checklist/CI/runbook docs and docs-contract tests.
+
+Out of scope:
+- Redesigning ingress admission engine behavior.
+- Changing runtime queue/concurrency defaults.
+- Incident workflow tooling changes.
+
+## Acceptance Criteria
+AC-1 (Given/When/Then):
+- Given a valid service-api axum ingress summary report,
+- When the policy checker validates the report,
+- Then the output includes deterministic admission decision taxonomy markers for `accept`, `defer`, and `reject`, and returns `final_decision=GO`.
+
+AC-2 (Given/When/Then):
+- Given a tampered admission decision taxonomy field in the summary report,
+- When policy validation runs,
+- Then validation fails closed with deterministic mismatch reason codes.
+
+AC-3 (Given/When/Then):
+- Given a runbook missing admission decision taxonomy markers,
+- When the contract lane validates runbook parity,
+- Then the lane fails closed with deterministic taxonomy/parity drift reasons.
+
+AC-4 (Given/When/Then):
+- Given CI/docs/release operator documents,
+- When docs-contract tests run,
+- Then all required admission decision taxonomy and runbook-parity markers are present and synchronized.
+
+## Conformance Cases
+- C-01 (AC-1, Functional): baseline policy output contains deterministic admission decision taxonomy version/csv and `accept/defer/reject` status markers.
+- C-02 (AC-1, Integration): contract-lane output/report propagate admission decision taxonomy markers.
+- C-03 (AC-2, Regression): tampered admission decision taxonomy version fails with deterministic mismatch reason.
+- C-04 (AC-2, Regression): tampered admission decision reason-codes csv fails with deterministic mismatch reason.
+- C-05 (AC-3, Regression): runbook taxonomy marker drift fails lane with deterministic taxonomy drift reason.
+- C-06 (AC-3, Regression): runbook marker divergence fails lane with deterministic parity mismatch reason.
+- C-07 (AC-4, Docs): docs-contract tests assert admission decision taxonomy/runbook markers in CI strategy, release checklist, and runbook docs.
+
+## Success Metrics / Signals
+- Service-api axum policy checker and contract-lane tests pass with new deterministic markers.
+- Runbook drift/divergence fixtures fail deterministically.
+- Updated docs-contract tests pass without flaky ordering or output variance.

--- a/specs/4222/tasks.md
+++ b/specs/4222/tasks.md
@@ -1,0 +1,19 @@
+# Tasks — #4222 Admission Decision Taxonomy + Runbook Parity
+
+Status: Implemented
+
+## Ordered Tasks
+1. T1 (Red, Regression/Integration): add failing assertions/tamper fixtures for admission decision taxonomy markers and runbook parity divergence in service-api axum policy/lane tests.
+2. T2 (Green, Functional): emit admission decision taxonomy markers in validation summary output and stdout markers.
+3. T3 (Green, Functional/Regression): enforce admission decision taxonomy checks in policy checker with deterministic fail-closed reasons.
+4. T4 (Green, Integration): wire lane required markers, summary propagation, and runbook marker checks for admission decision taxonomy parity.
+5. T5 (Green, Docs): update strategy/runbook/release checklist/ops configuration marker references and corresponding docs-contract tests.
+6. T6 (Verify, Regression): run targeted shell and Rust docs-contract test commands and capture outputs for PR evidence.
+
+## Tier Mapping
+- Unit: targeted marker validation helpers via policy/lane checker tests.
+- Functional: baseline GO-path marker validation for summary/policy.
+- Conformance: C-01..C-07 via script and docs-contract tests.
+- Integration: contract-lane report/policy/runbook composition checks.
+- Regression: tampered taxonomy/runbook divergence fixtures.
+- Performance: CI smoke boundary unchanged; no new heavy lanes.

--- a/specs/4227/plan.md
+++ b/specs/4227/plan.md
@@ -1,0 +1,12 @@
+# Plan — #4227 Red Tests for Admission Taxonomy/Runbook Divergence
+
+Status: Implemented
+
+## Approach
+- Extend `scripts/runtime/test_check_service_api_axum_ingress_live_policy.sh` with admission decision taxonomy red/tamper cases.
+- Extend `scripts/runtime/test_validate_service_api_axum_ingress_live_contract_lane.sh` with runbook drift/divergence fixtures for admission decision markers.
+- Ensure deterministic reason-code assertions and no flaky timing dependencies.
+
+## Risks
+- Drift in reason-code literals causing brittle tests.
+  - Mitigation: assert exact deterministic literals and reuse canonical marker constants.

--- a/specs/4227/spec.md
+++ b/specs/4227/spec.md
@@ -1,0 +1,29 @@
+# Spec — #4227 Subtask: Red Tests for Admission Taxonomy Drift and Runbook Marker Divergence
+
+Status: Implemented
+Priority: P1
+Parent: #4222
+Milestone: R27.24 Async API concurrency and admission-backpressure governance
+
+## Problem Statement
+Without explicit red tests, admission decision taxonomy and runbook parity changes can regress silently and reintroduce aspirational/incomplete merges.
+
+## Scope
+In scope:
+- Add failing/tamper tests for admission decision taxonomy drift in policy checks.
+- Add failing/tamper tests for runbook marker divergence in contract-lane checks.
+
+Out of scope:
+- Implementing final production marker emission/checking logic.
+
+## Acceptance Criteria
+AC-1: Policy red tests fail deterministically on admission decision taxonomy drift.
+AC-2: Lane red tests fail deterministically on runbook marker divergence.
+AC-3: Regression fixtures preserve deterministic reason-code outputs.
+
+## Conformance Cases
+- C-01 (AC-1, Regression): tampered admission decision taxonomy version fails with deterministic mismatch reason.
+- C-02 (AC-1, Regression): tampered admission decision reason-codes csv fails with deterministic mismatch reason.
+- C-03 (AC-2, Regression): runbook taxonomy marker drift fixture fails with deterministic reason.
+- C-04 (AC-2, Regression): runbook marker divergence fixture fails with deterministic reason.
+- C-05 (AC-3, Regression): repeated tampered runs keep deterministic reason-code ordering.

--- a/specs/4227/tasks.md
+++ b/specs/4227/tasks.md
@@ -1,0 +1,7 @@
+# Tasks — #4227 Red Tests
+
+Status: Implemented
+
+1. T1: Add failing policy-checker assertions for missing/tampered admission decision taxonomy markers.
+2. T2: Add failing lane assertions for runbook taxonomy and marker divergence.
+3. T3: Add deterministic reason-code assertions for both tamper paths.

--- a/specs/4228/plan.md
+++ b/specs/4228/plan.md
@@ -1,0 +1,16 @@
+# Plan — #4228 Implementation
+
+Status: Implemented
+
+## Approach
+- Extend service-api axum validation summary marker set and serialized JSON/stdout outputs.
+- Extend policy checker required/verified field enforcement and mismatch taxonomy mappings.
+- Extend contract-lane required marker sets, runbook parity markers, and summary propagation fields.
+- Update docs and docs-contract tests to match the canonical marker set.
+
+## Contract Additions
+- Admission decision taxonomy markers (`accept`, `defer`, `reject`).
+- Admission decision runbook parity markers and deterministic drift reason names.
+
+## Mitigations
+- Keep existing protocol mismatch and admission budget markers unchanged to avoid cross-issue regression.

--- a/specs/4228/spec.md
+++ b/specs/4228/spec.md
@@ -1,0 +1,33 @@
+# Spec — #4228 Subtask: Implement Admission Taxonomy Enforcement and Runbook Marker Parity Checks
+
+Status: Implemented
+Priority: P1
+Parent: #4222
+Milestone: R27.24 Async API concurrency and admission-backpressure governance
+
+## Problem Statement
+After red tests, production scripts must enforce admission decision taxonomy output and runbook parity checks to keep overload governance deterministic.
+
+## Scope
+In scope:
+- Implement admission decision taxonomy marker emission in validation reports.
+- Implement policy checker enforcement + deterministic mismatch reasons.
+- Implement contract-lane runbook parity marker checks.
+
+Out of scope:
+- Admission algorithm redesign.
+- CI topology changes.
+
+## Acceptance Criteria
+AC-1: Validation + policy outputs include deterministic admission decision taxonomy markers.
+AC-2: Policy checker fails closed on admission decision taxonomy drift.
+AC-3: Contract lane fails closed on runbook admission marker parity drift/divergence.
+AC-4: Docs and docs-contract tests reflect and enforce the marker contract.
+
+## Conformance Cases
+- C-01 (AC-1, Functional): baseline validation and policy output include taxonomy version/csv + accept/defer/reject markers.
+- C-02 (AC-2, Regression): tampered admission decision taxonomy version fails policy.
+- C-03 (AC-2, Regression): tampered admission decision taxonomy csv fails policy.
+- C-04 (AC-3, Regression): runbook taxonomy marker drift fails lane.
+- C-05 (AC-3, Regression): runbook marker divergence fails lane.
+- C-06 (AC-4, Docs): docs-contract tests assert new taxonomy/parity markers.

--- a/specs/4228/tasks.md
+++ b/specs/4228/tasks.md
@@ -1,0 +1,8 @@
+# Tasks — #4228 Implementation
+
+Status: Implemented
+
+1. T1: Implement validation report marker emission for admission decision taxonomy.
+2. T2: Implement policy checker enforcement and deterministic mismatch reason mappings.
+3. T3: Implement lane/runbook parity marker checks and summary propagation.
+4. T4: Update docs + docs-contract tests and run verification commands.


### PR DESCRIPTION
## Summary
This PR adds deterministic Service API axum **admission decision taxonomy** contracts (`accept`/`defer`/`reject`) across validation, policy checking, lane propagation, runbook parity checks, and docs-contract coverage. It also adds red/tamper regression tests for taxonomy drift and runbook marker divergence.

## Links
- Milestone: `R27.24 Async API concurrency and admission-backpressure governance`
- Closes #4222
- Closes #4227
- Closes #4228
- Spec: `specs/4222/spec.md`
- Plan: `specs/4222/plan.md`
- Tasks: `specs/4222/tasks.md`
- Subtask specs: `specs/4227/spec.md`, `specs/4228/spec.md`

## Human Review
P1 multi-module/spec-driven change. Human review requested per `AGENTS.md` self-acceptance policy.

## Spec Verification (AC -> tests)
| AC | Status | Test(s) |
|---|---|---|
| AC-1 deterministic admission decision taxonomy markers | ✅ | `bash scripts/runtime/test_check_service_api_axum_ingress_live_policy.sh`; `bash scripts/runtime/test_validate_service_api_axum_ingress_live_contract_lane.sh` |
| AC-2 fail-closed on taxonomy drift | ✅ | `bash scripts/runtime/test_check_service_api_axum_ingress_live_policy.sh` tamper cases for `admission_decision_reason_taxonomy_version` and `admission_decision_reason_codes_csv` |
| AC-3 runbook parity fail-closed on marker drift/divergence | ✅ | `bash scripts/runtime/test_validate_service_api_axum_ingress_live_contract_lane.sh` admission-runbook drift/divergence fixtures |
| AC-4 docs + docs-contract synchronization | ✅ | `cargo test -p kamn-core --test service_api_ops_configuration_docs`; `cargo test -p kamn-core --test ci_strategy_docs`; `cargo test -p kamn-core --test release_gonogo_checklist_docs`; `cargo test -p kamn-core --test kolme_devnet_ops_docs` |

## TDD Evidence
### RED
- `bash scripts/runtime/test_check_service_api_axum_ingress_live_policy.sh`
  - Failed with: `expected service api axum ingress policy checker admission decision taxonomy status marker`
- `bash scripts/runtime/test_validate_service_api_axum_ingress_live_contract_lane.sh`
  - Failed with: `expected service api axum ingress contract lane admission decision taxonomy status marker`

### GREEN
- `python3 -m py_compile scripts/runtime/service_api_axum_ingress_live_contract.py`
- `bash -n scripts/runtime/validate_service_api_axum_ingress_live.sh scripts/runtime/validate_service_api_axum_ingress_live_contract_lane.sh scripts/runtime/test_check_service_api_axum_ingress_live_policy.sh scripts/runtime/test_validate_service_api_axum_ingress_live_contract_lane.sh`
- `bash scripts/runtime/test_check_service_api_axum_ingress_live_policy.sh`
- `bash scripts/runtime/test_validate_service_api_axum_ingress_live_contract_lane.sh`
- `cargo fmt --check`
- `cargo test -p kamn-core --test service_api_ops_configuration_docs`
- `cargo test -p kamn-core --test ci_strategy_docs`
- `cargo test -p kamn-core --test release_gonogo_checklist_docs`
- `cargo test -p kamn-core --test kolme_devnet_ops_docs`

### REGRESSION
- Added deterministic tamper coverage for:
  - `admission_decision_reason_taxonomy_version` drift
  - `admission_decision_reason_codes_csv` drift
  - `admission_decision_defer_status` marker divergence
  - runbook admission decision taxonomy drift/divergence fixtures

## Test Tiers
| Tier | ✅/❌/N/A | Tests | N/A Why |
|---|---|---|---|
| Unit | ✅ | shell/python checker assertions in policy/lane test harnesses | |
| Property | N/A | | no invariant/property harness in scope |
| Contract/DbC | N/A | | no Rust contracts crate surface changed |
| Snapshot | N/A | | no snapshot harness in scope |
| Functional | ✅ | service-api axum validation/policy/lane shell tests | |
| Conformance | ✅ | C-01..C-07 mapped in `specs/4222/spec.md` | |
| Integration | ✅ | lane validation + policy + runbook parity composition tests | |
| Fuzz | N/A | | no parser/untrusted fuzz target changed |
| Mutation | N/A | | runtime shell/docs-contract path; no mutation gate target configured |
| Regression | ✅ | tampered taxonomy/runbook divergence fixtures in updated shell tests | |
| Performance | ✅ | CI/local budget guards unchanged and validated by lane checks | |

## Risks / Rollback
- Risk: marker-name drift across shell/docs/tests.
- Mitigation: canonicalized marker literals and added docs-contract assertions.
- Rollback: revert this PR commit to restore previous marker contract surface.

## Docs / ADR
- Updated docs:
  - `docs/ci/strategy.md`
  - `docs/deploy/kolme_devnet_ops.md`
  - `docs/foundation/release-gonogo-checklist.md`
  - `docs/ops/configuration.md`
- ADR: not required (no architecture or dependency decision change).
