### PR TITLE
feat(runtime): enforce native-fallback profile compatibility checks

### DIFF
--- a/crates/kamn-core/tests/runtime_network_docs.rs
+++ b/crates/kamn-core/tests/runtime_network_docs.rs
@@ -39,6 +39,8 @@ fn doc_contains_runtime_network_scope_and_models() {
     assert!(DOC.contains("p2p-live-libp2p-provider:native"));
     assert!(DOC.contains("runtime_transport_profile_gossip_disabled_for_production"));
     assert!(DOC.contains("runtime_transport_profile_in_memory_fallback_forbidden"));
+    assert!(DOC.contains("runtime_transport_profile_pair_disallowed"));
+    assert!(DOC.contains("runtime_transport_profile_fallback_marker_without_in_memory_profile"));
     assert!(DOC.contains("runtime_transport_profile_live_marker_missing"));
     assert!(DOC.contains("runtime_transport_profile_live_provider_missing"));
     assert!(DOC.contains("runtime_transport_profile_compile_mode_not_native"));

--- a/crates/kamn-node/src/main_tests/runtime_tests.rs
+++ b/crates/kamn-node/src/main_tests/runtime_tests.rs
@@ -993,6 +993,48 @@ fn functional_production_transport_profile_classifier_rejects_in_memory_fallback
 }
 
 #[test]
+fn functional_transport_profile_classifier_rejects_live_and_fallback_profile_pair_conflict() {
+    let components = vec![
+        "p2p-discovery".to_owned(),
+        "p2p-gossip-transport".to_owned(),
+        "p2p-transport-profile:libp2p-live".to_owned(),
+        "p2p-transport-profile:in-memory-deterministic".to_owned(),
+        "p2p-in-memory-transport-fallback".to_owned(),
+    ];
+    assert_eq!(
+        classify_production_transport_profile_violation(RuntimeMode::full(), true, &components),
+        Some("runtime_transport_profile_pair_disallowed")
+    );
+}
+
+#[test]
+fn functional_transport_profile_classifier_rejects_fallback_marker_without_profile_pair() {
+    let components = vec![
+        "p2p-discovery".to_owned(),
+        "p2p-gossip-transport".to_owned(),
+        "p2p-in-memory-transport-fallback".to_owned(),
+    ];
+    assert_eq!(
+        classify_production_transport_profile_violation(RuntimeMode::planning(), true, &components),
+        Some("runtime_transport_profile_fallback_marker_without_in_memory_profile")
+    );
+}
+
+#[test]
+fn functional_transport_profile_classifier_accepts_planning_in_memory_profile_pair() {
+    let components = vec![
+        "p2p-discovery".to_owned(),
+        "p2p-gossip-transport".to_owned(),
+        "p2p-transport-profile:in-memory-deterministic".to_owned(),
+        "p2p-in-memory-transport-fallback".to_owned(),
+    ];
+    assert_eq!(
+        classify_production_transport_profile_violation(RuntimeMode::planning(), true, &components),
+        None
+    );
+}
+
+#[test]
 fn functional_production_transport_profile_classifier_rejects_contract_only_compile_mode() {
     let components = vec![
         "p2p-discovery".to_owned(),

--- a/crates/kamn-node/src/runtime_orchestration.rs
+++ b/crates/kamn-node/src/runtime_orchestration.rs
@@ -21,6 +21,10 @@ const RUNTIME_TRANSPORT_PROFILE_GOSSIP_DISABLED_FOR_PRODUCTION_REASON: &str =
     "runtime_transport_profile_gossip_disabled_for_production";
 const RUNTIME_TRANSPORT_PROFILE_IN_MEMORY_FALLBACK_FORBIDDEN_REASON: &str =
     "runtime_transport_profile_in_memory_fallback_forbidden";
+const RUNTIME_TRANSPORT_PROFILE_PAIR_DISALLOWED_REASON: &str =
+    "runtime_transport_profile_pair_disallowed";
+const RUNTIME_TRANSPORT_PROFILE_FALLBACK_MARKER_WITHOUT_IN_MEMORY_PROFILE_REASON: &str =
+    "runtime_transport_profile_fallback_marker_without_in_memory_profile";
 const RUNTIME_TRANSPORT_PROFILE_LIVE_MARKER_MISSING_REASON: &str =
     "runtime_transport_profile_live_marker_missing";
 const RUNTIME_TRANSPORT_PROFILE_LIVE_PROVIDER_MISSING_REASON: &str =
@@ -49,6 +53,12 @@ fn production_transport_profile_remediation(reason_code: &'static str) -> &'stat
         }
         RUNTIME_TRANSPORT_PROFILE_IN_MEMORY_FALLBACK_FORBIDDEN_REASON => {
             "ensure runtime wiring emits p2p-transport-profile:libp2p-live and remove in-memory fallback markers"
+        }
+        RUNTIME_TRANSPORT_PROFILE_PAIR_DISALLOWED_REASON => {
+            "ensure runtime wiring emits exactly one transport profile family (libp2p-live OR in-memory-deterministic), not both"
+        }
+        RUNTIME_TRANSPORT_PROFILE_FALLBACK_MARKER_WITHOUT_IN_MEMORY_PROFILE_REASON => {
+            "ensure p2p-in-memory-transport-fallback is only emitted with p2p-transport-profile:in-memory-deterministic"
         }
         RUNTIME_TRANSPORT_PROFILE_LIVE_MARKER_MISSING_REASON => {
             "ensure bootstrap uses RuntimeTransportProfile::Libp2pLive for production runtime modes"
@@ -122,6 +132,22 @@ pub(crate) fn classify_production_transport_profile_violation(
     enable_gossip: bool,
     components: &[String],
 ) -> Option<&'static str> {
+    let has_component = |expected: &str| components.iter().any(|component| component == expected);
+    let has_live_profile = has_component("p2p-transport-profile:libp2p-live");
+    let has_in_memory_profile = has_component("p2p-transport-profile:in-memory-deterministic");
+    let has_in_memory_fallback = has_component("p2p-in-memory-transport-fallback");
+    let has_live_provider = has_component("p2p-live-libp2p-provider");
+
+    if has_live_profile && (has_in_memory_profile || has_in_memory_fallback) {
+        return Some(RUNTIME_TRANSPORT_PROFILE_PAIR_DISALLOWED_REASON);
+    }
+    if has_in_memory_profile && has_live_provider {
+        return Some(RUNTIME_TRANSPORT_PROFILE_PAIR_DISALLOWED_REASON);
+    }
+    if has_in_memory_fallback && !has_in_memory_profile {
+        return Some(RUNTIME_TRANSPORT_PROFILE_FALLBACK_MARKER_WITHOUT_IN_MEMORY_PROFILE_REASON);
+    }
+
     if !runtime_mode_requires_live_transport_profile(runtime_mode) {
         return None;
     }
@@ -129,16 +155,13 @@ pub(crate) fn classify_production_transport_profile_violation(
         return Some(RUNTIME_TRANSPORT_PROFILE_GOSSIP_DISABLED_FOR_PRODUCTION_REASON);
     }
 
-    let has_component = |expected: &str| components.iter().any(|component| component == expected);
-    if has_component("p2p-transport-profile:in-memory-deterministic")
-        || has_component("p2p-in-memory-transport-fallback")
-    {
+    if has_in_memory_profile || has_in_memory_fallback {
         return Some(RUNTIME_TRANSPORT_PROFILE_IN_MEMORY_FALLBACK_FORBIDDEN_REASON);
     }
-    if !has_component("p2p-transport-profile:libp2p-live") {
+    if !has_live_profile {
         return Some(RUNTIME_TRANSPORT_PROFILE_LIVE_MARKER_MISSING_REASON);
     }
-    if !has_component("p2p-live-libp2p-provider") {
+    if !has_live_provider {
         return Some(RUNTIME_TRANSPORT_PROFILE_LIVE_PROVIDER_MISSING_REASON);
     }
     if has_component("p2p-live-libp2p-provider:contract-only")

--- a/docs/architecture/p2p-transport.md
+++ b/docs/architecture/p2p-transport.md
@@ -262,6 +262,10 @@ Deterministic reason-code markers:
     - remediation: remove `--disable-gossip` or switch to non-production runtime mode
   - `runtime_transport_profile_in_memory_fallback_forbidden`
     - remediation: remove in-memory fallback markers and enforce live profile markers
+  - `runtime_transport_profile_pair_disallowed`
+    - remediation: enforce exactly one transport-profile family (`libp2p-live` or `in-memory-deterministic`)
+  - `runtime_transport_profile_fallback_marker_without_in_memory_profile`
+    - remediation: emit `p2p-in-memory-transport-fallback` only with `p2p-transport-profile:in-memory-deterministic`
   - `gate_policy_native_libp2p_provider_marker_mismatch`
     - remediation: restore `p2p-live-libp2p-provider:native` marker in runtime report path
   - `gate_policy_libp2p_fallback_marker_blocklist_mismatch`

--- a/docs/foundation/runtime-network.md
+++ b/docs/foundation/runtime-network.md
@@ -224,6 +224,8 @@ This document captures the initial runtime-network foundation slice for peer lif
 - Fail-closed production policy reason codes:
   - `runtime_transport_profile_gossip_disabled_for_production`
   - `runtime_transport_profile_in_memory_fallback_forbidden`
+  - `runtime_transport_profile_pair_disallowed`
+  - `runtime_transport_profile_fallback_marker_without_in_memory_profile`
   - `runtime_transport_profile_live_marker_missing`
   - `runtime_transport_profile_live_provider_missing`
   - `runtime_transport_profile_compile_mode_not_native`
@@ -234,6 +236,14 @@ This document captures the initial runtime-network foundation slice for peer lif
   - `runtime_transport_profile_in_memory_fallback_forbidden`
     - remove in-memory fallback profile markers
     - ensure runtime wiring emits `p2p-transport-profile:libp2p-live`
+  - `runtime_transport_profile_pair_disallowed`
+    - ensure runtime wiring emits only one transport profile family
+      (`p2p-transport-profile:libp2p-live` OR
+      `p2p-transport-profile:in-memory-deterministic`)
+    - remove mixed live+fallback marker combinations
+  - `runtime_transport_profile_fallback_marker_without_in_memory_profile`
+    - ensure `p2p-in-memory-transport-fallback` is emitted only with
+      `p2p-transport-profile:in-memory-deterministic`
   - `runtime_transport_profile_live_marker_missing`
     - ensure bootstrap path selects `RuntimeTransportProfile::Libp2pLive`
   - `runtime_transport_profile_live_provider_missing`

--- a/specs/3879/plan.md
+++ b/specs/3879/plan.md
@@ -1,18 +1,19 @@
 # Issue #3879 Plan
 
 - Issue: #3879
-- Status: InProgress
+- Status: Completed
 
 ## Approach
-- Implement issue #3879 using Red->Green->Refactor test-first flow.
-- Keep markers and reason taxonomy deterministic and fail closed where applicable.
-- Preserve CI-fast boundaries by keeping heavy validation lanes explicitly governed.
+- Add runtime transport profile compatibility checks for unsupported live/fallback pairings.
+- Add deterministic reason-code classification for fallback marker linkage violations.
+- Preserve existing production fallback rejection behavior and document the expanded taxonomy.
 
 ## Affected Modules
-- scripts/runtime/
-- scripts/ci/
-- scripts/deploy/
-- docs/plans/2026-02-14-production-service-next-steps.md
+- crates/kamn-node/src/runtime_orchestration.rs
+- crates/kamn-node/src/main_tests/runtime_tests.rs
+- docs/foundation/runtime-network.md
+- docs/architecture/p2p-transport.md
+- crates/kamn-core/tests/runtime_network_docs.rs
 
 ## Risks and Mitigations
 - Risk level: low
@@ -21,6 +22,9 @@
 ## Interface Contract
 - No protocol or wire-format changes without explicit approval and ADR if needed.
 - Runtime evidence outputs must remain deterministic and machine-checkable.
+- Added deterministic compatibility reason codes:
+  - `runtime_transport_profile_pair_disallowed`
+  - `runtime_transport_profile_fallback_marker_without_in_memory_profile`
 
 ## ADR
 - No ADR required at planning stage; open ADR if dependency/protocol architecture changes emerge.

--- a/specs/3879/spec.md
+++ b/specs/3879/spec.md
@@ -1,7 +1,7 @@
 # Issue #3879 Spec
 
 - Title: Subtask: add native-fallback profile compatibility validation checks
-- Status: Reviewed
+- Status: Implemented
 - Priority: P1
 - Milestone: specs/milestones/r26-4-native-libp2p-production-activation-and-live-node-validation/index.md
 
@@ -23,12 +23,18 @@ Out:
 ## Conformance Cases
 | Case | AC | Tier | Input | Expected |
 |---|---|---|---|---|
-| C-01 | AC-1 | Unit/Functional/Integration/Regression | TBD in implementation task |  Unsupported profile pairs fail closed deterministically. |
-| C-02 | AC-2 | Unit/Functional/Integration/Regression | TBD in implementation task |  Supported pairs pass with stable markers. |
-| C-03 | AC-3 | Unit/Functional/Integration/Regression | TBD in implementation task |  Unit, Functional, Integration, and Regression tests are present and passing (or justified N/A). |
+| C-01 | AC-1 | Unit/Functional | `cargo test -p kamn-node main_tests::runtime_tests::functional_transport_profile_classifier_rejects_live_and_fallback_profile_pair_conflict -- --exact` | mixed live/fallback profile family fails closed with `runtime_transport_profile_pair_disallowed`. |
+| C-02 | AC-1 | Unit/Functional | `cargo test -p kamn-node main_tests::runtime_tests::functional_transport_profile_classifier_rejects_fallback_marker_without_profile_pair -- --exact` | fallback marker without in-memory profile fails closed with deterministic reason code. |
+| C-03 | AC-2 | Unit/Functional | `cargo test -p kamn-node main_tests::runtime_tests::functional_transport_profile_classifier_accepts_planning_in_memory_profile_pair -- --exact` | supported planning-mode in-memory profile/fallback pair passes. |
+| C-04 | AC-3 | Regression | `cargo test -p kamn-node main_tests::runtime_tests::functional_production_transport_profile_classifier_rejects_in_memory_fallback -- --exact` | existing production fallback rejection behavior remains stable. |
+| C-05 | AC-3 | Docs/Contract | `cargo test -p kamn-core --test runtime_network_docs` | runtime-network docs contain new transport profile pair reason taxonomy markers. |
 
 ## Test Mapping
-- To be completed in implementation phase for issue #3879.
+- `crates/kamn-node/src/runtime_orchestration.rs`
+- `crates/kamn-node/src/main_tests/runtime_tests.rs`
+- `docs/foundation/runtime-network.md`
+- `docs/architecture/p2p-transport.md`
+- `crates/kamn-core/tests/runtime_network_docs.rs`
 
 ## Success Metrics
 - All ACs have matching conformance tests and pass in CI/local-heavy lanes as applicable.

--- a/specs/3879/tasks.md
+++ b/specs/3879/tasks.md
@@ -1,15 +1,21 @@
 # Issue #3879 Tasks
 
 - Issue: #3879
-- Status: InProgress
+- Status: Completed
 
 ## Ordered Tasks
-- T1 (Red): add failing tests derived from acceptance criteria and conformance cases.
-- T2 (Green): implement minimal code and lane wiring to satisfy ACs deterministically.
-- T3 (Refactor): keep module and lane boundaries clear and reduce drift risk.
-- T4 (Regression): add drift, marker-taxonomy, and docs-parity checks as required.
-- T5 (Docs): update required docs surfaces declared by issue #3879.
-- T6 (Verify): run scoped cargo tests plus relevant runtime/ci/deploy lane scripts for this issue surface.
+- T1 (Red): add failing runtime profile-pair tests for mixed live/fallback profiles and invalid fallback marker linkage.
+- T2 (Green): implement deterministic compatibility classification checks in runtime orchestration.
+- T3 (Refactor): keep existing production-only policy checks stable while adding cross-profile pair validation.
+- T4 (Regression): preserve existing in-memory fallback rejection for production modes.
+- T5 (Docs): update runtime-network and p2p-transport docs with new compatibility reason markers.
+- T6 (Verify): run:
+  - cargo test -p kamn-node main_tests::runtime_tests::functional_transport_profile_classifier_rejects_live_and_fallback_profile_pair_conflict -- --exact
+  - cargo test -p kamn-node main_tests::runtime_tests::functional_transport_profile_classifier_rejects_fallback_marker_without_profile_pair -- --exact
+  - cargo test -p kamn-node main_tests::runtime_tests::functional_transport_profile_classifier_accepts_planning_in_memory_profile_pair -- --exact
+  - cargo test -p kamn-node main_tests::runtime_tests::functional_production_transport_profile_classifier_rejects_in_memory_fallback -- --exact
+  - cargo test -p kamn-core --test runtime_network_docs
 
 ## Completion Evidence
-- To be filled when implementation lands; include passing commands and AC->test mapping.
+- Runtime transport profile compatibility checks now fail closed for unsupported live/fallback pairings and fallback-marker linkage drift.
+- Scoped runtime tests and runtime-network docs contract suite pass.


### PR DESCRIPTION
## Summary
Implements native/fallback transport profile compatibility validation for runtime profile selection and marker linkage.

Adds deterministic fail-closed reason codes for unsupported profile pairs, preserves existing production fallback rejection behavior, and updates runtime docs/contracts accordingly.

## Links
- Milestone: https://github.com/njfio/kamn/milestone/32
- Parent task: #3878
- Parent story: #3877
- Spec: `specs/3879/spec.md`
- Plan: `specs/3879/plan.md`
- Closes #3879

## Spec Verification (AC → tests)
| AC | ✅/❌ | Test(s) |
|---|---|---|
| AC-1 Unsupported profile pairs fail closed deterministically | ✅ | `cargo test -p kamn-node main_tests::runtime_tests::functional_transport_profile_classifier_rejects_live_and_fallback_profile_pair_conflict -- --exact`; `cargo test -p kamn-node main_tests::runtime_tests::functional_transport_profile_classifier_rejects_fallback_marker_without_profile_pair -- --exact` |
| AC-2 Supported pairs pass with stable markers | ✅ | `cargo test -p kamn-node main_tests::runtime_tests::functional_transport_profile_classifier_accepts_planning_in_memory_profile_pair -- --exact` |
| AC-3 Unit/Functional/Integration/Regression coverage present and passing | ✅ | `cargo test -p kamn-node main_tests::runtime_tests::functional_production_transport_profile_classifier_rejects_in_memory_fallback -- --exact`; `cargo test -p kamn-core --test runtime_network_docs` |

## TDD Evidence
- RED: New compatibility tests were added for live+fallback pair conflict and fallback-marker linkage mismatch.
- GREEN:
  - `cargo test -p kamn-node main_tests::runtime_tests::functional_transport_profile_classifier_rejects_live_and_fallback_profile_pair_conflict -- --exact`
  - `cargo test -p kamn-node main_tests::runtime_tests::functional_transport_profile_classifier_rejects_fallback_marker_without_profile_pair -- --exact`
  - `cargo test -p kamn-node main_tests::runtime_tests::functional_transport_profile_classifier_accepts_planning_in_memory_profile_pair -- --exact`
  - `cargo test -p kamn-node main_tests::runtime_tests::functional_production_transport_profile_classifier_rejects_in_memory_fallback -- --exact`
  - `cargo test -p kamn-core --test runtime_network_docs`
- REGRESSION summary: existing production in-memory fallback rejection test remains green.

## Test Tiers
| Tier | ✅/❌/N/A | Tests | N/A Why |
|---|---|---|---|
| Unit | ✅ | runtime profile classifier unit/functional tests above | |
| Property | N/A | | no property-invariant harness added in this subtask |
| Contract/DbC | ✅ | `cargo test -p kamn-core --test runtime_network_docs` | |
| Snapshot | N/A | | no snapshots |
| Functional | ✅ | runtime classifier tests above | |
| Conformance | ✅ | `specs/3879/spec.md` C-01..C-05 mapping | |
| Integration | N/A | | no cross-service runtime integration lane added in this subtask |
| Fuzz | N/A | | no parser/untrusted input changes |
| Mutation | N/A | | scoped runtime classification change only; mutation lane not required for this subtask |
| Regression | ✅ | in-memory fallback regression test above | |
| Performance | N/A | | no performance-sensitive path changes |

## Mutation
N/A for this scoped subtask.

## Risks/Rollback
- Risk: low (reason-code taxonomy expansion in classifier path).
- Rollback: revert this PR commit.

## Docs/ADR
- Updated docs:
  - `docs/foundation/runtime-network.md`
  - `docs/architecture/p2p-transport.md`
- ADR: not required.
