### PR TITLE
docs(spec): close signature realism and parity task chain (#3848)

### DIFF
--- a/specs/3848/plan.md
+++ b/specs/3848/plan.md
@@ -1,0 +1,22 @@
+# Plan - Issue #3848
+
+## Approach
+
+1. Validate child-subtask behavior for matrix and policy checker coverage.
+2. Validate composed signature parity contract-lane behavior.
+3. Add task-level lifecycle artifacts and close with AC-to-test mapping.
+
+## Affected Paths
+
+- `specs/3848/spec.md`
+- `specs/3848/plan.md`
+- `specs/3848/tasks.md`
+
+## Risks / Mitigations
+
+- Risk: signature realism task remains open while contract coverage exists.
+  Mitigation: consolidate child coverage and close with explicit conformance evidence.
+
+## ADR
+
+- Not required (lifecycle artifact closure only).

--- a/specs/3848/spec.md
+++ b/specs/3848/spec.md
@@ -1,0 +1,42 @@
+# Spec - Issue #3848
+
+- Title: Task: enforce signature realism and managed-signer parity in live validation matrix
+- Parent: #3844
+- Milestone: R27.3 Live libp2p+Kolme proof and governance budgets
+- Status: Implemented
+- Priority: P1
+
+## Problem Statement
+
+Simulated signature pathways were insufficient for production-readiness evidence; live validation needed real signer profile parity and deterministic policy contracts.
+
+## Objective
+
+Close signature realism/managed-signer parity task with deterministic matrix, policy checker, and contract-lane coverage.
+
+## Scope
+
+In scope:
+- Real secp256k1 signer profile parity matrix checks (`#3849`).
+- Signature parity policy checker and reason-taxonomy drift contracts (`#3850`).
+- Task-level conformance closure artifacts.
+
+Out of scope:
+- New wallet integrations.
+
+## Acceptance Criteria
+
+- AC-1: Real signer profile matrix checks remain deterministic and schema-validated.
+- AC-2: Parity policy checker enforces deterministic fail-closed taxonomy behavior.
+- AC-3: Contract-lane composition for matrix + policy + docs parity remains passing.
+- AC-4: Task-level conformance coverage remains auditable and green.
+
+## Conformance Cases
+
+- C-01 (AC-1): `bash scripts/kolme/test_run_signature_parity_matrix.sh` passes.
+- C-02 (AC-2): `bash scripts/kolme/test_check_signature_parity_policy.sh` passes.
+- C-03 (AC-3/AC-4): `bash scripts/kolme/test_run_signature_parity_contract_lane.sh` passes.
+
+## Success Metrics
+
+- Signature realism evidence is deterministic and fail-closed across matrix, policy, and composed contract lanes.

--- a/specs/3848/tasks.md
+++ b/specs/3848/tasks.md
@@ -1,0 +1,12 @@
+# Tasks - Issue #3848
+
+- [x] T1 (Red): define signer-parity matrix/policy fail-closed scenarios.
+- [x] T2 (Green): deliver child implementations (`#3849`, `#3850`).
+- [x] T3 (Refactor/Docs): preserve composed contract-lane/docs marker coverage.
+- [x] T4 (Verify): execute matrix, policy, and contract-lane suites.
+
+## Planned Verification Commands
+
+- `bash scripts/kolme/test_run_signature_parity_matrix.sh`
+- `bash scripts/kolme/test_check_signature_parity_policy.sh`
+- `bash scripts/kolme/test_run_signature_parity_contract_lane.sh`

--- a/specs/3849/plan.md
+++ b/specs/3849/plan.md
@@ -1,0 +1,22 @@
+# Plan - Issue #3849
+
+## Approach
+
+1. Validate parity matrix schema/status and vector coverage via existing matrix runner test suite.
+2. Validate deterministic negative-vector reason-code mapping.
+3. Record AC-to-test traceability in closure artifacts.
+
+## Affected Paths
+
+- `specs/3849/spec.md`
+- `specs/3849/plan.md`
+- `specs/3849/tasks.md`
+
+## Risks / Mitigations
+
+- Risk: signer-profile parity regressions without clear conformance traceability.
+  Mitigation: keep vector-level coverage and reason-code assertions in executable suite mapping.
+
+## ADR
+
+- Not required (lifecycle artifact closure only).

--- a/specs/3849/spec.md
+++ b/specs/3849/spec.md
@@ -1,0 +1,38 @@
+# Spec - Issue #3849
+
+- Title: Subtask: add real secp256k1 signer profile matrix checks for managed and failover paths
+- Parent: #3848
+- Milestone: R27.3 Live libp2p+Kolme proof and governance budgets
+- Status: Implemented
+- Priority: P1
+
+## Problem Statement
+
+Production-readiness validation required deterministic real secp256k1 signer-profile matrix checks, including known-bad failover-path proofs.
+
+## Objective
+
+Provide deterministic signature parity matrix coverage for managed/failover signer paths and required negative vectors.
+
+## Scope
+
+In scope:
+- Signature parity matrix runner contract coverage and schema checks.
+- Required negative-vector reason-code assertions for bad signature/recovery/pubkey cases.
+
+Out of scope:
+- New wallet integrations.
+
+## Acceptance Criteria
+
+- AC-1: Signature parity matrix runner emits deterministic schema/status markers.
+- AC-2: Managed/failover negative vectors are present and fail closed with required reason codes.
+- AC-3: Matrix runner supports bounded case execution and invalid-fixture fail-closed behavior.
+
+## Conformance Cases
+
+- C-01 (AC-1/AC-2/AC-3): `bash scripts/kolme/test_run_signature_parity_matrix.sh` passes.
+
+## Success Metrics
+
+- Signer-profile matrix proofs remain deterministic and auditable for real secp256k1 parity paths.

--- a/specs/3849/tasks.md
+++ b/specs/3849/tasks.md
@@ -1,0 +1,10 @@
+# Tasks - Issue #3849
+
+- [x] T1 (Red): define negative-vector fail-closed reason-code expectations.
+- [x] T2 (Green): deliver deterministic secp256k1 parity matrix runner behavior.
+- [x] T3 (Refactor/Docs): preserve vector/marker contract traceability.
+- [x] T4 (Verify): execute signature parity matrix runner suite.
+
+## Planned Verification Commands
+
+- `bash scripts/kolme/test_run_signature_parity_matrix.sh`

--- a/specs/3850/plan.md
+++ b/specs/3850/plan.md
@@ -1,0 +1,22 @@
+# Plan - Issue #3850
+
+## Approach
+
+1. Validate valid-path policy schema/final-decision behavior.
+2. Validate deterministic fail-closed behavior for invalid/missing-reason scenarios.
+3. Capture AC-to-test mapping in lifecycle artifacts.
+
+## Affected Paths
+
+- `specs/3850/spec.md`
+- `specs/3850/plan.md`
+- `specs/3850/tasks.md`
+
+## Risks / Mitigations
+
+- Risk: reason-taxonomy drift weakens policy determinism.
+  Mitigation: preserve explicit reason-code assertions in conformance mapping.
+
+## ADR
+
+- Not required (lifecycle artifact closure only).

--- a/specs/3850/spec.md
+++ b/specs/3850/spec.md
@@ -1,0 +1,38 @@
+# Spec - Issue #3850
+
+- Title: Subtask: add signature parity policy checker and reason-taxonomy drift contracts
+- Parent: #3848
+- Milestone: R27.3 Live libp2p+Kolme proof and governance budgets
+- Status: Implemented
+- Priority: P1
+
+## Problem Statement
+
+Signature parity policy evaluation needed deterministic reason-taxonomy enforcement to fail closed on schema/vector drift.
+
+## Objective
+
+Enforce deterministic signature parity policy checking with explicit drift/failure reason markers.
+
+## Scope
+
+In scope:
+- Signature parity policy checker schema/final-decision validation.
+- Fail-closed checks for invalid reports and missing required reason codes.
+
+Out of scope:
+- Runtime feature additions.
+
+## Acceptance Criteria
+
+- AC-1: Policy checker emits deterministic policy schema/final decision for valid reports.
+- AC-2: Invalid report structure fails closed with deterministic reason markers.
+- AC-3: Missing NO-GO case reason codes fail closed with deterministic reason markers.
+
+## Conformance Cases
+
+- C-01 (AC-1/AC-2/AC-3): `bash scripts/kolme/test_check_signature_parity_policy.sh` passes.
+
+## Success Metrics
+
+- Signature parity policy drift is detected deterministically with stable reason taxonomy markers.

--- a/specs/3850/tasks.md
+++ b/specs/3850/tasks.md
@@ -1,0 +1,10 @@
+# Tasks - Issue #3850
+
+- [x] T1 (Red): define invalid-report and missing-reason fail-closed policy scenarios.
+- [x] T2 (Green): deliver deterministic signature parity policy checker behavior.
+- [x] T3 (Refactor/Docs): preserve reason-taxonomy marker contracts.
+- [x] T4 (Verify): execute signature parity policy checker suite.
+
+## Planned Verification Commands
+
+- `bash scripts/kolme/test_check_signature_parity_policy.sh`


### PR DESCRIPTION
## Summary
Adds missing lifecycle artifacts for the signature-realism/parity task chain (`#3848`, `#3849`, `#3850`) with deterministic AC->conformance mapping for matrix, policy, and contract-lane coverage.

## Links
- Milestone: R27.3 Live libp2p+Kolme proof and governance budgets
- Closes #3848
- Closes #3849
- Closes #3850
- Spec: `specs/3848/spec.md`, `specs/3849/spec.md`, `specs/3850/spec.md`
- Plan: `specs/3848/plan.md`, `specs/3849/plan.md`, `specs/3850/plan.md`

## Spec Verification (AC -> tests)
| AC | ✅/❌ | Test(s) |
|---|---|---|
| #3849 AC-1..AC-3 | ✅ | `bash scripts/kolme/test_run_signature_parity_matrix.sh` |
| #3850 AC-1..AC-3 | ✅ | `bash scripts/kolme/test_check_signature_parity_policy.sh` |
| #3848 AC-1..AC-4 | ✅ | combined checks above + `bash scripts/kolme/test_run_signature_parity_contract_lane.sh` |

## TDD Evidence
- RED: fail-closed cases remain encoded in matrix/policy/contract-lane suites.
- GREEN:
  - `bash scripts/kolme/test_run_signature_parity_matrix.sh`
  - `bash scripts/kolme/test_check_signature_parity_policy.sh`
  - `bash scripts/kolme/test_run_signature_parity_contract_lane.sh`
- REGRESSION: all listed checks pass.

## Test Tiers
| Tier | ✅/❌/N/A | Tests | N/A Why |
|---|---|---|---|
| Unit | ✅ | helper assertions in listed suites | |
| Property | N/A | | Not applicable for lifecycle-closure docs-only delta |
| Contract/DbC | ✅ | signature parity contract-lane suite | |
| Snapshot | N/A | | No snapshot changes |
| Functional | ✅ | matrix/policy suites | |
| Conformance | ✅ | AC-mapped checks above | |
| Integration | ✅ | composed contract-lane coverage | |
| Fuzz | N/A | | Not applicable |
| Mutation | N/A | | No implementation code changed in this delta |
| Regression | ✅ | fail-closed drift checks in listed suites | |
| Performance | N/A | | No runtime-path changes |

## Risks / Rollback
- Risk: low (spec/lifecycle artifacts only).
- Rollback: revert PR commit if needed.

## Docs / ADR
- Added lifecycle artifacts only under `specs/3848/*`, `specs/3849/*`, `specs/3850/*`.
- ADR: not required.
