### PR TITLE
docs(spec): close triadic topology and live-proof task chain (#3845)

### DIFF
--- a/specs/3845/plan.md
+++ b/specs/3845/plan.md
@@ -1,0 +1,22 @@
+# Plan - Issue #3845
+
+## Approach
+
+1. Validate child-subtask contract coverage (`#3846`, `#3847`) through existing deterministic script suites.
+2. Consolidate AC-to-test traceability at task level.
+3. Close with lifecycle artifacts.
+
+## Affected Paths
+
+- `specs/3845/spec.md`
+- `specs/3845/plan.md`
+- `specs/3845/tasks.md`
+
+## Risks / Mitigations
+
+- Risk: task remains open while child contract coverage is already implemented.
+  Mitigation: provide explicit closure artifacts and consolidated conformance evidence.
+
+## ADR
+
+- Not required (lifecycle artifact closure only).

--- a/specs/3845/spec.md
+++ b/specs/3845/spec.md
@@ -1,0 +1,42 @@
+# Spec - Issue #3845
+
+- Title: Task: implement triadic local topology orchestrator and convergence/finality live lane
+- Parent: #3844
+- Milestone: R27.3 Live libp2p+Kolme proof and governance budgets
+- Status: Implemented
+- Priority: P1
+
+## Problem Statement
+
+Combined libp2p+Kolme readiness required triadic topology orchestration and deterministic convergence/finality artifact contracts.
+
+## Objective
+
+Close triadic topology orchestration and combined live-proof artifact schema coverage through deterministic contract-lane validation.
+
+## Scope
+
+In scope:
+- Triadic three-node orchestration contract lane validation (`#3846`).
+- Combined live-node validation bundle schema/policy/docs contract validation (`#3847`).
+- Task-level closure artifacts and consolidated verification.
+
+Out of scope:
+- Protocol redesign and unrelated runtime feature work.
+
+## Acceptance Criteria
+
+- AC-1: Triadic local topology orchestration contract lane remains deterministic.
+- AC-2: Combined live-proof convergence/finality bundle schema/policy contracts remain deterministic.
+- AC-3: Docs parity and regression markers for bundle contracts remain enforced.
+- AC-4: Task-level conformance coverage remains passing and auditable.
+
+## Conformance Cases
+
+- C-01 (AC-1): `bash scripts/kolme/test_run_triadic_devnet_smoke_contract_lane.sh` passes.
+- C-02 (AC-2/AC-3): `bash scripts/kolme/test_run_local_live_node_validation_bundle_contract_lane.sh` passes.
+- C-03 (AC-4): consolidated checks above pass in task closure run.
+
+## Success Metrics
+
+- Triadic topology and live-proof artifact contracts remain deterministic and fail closed on drift.

--- a/specs/3845/tasks.md
+++ b/specs/3845/tasks.md
@@ -1,0 +1,11 @@
+# Tasks - Issue #3845
+
+- [x] T1 (Red): define triadic topology and live-proof schema drift scenarios in contract suites.
+- [x] T2 (Green): deliver child implementations (`#3846`, `#3847`).
+- [x] T3 (Refactor/Docs): preserve deterministic marker/docs parity contracts.
+- [x] T4 (Verify): execute representative triadic + live-proof bundle conformance checks.
+
+## Planned Verification Commands
+
+- `bash scripts/kolme/test_run_triadic_devnet_smoke_contract_lane.sh`
+- `bash scripts/kolme/test_run_local_live_node_validation_bundle_contract_lane.sh`

--- a/specs/3846/plan.md
+++ b/specs/3846/plan.md
@@ -1,0 +1,22 @@
+# Plan - Issue #3846
+
+## Approach
+
+1. Validate triadic contract lane wrapper/manifest coverage markers.
+2. Validate deterministic PASS output schema from triadic lane contract execution.
+3. Capture closure artifacts with AC-to-test mapping.
+
+## Affected Paths
+
+- `specs/3846/spec.md`
+- `specs/3846/plan.md`
+- `specs/3846/tasks.md`
+
+## Risks / Mitigations
+
+- Risk: triadic lane drift without explicit closure traceability.
+  Mitigation: keep conformance bound to executable contract-lane script.
+
+## ADR
+
+- Not required (lifecycle artifact closure only).

--- a/specs/3846/spec.md
+++ b/specs/3846/spec.md
@@ -1,0 +1,38 @@
+# Spec - Issue #3846
+
+- Title: Subtask: add three-node orchestration harness with deterministic churn and recovery drills
+- Parent: #3845
+- Milestone: R27.3 Live libp2p+Kolme proof and governance budgets
+- Status: Implemented
+- Priority: P1
+
+## Problem Statement
+
+Readiness validation required deterministic triadic topology coverage for churn/recovery behavior beyond single-path checks.
+
+## Objective
+
+Provide deterministic three-node orchestration contract coverage for triadic devnet smoke/convergence behavior.
+
+## Scope
+
+In scope:
+- Triadic devnet smoke contract-lane wrapper/manifest/implementation checks.
+- Deterministic schema and PASS decision assertions for triadic validation output.
+
+Out of scope:
+- Protocol redesign.
+
+## Acceptance Criteria
+
+- AC-1: Triadic contract lane wiring (wrapper/manifest/implementation markers) is valid.
+- AC-2: Contract lane emits deterministic success marker and valid report schema.
+- AC-3: Triadic report final decision is deterministic (`PASS`) for baseline path.
+
+## Conformance Cases
+
+- C-01 (AC-1/AC-2/AC-3): `bash scripts/kolme/test_run_triadic_devnet_smoke_contract_lane.sh` passes.
+
+## Success Metrics
+
+- Triadic orchestration coverage remains executable and deterministic for local-heavy readiness proofs.

--- a/specs/3846/tasks.md
+++ b/specs/3846/tasks.md
@@ -1,0 +1,10 @@
+# Tasks - Issue #3846
+
+- [x] T1 (Red): define triadic contract-lane fail/coverage checks.
+- [x] T2 (Green): deliver deterministic triadic lane orchestration contract behavior.
+- [x] T3 (Refactor/Docs): preserve schema/marker traceability.
+- [x] T4 (Verify): execute triadic contract-lane suite.
+
+## Planned Verification Commands
+
+- `bash scripts/kolme/test_run_triadic_devnet_smoke_contract_lane.sh`

--- a/specs/3847/plan.md
+++ b/specs/3847/plan.md
@@ -1,0 +1,22 @@
+# Plan - Issue #3847
+
+## Approach
+
+1. Validate live-node bundle contract-lane wrapper/manifest/implementation coverage.
+2. Validate deterministic summary/policy schema and marker assertions.
+3. Record AC-to-test mapping in lifecycle artifacts for closure.
+
+## Affected Paths
+
+- `specs/3847/spec.md`
+- `specs/3847/plan.md`
+- `specs/3847/tasks.md`
+
+## Risks / Mitigations
+
+- Risk: live-proof schema/marker drift across scripts/docs.
+  Mitigation: keep docs parity and policy marker assertions in executable conformance suite.
+
+## ADR
+
+- Not required (lifecycle artifact closure only).

--- a/specs/3847/spec.md
+++ b/specs/3847/spec.md
@@ -1,0 +1,39 @@
+# Spec - Issue #3847
+
+- Title: Subtask: define combined live-proof artifact schema for convergence and finality checkpoints
+- Parent: #3845
+- Milestone: R27.3 Live libp2p+Kolme proof and governance budgets
+- Status: Implemented
+- Priority: P1
+
+## Problem Statement
+
+Combined live-proof evidence needed deterministic schema and checkpoint marker contracts for convergence/finality promotion decisions.
+
+## Objective
+
+Enforce combined live-node validation bundle schema and policy-marker contracts for convergence/finality checkpoints.
+
+## Scope
+
+In scope:
+- Contract-lane wiring and manifest coverage for live-node validation bundle flow.
+- Required artifact lineage markers (rollback/recovery) and policy GO path checks.
+- Docs parity checks for required runner/policy/marker snippets.
+
+Out of scope:
+- New runtime behavior beyond contract coverage.
+
+## Acceptance Criteria
+
+- AC-1: Live-node validation bundle contract lane wiring and coverage markers remain valid.
+- AC-2: Summary/policy schemas and deterministic marker fields are validated in contract tests.
+- AC-3: Docs parity for required bundle markers and regression notes remains enforced.
+
+## Conformance Cases
+
+- C-01 (AC-1/AC-2/AC-3): `bash scripts/kolme/test_run_local_live_node_validation_bundle_contract_lane.sh` passes.
+
+## Success Metrics
+
+- Combined live-proof artifact schema/contracts remain deterministic and fail closed on marker drift.

--- a/specs/3847/tasks.md
+++ b/specs/3847/tasks.md
@@ -1,0 +1,10 @@
+# Tasks - Issue #3847
+
+- [x] T1 (Red): define schema/marker drift checks for combined live-proof bundle contracts.
+- [x] T2 (Green): deliver deterministic live-proof summary/policy contract behavior.
+- [x] T3 (Refactor/Docs): enforce docs parity for required bundle markers.
+- [x] T4 (Verify): execute live-node validation bundle contract suite.
+
+## Planned Verification Commands
+
+- `bash scripts/kolme/test_run_local_live_node_validation_bundle_contract_lane.sh`


### PR DESCRIPTION
## Summary
Adds missing lifecycle artifacts for the triadic topology and live-proof task chain (`#3845`, `#3846`, `#3847`) with deterministic AC->conformance mapping for existing contract-lane implementations.

## Links
- Milestone: R27.3 Live libp2p+Kolme proof and governance budgets
- Closes #3845
- Closes #3846
- Closes #3847
- Spec: `specs/3845/spec.md`, `specs/3846/spec.md`, `specs/3847/spec.md`
- Plan: `specs/3845/plan.md`, `specs/3846/plan.md`, `specs/3847/plan.md`

## Spec Verification (AC -> tests)
| AC | ✅/❌ | Test(s) |
|---|---|---|
| #3846 AC-1..AC-3 | ✅ | `bash scripts/kolme/test_run_triadic_devnet_smoke_contract_lane.sh` |
| #3847 AC-1..AC-3 | ✅ | `bash scripts/kolme/test_run_local_live_node_validation_bundle_contract_lane.sh` |
| #3845 AC-1..AC-4 | ✅ | combined checks above |

## TDD Evidence
- RED: fail/coverage scenarios remain encoded in the contract-lane suites.
- GREEN:
  - `bash scripts/kolme/test_run_triadic_devnet_smoke_contract_lane.sh`
  - `bash scripts/kolme/test_run_local_live_node_validation_bundle_contract_lane.sh`
- REGRESSION: all listed checks pass.

## Test Tiers
| Tier | ✅/❌/N/A | Tests | N/A Why |
|---|---|---|---|
| Unit | ✅ | helper assertions embedded in listed contract suites | |
| Property | N/A | | Not applicable for lifecycle-closure docs-only delta |
| Contract/DbC | ✅ | listed Kolme contract-lane suites | |
| Snapshot | N/A | | No snapshot changes |
| Functional | ✅ | listed Kolme suites | |
| Conformance | ✅ | AC-mapped checks above | |
| Integration | ✅ | triadic + live-proof composed contracts | |
| Fuzz | N/A | | Not applicable |
| Mutation | N/A | | No implementation code changed in this delta |
| Regression | ✅ | coverage/marker drift checks in listed suites | |
| Performance | N/A | | No runtime-path code changes |

## Risks / Rollback
- Risk: low (spec/lifecycle artifacts only).
- Rollback: revert PR commit if needed.

## Docs / ADR
- Added lifecycle artifacts only under `specs/3845/*`, `specs/3846/*`, `specs/3847/*`.
- ADR: not required.
