### PR TITLE
test(framework): enforce declarative taxonomy marker conformance (#4880)

### DIFF
--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -3971,6 +3971,21 @@ Fast-mode CI tooling regression coverage includes:
     - `reason_codes=combined_shell_surface_ratio_delta_fail_exceeded`
     - `reason_codes=combined_shell_surface_budget_status_fail`
     - `reason_codes=combined_shell_surface_threshold_order_invalid`
+- Declarative policy checker schema/taxonomy contract (`test_declarative_policy_checker_contract.sh`)
+  - checker command:
+    - `python3 scripts/framework/declarative_policy_checker.py --policy-file <policy.json> --report-file <report.json> --output-json <output.json>`
+  - deterministic policy schema markers:
+    - `policy.schema_version=kamn.framework.declarative-policy.v1`
+    - `output.schema_version=kamn.framework.declarative-policy-report.v1`
+  - deterministic taxonomy marker contract:
+    - `policy.reason_taxonomy_version` must match `<namespace>.v<integer>` (fail closed otherwise)
+    - invalid marker failure string: `policy field 'reason_taxonomy_version' must end with .v<integer>`
+  - deterministic mismatch/failure surface:
+    - `policy schema_version mismatch`
+    - `expected-final-decision mismatch: expected GO|NO-GO, found GO|NO-GO`
+  - coverage commands:
+    - `python3 scripts/framework/test_declarative_policy_checker.py`
+    - `bash scripts/framework/test_declarative_policy_checker_contract.sh`
 - Fast-gate workflow governance wiring:
   - `.github/workflows/ci-fast-gate.yml` runs, under `run_script_surface_budget_checks` scope:
     - `bash scripts/ci/check_script_duplication_budget.sh --budget-file .ci/script-surface-budget.env --baseline-file .ci/script-surface-baseline.env --waiver-file .ci/script-surface-budget-waiver.json --output-json ci-script-surface-budget.json`

--- a/scripts/framework/declarative_policy_checker.py
+++ b/scripts/framework/declarative_policy_checker.py
@@ -124,6 +124,10 @@ def _validate_policy(policy: dict[str, Any]) -> dict[str, Any]:
         if not isinstance(value, str) or not value.strip():
             fail(f"policy field '{field_name}' must be a non-empty string")
 
+    reason_taxonomy_version = policy["reason_taxonomy_version"]
+    if not re.fullmatch(r"[A-Za-z0-9_.-]+\.v[0-9]+", reason_taxonomy_version):
+        fail("policy field 'reason_taxonomy_version' must end with .v<integer>")
+
     checks = policy.get("checks")
     if not isinstance(checks, list) or not checks:
         fail("policy field 'checks' must be a non-empty list")

--- a/scripts/framework/test_declarative_policy_checker.py
+++ b/scripts/framework/test_declarative_policy_checker.py
@@ -63,6 +63,16 @@ class DeclarativePolicyCheckerTests(unittest.TestCase):
         with self.assertRaisesRegex(ContractError, "missing required 'expected' value"):
             _validate_policy(policy)
 
+    def test_validate_policy_rejects_invalid_reason_taxonomy_version_marker(self) -> None:
+        policy = self._base_policy()
+        policy["reason_taxonomy_version"] = "kamn.example.reason-taxonomy"
+
+        with self.assertRaisesRegex(
+            ContractError,
+            "reason_taxonomy_version.*must end with .v<integer>",
+        ):
+            _validate_policy(policy)
+
     def test_resolve_field_supports_nested_dict_and_list_lookup(self) -> None:
         payload = {"outer": {"items": [{"value": "ok"}]}}
         self.assertEqual(_resolve_field(payload, "outer.items.0.value"), "ok")

--- a/scripts/framework/test_declarative_policy_checker_contract.sh
+++ b/scripts/framework/test_declarative_policy_checker_contract.sh
@@ -127,4 +127,37 @@ fi
 
 printf '%s\n' "$invalid_output" | grep -q 'policy schema_version mismatch'
 
+INVALID_TAXONOMY_POLICY="$TMP_DIR/invalid-taxonomy-policy.json"
+bash "$ROOT_DIR/scripts/lib/write_json_file.sh" "$INVALID_TAXONOMY_POLICY" <<'JSON'
+{
+  "schema_version": "kamn.framework.declarative-policy.v1",
+  "policy_name": "invalid.taxonomy.policy",
+  "reason_taxonomy_version": "kamn.example.reason-taxonomy",
+  "reason_key_prefix": "example_reason_codes",
+  "success_reason_code": "none",
+  "checks": [
+    {
+      "field": "status",
+      "op": "equals",
+      "expected": "pass",
+      "reason_code": "status_not_pass"
+    }
+  ]
+}
+JSON
+
+set +e
+invalid_taxonomy_output="$(python3 "$CHECKER" \
+  --policy-file "$INVALID_TAXONOMY_POLICY" \
+  --report-file "$PASS_REPORT" 2>&1)"
+invalid_taxonomy_status=$?
+set -e
+
+if [ "$invalid_taxonomy_status" -eq 0 ]; then
+  echo "expected checker to fail on invalid reason_taxonomy_version marker format" >&2
+  exit 1
+fi
+
+printf '%s\n' "$invalid_taxonomy_output" | grep -q "policy field 'reason_taxonomy_version' must end with .v<integer>"
+
 echo "declarative policy checker contract tests passed."

--- a/specs/4880/plan.md
+++ b/specs/4880/plan.md
@@ -8,7 +8,10 @@
 
 ## Affected Modules
 
-- To be finalized during implementation from concrete file-level impact in script framework, CI policy, docs-contract, and template surfaces.
+- `scripts/framework/declarative_policy_checker.py`
+- `scripts/framework/test_declarative_policy_checker.py`
+- `scripts/framework/test_declarative_policy_checker_contract.sh`
+- `docs/ci/strategy.md`
 
 ## Risks / Mitigations
 

--- a/specs/4880/spec.md
+++ b/specs/4880/spec.md
@@ -3,7 +3,7 @@
 - Title: Subtask: implement declarative_policy_checker.py and schema conformance contracts
 - Parent: - Parent task: #4868
 - Milestone: R27.43 Shell LOC maintainability and shell-to-Rust ratio sustainment governance
-- Status: Reviewed
+- Status: Implemented
 - Priority: P1
 
 ## Objective

--- a/specs/4880/tasks.md
+++ b/specs/4880/tasks.md
@@ -1,6 +1,16 @@
 # Tasks — Issue #4880
 
-- [ ] T1 (Red): add or update failing tests mapped to conformance cases before implementation.
-- [ ] T2 (Green): implement minimal changes to satisfy all acceptance criteria.
-- [ ] T3 (Refactor): reduce duplication and improve maintainability while preserving deterministic outputs.
-- [ ] T4 (Verify): run required test tiers, capture evidence, and update process log/issue status.
+- [x] T1 (Red): add or update failing tests mapped to conformance cases before implementation.
+  - Evidence:
+    - `python3 scripts/framework/test_declarative_policy_checker.py` failed with `ContractError not raised` for invalid `reason_taxonomy_version` marker.
+    - `bash scripts/framework/test_declarative_policy_checker_contract.sh` failed with `expected checker to fail on invalid reason_taxonomy_version marker format`.
+- [x] T2 (Green): implement minimal changes to satisfy all acceptance criteria.
+  - Evidence: `scripts/framework/declarative_policy_checker.py` now fail-closes invalid taxonomy markers with deterministic validation (`reason_taxonomy_version` must match `<namespace>.v<integer>`).
+- [x] T3 (Refactor): reduce duplication and improve maintainability while preserving deterministic outputs.
+  - Evidence: added explicit schema/taxonomy contract section for declarative checker in `docs/ci/strategy.md` and aligned unit + shell contract tests to the same marker rule.
+- [x] T4 (Verify): run required test tiers, capture evidence, and update process log/issue status.
+  - Evidence:
+    - `python3 scripts/framework/test_declarative_policy_checker.py` -> passed
+    - `bash scripts/framework/test_declarative_policy_checker_contract.sh` -> passed
+    - `bash scripts/framework/test_contract_framework.sh` -> passed
+    - `KAMN_CI_TOOLS_FAST_MODE=true timeout 900 bash scripts/ci/test_ci_tools.sh` -> passed


### PR DESCRIPTION
## Summary
This PR completes #4880 by adding deterministic taxonomy-marker validation to `declarative_policy_checker.py`, extending conformance tests for invalid taxonomy markers, and documenting declarative checker schema/taxonomy contracts in CI strategy docs.
The checker now fail-closes when `reason_taxonomy_version` does not match `<namespace>.v<integer>`.

## Linked Issues
- Closes #4880

## Validation
- [x] Relevant local checks passed.
- [x] CI fast-gate checks expected to pass.

## CI Impact Declaration
- [x] No CI scope impact.
- [ ] CI scope impact present (explain below).

CI scope impact details (required when CI scope impact is present):
Workflow(s) touched: None.
Expected runtime delta: None.
Expected runner-minute delta: None.
Rollback plan if CI cost/runtime regresses: N/A.

## Shell-Surface Impact Declaration
- [ ] No shell-surface impact.
- [x] Shell-surface impact present (explain below).

Shell-surface impact details (required when shell-surface impact is present):
shell_loc_delta_actual: 33
rust_loc_delta_actual: 0
shell_to_rust_ratio_delta_actual: 0.000
shell_surface_ratio_target_status: regressed_with_waiver
shell_surface_mitigation_issue: #4859
- regressed_with_waiver requires shell_surface_mitigation_issue to link #<issue-id>

## Links
- Milestone: R27.43 Shell LOC maintainability and shell-to-Rust ratio sustainment governance
- Spec: `specs/4880/spec.md`
- Plan: `specs/4880/plan.md`
- Tasks: `specs/4880/tasks.md`

## Spec Verification (AC -> tests)
| AC | ✅/❌ | Test(s) |
|---|---|---|
| AC-1: Declarative checker validates schema and returns deterministic reason outputs. | ✅ | `python3 scripts/framework/test_declarative_policy_checker.py`; `bash scripts/framework/test_declarative_policy_checker_contract.sh` |
| AC-2: Conformance tests cover success/failure/taxonomy mismatch paths. | ✅ | `python3 scripts/framework/test_declarative_policy_checker.py`; `bash scripts/framework/test_declarative_policy_checker_contract.sh` |
| AC-3: Unit/Functional/Integration/Regression tests are present and passing. | ✅ | `bash scripts/framework/test_contract_framework.sh`; `KAMN_CI_TOOLS_FAST_MODE=true timeout 900 bash scripts/ci/test_ci_tools.sh` |

## TDD Evidence
- RED:
  - `python3 scripts/framework/test_declarative_policy_checker.py` failed with `ContractError not raised` on invalid taxonomy marker test.
  - `bash scripts/framework/test_declarative_policy_checker_contract.sh` failed with `expected checker to fail on invalid reason_taxonomy_version marker format`.
- GREEN:
  - `python3 scripts/framework/test_declarative_policy_checker.py` passed.
  - `bash scripts/framework/test_declarative_policy_checker_contract.sh` passed.
- REGRESSION:
  - `bash scripts/framework/test_contract_framework.sh`
  - `KAMN_CI_TOOLS_FAST_MODE=true timeout 900 bash scripts/ci/test_ci_tools.sh`

## Test Tiers
| Tier | ✅/❌/N/A | Tests | N/A Why |
|---|---|---|---|
| Unit | ✅ | `python3 scripts/framework/test_declarative_policy_checker.py` | |
| Property | N/A | | No property-based harness for this Python checker scope. |
| Contract/DbC | N/A | | Shell/Python scripts in this scope do not use DbC annotations. |
| Snapshot | N/A | | No snapshot assertions introduced. |
| Functional | ✅ | `bash scripts/framework/test_declarative_policy_checker_contract.sh` | |
| Conformance | ✅ | `bash scripts/framework/test_declarative_policy_checker_contract.sh` | |
| Integration | ✅ | `bash scripts/framework/test_contract_framework.sh` | |
| Fuzz | N/A | | No fuzz target introduced in this change. |
| Mutation | N/A | | `cargo-mutants` not applicable to this shell/Python scope. |
| Regression | ✅ | `KAMN_CI_TOOLS_FAST_MODE=true timeout 900 bash scripts/ci/test_ci_tools.sh` | |
| Performance | N/A | | Validation-rule update only; no performance hotspot change. |

## Mutation
- N/A for shell/Python-only scope.

## Risks/Rollback
- Risk: overly strict taxonomy-format validation rejects malformed legacy policies.
- Mitigation: deterministic unit + contract tests for success/failure paths.
- Rollback: revert commit `90f7af81`.

## Docs/ADR
- Updated docs:
  - `docs/ci/strategy.md`
- Updated specs:
  - `specs/4880/spec.md`
  - `specs/4880/plan.md`
  - `specs/4880/tasks.md`
- ADR: not required.
