### PR TITLE
test(runtime): add harness taxonomy drift red tests and runbook parity checks (#4197)

### DIFF
--- a/crates/kamn-core/tests/kolme_devnet_ops_docs.rs
+++ b/crates/kamn-core/tests/kolme_devnet_ops_docs.rs
@@ -132,6 +132,40 @@ fn plan_contains_sqlite_crash_replay_evidence_convergence_contract() {
 }
 
 #[test]
+fn deploy_compat_contains_local_full_stack_harness_taxonomy_runbook_parity_markers() {
+    assert!(DEPLOY_COMPAT.contains(
+        "## Local Full-Stack Harness Taxonomy and Runbook Marker Parity Contracts (Issue #4197)"
+    ));
+    assert!(DEPLOY_COMPAT.contains(
+        "combined_reason_taxonomy_version=kamn.runtime.local-full-stack-integration-reason-taxonomy.v1"
+    ));
+    assert!(DEPLOY_COMPAT.contains(
+        "runtime_phase_parity_reason_taxonomy_version=kamn.runtime.phase-module-extraction-parity-reason-taxonomy.v1"
+    ));
+    assert!(DEPLOY_COMPAT.contains(
+        "runtime_phase_parity_reason_codes_csv=runtime_phase_module_parity_drift_detected,runtime_extraction_evidence_output_unstable,ci_local_runtime_phase_parity_budget_boundary_exceeded"
+    ));
+    assert!(DEPLOY_COMPAT.contains(
+        "runtime_module_boundary_parity_reason_taxonomy_version=kamn.runtime.module-boundary-parity-reason-taxonomy.v1"
+    ));
+    assert!(DEPLOY_COMPAT.contains(
+        "runtime_module_boundary_parity_reason_codes_csv=runtime_orchestration_dispatch_boundary_drift_detected,runtime_daemon_phase_boundary_drift_detected,runtime_kolme_live_boundary_drift_detected,ci_local_runtime_module_boundary_budget_boundary_exceeded"
+    ));
+    assert!(DEPLOY_COMPAT.contains("runtime_phase_module_parity_status=verified"));
+    assert!(DEPLOY_COMPAT.contains("runtime_module_boundary_parity_status=verified"));
+    assert!(DEPLOY_COMPAT.contains(
+        "local_full_stack_harness_runbook_reason_codes_csv=local_full_stack_harness_taxonomy_mapping_drift_detected,runbook_marker_parity_mismatch"
+    ));
+    assert!(DEPLOY_COMPAT.contains("local_full_stack_harness_taxonomy_mapping_drift_detected"));
+    assert!(DEPLOY_COMPAT.contains("runbook_marker_parity_mismatch"));
+    assert!(DEPLOY_COMPAT.contains("test_check_local_full_stack_integration_live_policy.sh"));
+    assert!(
+        DEPLOY_COMPAT.contains("test_validate_local_full_stack_integration_live_contract_lane.sh")
+    );
+    assert!(DEPLOY_COMPAT.contains("Regression: #4197"));
+}
+
+#[test]
 fn deploy_compat_contains_drift_taxonomy_runbook_parity_markers() {
     assert!(DEPLOY_COMPAT
         .contains("## Drift Taxonomy and Runbook Marker Parity Contracts (Issue #4282)"));

--- a/docs/deploy/kolme_devnet_ops.md
+++ b/docs/deploy/kolme_devnet_ops.md
@@ -34,6 +34,34 @@ present, including:
 - `milestone_review_go_no_go_gate_kolme_fixture_profile_status_mismatch`
 - `milestone_review_go_no_go_gate_combined_lane_marker_contract_status_mismatch`
 
+## Local Full-Stack Harness Taxonomy and Runbook Marker Parity Contracts (Issue #4197)
+
+Local full-stack harness taxonomy markers and runbook marker declarations must remain synchronized
+to keep fail-closed remediation deterministic for runtime/transport/consensus convergence checks.
+
+Required checker/runbook parity markers:
+
+- `combined_reason_taxonomy_version=kamn.runtime.local-full-stack-integration-reason-taxonomy.v1`
+- `runtime_phase_parity_reason_taxonomy_version=kamn.runtime.phase-module-extraction-parity-reason-taxonomy.v1`
+- `runtime_phase_parity_reason_codes_csv=runtime_phase_module_parity_drift_detected,runtime_extraction_evidence_output_unstable,ci_local_runtime_phase_parity_budget_boundary_exceeded`
+- `runtime_module_boundary_parity_reason_taxonomy_version=kamn.runtime.module-boundary-parity-reason-taxonomy.v1`
+- `runtime_module_boundary_parity_reason_codes_csv=runtime_orchestration_dispatch_boundary_drift_detected,runtime_daemon_phase_boundary_drift_detected,runtime_kolme_live_boundary_drift_detected,ci_local_runtime_module_boundary_budget_boundary_exceeded`
+- `runtime_phase_module_parity_status=verified`
+- `runtime_module_boundary_parity_status=verified`
+- `local_full_stack_harness_runbook_reason_codes_csv=local_full_stack_harness_taxonomy_mapping_drift_detected,runbook_marker_parity_mismatch`
+
+Fail-closed drift reasons:
+
+- `local_full_stack_harness_taxonomy_mapping_drift_detected`
+- `runbook_marker_parity_mismatch`
+
+Validation commands:
+
+- `bash scripts/runtime/test_check_local_full_stack_integration_live_policy.sh`
+- `bash scripts/runtime/test_validate_local_full_stack_integration_live_contract_lane.sh`
+
+- `Regression: #4197`
+
 ## Crash-Recovery Replay Idempotency Taxonomy and Runbook Marker Parity Contracts (Issue #4237)
 
 Sqlite crash-recovery replay idempotency taxonomy markers and runbook marker declarations must stay

--- a/scripts/runtime/test_check_local_full_stack_integration_live_policy.sh
+++ b/scripts/runtime/test_check_local_full_stack_integration_live_policy.sh
@@ -8,6 +8,10 @@ TMP_POLICY="$(mktemp)"
 TMP_TAMPERED="$(mktemp)"
 trap 'rm -f "$TMP_REPORT" "$TMP_POLICY" "$TMP_TAMPERED"' EXIT
 
+EXPECTED_RUNTIME_PHASE_REASON_TAXONOMY_VERSION="kamn.runtime.phase-module-extraction-parity-reason-taxonomy.v1"
+EXPECTED_RUNTIME_PHASE_REASON_CODES_CSV="runtime_phase_module_parity_drift_detected,runtime_extraction_evidence_output_unstable,ci_local_runtime_phase_parity_budget_boundary_exceeded"
+EXPECTED_RUNTIME_MODULE_BOUNDARY_REASON_CODES_CSV="runtime_orchestration_dispatch_boundary_drift_detected,runtime_daemon_phase_boundary_drift_detected,runtime_kolme_live_boundary_drift_detected,ci_local_runtime_module_boundary_budget_boundary_exceeded"
+
 if [ ! -x "$POLICY_SCRIPT" ]; then
   echo "expected local full-stack integration policy script to be executable" >&2
   exit 1
@@ -331,6 +335,113 @@ if [ "$tampered_reason_taxonomy_code" -eq 0 ]; then
 fi
 if ! printf '%s\n' "$tampered_reason_taxonomy_output" | grep -q 'local_full_stack_integration_policy_reason_taxonomy_version_mismatch'; then
   echo "expected deterministic reason marker for tampered combined reason taxonomy version" >&2
+  exit 1
+fi
+
+cp "$TMP_REPORT" "$TMP_TAMPERED"
+python3 - "$TMP_TAMPERED" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+payload = json.loads(path.read_text(encoding="utf-8"))
+payload["runtime_phase_parity_reason_taxonomy_version"] = "v0"
+path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+set +e
+tampered_runtime_phase_reason_taxonomy_output="$(
+  bash "$POLICY_SCRIPT" \
+    --report-file "$TMP_TAMPERED" \
+    --expected-final-decision GO \
+    --ci-fast-gate PASS \
+    --output-json "$TMP_POLICY" 2>&1
+)"
+tampered_runtime_phase_reason_taxonomy_code=$?
+set -e
+if [ "$tampered_runtime_phase_reason_taxonomy_code" -eq 0 ]; then
+  echo "expected runtime phase parity reason taxonomy drift to fail local full-stack integration policy check" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$tampered_runtime_phase_reason_taxonomy_output" | grep -q 'local_full_stack_integration_policy_runtime_phase_parity_reason_taxonomy_version_mismatch'; then
+  echo "expected deterministic reason marker for runtime phase parity reason taxonomy drift" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$tampered_runtime_phase_reason_taxonomy_output" | grep -q '^reason_codes_value=runtime_extraction_evidence_output_unstable$'; then
+  echo "expected normalized reason mapping for runtime phase parity reason taxonomy drift" >&2
+  exit 1
+fi
+
+cp "$TMP_REPORT" "$TMP_TAMPERED"
+python3 - "$TMP_TAMPERED" "$EXPECTED_RUNTIME_PHASE_REASON_CODES_CSV" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+expected = sys.argv[2]
+payload = json.loads(path.read_text(encoding="utf-8"))
+payload["runtime_phase_parity_reason_codes_csv"] = expected.split(",")[0]
+path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+set +e
+tampered_runtime_phase_reason_codes_output="$(
+  bash "$POLICY_SCRIPT" \
+    --report-file "$TMP_TAMPERED" \
+    --expected-final-decision GO \
+    --ci-fast-gate PASS \
+    --output-json "$TMP_POLICY" 2>&1
+)"
+tampered_runtime_phase_reason_codes_code=$?
+set -e
+if [ "$tampered_runtime_phase_reason_codes_code" -eq 0 ]; then
+  echo "expected runtime phase parity reason code drift to fail local full-stack integration policy check" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$tampered_runtime_phase_reason_codes_output" | grep -q 'local_full_stack_integration_policy_runtime_phase_parity_reason_codes_csv_mismatch'; then
+  echo "expected deterministic reason marker for runtime phase parity reason code drift" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$tampered_runtime_phase_reason_codes_output" | grep -q '^reason_codes_value=runtime_extraction_evidence_output_unstable$'; then
+  echo "expected normalized reason mapping for runtime phase parity reason code drift" >&2
+  exit 1
+fi
+
+cp "$TMP_REPORT" "$TMP_TAMPERED"
+python3 - "$TMP_TAMPERED" "$EXPECTED_RUNTIME_MODULE_BOUNDARY_REASON_CODES_CSV" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+expected = sys.argv[2]
+payload = json.loads(path.read_text(encoding="utf-8"))
+payload["runtime_module_boundary_parity_reason_codes_csv"] = expected.split(",")[0]
+path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+set +e
+tampered_runtime_module_boundary_reason_codes_output="$(
+  bash "$POLICY_SCRIPT" \
+    --report-file "$TMP_TAMPERED" \
+    --expected-final-decision GO \
+    --ci-fast-gate PASS \
+    --output-json "$TMP_POLICY" 2>&1
+)"
+tampered_runtime_module_boundary_reason_codes_code=$?
+set -e
+if [ "$tampered_runtime_module_boundary_reason_codes_code" -eq 0 ]; then
+  echo "expected runtime module boundary reason code drift to fail local full-stack integration policy check" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$tampered_runtime_module_boundary_reason_codes_output" | grep -q 'local_full_stack_integration_policy_runtime_module_boundary_parity_reason_codes_csv_mismatch'; then
+  echo "expected deterministic reason marker for runtime module boundary reason code drift" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$tampered_runtime_module_boundary_reason_codes_output" | grep -q '^runtime_module_boundary_reason_codes_value=runtime_orchestration_dispatch_boundary_drift_detected$'; then
+  echo "expected normalized runtime module boundary reason mapping for reason code drift" >&2
   exit 1
 fi
 

--- a/scripts/runtime/test_validate_local_full_stack_integration_live_contract_lane.sh
+++ b/scripts/runtime/test_validate_local_full_stack_integration_live_contract_lane.sh
@@ -5,6 +5,9 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 CONTRACT_LANE="$ROOT_DIR/scripts/runtime/validate_local_full_stack_integration_live_contract_lane.sh"
 VALIDATION_SCRIPT="$ROOT_DIR/scripts/runtime/validate_local_full_stack_integration_live.sh"
 POLICY_CHECKER="$ROOT_DIR/scripts/runtime/check_local_full_stack_integration_live_policy.sh"
+RUNBOOK_DOC="$ROOT_DIR/docs/deploy/kolme_devnet_ops.md"
+RUNBOOK_TAXONOMY_REASON_CODE="local_full_stack_harness_taxonomy_mapping_drift_detected"
+RUNBOOK_MARKER_PARITY_REASON_CODE="runbook_marker_parity_mismatch"
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
 
@@ -20,6 +23,46 @@ if [ ! -x "$POLICY_CHECKER" ]; then
   echo "expected local full-stack integration policy checker script to be executable" >&2
   exit 1
 fi
+if [ ! -f "$RUNBOOK_DOC" ]; then
+  echo "expected local full-stack integration runbook doc to exist" >&2
+  exit 1
+fi
+
+check_local_full_stack_runbook_parity() {
+  local runbook_file="${1:?runbook file is required}"
+  python3 - "$runbook_file" <<'PY'
+import pathlib
+import sys
+
+runbook_file = pathlib.Path(sys.argv[1])
+runbook = runbook_file.read_text(encoding="utf-8")
+
+required_taxonomy_markers = [
+    "## Local Full-Stack Harness Taxonomy and Runbook Marker Parity Contracts (Issue #4197)",
+    "combined_reason_taxonomy_version=kamn.runtime.local-full-stack-integration-reason-taxonomy.v1",
+    "runtime_phase_parity_reason_taxonomy_version=kamn.runtime.phase-module-extraction-parity-reason-taxonomy.v1",
+    "runtime_phase_parity_reason_codes_csv=runtime_phase_module_parity_drift_detected,runtime_extraction_evidence_output_unstable,ci_local_runtime_phase_parity_budget_boundary_exceeded",
+    "runtime_module_boundary_parity_reason_taxonomy_version=kamn.runtime.module-boundary-parity-reason-taxonomy.v1",
+    "runtime_module_boundary_parity_reason_codes_csv=runtime_orchestration_dispatch_boundary_drift_detected,runtime_daemon_phase_boundary_drift_detected,runtime_kolme_live_boundary_drift_detected,ci_local_runtime_module_boundary_budget_boundary_exceeded",
+]
+missing_taxonomy_markers = [
+    marker for marker in required_taxonomy_markers if marker not in runbook
+]
+if missing_taxonomy_markers:
+    raise SystemExit("local_full_stack_harness_taxonomy_mapping_drift_detected")
+
+required_runbook_parity_markers = [
+    "runtime_phase_module_parity_status=verified",
+    "runtime_module_boundary_parity_status=verified",
+    "local_full_stack_harness_runbook_reason_codes_csv=local_full_stack_harness_taxonomy_mapping_drift_detected,runbook_marker_parity_mismatch",
+]
+missing_parity_markers = [
+    marker for marker in required_runbook_parity_markers if marker not in runbook
+]
+if missing_parity_markers:
+    raise SystemExit("runbook_marker_parity_mismatch")
+PY
+}
 
 lane_report="$TMP_DIR/local-full-stack-integration-contract-lane-report.json"
 policy_report="$TMP_DIR/local-full-stack-integration-policy-report.json"
@@ -432,6 +475,69 @@ if policy_payload.get("runtime_module_boundary_reason_codes_value") != "none":
 if policy_payload.get("runtime_module_boundary_evidence_outputs_csv") != "runtime_module_boundary_parity_status,runtime_module_boundary_evidence_status,ci_local_runtime_module_boundary_budget_boundary_status":
     raise SystemExit("expected policy runtime_module_boundary_evidence_outputs_csv marker")
 PY
+
+check_local_full_stack_runbook_parity "$RUNBOOK_DOC"
+
+runbook_taxonomy_drift_file="$TMP_DIR/kolme-devnet-ops.taxonomy-drift.md"
+cp "$RUNBOOK_DOC" "$runbook_taxonomy_drift_file"
+python3 - "$runbook_taxonomy_drift_file" <<'PY'
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+payload = path.read_text(encoding="utf-8")
+payload = payload.replace(
+    "combined_reason_taxonomy_version=kamn.runtime.local-full-stack-integration-reason-taxonomy.v1",
+    "combined_reason_taxonomy_version=v0",
+)
+path.write_text(payload, encoding="utf-8")
+PY
+
+set +e
+runbook_taxonomy_drift_output="$(
+  check_local_full_stack_runbook_parity "$runbook_taxonomy_drift_file" 2>&1
+)"
+runbook_taxonomy_drift_code=$?
+set -e
+if [ "$runbook_taxonomy_drift_code" -eq 0 ]; then
+  echo "expected runbook taxonomy drift to fail local full-stack runbook parity check" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$runbook_taxonomy_drift_output" | grep -q "$RUNBOOK_TAXONOMY_REASON_CODE"; then
+  echo "expected deterministic runbook taxonomy drift reason marker" >&2
+  exit 1
+fi
+
+runbook_marker_divergence_file="$TMP_DIR/kolme-devnet-ops.runbook-divergence.md"
+cp "$RUNBOOK_DOC" "$runbook_marker_divergence_file"
+python3 - "$runbook_marker_divergence_file" <<'PY'
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+payload = path.read_text(encoding="utf-8")
+payload = payload.replace(
+    "local_full_stack_harness_runbook_reason_codes_csv=local_full_stack_harness_taxonomy_mapping_drift_detected,runbook_marker_parity_mismatch",
+    "",
+    1,
+)
+path.write_text(payload, encoding="utf-8")
+PY
+
+set +e
+runbook_marker_divergence_output="$(
+  check_local_full_stack_runbook_parity "$runbook_marker_divergence_file" 2>&1
+)"
+runbook_marker_divergence_code=$?
+set -e
+if [ "$runbook_marker_divergence_code" -eq 0 ]; then
+  echo "expected runbook marker divergence to fail local full-stack runbook parity check" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$runbook_marker_divergence_output" | grep -q "$RUNBOOK_MARKER_PARITY_REASON_CODE"; then
+  echo "expected deterministic runbook marker divergence reason marker" >&2
+  exit 1
+fi
 
 if ! grep -q "check_local_full_stack_integration_live_policy.sh" "$CONTRACT_LANE"; then
   echo "expected local full-stack integration contract lane to compose policy checker" >&2

--- a/specs/4197/plan.md
+++ b/specs/4197/plan.md
@@ -1,0 +1,29 @@
+# Plan — #4197 Local Full-Stack Harness Taxonomy Drift and Runbook Divergence Red Tests
+
+## Approach
+1. Extend `scripts/runtime/test_check_local_full_stack_integration_live_policy.sh` with additional taxonomy drift tamper assertions for runtime-phase and runtime-module parity markers.
+2. Extend `scripts/runtime/test_validate_local_full_stack_integration_live_contract_lane.sh` with runbook parity checks against `docs/deploy/kolme_devnet_ops.md` plus tampered-runbook divergence assertions.
+3. Add a deploy runbook section in `docs/deploy/kolme_devnet_ops.md` for local full-stack harness taxonomy and runbook marker mapping.
+4. Add docs-contract assertions in `crates/kamn-core/tests/kolme_devnet_ops_docs.rs`.
+
+## Affected Modules
+- `scripts/runtime/test_check_local_full_stack_integration_live_policy.sh`
+- `scripts/runtime/test_validate_local_full_stack_integration_live_contract_lane.sh`
+- `docs/deploy/kolme_devnet_ops.md`
+- `crates/kamn-core/tests/kolme_devnet_ops_docs.rs`
+
+## Risks / Mitigations
+- Risk: very long marker strings can introduce brittle copy mistakes.
+- Mitigation: centralize expected marker constants in tests and assert exact deterministic values.
+
+- Risk: runbook drift check logic could be non-deterministic.
+- Mitigation: enforce ordered required marker list and deterministic reason code mapping in the test path.
+
+## Interfaces / Contracts
+- Local full-stack policy mismatch reasons:
+  - `local_full_stack_integration_policy_runtime_phase_parity_reason_taxonomy_version_mismatch`
+  - `local_full_stack_integration_policy_runtime_phase_parity_reason_codes_csv_mismatch`
+  - `local_full_stack_integration_policy_runtime_module_boundary_parity_reason_codes_csv_mismatch`
+- Runbook divergence reason markers introduced for red tests:
+  - `local_full_stack_harness_taxonomy_mapping_drift_detected`
+  - `runbook_marker_parity_mismatch`

--- a/specs/4197/spec.md
+++ b/specs/4197/spec.md
@@ -1,0 +1,47 @@
+# Spec — #4197 Subtask: Red Tests for Harness Reason-Taxonomy Drift and Runbook Marker Divergence
+
+Status: Implemented
+Priority: P1
+Parent: #4192
+Milestone: R27.22 End-to-end live validation harness and promotion evidence convergence
+
+## Problem Statement
+Local full-stack harness taxonomy markers and runbook marker declarations can drift independently, which risks ambiguous remediation when contract checks fail.
+
+## Scope
+In scope:
+- Add red-path tests for local full-stack harness taxonomy drift.
+- Add red-path tests for runbook marker divergence in local full-stack harness governance docs.
+- Add `docs/deploy/kolme_devnet_ops.md` section defining harness taxonomy and runbook parity markers.
+- Add docs-contract assertions for the new runbook section.
+
+Out of scope:
+- Runtime/transport feature redesign.
+- New CI workflow topology.
+
+## Acceptance Criteria
+AC-1 (Given/When/Then):
+- Given local full-stack policy input with tampered taxonomy marker values,
+- When policy checker tests run,
+- Then tests fail closed with deterministic taxonomy mismatch reasons.
+
+AC-2 (Given/When/Then):
+- Given runbook marker divergence in `docs/deploy/kolme_devnet_ops.md`,
+- When contract-lane tests validate runbook marker parity,
+- Then tests fail with deterministic runbook divergence reasons.
+
+AC-3 (Given/When/Then):
+- Given deploy runbook docs contracts,
+- When docs-contract tests run,
+- Then full-stack harness taxonomy/runbook marker section and required markers are present.
+
+## Conformance Cases
+- C-01 (AC-1, Regression): tamper `runtime_phase_parity_reason_taxonomy_version` and assert deterministic mismatch reason.
+- C-02 (AC-1, Regression): tamper `runtime_phase_parity_reason_codes_csv` and assert deterministic mismatch reason.
+- C-03 (AC-1, Regression): tamper `runtime_module_boundary_parity_reason_codes_csv` and assert deterministic mismatch reason.
+- C-04 (AC-2, Regression): tamper runbook marker declarations and assert deterministic runbook marker divergence reason.
+- C-05 (AC-3, Docs): docs include full-stack harness taxonomy/runbook marker contract section and regression anchors.
+
+## Success Metrics / Signals
+- Updated local full-stack policy/contract-lane shell tests pass with deterministic taxonomy/runbook drift assertions.
+- `kolme_devnet_ops` docs-contract tests pass with required marker coverage.

--- a/specs/4197/tasks.md
+++ b/specs/4197/tasks.md
@@ -1,0 +1,15 @@
+# Tasks — #4197 Local Full-Stack Harness Taxonomy Drift and Runbook Divergence Red Tests
+
+## Ordered Tasks
+- T1 (Regression): extend `scripts/runtime/test_check_local_full_stack_integration_live_policy.sh` with taxonomy drift tamper tests.
+- T2 (Regression): extend `scripts/runtime/test_validate_local_full_stack_integration_live_contract_lane.sh` with runbook parity and runbook-tamper divergence tests.
+- T3 (Docs): add local full-stack harness taxonomy/runbook mapping section in `docs/deploy/kolme_devnet_ops.md`.
+- T4 (Docs Contract): add assertions in `crates/kamn-core/tests/kolme_devnet_ops_docs.rs`.
+- T5 (Verify): run targeted shell tests and docs-contract tests.
+
+## Test Tier Mapping
+- Unit: N/A (script/docs contract scope)
+- Functional: local full-stack policy checker pass/fail assertions
+- Integration: local full-stack contract-lane composition test
+- Regression: taxonomy drift tamper and runbook divergence tamper checks
+- Performance: N/A (bounded ci-smoke path only)


### PR DESCRIPTION
## Summary
Adds red-path coverage for local full-stack harness taxonomy drift and runbook marker divergence for `#4197`.
Extends existing local full-stack policy/contract-lane shell tests with deterministic tamper checks, and updates `docs/deploy/kolme_devnet_ops.md` plus docs-contract assertions so drift is caught fail-closed.

Human review requested for this P1 multi-module change per `AGENTS.md` self-acceptance rule.

## Links
- Milestone: R27.22 End-to-end live validation harness and promotion evidence convergence
- Closes #4197
- Parent: #4192
- Spec: `specs/4197/spec.md`
- Plan: `specs/4197/plan.md`
- Tasks: `specs/4197/tasks.md`

## Spec Verification (AC -> tests)
| AC | ✅/❌ | Test(s) |
|---|---|---|
| AC-1: taxonomy drift fails closed with deterministic mismatch reasons | ✅ | `bash scripts/runtime/test_check_local_full_stack_integration_live_policy.sh` |
| AC-2: runbook marker divergence fails with deterministic runbook reason markers | ✅ | `bash scripts/runtime/test_validate_local_full_stack_integration_live_contract_lane.sh` |
| AC-3: deploy runbook section/markers are contract-enforced | ✅ | `cargo test -p kamn-core --test kolme_devnet_ops_docs` |

## TDD Evidence
RED:
```bash
tmp_red_report="$(mktemp)"
bash scripts/runtime/validate_local_full_stack_integration_live.sh --mode dry-run --max-seconds 120 --output-json "$tmp_red_report"
python3 - "$tmp_red_report" <<'PY'
import json
import pathlib
import sys
path = pathlib.Path(sys.argv[1])
payload = json.loads(path.read_text(encoding='utf-8'))
payload['runtime_phase_parity_reason_taxonomy_version'] = 'v0'
path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding='utf-8')
PY
bash scripts/runtime/check_local_full_stack_integration_live_policy.sh --report-file "$tmp_red_report" --expected-final-decision GO --ci-fast-gate PASS
```
Output excerpt:
```text
RED_EXIT=1
status=fail
final_decision=NO-GO
reason_codes_value=runtime_extraction_evidence_output_unstable
failed_checks=local_full_stack_integration_policy_runtime_phase_parity_reason_taxonomy_version_mismatch,local_full_stack_integration_policy_expected_decision_mismatch
```

GREEN:
```bash
bash scripts/runtime/test_check_local_full_stack_integration_live_policy.sh
bash scripts/runtime/test_validate_local_full_stack_integration_live_contract_lane.sh
cargo test -p kamn-core --test kolme_devnet_ops_docs
```
Output excerpt:
```text
local full-stack integration policy checker tests passed.
local full-stack integration contract lane tests passed.
test result: ok. 90 passed; 0 failed
```

REGRESSION summary:
- Added deterministic tamper assertions for runtime-phase taxonomy/codes drift and runtime-module boundary reason-codes drift.
- Added deterministic runbook parity check + tampered runbook divergence checks for local full-stack markers.

## Test Tiers
| Tier | ✅/❌/N/A | Tests | N/A Why |
|---|---|---|---|
| Unit | N/A | N/A | Shell/docs-contract scope; no isolated Rust unit behavior changed |
| Property | N/A | N/A | No proptest/invariant parser surface changed |
| Contract/DbC | N/A | N/A | No Rust contract macro surface changed |
| Snapshot | N/A | N/A | No snapshot fixtures changed |
| Functional | ✅ | `bash scripts/runtime/test_check_local_full_stack_integration_live_policy.sh` | |
| Conformance | ✅ | `bash scripts/runtime/test_check_local_full_stack_integration_live_policy.sh`; `cargo test -p kamn-core --test kolme_devnet_ops_docs` | |
| Integration | ✅ | `bash scripts/runtime/test_validate_local_full_stack_integration_live_contract_lane.sh` | |
| Fuzz | N/A | N/A | No untrusted parser/fuzz target change |
| Mutation | N/A | N/A | Script/docs-contract delta; no critical Rust logic path changed |
| Regression | ✅ | taxonomy drift + runbook divergence tamper checks in updated shell tests | |
| Performance | N/A | N/A | bounded ci-smoke budgets unchanged |

## Mutation
- N/A for this script/docs contract delta.

## Risks / Rollback
- Risk: runbook marker wording edits must preserve contract marker strings.
- Rollback: revert commit `d54ab215`.

## Docs / ADR
- Updated: `docs/deploy/kolme_devnet_ops.md`
- Updated: `specs/4197/spec.md`, `specs/4197/plan.md`, `specs/4197/tasks.md`
- ADR: not required (no architecture/protocol/dependency change)
