### PR TITLE
feat(framework): add declarative policy checker contract lane (#4827)

### DIFF
--- a/scripts/framework/declarative_policy_checker.py
+++ b/scripts/framework/declarative_policy_checker.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""Declarative policy checker for contract-lane report validation."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import re
+import sys
+from typing import Any
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR.parent))
+
+from framework.contract_framework import ContractError, fail, load_json, write_json  # noqa: E402
+
+POLICY_SCHEMA_VERSION = "kamn.framework.declarative-policy.v1"
+OUTPUT_SCHEMA_VERSION = "kamn.framework.declarative-policy-report.v1"
+
+_MISSING = object()
+_CHECK_OPERATORS = {
+    "equals",
+    "not_equals",
+    "in",
+    "not_in",
+    "contains",
+    "not_contains",
+    "gt",
+    "gte",
+    "lt",
+    "lte",
+    "regex",
+    "exists",
+}
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Evaluate a report JSON file against declarative policy checks."
+    )
+    parser.add_argument("--policy-file", required=True, help="Declarative policy JSON file.")
+    parser.add_argument("--report-file", required=True, help="Report JSON file.")
+    parser.add_argument(
+        "--expected-final-decision",
+        choices=("GO", "NO-GO"),
+        default="",
+        help="Optional decision assertion for contract-lane wrappers.",
+    )
+    parser.add_argument(
+        "--ci-fast-gate",
+        default="",
+        help="Optional CI gate marker to include in emitted JSON output.",
+    )
+    parser.add_argument(
+        "--output-json",
+        default="",
+        help="Optional output path for checker evaluation report JSON.",
+    )
+    return parser.parse_args(argv)
+
+
+def _validate_policy(policy: dict[str, Any]) -> dict[str, Any]:
+    if policy.get("schema_version") != POLICY_SCHEMA_VERSION:
+        fail("policy schema_version mismatch")
+
+    required_string_fields = (
+        "policy_name",
+        "reason_taxonomy_version",
+        "reason_key_prefix",
+        "success_reason_code",
+    )
+    for field_name in required_string_fields:
+        value = policy.get(field_name)
+        if not isinstance(value, str) or not value.strip():
+            fail(f"policy field '{field_name}' must be a non-empty string")
+
+    checks = policy.get("checks")
+    if not isinstance(checks, list) or not checks:
+        fail("policy field 'checks' must be a non-empty list")
+
+    for idx, check in enumerate(checks):
+        if not isinstance(check, dict):
+            fail(f"policy check at index {idx} must be an object")
+
+        field_name = check.get("field")
+        op = check.get("op")
+        reason_code = check.get("reason_code")
+
+        if not isinstance(field_name, str) or not field_name.strip():
+            fail(f"policy check {idx} field must be a non-empty string")
+        if not isinstance(op, str) or op not in _CHECK_OPERATORS:
+            fail(f"policy check {idx} op must be one of: {', '.join(sorted(_CHECK_OPERATORS))}")
+        if not isinstance(reason_code, str) or not reason_code.strip():
+            fail(f"policy check {idx} reason_code must be a non-empty string")
+
+        if op != "exists" and "expected" not in check:
+            fail(f"policy check {idx} missing required 'expected' value")
+
+        if op == "exists" and "expected" in check and not isinstance(check["expected"], bool):
+            fail(f"policy check {idx} expected must be a boolean for exists op")
+
+    return policy
+
+
+def _resolve_field(payload: Any, field_path: str) -> Any:
+    cursor: Any = payload
+    for token in field_path.split("."):
+        if isinstance(cursor, dict):
+            if token not in cursor:
+                return _MISSING
+            cursor = cursor[token]
+            continue
+        if isinstance(cursor, list):
+            if not token.isdigit():
+                return _MISSING
+            index = int(token)
+            if index < 0 or index >= len(cursor):
+                return _MISSING
+            cursor = cursor[index]
+            continue
+        return _MISSING
+    return cursor
+
+
+def _is_number(value: Any) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def _evaluate_check(check: dict[str, Any], report_payload: dict[str, Any]) -> bool:
+    field_value = _resolve_field(report_payload, check["field"])
+    exists = field_value is not _MISSING
+    op = check["op"]
+    expected = check.get("expected")
+
+    if op == "exists":
+        expected_exists = expected if isinstance(expected, bool) else True
+        return exists == expected_exists
+
+    if not exists:
+        return False
+
+    if op == "equals":
+        return field_value == expected
+    if op == "not_equals":
+        return field_value != expected
+    if op == "in":
+        return isinstance(expected, list) and field_value in expected
+    if op == "not_in":
+        return isinstance(expected, list) and field_value not in expected
+    if op == "contains":
+        if isinstance(field_value, str):
+            return isinstance(expected, str) and expected in field_value
+        if isinstance(field_value, list):
+            return expected in field_value
+        return False
+    if op == "not_contains":
+        if isinstance(field_value, str):
+            return isinstance(expected, str) and expected not in field_value
+        if isinstance(field_value, list):
+            return expected not in field_value
+        return False
+    if op == "gt":
+        return _is_number(field_value) and _is_number(expected) and field_value > expected
+    if op == "gte":
+        return _is_number(field_value) and _is_number(expected) and field_value >= expected
+    if op == "lt":
+        return _is_number(field_value) and _is_number(expected) and field_value < expected
+    if op == "lte":
+        return _is_number(field_value) and _is_number(expected) and field_value <= expected
+    if op == "regex":
+        if not isinstance(field_value, str) or not isinstance(expected, str):
+            return False
+        return re.search(expected, field_value) is not None
+    fail(f"unsupported op: {op}")
+    return False
+
+
+def _evaluate(policy: dict[str, Any], report_payload: dict[str, Any]) -> dict[str, Any]:
+    failed_reasons: list[str] = []
+    for check in policy["checks"]:
+        if not _evaluate_check(check, report_payload):
+            failed_reasons.append(check["reason_code"])
+
+    final_decision = "GO" if not failed_reasons else "NO-GO"
+    reason_codes = [policy["success_reason_code"]] if final_decision == "GO" else failed_reasons
+    reason_codes_csv = ",".join(reason_codes)
+    status = "pass" if final_decision == "GO" else "fail"
+    reason_key = f"{policy['reason_key_prefix']}:{final_decision}:v1"
+
+    return {
+        "schema_version": OUTPUT_SCHEMA_VERSION,
+        "policy_schema_version": policy["schema_version"],
+        "policy_name": policy["policy_name"],
+        "status": status,
+        "final_decision": final_decision,
+        "reason_taxonomy_version": policy["reason_taxonomy_version"],
+        "reason_codes": reason_codes,
+        "reason_codes_csv": reason_codes_csv,
+        "reason_key": reason_key,
+        "check_count": len(policy["checks"]),
+        "failed_check_count": len(failed_reasons),
+    }
+
+
+def main(argv: list[str]) -> int:
+    args = _parse_args(argv)
+
+    policy_file = Path(args.policy_file).resolve()
+    report_file = Path(args.report_file).resolve()
+
+    if not policy_file.is_file():
+        fail(f"policy file not found: {policy_file}")
+    if not report_file.is_file():
+        fail(f"report file not found: {report_file}")
+
+    policy_payload = _validate_policy(dict(load_json(policy_file)))
+    report_payload = dict(load_json(report_file))
+
+    output = _evaluate(policy_payload, report_payload)
+    output["policy_file"] = str(policy_file)
+    output["report_file"] = str(report_file)
+    if args.ci_fast_gate:
+        output["ci_fast_gate"] = args.ci_fast_gate
+
+    output_json_path = Path(args.output_json).resolve() if args.output_json else None
+    if output_json_path is not None:
+        write_json(output_json_path, output)
+
+    print("status=ok")
+    print(f"policy_name={output['policy_name']}")
+    print(f"final_decision={output['final_decision']}")
+    print(f"reason_codes={output['reason_codes_csv']}")
+    print(f"reason_taxonomy_version={output['reason_taxonomy_version']}")
+    print(f"reason_key={output['reason_key']}")
+    print(f"check_count={output['check_count']}")
+    print(f"failed_check_count={output['failed_check_count']}")
+    if output_json_path is not None:
+        print(f"output_json={output_json_path}")
+
+    if args.expected_final_decision and output["final_decision"] != args.expected_final_decision:
+        fail(
+            "expected-final-decision mismatch: "
+            f"expected {args.expected_final_decision}, found {output['final_decision']}"
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main(sys.argv[1:]))
+    except ContractError as error:
+        print(error, file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/framework/test_contract_framework.sh
+++ b/scripts/framework/test_contract_framework.sh
@@ -5,8 +5,10 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
 python3 "$ROOT_DIR/scripts/framework/test_contract_framework.py"
 python3 "$ROOT_DIR/scripts/framework/test_contract_lane_helpers.py"
+python3 "$ROOT_DIR/scripts/framework/test_declarative_policy_checker.py"
 python3 "$ROOT_DIR/scripts/framework/test_lane_manifest.py"
 python3 "$ROOT_DIR/scripts/framework/test_manifest_wrapper_dispatch.py"
 python3 "$ROOT_DIR/scripts/framework/test_pilot_lane_manifests.py"
+bash "$ROOT_DIR/scripts/framework/test_declarative_policy_checker_contract.sh"
 
-echo "contract framework unit tests passed."
+echo "contract framework tests passed."

--- a/scripts/framework/test_declarative_policy_checker.py
+++ b/scripts/framework/test_declarative_policy_checker.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Unit tests for declarative policy checker evaluation behavior."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import tempfile
+import unittest
+
+from declarative_policy_checker import (  # noqa: E402
+    OUTPUT_SCHEMA_VERSION,
+    POLICY_SCHEMA_VERSION,
+    _MISSING,
+    _evaluate,
+    _evaluate_check,
+    _resolve_field,
+    _validate_policy,
+    main,
+)
+from framework.contract_framework import ContractError
+
+
+class DeclarativePolicyCheckerTests(unittest.TestCase):
+    def _base_policy(self) -> dict:
+        return {
+            "schema_version": POLICY_SCHEMA_VERSION,
+            "policy_name": "example.policy",
+            "reason_taxonomy_version": "kamn.example.reason-taxonomy.v1",
+            "reason_key_prefix": "example_reason_codes",
+            "success_reason_code": "none",
+            "checks": [
+                {
+                    "field": "status",
+                    "op": "equals",
+                    "expected": "pass",
+                    "reason_code": "status_not_pass",
+                },
+                {
+                    "field": "error_count",
+                    "op": "lte",
+                    "expected": 0,
+                    "reason_code": "error_count_exceeded",
+                },
+            ],
+        }
+
+    def _write_json(self, path: Path, payload: dict) -> None:
+        path.write_text(json.dumps(payload), encoding="utf-8")
+
+    def test_validate_policy_accepts_valid_payload(self) -> None:
+        policy = _validate_policy(self._base_policy())
+        self.assertEqual(policy["policy_name"], "example.policy")
+        self.assertEqual(policy["schema_version"], POLICY_SCHEMA_VERSION)
+
+    def test_validate_policy_rejects_missing_expected_for_non_exists_check(self) -> None:
+        policy = self._base_policy()
+        policy["checks"][0].pop("expected")
+
+        with self.assertRaisesRegex(ContractError, "missing required 'expected' value"):
+            _validate_policy(policy)
+
+    def test_resolve_field_supports_nested_dict_and_list_lookup(self) -> None:
+        payload = {"outer": {"items": [{"value": "ok"}]}}
+        self.assertEqual(_resolve_field(payload, "outer.items.0.value"), "ok")
+        self.assertIs(_resolve_field(payload, "outer.items.one.value"), _MISSING)
+        self.assertIs(_resolve_field(payload, "outer.items.9.value"), _MISSING)
+
+    def test_evaluate_check_supports_exists_and_regex(self) -> None:
+        payload = {"status": "pass", "detail": "lane finished successfully"}
+        self.assertTrue(
+            _evaluate_check(
+                {"field": "status", "op": "exists", "expected": True, "reason_code": "unused"},
+                payload,
+            )
+        )
+        self.assertTrue(
+            _evaluate_check(
+                {
+                    "field": "detail",
+                    "op": "regex",
+                    "expected": "finished\\s+successfully",
+                    "reason_code": "unused",
+                },
+                payload,
+            )
+        )
+        self.assertFalse(
+            _evaluate_check(
+                {"field": "missing", "op": "exists", "expected": True, "reason_code": "unused"},
+                payload,
+            )
+        )
+
+    def test_evaluate_returns_go_with_success_reason(self) -> None:
+        policy = _validate_policy(self._base_policy())
+        report = {"status": "pass", "error_count": 0}
+
+        result = _evaluate(policy, report)
+        self.assertEqual(result["schema_version"], OUTPUT_SCHEMA_VERSION)
+        self.assertEqual(result["status"], "pass")
+        self.assertEqual(result["final_decision"], "GO")
+        self.assertEqual(result["reason_codes"], ["none"])
+        self.assertEqual(result["reason_key"], "example_reason_codes:GO:v1")
+        self.assertEqual(result["failed_check_count"], 0)
+
+    def test_evaluate_returns_no_go_with_all_failed_reason_codes(self) -> None:
+        policy = _validate_policy(self._base_policy())
+        report = {"status": "fail", "error_count": 3}
+
+        result = _evaluate(policy, report)
+        self.assertEqual(result["status"], "fail")
+        self.assertEqual(result["final_decision"], "NO-GO")
+        self.assertEqual(result["reason_codes"], ["status_not_pass", "error_count_exceeded"])
+        self.assertEqual(result["reason_key"], "example_reason_codes:NO-GO:v1")
+        self.assertEqual(result["failed_check_count"], 2)
+
+    def test_main_writes_output_json_and_ci_fast_gate(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            policy_path = temp_path / "policy.json"
+            report_path = temp_path / "report.json"
+            output_path = temp_path / "output.json"
+            self._write_json(policy_path, self._base_policy())
+            self._write_json(report_path, {"status": "pass", "error_count": 0})
+
+            rc = main(
+                [
+                    "--policy-file",
+                    str(policy_path),
+                    "--report-file",
+                    str(report_path),
+                    "--expected-final-decision",
+                    "GO",
+                    "--ci-fast-gate",
+                    "PASS",
+                    "--output-json",
+                    str(output_path),
+                ]
+            )
+
+            self.assertEqual(rc, 0)
+            output = json.loads(output_path.read_text(encoding="utf-8"))
+            self.assertEqual(output["final_decision"], "GO")
+            self.assertEqual(output["ci_fast_gate"], "PASS")
+            self.assertEqual(output["policy_name"], "example.policy")
+
+    def test_main_raises_when_expected_final_decision_mismatches(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            policy_path = temp_path / "policy.json"
+            report_path = temp_path / "report.json"
+            self._write_json(policy_path, self._base_policy())
+            self._write_json(report_path, {"status": "fail", "error_count": 3})
+
+            with self.assertRaisesRegex(ContractError, "expected-final-decision mismatch"):
+                main(
+                    [
+                        "--policy-file",
+                        str(policy_path),
+                        "--report-file",
+                        str(report_path),
+                        "--expected-final-decision",
+                        "GO",
+                    ]
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/framework/test_declarative_policy_checker_contract.sh
+++ b/scripts/framework/test_declarative_policy_checker_contract.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CHECKER="$ROOT_DIR/scripts/framework/declarative_policy_checker.py"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+if [ ! -x "$CHECKER" ]; then
+  echo "expected declarative policy checker to be executable: $CHECKER" >&2
+  exit 1
+fi
+
+PASS_POLICY="$TMP_DIR/pass-policy.json"
+bash "$ROOT_DIR/scripts/lib/write_json_file.sh" "$PASS_POLICY" <<'JSON'
+{
+  "schema_version": "kamn.framework.declarative-policy.v1",
+  "policy_name": "example.policy",
+  "reason_taxonomy_version": "kamn.example.reason-taxonomy.v1",
+  "reason_key_prefix": "example_reason_codes",
+  "success_reason_code": "none",
+  "checks": [
+    {
+      "field": "status",
+      "op": "equals",
+      "expected": "pass",
+      "reason_code": "status_not_pass"
+    },
+    {
+      "field": "error_count",
+      "op": "lte",
+      "expected": 0,
+      "reason_code": "error_count_exceeded"
+    },
+    {
+      "field": "markers",
+      "op": "contains",
+      "expected": "ready",
+      "reason_code": "marker_ready_missing"
+    }
+  ]
+}
+JSON
+
+PASS_REPORT="$TMP_DIR/pass-report.json"
+bash "$ROOT_DIR/scripts/lib/write_json_file.sh" "$PASS_REPORT" <<'JSON'
+{
+  "status": "pass",
+  "error_count": 0,
+  "markers": ["ready", "stable"]
+}
+JSON
+
+PASS_OUTPUT_JSON="$TMP_DIR/pass-output.json"
+pass_output="$(python3 "$CHECKER" \
+  --policy-file "$PASS_POLICY" \
+  --report-file "$PASS_REPORT" \
+  --expected-final-decision GO \
+  --output-json "$PASS_OUTPUT_JSON")"
+
+printf '%s\n' "$pass_output" | grep -q '^status=ok$'
+printf '%s\n' "$pass_output" | grep -q '^final_decision=GO$'
+printf '%s\n' "$pass_output" | grep -q '^reason_codes=none$'
+printf '%s\n' "$pass_output" | grep -q '^reason_key=example_reason_codes:GO:v1$'
+
+python3 - "$PASS_OUTPUT_JSON" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+payload = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+if payload.get("schema_version") != "kamn.framework.declarative-policy-report.v1":
+    raise SystemExit("unexpected output schema")
+if payload.get("status") != "pass":
+    raise SystemExit("expected pass status in output JSON")
+if payload.get("reason_codes") != ["none"]:
+    raise SystemExit("expected success reason code list")
+PY
+
+FAIL_REPORT="$TMP_DIR/fail-report.json"
+bash "$ROOT_DIR/scripts/lib/write_json_file.sh" "$FAIL_REPORT" <<'JSON'
+{
+  "status": "fail",
+  "error_count": 2,
+  "markers": ["stable"]
+}
+JSON
+
+set +e
+fail_output="$(python3 "$CHECKER" \
+  --policy-file "$PASS_POLICY" \
+  --report-file "$FAIL_REPORT" \
+  --expected-final-decision GO 2>&1)"
+fail_status=$?
+set -e
+
+if [ "$fail_status" -eq 0 ]; then
+  echo "expected checker to fail when evaluated final decision does not match expected GO" >&2
+  exit 1
+fi
+
+printf '%s\n' "$fail_output" | grep -q '^status=ok$'
+printf '%s\n' "$fail_output" | grep -q '^final_decision=NO-GO$'
+printf '%s\n' "$fail_output" | grep -q 'error_count_exceeded'
+printf '%s\n' "$fail_output" | grep -q 'marker_ready_missing'
+printf '%s\n' "$fail_output" | grep -q 'status_not_pass'
+
+INVALID_POLICY="$TMP_DIR/invalid-policy.json"
+bash "$ROOT_DIR/scripts/lib/write_json_file.sh" "$INVALID_POLICY" <<'JSON'
+{
+  "schema_version": "kamn.framework.declarative-policy.v0",
+  "checks": []
+}
+JSON
+
+set +e
+invalid_output="$(python3 "$CHECKER" \
+  --policy-file "$INVALID_POLICY" \
+  --report-file "$PASS_REPORT" 2>&1)"
+invalid_status=$?
+set -e
+
+if [ "$invalid_status" -eq 0 ]; then
+  echo "expected checker to fail on invalid policy schema_version" >&2
+  exit 1
+fi
+
+printf '%s\n' "$invalid_output" | grep -q 'policy schema_version mismatch'
+
+echo "declarative policy checker contract tests passed."

--- a/specs/4827/plan.md
+++ b/specs/4827/plan.md
@@ -2,26 +2,34 @@
 
 ## Approach
 
-- Execute the smallest deterministic implementation slice that satisfies all ACs.
-- Add/extend red->green regression coverage before broad migration changes.
-- Preserve CI smoke/runtime budget boundaries and deterministic reason-taxonomy outputs.
+1. Add checker implementation with strict schema validation and deterministic fail-closed behavior.
+2. Capture RED first with shell contract test requiring executable checker and expected GO/NO-GO mismatch handling.
+3. Add Python unit tests for field resolution, operator evaluation, output generation, and mismatch rejection.
+4. Wire new tests into framework regression runner to keep future work on a single entrypoint.
 
 ## Affected Modules
 
-- To be finalized during implementation from concrete file-level impact.
+- `scripts/framework/declarative_policy_checker.py`
+- `scripts/framework/test_declarative_policy_checker.py`
+- `scripts/framework/test_declarative_policy_checker_contract.sh`
+- `scripts/framework/test_contract_framework.sh`
 
 ## Risks / Mitigations
 
-- Risk: migration drift or hidden coupling across scripts/wrappers/manifests.
-  Mitigation: phased rollout with deterministic regression suites and compatibility checks.
-- Risk: CI cost increase.
-  Mitigation: enforce bounded smoke limits and local-heavy opt-in boundaries.
+- Risk: policy checks become non-deterministic due to reason ordering drift.
+  Mitigation: preserve policy order traversal and assert ordered reason code output in tests.
+- Risk: invalid policy payloads slip through and cause runtime ambiguity.
+  Mitigation: strict upfront schema validation with explicit failure messages.
+- Risk: checker integration regresses existing framework test entrypoint.
+  Mitigation: include checker unit + shell contract tests in `test_contract_framework.sh`.
 
 ## Interfaces / Contracts
 
-- Preserve existing lane entrypoint compatibility unless explicitly versioned.
-- Emit stable key=value outputs and reason taxonomy/version markers on policy paths.
+- Input policy schema version: `kamn.framework.declarative-policy.v1`
+- Output report schema version: `kamn.framework.declarative-policy-report.v1`
+- Stable CLI markers: `status`, `final_decision`, `reason_codes`, `reason_taxonomy_version`, `reason_key`
+- Fail-closed mismatch contract: `--expected-final-decision` mismatch exits non-zero with stable mismatch text.
 
 ## ADR
 
-- Required only if this issue introduces protocol/dependency/architecture decisions.
+No ADR required for this issue. No new dependency, protocol version family, or architecture boundary was introduced.

--- a/specs/4827/spec.md
+++ b/specs/4827/spec.md
@@ -1,43 +1,48 @@
 # Spec — Issue #4827
 
-- Title: Subtask: build declarative_policy_checker.py and declarative policy schema contracts
-- Parent: Parent task: #4815
+- Title: Subtask: build `declarative_policy_checker.py` and declarative policy schema contracts
+- Parent: Parent task `#4815`
 - Milestone: R27.42 Shell LOC reduction and script-to-Rust ratio inversion governance
-- Status: Reviewed
+- Status: Implemented
 - Priority: P1
 
 ## Objective
 
-Deliver the scoped implementation slice with deterministic tests and fail-closed governance behavior.
+Add a reusable Python checker that evaluates policy checks against report JSON payloads and emits deterministic `GO/NO-GO` outputs with stable reason taxonomy markers.
 
 ## Problem Statement
 
-Without this scoped slice, the broader shell-surface reduction program cannot safely progress with measurable, reversible increments.
+Contract lane wrappers currently rely on script-specific ad hoc policy checks. This blocks broad shell LOC reduction and reuse because behavior and failure semantics are not centralized behind one declarative evaluator contract.
 
 ## Scope
 
 In scope:
-- targeted implementation for the subtask objective
-- failing-to-passing contract tests for the changed surface
-- spec/docs updates for changed behavior
+- `scripts/framework/declarative_policy_checker.py` implementation
+- deterministic policy schema validation (`kamn.framework.declarative-policy.v1`)
+- deterministic output schema emission (`kamn.framework.declarative-policy-report.v1`)
+- unit tests and contract-lane shell tests for checker behavior
+- integration into `scripts/framework/test_contract_framework.sh`
 
 Out of scope:
-- phase work outside this subtask boundary
-- unrelated refactors
+- broad migration of all lane policies to declarative checker in this issue
+- protocol/schema changes outside checker policy/output versions above
 
 ## Acceptance Criteria
 
-- AC-1: Subtask implementation is complete and test-verified against deterministic acceptance behavior.
-- AC-2: Red/green regression evidence is captured in PR/issue process logs.
-- AC-3: No unintended script-surface expansion occurs without explicit accounting.
+- AC-1: Given a valid policy and report file, when checker evaluation succeeds with no failed checks, then checker exits `0`, prints `status=ok`, `final_decision=GO`, and writes output JSON with schema version `kamn.framework.declarative-policy-report.v1`.
+- AC-2: Given a valid policy and a report that violates one or more checks, when `--expected-final-decision GO` is supplied, then checker fails closed (non-zero), still emits deterministic markers (`status=ok`, `final_decision=NO-GO`, ordered reason codes), and includes stable `reason_key`.
+- AC-3: Given an invalid policy schema payload, when checker runs, then checker exits non-zero with deterministic validation failure text and no silent fallback behavior.
+- AC-4: Checker behavior is covered by deterministic tests wired into framework regression entrypoint (`test_contract_framework.sh`).
 
 ## Conformance Cases
 
-- C-01: verify AC-1 with deterministic pass/fail evidence and fail-closed reasons.
-- C-02: verify AC-2 with deterministic pass/fail evidence and fail-closed reasons.
-- C-03: verify AC-3 with deterministic pass/fail evidence and fail-closed reasons.
+- C-01 (AC-1, Functional/Conformance): `test_main_writes_output_json_and_ci_fast_gate` validates success path output file and GO markers.
+- C-02 (AC-2, Functional/Conformance): `test_main_raises_when_expected_final_decision_mismatches` plus `test_declarative_policy_checker_contract.sh` validates fail-closed mismatch with NO-GO reason output.
+- C-03 (AC-3, Unit/Conformance): `test_validate_policy_rejects_missing_expected_for_non_exists_check` and invalid-schema shell case validate deterministic validation rejection.
+- C-04 (AC-4, Integration): `scripts/framework/test_contract_framework.sh` runs checker unit and shell contract suites.
 
 ## Success Metrics / Signals
 
-- Required tests for this scope pass and emit deterministic governance markers.
-- Shell-surface reduction or containment impact is explicitly measurable for this scope.
+- Checker produces deterministic key/value outputs and output JSON fields for both GO and NO-GO decisions.
+- `scripts/framework/test_contract_framework.sh` remains green with checker coverage included.
+- No new shell wrapper family introduced for this capability; behavior is consolidated in one Python module + tests.

--- a/specs/4827/tasks.md
+++ b/specs/4827/tasks.md
@@ -1,6 +1,12 @@
 # Tasks — Issue #4827
 
-- [ ] T1 (Red): add or update failing tests mapped to conformance cases before implementation.
-- [ ] T2 (Green): implement minimal changes to satisfy all acceptance criteria.
-- [ ] T3 (Refactor): consolidate duplication while preserving deterministic outputs/contracts.
-- [ ] T4 (Verify): run required test tiers, capture evidence, and update issue process log.
+- [x] T1 (Red): add failing contract test before implementation.
+  Evidence: `bash scripts/framework/test_declarative_policy_checker_contract.sh` failed with `expected declarative policy checker to be executable`.
+- [x] T2 (Green): implement checker and schema validation/output behavior.
+  Evidence: `scripts/framework/declarative_policy_checker.py` added; contract test now passes.
+- [x] T3 (Refactor): centralize policy evaluation semantics and operator handling in one module with reusable functions.
+- [x] T4 (Verify): run deterministic suites and record results.
+  Evidence:
+  - `python3 scripts/framework/test_declarative_policy_checker.py`
+  - `bash scripts/framework/test_declarative_policy_checker_contract.sh`
+  - `bash scripts/framework/test_contract_framework.sh`


### PR DESCRIPTION
## Summary
- Added `scripts/framework/declarative_policy_checker.py` to evaluate declarative policy JSON against report JSON with deterministic GO/NO-GO outputs and fail-closed expected-decision behavior.
- Added dedicated checker unit coverage and contract-lane shell coverage, then wired both into `scripts/framework/test_contract_framework.sh`.
- Replaced placeholder issue artifacts with concrete acceptance criteria, conformance mapping, and verification evidence for `#4827`.

## Links
- Milestone: https://github.com/njfio/kamn/milestone/33
- Closes #4827
- Spec: `specs/4827/spec.md`
- Plan: `specs/4827/plan.md`

## Spec Verification (AC -> tests)
| AC | ✅/❌ | Test(s) |
|---|---|---|
| AC-1: valid policy/report yields deterministic GO + output schema | ✅ | `python3 scripts/framework/test_declarative_policy_checker.py` (`test_main_writes_output_json_and_ci_fast_gate`), `bash scripts/framework/test_declarative_policy_checker_contract.sh` |
| AC-2: mismatch against expected GO fails closed with deterministic NO-GO markers | ✅ | `python3 scripts/framework/test_declarative_policy_checker.py` (`test_main_raises_when_expected_final_decision_mismatches`), `bash scripts/framework/test_declarative_policy_checker_contract.sh` |
| AC-3: invalid policy schema is deterministically rejected | ✅ | `bash scripts/framework/test_declarative_policy_checker_contract.sh` (invalid schema case), `python3 scripts/framework/test_declarative_policy_checker.py` (`test_validate_policy_rejects_missing_expected_for_non_exists_check`) |
| AC-4: checker coverage integrated into framework regression entrypoint | ✅ | `bash scripts/framework/test_contract_framework.sh` |

## TDD Evidence
- RED:
  - `bash scripts/framework/test_declarative_policy_checker_contract.sh`
  - Pre-implementation failure: `expected declarative policy checker to be executable: /home/n/Code/kamn/scripts/framework/declarative_policy_checker.py`
- GREEN:
  - `python3 scripts/framework/test_declarative_policy_checker.py` -> `Ran 8 tests ... OK`
  - `bash scripts/framework/test_declarative_policy_checker_contract.sh` -> `declarative policy checker contract tests passed.`
- REGRESSION:
  - `bash scripts/framework/test_contract_framework.sh` -> `contract framework tests passed.`
  - `bash scripts/ci/test_ci_tools.sh` -> `All CI tool regression tests passed.`

## Test Tiers
| Tier | ✅/❌/N/A | Tests | N/A Why |
|---|---|---|---|
| Unit | ✅ | `python3 scripts/framework/test_declarative_policy_checker.py` | |
| Property | N/A | | No randomized invariant harness added for this deterministic checker subtask; operator/field behavior covered by unit and contract tests. |
| Contract/DbC | N/A | | Rust contracts framework (`contracts`) not applicable to this Python script-only change. |
| Snapshot | N/A | | No snapshot outputs introduced; behavior asserted directly via deterministic key/value and JSON-field checks. |
| Functional | ✅ | `bash scripts/framework/test_declarative_policy_checker_contract.sh` | |
| Conformance | ✅ | `python3 scripts/framework/test_declarative_policy_checker.py`, `bash scripts/framework/test_declarative_policy_checker_contract.sh` | |
| Integration | ✅ | `bash scripts/framework/test_contract_framework.sh` | |
| Fuzz | N/A | | Untrusted parser fuzzing not introduced in this scoped subtask; follow-up can extend if policy surface broadens. |
| Mutation | N/A | | `cargo-mutants` is Rust-targeted and not applicable to this Python-only checker implementation. |
| Regression | ✅ | `bash scripts/framework/test_contract_framework.sh`, `bash scripts/ci/test_ci_tools.sh` | |
| Performance | N/A | | No runtime hotspot or throughput-sensitive path introduced in this subtask. |

## Mutation
- N/A for this Python-only change (`cargo-mutants` scope is Rust).

## Risks/Rollback
- Risks: low; behavior is additive and isolated under `scripts/framework/`.
- Rollback: revert this PR commit to remove checker and test wiring.

## Docs/ADR
- Updated: `specs/4827/spec.md`, `specs/4827/plan.md`, `specs/4827/tasks.md`
- ADR: not required (no dependency/protocol/architecture boundary changes).

## Validation
- [x] Relevant local checks passed.
- [x] CI fast-gate checks expected to pass.

## CI Impact Declaration
- [x] No CI scope impact.
- [ ] CI scope impact present (explain below).

CI scope impact details (required when CI scope impact is present):
- Workflow(s) touched:
- Expected runtime delta:
- Expected runner-minute delta:
- Rollback plan if CI cost/runtime regresses:
