### PR TITLE
feat(ci): enforce combined shell-surface decline window policy

### DIFF
--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -3968,9 +3968,16 @@ Fast-mode CI tooling regression coverage includes:
 - Combined shell-surface trend policy checker (`test_check_combined_shell_surface_trend_policy.sh`)
   - policy command:
     - `bash scripts/ci/check_combined_shell_surface_trend_policy.sh --report-file /tmp/combined-shell-surface-trend-report.json --threshold-file fixtures/ci/combined_shell_surface_trend_thresholds.json --output-json /tmp/combined-shell-surface-trend-policy-report.json`
+    - deterministic date override for contract tests:
+      - `bash scripts/ci/check_combined_shell_surface_trend_policy.sh --report-file /tmp/combined-shell-surface-trend-report.json --threshold-file fixtures/ci/combined_shell_surface_trend_thresholds.json --today 2026-02-18 --output-json /tmp/combined-shell-surface-trend-policy-report.json`
+  - threshold metadata contract:
+    - `threshold_refreshed_on` (`YYYY-MM-DD`)
+    - `threshold_max_age_days` (non-negative integer)
+    - `warn_non_declining_window_days` (non-negative integer)
+    - `fail_non_declining_window_days` (integer greater than `warn_non_declining_window_days`)
   - deterministic taxonomy markers:
     - `reason_taxonomy_version=kamn.ci.combined-shell-surface-trend-policy-reason-taxonomy.v1`
-    - `reason_codes_csv=combined_shell_surface_budget_status_fail,combined_shell_surface_delta_ratio_invalid,combined_shell_surface_delta_script_count_invalid,combined_shell_surface_delta_shell_line_total_invalid,combined_shell_surface_ratio_delta_fail_exceeded,combined_shell_surface_ratio_delta_warn_exceeded,combined_shell_surface_ratio_fail_ceiling_exceeded,combined_shell_surface_ratio_invalid,combined_shell_surface_ratio_warn_ceiling_exceeded,combined_shell_surface_report_schema_mismatch,combined_shell_surface_rust_line_total_invalid,combined_shell_surface_script_count_delta_fail_exceeded,combined_shell_surface_script_count_delta_warn_exceeded,combined_shell_surface_script_count_invalid,combined_shell_surface_shell_line_total_delta_fail_exceeded,combined_shell_surface_shell_line_total_delta_warn_exceeded,combined_shell_surface_shell_line_total_invalid,combined_shell_surface_threshold_order_invalid,combined_shell_surface_threshold_schema_mismatch,combined_shell_surface_threshold_value_invalid`
+    - `reason_codes_csv=combined_shell_surface_budget_status_fail,combined_shell_surface_decline_window_fail_exceeded,combined_shell_surface_decline_window_warn_exceeded,combined_shell_surface_delta_ratio_invalid,combined_shell_surface_delta_script_count_invalid,combined_shell_surface_delta_shell_line_total_invalid,combined_shell_surface_ratio_delta_fail_exceeded,combined_shell_surface_ratio_delta_warn_exceeded,combined_shell_surface_ratio_fail_ceiling_exceeded,combined_shell_surface_ratio_invalid,combined_shell_surface_ratio_warn_ceiling_exceeded,combined_shell_surface_report_schema_mismatch,combined_shell_surface_rust_line_total_invalid,combined_shell_surface_script_count_delta_fail_exceeded,combined_shell_surface_script_count_delta_warn_exceeded,combined_shell_surface_script_count_invalid,combined_shell_surface_shell_line_total_delta_fail_exceeded,combined_shell_surface_shell_line_total_delta_warn_exceeded,combined_shell_surface_shell_line_total_invalid,combined_shell_surface_threshold_date_invalid,combined_shell_surface_threshold_file_stale,combined_shell_surface_threshold_order_invalid,combined_shell_surface_threshold_schema_mismatch,combined_shell_surface_threshold_value_invalid,combined_shell_surface_today_override_invalid`
   - normalized reason markers:
     - `reason_codes=none|<csv>`
     - `reason_codes_value=none|<csv>`
@@ -3980,6 +3987,11 @@ Fast-mode CI tooling regression coverage includes:
     - `reason_codes=combined_shell_surface_ratio_fail_ceiling_exceeded`
     - `reason_codes=combined_shell_surface_ratio_delta_fail_exceeded`
     - `reason_codes=combined_shell_surface_budget_status_fail`
+    - `reason_codes=combined_shell_surface_decline_window_warn_exceeded`
+    - `reason_codes=combined_shell_surface_decline_window_fail_exceeded`
+    - `reason_codes=combined_shell_surface_threshold_file_stale`
+    - `reason_codes=combined_shell_surface_threshold_date_invalid`
+    - `reason_codes=combined_shell_surface_today_override_invalid`
     - `reason_codes=combined_shell_surface_threshold_order_invalid`
 - Declarative policy checker schema/taxonomy contract (`test_declarative_policy_checker_contract.sh`)
   - checker command:

--- a/fixtures/ci/combined_shell_surface_trend_thresholds.json
+++ b/fixtures/ci/combined_shell_surface_trend_thresholds.json
@@ -7,5 +7,9 @@
   "warn_shell_to_rust_ratio": 0.305,
   "fail_shell_to_rust_ratio": 0.34,
   "warn_shell_to_rust_ratio_increase": 0.005,
-  "fail_shell_to_rust_ratio_increase": 0.02
+  "fail_shell_to_rust_ratio_increase": 0.02,
+  "threshold_refreshed_on": "2026-01-01",
+  "threshold_max_age_days": 36500,
+  "warn_non_declining_window_days": 3650,
+  "fail_non_declining_window_days": 7300
 }

--- a/scripts/ci/check_combined_shell_surface_trend_policy.sh
+++ b/scripts/ci/check_combined_shell_surface_trend_policy.sh
@@ -8,6 +8,7 @@ DEFAULT_REPORT_GENERATOR="$ROOT_DIR/scripts/ci/generate_combined_shell_surface_t
 report_file=""
 threshold_file="$DEFAULT_THRESHOLD_FILE"
 output_json=""
+today_override=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -21,6 +22,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --output-json)
       output_json="${2:-}"
+      shift 2
+      ;;
+    --today)
+      today_override="${2:-}"
       shift 2
       ;;
     *)
@@ -53,17 +58,18 @@ if [[ -z "$output_json" ]]; then
 fi
 mkdir -p "$(dirname "$output_json")"
 
-python3 - "$report_file" "$threshold_file" "$output_json" <<'PY'
+python3 - "$report_file" "$threshold_file" "$output_json" "$today_override" <<'PY'
 import json
 import sys
+from datetime import date
 from pathlib import Path
 
-REASON_TAXONOMY_VERSION = (
-    "kamn.ci.combined-shell-surface-trend-policy-reason-taxonomy.v1"
-)
+REASON_TAXONOMY_VERSION = "kamn.ci.combined-shell-surface-trend-policy-reason-taxonomy.v1"
 REASON_CODES_CSV = ",".join(
     [
         "combined_shell_surface_budget_status_fail",
+        "combined_shell_surface_decline_window_fail_exceeded",
+        "combined_shell_surface_decline_window_warn_exceeded",
         "combined_shell_surface_delta_ratio_invalid",
         "combined_shell_surface_delta_script_count_invalid",
         "combined_shell_surface_delta_shell_line_total_invalid",
@@ -80,25 +86,35 @@ REASON_CODES_CSV = ",".join(
         "combined_shell_surface_shell_line_total_delta_fail_exceeded",
         "combined_shell_surface_shell_line_total_delta_warn_exceeded",
         "combined_shell_surface_shell_line_total_invalid",
+        "combined_shell_surface_threshold_date_invalid",
+        "combined_shell_surface_threshold_file_stale",
         "combined_shell_surface_threshold_order_invalid",
         "combined_shell_surface_threshold_schema_mismatch",
         "combined_shell_surface_threshold_value_invalid",
+        "combined_shell_surface_today_override_invalid",
     ]
 )
 
 report_path = Path(sys.argv[1])
 threshold_path = Path(sys.argv[2])
 output_path = Path(sys.argv[3])
+today_override = sys.argv[4].strip()
 
 report = json.loads(report_path.read_text(encoding="utf-8"))
 thresholds = json.loads(threshold_path.read_text(encoding="utf-8"))
 
 reason_codes: list[str] = []
 
+
+def add_reason(code: str) -> None:
+    if code not in reason_codes:
+        reason_codes.append(code)
+
+
 if report.get("schema_version") != "kamn.ci.combined-shell-surface-trend-report.v1":
-    reason_codes.append("combined_shell_surface_report_schema_mismatch")
+    add_reason("combined_shell_surface_report_schema_mismatch")
 if thresholds.get("schema_version") != "kamn.ci.combined-shell-surface-trend-thresholds.v1":
-    reason_codes.append("combined_shell_surface_threshold_schema_mismatch")
+    add_reason("combined_shell_surface_threshold_schema_mismatch")
 
 current = report.get("current", {})
 deltas = report.get("deltas", {})
@@ -114,10 +130,23 @@ delta_shell_to_rust_ratio = deltas.get("shell_to_rust_ratio")
 script_budget_status = script_budget.get("status")
 
 if script_budget_status != "pass":
-    reason_codes.append("combined_shell_surface_budget_status_fail")
+    add_reason("combined_shell_surface_budget_status_fail")
 
 warn_codes: list[str] = []
 fail_codes: list[str] = []
+
+warn_script_count_increase = 0
+fail_script_count_increase = 0
+warn_shell_line_total_increase = 0
+fail_shell_line_total_increase = 0
+warn_shell_to_rust_ratio = 0.0
+fail_shell_to_rust_ratio = 0.0
+warn_shell_to_rust_ratio_increase = 0.0
+fail_shell_to_rust_ratio_increase = 0.0
+warn_non_declining_window_days = 0
+fail_non_declining_window_days = 0
+threshold_max_age_days = 0
+threshold_refreshed_on = ""
 
 try:
     warn_script_count_increase = int(thresholds["warn_script_count_increase"])
@@ -128,36 +157,64 @@ try:
     fail_shell_to_rust_ratio = float(thresholds["fail_shell_to_rust_ratio"])
     warn_shell_to_rust_ratio_increase = float(thresholds["warn_shell_to_rust_ratio_increase"])
     fail_shell_to_rust_ratio_increase = float(thresholds["fail_shell_to_rust_ratio_increase"])
+
+    warn_non_declining_window_days = int(thresholds["warn_non_declining_window_days"])
+    fail_non_declining_window_days = int(thresholds["fail_non_declining_window_days"])
+    threshold_max_age_days = int(thresholds["threshold_max_age_days"])
+    threshold_refreshed_on = str(thresholds["threshold_refreshed_on"])
 except Exception:
-    reason_codes.append("combined_shell_surface_threshold_value_invalid")
-    warn_script_count_increase = fail_script_count_increase = 0
-    warn_shell_line_total_increase = fail_shell_line_total_increase = 0
-    warn_shell_to_rust_ratio = fail_shell_to_rust_ratio = 0.0
-    warn_shell_to_rust_ratio_increase = fail_shell_to_rust_ratio_increase = 0.0
+    add_reason("combined_shell_surface_threshold_value_invalid")
 
 if warn_script_count_increase >= fail_script_count_increase:
-    reason_codes.append("combined_shell_surface_threshold_order_invalid")
+    add_reason("combined_shell_surface_threshold_order_invalid")
 if warn_shell_line_total_increase >= fail_shell_line_total_increase:
-    reason_codes.append("combined_shell_surface_threshold_order_invalid")
+    add_reason("combined_shell_surface_threshold_order_invalid")
 if warn_shell_to_rust_ratio >= fail_shell_to_rust_ratio:
-    reason_codes.append("combined_shell_surface_threshold_order_invalid")
+    add_reason("combined_shell_surface_threshold_order_invalid")
 if warn_shell_to_rust_ratio_increase >= fail_shell_to_rust_ratio_increase:
-    reason_codes.append("combined_shell_surface_threshold_order_invalid")
+    add_reason("combined_shell_surface_threshold_order_invalid")
+if warn_non_declining_window_days >= fail_non_declining_window_days:
+    add_reason("combined_shell_surface_threshold_order_invalid")
 
 if not isinstance(script_count, int):
-    reason_codes.append("combined_shell_surface_script_count_invalid")
+    add_reason("combined_shell_surface_script_count_invalid")
 if not isinstance(shell_line_total, int):
-    reason_codes.append("combined_shell_surface_shell_line_total_invalid")
+    add_reason("combined_shell_surface_shell_line_total_invalid")
 if not isinstance(rust_line_total, int) or rust_line_total <= 0:
-    reason_codes.append("combined_shell_surface_rust_line_total_invalid")
+    add_reason("combined_shell_surface_rust_line_total_invalid")
 if not isinstance(shell_to_rust_ratio, (int, float)):
-    reason_codes.append("combined_shell_surface_ratio_invalid")
+    add_reason("combined_shell_surface_ratio_invalid")
 if not isinstance(delta_script_count, int):
-    reason_codes.append("combined_shell_surface_delta_script_count_invalid")
+    add_reason("combined_shell_surface_delta_script_count_invalid")
 if not isinstance(delta_shell_line_total, int):
-    reason_codes.append("combined_shell_surface_delta_shell_line_total_invalid")
+    add_reason("combined_shell_surface_delta_shell_line_total_invalid")
 if not isinstance(delta_shell_to_rust_ratio, (int, float)):
-    reason_codes.append("combined_shell_surface_delta_ratio_invalid")
+    add_reason("combined_shell_surface_delta_ratio_invalid")
+
+if today_override:
+    try:
+        today = date.fromisoformat(today_override)
+    except ValueError:
+        add_reason("combined_shell_surface_today_override_invalid")
+        today = None
+else:
+    today = date.today()
+
+threshold_date = None
+if threshold_refreshed_on:
+    try:
+        threshold_date = date.fromisoformat(threshold_refreshed_on)
+    except ValueError:
+        add_reason("combined_shell_surface_threshold_date_invalid")
+
+threshold_age_days = None
+if threshold_date is not None and today is not None:
+    threshold_age_days = (today - threshold_date).days
+    if threshold_age_days < 0:
+        add_reason("combined_shell_surface_threshold_date_invalid")
+
+if threshold_age_days is not None and threshold_age_days > threshold_max_age_days:
+    add_reason("combined_shell_surface_threshold_file_stale")
 
 if not reason_codes:
     if delta_script_count > fail_script_count_increase:
@@ -179,6 +236,17 @@ if not reason_codes:
         fail_codes.append("combined_shell_surface_ratio_delta_fail_exceeded")
     elif delta_shell_to_rust_ratio > warn_shell_to_rust_ratio_increase:
         warn_codes.append("combined_shell_surface_ratio_delta_warn_exceeded")
+
+    non_declining = (
+        delta_script_count > 0
+        or delta_shell_line_total > 0
+        or delta_shell_to_rust_ratio > 0
+    )
+    if non_declining and threshold_age_days is not None:
+        if threshold_age_days > fail_non_declining_window_days:
+            fail_codes.append("combined_shell_surface_decline_window_fail_exceeded")
+        elif threshold_age_days > warn_non_declining_window_days:
+            warn_codes.append("combined_shell_surface_decline_window_warn_exceeded")
 
 all_reason_codes = reason_codes + fail_codes + warn_codes
 
@@ -232,6 +300,11 @@ policy_report = {
         "fail_shell_to_rust_ratio": fail_shell_to_rust_ratio,
         "warn_shell_to_rust_ratio_increase": warn_shell_to_rust_ratio_increase,
         "fail_shell_to_rust_ratio_increase": fail_shell_to_rust_ratio_increase,
+        "threshold_refreshed_on": threshold_refreshed_on,
+        "threshold_max_age_days": threshold_max_age_days,
+        "warn_non_declining_window_days": warn_non_declining_window_days,
+        "fail_non_declining_window_days": fail_non_declining_window_days,
+        "threshold_age_days": threshold_age_days,
     },
 }
 

--- a/scripts/ci/test_check_combined_shell_surface_trend_policy.sh
+++ b/scripts/ci/test_check_combined_shell_surface_trend_policy.sh
@@ -65,7 +65,7 @@ if ! printf '%s\n' "$policy_output" | grep -q '^reason_taxonomy_version=kamn.ci.
   echo "expected combined shell-surface policy checker reason taxonomy marker" >&2
   exit 1
 fi
-if ! printf '%s\n' "$policy_output" | grep -q '^reason_codes_csv=combined_shell_surface_budget_status_fail,combined_shell_surface_delta_ratio_invalid,combined_shell_surface_delta_script_count_invalid,combined_shell_surface_delta_shell_line_total_invalid,combined_shell_surface_ratio_delta_fail_exceeded,combined_shell_surface_ratio_delta_warn_exceeded,combined_shell_surface_ratio_fail_ceiling_exceeded,combined_shell_surface_ratio_invalid,combined_shell_surface_ratio_warn_ceiling_exceeded,combined_shell_surface_report_schema_mismatch,combined_shell_surface_rust_line_total_invalid,combined_shell_surface_script_count_delta_fail_exceeded,combined_shell_surface_script_count_delta_warn_exceeded,combined_shell_surface_script_count_invalid,combined_shell_surface_shell_line_total_delta_fail_exceeded,combined_shell_surface_shell_line_total_delta_warn_exceeded,combined_shell_surface_shell_line_total_invalid,combined_shell_surface_threshold_order_invalid,combined_shell_surface_threshold_schema_mismatch,combined_shell_surface_threshold_value_invalid$'; then
+if ! printf '%s\n' "$policy_output" | grep -q '^reason_codes_csv=combined_shell_surface_budget_status_fail,combined_shell_surface_decline_window_fail_exceeded,combined_shell_surface_decline_window_warn_exceeded,combined_shell_surface_delta_ratio_invalid,combined_shell_surface_delta_script_count_invalid,combined_shell_surface_delta_shell_line_total_invalid,combined_shell_surface_ratio_delta_fail_exceeded,combined_shell_surface_ratio_delta_warn_exceeded,combined_shell_surface_ratio_fail_ceiling_exceeded,combined_shell_surface_ratio_invalid,combined_shell_surface_ratio_warn_ceiling_exceeded,combined_shell_surface_report_schema_mismatch,combined_shell_surface_rust_line_total_invalid,combined_shell_surface_script_count_delta_fail_exceeded,combined_shell_surface_script_count_delta_warn_exceeded,combined_shell_surface_script_count_invalid,combined_shell_surface_shell_line_total_delta_fail_exceeded,combined_shell_surface_shell_line_total_delta_warn_exceeded,combined_shell_surface_shell_line_total_invalid,combined_shell_surface_threshold_date_invalid,combined_shell_surface_threshold_file_stale,combined_shell_surface_threshold_order_invalid,combined_shell_surface_threshold_schema_mismatch,combined_shell_surface_threshold_value_invalid,combined_shell_surface_today_override_invalid$'; then
   echo "expected combined shell-surface policy checker reason code taxonomy marker" >&2
   exit 1
 fi
@@ -88,7 +88,7 @@ if payload.get("reason_codes") not in ([], None):
     raise SystemExit("expected empty reason_codes for passing policy")
 if payload.get("reason_taxonomy_version") != "kamn.ci.combined-shell-surface-trend-policy-reason-taxonomy.v1":
     raise SystemExit("expected reason taxonomy version in passing combined shell-surface policy report")
-if payload.get("reason_codes_csv") != "combined_shell_surface_budget_status_fail,combined_shell_surface_delta_ratio_invalid,combined_shell_surface_delta_script_count_invalid,combined_shell_surface_delta_shell_line_total_invalid,combined_shell_surface_ratio_delta_fail_exceeded,combined_shell_surface_ratio_delta_warn_exceeded,combined_shell_surface_ratio_fail_ceiling_exceeded,combined_shell_surface_ratio_invalid,combined_shell_surface_ratio_warn_ceiling_exceeded,combined_shell_surface_report_schema_mismatch,combined_shell_surface_rust_line_total_invalid,combined_shell_surface_script_count_delta_fail_exceeded,combined_shell_surface_script_count_delta_warn_exceeded,combined_shell_surface_script_count_invalid,combined_shell_surface_shell_line_total_delta_fail_exceeded,combined_shell_surface_shell_line_total_delta_warn_exceeded,combined_shell_surface_shell_line_total_invalid,combined_shell_surface_threshold_order_invalid,combined_shell_surface_threshold_schema_mismatch,combined_shell_surface_threshold_value_invalid":
+if payload.get("reason_codes_csv") != "combined_shell_surface_budget_status_fail,combined_shell_surface_decline_window_fail_exceeded,combined_shell_surface_decline_window_warn_exceeded,combined_shell_surface_delta_ratio_invalid,combined_shell_surface_delta_script_count_invalid,combined_shell_surface_delta_shell_line_total_invalid,combined_shell_surface_ratio_delta_fail_exceeded,combined_shell_surface_ratio_delta_warn_exceeded,combined_shell_surface_ratio_fail_ceiling_exceeded,combined_shell_surface_ratio_invalid,combined_shell_surface_ratio_warn_ceiling_exceeded,combined_shell_surface_report_schema_mismatch,combined_shell_surface_rust_line_total_invalid,combined_shell_surface_script_count_delta_fail_exceeded,combined_shell_surface_script_count_delta_warn_exceeded,combined_shell_surface_script_count_invalid,combined_shell_surface_shell_line_total_delta_fail_exceeded,combined_shell_surface_shell_line_total_delta_warn_exceeded,combined_shell_surface_shell_line_total_invalid,combined_shell_surface_threshold_date_invalid,combined_shell_surface_threshold_file_stale,combined_shell_surface_threshold_order_invalid,combined_shell_surface_threshold_schema_mismatch,combined_shell_surface_threshold_value_invalid,combined_shell_surface_today_override_invalid":
     raise SystemExit("expected deterministic reason_codes_csv marker in passing combined shell-surface policy report")
 if payload.get("reason_codes_value") != "none":
     raise SystemExit("expected reason_codes_value=none in passing combined shell-surface policy report")
@@ -271,6 +271,100 @@ if [[ "$invalid_threshold_value_code" -eq 0 ]]; then
 fi
 if ! printf '%s\n' "$invalid_threshold_value_output" | grep -q 'combined_shell_surface_threshold_value_invalid'; then
   echo "expected deterministic threshold-value reason code for invalid combined shell-surface threshold fixture" >&2
+  exit 1
+fi
+
+stale_thresholds="$TMP_DIR/combined-shell-surface-trend-thresholds.stale.json"
+cp "$THRESHOLDS" "$stale_thresholds"
+python3 - "$stale_thresholds" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+payload = json.loads(path.read_text(encoding="utf-8"))
+payload["threshold_refreshed_on"] = "2025-01-01"
+payload["threshold_max_age_days"] = 30
+path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+PY
+
+set +e
+stale_threshold_output="$(bash "$CHECKER" --report-file "$report_file" --threshold-file "$stale_thresholds" --today 2026-02-18 --output-json "$TMP_DIR/stale-threshold-policy.json" 2>&1)"
+stale_threshold_code=$?
+set -e
+if [[ "$stale_threshold_code" -eq 0 ]]; then
+  echo "expected stale threshold metadata to fail combined shell-surface policy validation" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$stale_threshold_output" | grep -q 'combined_shell_surface_threshold_file_stale'; then
+  echo "expected deterministic threshold-stale reason code for stale threshold metadata" >&2
+  exit 1
+fi
+
+decline_thresholds="$TMP_DIR/combined-shell-surface-trend-thresholds.decline-window.json"
+cp "$THRESHOLDS" "$decline_thresholds"
+python3 - "$decline_thresholds" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+payload = json.loads(path.read_text(encoding="utf-8"))
+payload["threshold_refreshed_on"] = "2026-01-01"
+payload["threshold_max_age_days"] = 365
+payload["warn_non_declining_window_days"] = 14
+payload["fail_non_declining_window_days"] = 30
+path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+PY
+
+decline_warn_report="$TMP_DIR/combined-shell-surface-trend-report.decline-warn.json"
+cp "$report_file" "$decline_warn_report"
+python3 - "$decline_warn_report" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+payload = json.loads(path.read_text(encoding="utf-8"))
+payload["deltas"]["script_count"] = 1
+payload["deltas"]["shell_line_total"] = 1
+payload["deltas"]["shell_to_rust_ratio"] = 0.001
+path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+PY
+
+decline_warn_output="$(bash "$CHECKER" --report-file "$decline_warn_report" --threshold-file "$decline_thresholds" --today 2026-01-20 --output-json "$TMP_DIR/decline-warn-policy.json")"
+if ! printf '%s\n' "$decline_warn_output" | grep -q '^policy_decision=WARN$'; then
+  echo "expected WARN decision when non-declining window exceeds warn threshold" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$decline_warn_output" | grep -q 'combined_shell_surface_decline_window_warn_exceeded'; then
+  echo "expected deterministic decline-window warn reason code for non-declining trajectory" >&2
+  exit 1
+fi
+
+set +e
+decline_fail_output="$(bash "$CHECKER" --report-file "$decline_warn_report" --threshold-file "$decline_thresholds" --today 2026-02-20 --output-json "$TMP_DIR/decline-fail-policy.json" 2>&1)"
+decline_fail_code=$?
+set -e
+if [[ "$decline_fail_code" -eq 0 ]]; then
+  echo "expected NO-GO decision when non-declining window exceeds fail threshold" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$decline_fail_output" | grep -q 'combined_shell_surface_decline_window_fail_exceeded'; then
+  echo "expected deterministic decline-window fail reason code for prolonged non-declining trajectory" >&2
+  exit 1
+fi
+
+set +e
+invalid_today_output="$(bash "$CHECKER" --report-file "$report_file" --threshold-file "$decline_thresholds" --today not-a-date --output-json "$TMP_DIR/invalid-today-policy.json" 2>&1)"
+invalid_today_code=$?
+set -e
+if [[ "$invalid_today_code" -eq 0 ]]; then
+  echo "expected invalid --today value to fail combined shell-surface policy validation" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$invalid_today_output" | grep -q 'combined_shell_surface_today_override_invalid'; then
+  echo "expected deterministic today-override-invalid reason code for malformed --today input" >&2
   exit 1
 fi
 

--- a/specs/3972/plan.md
+++ b/specs/3972/plan.md
@@ -1,0 +1,44 @@
+# Plan — Issue #3972
+
+## Approach
+
+1. Add red tests for decline-window warn/fail and threshold staleness/invalid-date paths in `test_check_combined_shell_surface_trend_policy.sh`.
+2. Extend `check_combined_shell_surface_trend_policy.sh`:
+   - parse new threshold keys,
+   - add optional `--today` override for deterministic tests,
+   - evaluate non-declining window warn/fail gates,
+   - evaluate threshold metadata staleness gate.
+3. Update threshold fixture defaults to include new keys.
+4. Update CI strategy docs with decline-window policy markers.
+5. Run targeted contracts and fast CI tools regression lane.
+
+## Affected Paths
+
+- `scripts/ci/check_combined_shell_surface_trend_policy.sh`
+- `scripts/ci/test_check_combined_shell_surface_trend_policy.sh`
+- `fixtures/ci/combined_shell_surface_trend_thresholds.json`
+- `docs/ci/strategy.md`
+- `specs/3972/spec.md`
+- `specs/3972/plan.md`
+- `specs/3972/tasks.md`
+
+## Risks / Mitigations
+
+- Risk: Added window gates could unexpectedly NO-GO current baseline state.
+  Mitigation: initialize threshold metadata as fresh and windows reasonable; test warn/fail via `--today` overrides.
+
+- Risk: Contract tests brittle due reason csv exact-match string.
+  Mitigation: update deterministic csv string and corresponding test assertions together.
+
+## Interfaces / Contracts
+
+- New reason codes:
+  - `combined_shell_surface_decline_window_warn_exceeded`
+  - `combined_shell_surface_decline_window_fail_exceeded`
+  - `combined_shell_surface_threshold_file_stale`
+  - `combined_shell_surface_threshold_date_invalid`
+  - `combined_shell_surface_today_override_invalid`
+
+## ADR
+
+- Not required (CI policy evolution only; no protocol/dependency change).

--- a/specs/3972/spec.md
+++ b/specs/3972/spec.md
@@ -1,0 +1,52 @@
+# Spec — Issue #3972
+
+- Title: Subtask: implement shell-surface decline trajectory checker with deterministic fail codes
+- Parent: #3967
+- Milestone: R27.7 Script-surface consolidation and docs graduation
+- Status: Implemented
+- Priority: P1
+
+## Problem Statement
+
+The current combined shell-surface trend policy enforces static delta/ratio thresholds, but it does not enforce a time-bounded decline trajectory window. A stale threshold/baseline window can allow prolonged non-improving shell-surface behavior.
+
+## Objective
+
+Extend the combined shell-surface trend policy checker to enforce explicit decline-window and threshold-staleness controls with deterministic reason codes and CI contract coverage.
+
+## Scope
+
+In scope:
+- Add decline-window configuration keys to combined shell-surface thresholds.
+- Enforce warn/fail when positive shell-surface deltas persist beyond configured windows.
+- Enforce fail-closed threshold staleness checks.
+- Add deterministic reason codes and test coverage for new paths.
+- Update CI strategy docs for new decline-window governance markers.
+
+Out of scope:
+- Automatic baseline refresh and auto-remediation.
+- Non-shell surface decline policy.
+
+## Acceptance Criteria
+
+- AC-1: Combined trend checker supports explicit decline-window config (`threshold_refreshed_on`, `warn_non_declining_window_days`, `fail_non_declining_window_days`, `threshold_max_age_days`).
+- AC-2: Checker emits deterministic reason codes when non-declining trajectory exceeds warn/fail windows.
+- AC-3: Checker emits deterministic fail reason when threshold metadata is stale or invalid.
+- AC-4: Functional/integration/regression tests validate new decline-window and staleness paths.
+- AC-5: `docs/ci/strategy.md` documents decline-window policy markers and commands.
+
+## Conformance Cases
+
+- C-01 (AC-1): Valid threshold file with fresh `threshold_refreshed_on` passes schema/value checks.
+- C-02 (AC-2): Positive deltas + exceeded warn window yields `policy_decision=WARN` and `combined_shell_surface_decline_window_warn_exceeded`.
+- C-03 (AC-2): Positive deltas + exceeded fail window yields `policy_decision=NO-GO` and `combined_shell_surface_decline_window_fail_exceeded`.
+- C-04 (AC-3): Stale threshold metadata yields fail with `combined_shell_surface_threshold_file_stale`.
+- C-05 (AC-3): Invalid threshold date/today override yields deterministic invalid-date reason code.
+- C-06 (AC-4): CI policy test lane remains green with new reason taxonomy/csv contract.
+- C-07 (AC-5): CI strategy docs contain decline-window marker details.
+
+## Success Metrics
+
+- Decline trajectory and staleness guards are enforced in policy checker output.
+- New reason taxonomy markers are deterministic and contract-tested.
+- Fast CI tools lane remains green.

--- a/specs/3972/tasks.md
+++ b/specs/3972/tasks.md
@@ -1,0 +1,13 @@
+# Tasks — Issue #3972
+
+- [x] T1 (Red): add failing tests for decline-window warn/fail, stale threshold metadata, and invalid date handling.
+- [x] T2 (Green): implement decline-window and staleness policy logic in combined trend checker.
+- [x] T3 (Refactor): align deterministic reason taxonomy/csv and threshold fixture metadata.
+- [x] T4 (Verify): run targeted contracts and fast CI tools regression lane.
+
+## Planned Verification Commands
+
+- `bash scripts/ci/test_check_combined_shell_surface_trend_policy.sh`
+- `bash scripts/ci/test_ci_strategy_contract.sh`
+- `bash scripts/ci/test_ci_tools_command_surface_contract.sh`
+- `KAMN_CI_TOOLS_FAST_MODE=true bash scripts/ci/test_ci_tools.sh`


### PR DESCRIPTION
## Summary
Adds decline-window and threshold-staleness enforcement to the combined shell-surface trend policy checker, including deterministic reason codes and deterministic `--today` override support for contract tests. Updates threshold fixture metadata and CI strategy docs to keep policy markers aligned. Includes issue spec/plan/tasks artifacts and verification evidence.

## Links
- Milestone: `R27.7 Script-surface consolidation and docs graduation`
- Closes #3972
- Spec: `specs/3972/spec.md`
- Plan: `specs/3972/plan.md`
- Tasks: `specs/3972/tasks.md`

## Spec Verification (AC → tests)
| AC | ✅/❌ | Test(s) |
|---|---|---|
| AC-1: support explicit decline-window + freshness config keys | ✅ | `bash scripts/ci/test_check_combined_shell_surface_trend_policy.sh` |
| AC-2: deterministic warn/fail reason codes for non-declining windows | ✅ | `bash scripts/ci/test_check_combined_shell_surface_trend_policy.sh` |
| AC-3: deterministic stale/invalid threshold metadata failures | ✅ | `bash scripts/ci/test_check_combined_shell_surface_trend_policy.sh` |
| AC-4: functional/integration/regression coverage for new paths | ✅ | `bash scripts/ci/test_check_combined_shell_surface_trend_policy.sh`; `bash scripts/ci/test_ci_strategy_contract.sh`; `bash scripts/ci/test_ci_tools_command_surface_contract.sh`; `KAMN_CI_TOOLS_FAST_MODE=true bash scripts/ci/test_ci_tools.sh` |
| AC-5: CI strategy docs include decline-window policy markers | ✅ | `bash scripts/ci/test_ci_strategy_contract.sh` |

## TDD Evidence
- RED:
  - `bash scripts/ci/test_check_combined_shell_surface_trend_policy.sh`
  - Excerpt: `expected combined shell-surface policy checker reason code taxonomy marker`
- GREEN:
  - `bash scripts/ci/test_check_combined_shell_surface_trend_policy.sh`
  - Excerpt: `combined shell-surface trend policy checker tests passed.`
- REGRESSION:
  - `bash scripts/ci/test_ci_strategy_contract.sh` → `CI strategy contract tests passed.`
  - `bash scripts/ci/test_ci_tools_command_surface_contract.sh` → `ci tools command surface contract tests passed.`
  - `KAMN_CI_TOOLS_FAST_MODE=true bash scripts/ci/test_ci_tools.sh` → `Fast-mode CI tool regression tests passed.`

## Test Tiers
| Tier | ✅/❌/N/A | Tests | N/A Why |
|---|---|---|---|
| Unit | N/A | N/A | Shell policy checker changes are validated via existing script-level contracts rather than discrete unit harnesses. |
| Property | N/A | N/A | No parser/invariant property-test harness exists for this shell lane. |
| Contract/DbC | N/A | N/A | Not a Rust public API surface using DbC macros. |
| Snapshot | N/A | N/A | No snapshot artifacts introduced. |
| Functional | ✅ | `bash scripts/ci/test_check_combined_shell_surface_trend_policy.sh` | |
| Conformance | ✅ | `bash scripts/ci/test_check_combined_shell_surface_trend_policy.sh` | |
| Integration | ✅ | `bash scripts/ci/test_ci_strategy_contract.sh`; `bash scripts/ci/test_ci_tools_command_surface_contract.sh`; `KAMN_CI_TOOLS_FAST_MODE=true bash scripts/ci/test_ci_tools.sh` | |
| Fuzz | N/A | N/A | No untrusted parser/input fuzz harness for this shell checker lane. |
| Mutation | N/A | N/A | `cargo-mutants` applies to Rust mutation paths; this change is shell/doc/fixture only. |
| Regression | ✅ | `KAMN_CI_TOOLS_FAST_MODE=true bash scripts/ci/test_ci_tools.sh` | |
| Performance | ✅ | `KAMN_CI_TOOLS_FAST_MODE=true bash scripts/ci/test_ci_tools.sh` | |

## Mutation
- Caught/Total: N/A (shell/doc/fixture change; no Rust mutation target)

## Risks / Rollback
- Risk: Tightening decline windows in fixture values could over-trigger NO-GO in unrelated checks.
- Mitigation: Default fixture windows/freshness are explicit and conservative; deterministic decline-window paths are tested with dedicated overridden fixtures.
- Rollback: Revert commit `6b268072`.

## Docs / ADR
- Updated: `docs/ci/strategy.md`
- ADR: not required (no architecture/protocol/dependency change)
