### PR TITLE
feat(runtime): fail-closed go/no-go readiness and budget checks

### DIFF
--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -4150,6 +4150,13 @@ The runtime go/no-go gate lane enforces a versioned release evidence manifest:
   - `PASS` => `status=pass`, `final_decision=GO`
   - `WARN` => `status=warn`, `final_decision=GO`
   - `FAIL` => `status=fail`, `final_decision=NO-GO`
+- activation readiness marker contract (must be present and mode-aligned):
+  - `go_no_go_evidence_status`
+  - `rollback_readiness_status`
+  - `dr_readiness_status`
+  - `local_full_stack_integration_status`
+  - `local_full_runtime_convergence_status`
+  - `transport_fault_matrix_status`
 - native libp2p provider marker contracts (consumed by go/no-go policy evaluation):
   - `native_libp2p_provider_marker=p2p-live-libp2p-provider:native`
   - `libp2p_fallback_marker_blocklist=p2p-in-memory-transport-fallback,p2p-live-libp2p-provider:contract-only`
@@ -4192,7 +4199,8 @@ The runtime go/no-go gate lane enforces a versioned release evidence manifest:
   - `waiver_expiry_invalid`
   - `waiver_expired`
   - `waiver_allowed_reason_codes_invalid`
-  - `runtime_budget_exceeded` (warning reason)
+  - `runtime_budget_exceeded` (fail-closed reason)
+  - `gate_required_artifact_status_mismatch:<artifact_id>` (readiness marker missing or status mismatch)
   - `gate_decision_fault_injection_triggered` (fail reason)
   - `gate_policy_native_libp2p_provider_marker_mismatch`
   - `gate_policy_libp2p_fallback_marker_blocklist_mismatch`

--- a/scripts/runtime/go_no_go_gate_lane_contract.py
+++ b/scripts/runtime/go_no_go_gate_lane_contract.py
@@ -372,6 +372,7 @@ def _validate_release_manifest(
 
 def _evaluate_go_no_go_policy(
     artifact_inventory: list[dict[str, str]],
+    readiness_markers: dict[str, str],
     observed_reason_codes: list[str],
     lane_mode: str,
     native_libp2p_provider_marker: str,
@@ -384,8 +385,16 @@ def _evaluate_go_no_go_policy(
     expected_artifact_status = "verified" if lane_mode == "run" else "dry_run_pending"
 
     for artifact in artifact_inventory:
+        artifact_id = artifact.get("artifact_id", "unknown")
         if artifact.get("status") != expected_artifact_status:
-            artifact_id = artifact.get("artifact_id", "unknown")
+            fail_reasons.append(f"gate_required_artifact_status_mismatch:{artifact_id}")
+            continue
+        readiness_marker_key = f"{artifact_id}_status"
+        readiness_marker_value = readiness_markers.get(readiness_marker_key)
+        if not isinstance(readiness_marker_value, str) or not readiness_marker_value:
+            fail_reasons.append(f"gate_required_artifact_status_mismatch:{artifact_id}")
+            continue
+        if readiness_marker_value != expected_artifact_status:
             fail_reasons.append(f"gate_required_artifact_status_mismatch:{artifact_id}")
 
     for reason_code in observed_reason_codes:
@@ -393,7 +402,7 @@ def _evaluate_go_no_go_policy(
             fail_reasons.append(reason_code)
             continue
         if reason_code == RUNTIME_BUDGET_EXCEEDED_REASON:
-            warn_reasons.append(reason_code)
+            fail_reasons.append(reason_code)
             continue
         if reason_code == WAIVER_APPLIED_REASON:
             warn_reasons.append(reason_code)
@@ -429,10 +438,12 @@ def run_go_no_go_gate_lane(args: argparse.Namespace) -> int:
         "gate_decision",
         "runtime_budget_warn",
         "libp2p_fallback_marker",
+        "readiness_marker_missing",
     }:
         fail(
             "--fault-profile must be one of: "
-            "none, gate_decision, runtime_budget_warn, libp2p_fallback_marker"
+            "none, gate_decision, runtime_budget_warn, libp2p_fallback_marker, "
+            "readiness_marker_missing"
         )
     if lane_mode == "run" and args.local_opt_in.strip() != "1":
         fail(f"run mode requires {RUN_MODE_OPT_IN_ENV}=1")
@@ -696,8 +707,25 @@ def run_go_no_go_gate_lane(args: argparse.Namespace) -> int:
     ci_fast_gate_scope = "ci-fast-gate" if ci_fast_gate_eligible else "local-only"
     run_mode_command_status = "executed" if lane_mode == "run" else "dry_run_no_commands_executed"
     mode_reason_code = RUN_REASON if lane_mode == "run" else DRY_RUN_REASON
+    go_no_go_evidence_status = "verified" if lane_mode == "run" else "dry_run_pending"
+    rollback_readiness_status = "verified" if lane_mode == "run" else "dry_run_pending"
+    dr_readiness_status = "verified" if lane_mode == "run" else "dry_run_pending"
+    local_full_stack_integration_status = "verified" if lane_mode == "run" else "dry_run_pending"
+    local_full_runtime_convergence_status = "verified" if lane_mode == "run" else "dry_run_pending"
+    transport_fault_matrix_status = "verified" if lane_mode == "run" else "dry_run_pending"
+    if fault_profile == "readiness_marker_missing":
+        go_no_go_evidence_status = ""
+    readiness_markers = {
+        "go_no_go_evidence_status": go_no_go_evidence_status,
+        "rollback_readiness_status": rollback_readiness_status,
+        "dr_readiness_status": dr_readiness_status,
+        "local_full_stack_integration_status": local_full_stack_integration_status,
+        "local_full_runtime_convergence_status": local_full_runtime_convergence_status,
+        "transport_fault_matrix_status": transport_fault_matrix_status,
+    }
     policy_outcome, final_decision, status, evaluator_reason_codes = _evaluate_go_no_go_policy(
         artifact_inventory,
+        readiness_markers,
         reason_codes,
         lane_mode,
         native_libp2p_provider_marker,
@@ -753,18 +781,12 @@ def run_go_no_go_gate_lane(args: argparse.Namespace) -> int:
         "run_mode_command_count": run_mode_command_count,
         "mode_reason_code": mode_reason_code,
         "fault_profile": fault_profile,
-        "go_no_go_evidence_status": "verified" if lane_mode == "run" else "dry_run_pending",
-        "rollback_readiness_status": "verified" if lane_mode == "run" else "dry_run_pending",
-        "dr_readiness_status": "verified" if lane_mode == "run" else "dry_run_pending",
-        "local_full_stack_integration_status": "verified"
-        if lane_mode == "run"
-        else "dry_run_pending",
-        "local_full_runtime_convergence_status": "verified"
-        if lane_mode == "run"
-        else "dry_run_pending",
-        "transport_fault_matrix_status": "verified"
-        if lane_mode == "run"
-        else "dry_run_pending",
+        "go_no_go_evidence_status": go_no_go_evidence_status,
+        "rollback_readiness_status": rollback_readiness_status,
+        "dr_readiness_status": dr_readiness_status,
+        "local_full_stack_integration_status": local_full_stack_integration_status,
+        "local_full_runtime_convergence_status": local_full_runtime_convergence_status,
+        "transport_fault_matrix_status": transport_fault_matrix_status,
         "policy_evaluator_status": "verified",
         "manifest_schema_version": manifest_payload["schema_version"],
         "manifest_registry_status": "verified",
@@ -812,20 +834,12 @@ def run_go_no_go_gate_lane(args: argparse.Namespace) -> int:
     print(f"run_mode_command_count={run_mode_command_count}")
     print(f"mode_reason_code={mode_reason_code}")
     print(f"fault_profile={fault_profile}")
-    if lane_mode == "run":
-        print("go_no_go_evidence_status=verified")
-        print("rollback_readiness_status=verified")
-        print("dr_readiness_status=verified")
-        print("local_full_stack_integration_status=verified")
-        print("local_full_runtime_convergence_status=verified")
-        print("transport_fault_matrix_status=verified")
-    else:
-        print("go_no_go_evidence_status=dry_run_pending")
-        print("rollback_readiness_status=dry_run_pending")
-        print("dr_readiness_status=dry_run_pending")
-        print("local_full_stack_integration_status=dry_run_pending")
-        print("local_full_runtime_convergence_status=dry_run_pending")
-        print("transport_fault_matrix_status=dry_run_pending")
+    print(f"go_no_go_evidence_status={go_no_go_evidence_status}")
+    print(f"rollback_readiness_status={rollback_readiness_status}")
+    print(f"dr_readiness_status={dr_readiness_status}")
+    print(f"local_full_stack_integration_status={local_full_stack_integration_status}")
+    print(f"local_full_runtime_convergence_status={local_full_runtime_convergence_status}")
+    print(f"transport_fault_matrix_status={transport_fault_matrix_status}")
     print("policy_evaluator_status=verified")
     print(f"manifest_schema_version={manifest_payload['schema_version']}")
     print(f"reason_taxonomy_version={GO_NO_GO_REASON_TAXONOMY_VERSION}")

--- a/scripts/runtime/test_run_go_no_go_gate_lane.sh
+++ b/scripts/runtime/test_run_go_no_go_gate_lane.sh
@@ -13,6 +13,7 @@ TMP_DIR="$(mktemp -d)"
 TMP_REPORT="$TMP_DIR/go-no-go-gate-report.json"
 TMP_FAULT_REPORT="$TMP_DIR/go-no-go-gate-fault-report.json"
 TMP_FALLBACK_MARKER_FAULT_REPORT="$TMP_DIR/go-no-go-gate-fallback-marker-fault-report.json"
+TMP_READINESS_MARKER_FAULT_REPORT="$TMP_DIR/go-no-go-gate-readiness-marker-fault-report.json"
 TMP_WARN_REPORT="$TMP_DIR/go-no-go-gate-warn-report.json"
 TMP_RUN_REPORT="$TMP_DIR/go-no-go-gate-run-mode-report.json"
 TMP_WAIVER_REPORT="$TMP_DIR/go-no-go-gate-waiver-report.json"
@@ -91,6 +92,55 @@ if [ ! -f "$RELEASE_MANIFEST_FILE" ]; then
   echo "expected release evidence manifest file for go/no-go gate lane" >&2
   exit 1
 fi
+
+python3 - "$ROOT_DIR" <<'PY'
+import importlib.util
+import pathlib
+import sys
+
+root = pathlib.Path(sys.argv[1])
+module_path = root / "scripts/runtime/go_no_go_gate_lane_contract.py"
+spec = importlib.util.spec_from_file_location("go_no_go_gate_lane_contract", module_path)
+module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(module)
+
+artifact_inventory = [
+    {"artifact_id": "go_no_go_evidence", "status": "dry_run_pending"},
+]
+
+# Unit: missing readiness marker fails closed.
+policy_outcome, final_decision, status, reason_codes = module._evaluate_go_no_go_policy(
+    artifact_inventory,
+    {"go_no_go_evidence_status": ""},
+    [],
+    "dry-run",
+    module.NATIVE_LIBP2P_PROVIDER_MARKER,
+    list(module.LIBP2P_FALLBACK_MARKER_BLOCKLIST),
+    [],
+    "verified",
+)
+if (policy_outcome, final_decision, status) != ("FAIL", "NO-GO", "fail"):
+    raise SystemExit("expected missing readiness marker unit check to fail closed")
+if "gate_required_artifact_status_mismatch:go_no_go_evidence" not in reason_codes:
+    raise SystemExit("expected deterministic readiness marker mismatch reason in unit check")
+
+# Unit: runtime budget overflow fails closed.
+policy_outcome, final_decision, status, reason_codes = module._evaluate_go_no_go_policy(
+    artifact_inventory,
+    {"go_no_go_evidence_status": "dry_run_pending"},
+    [module.RUNTIME_BUDGET_EXCEEDED_REASON],
+    "dry-run",
+    module.NATIVE_LIBP2P_PROVIDER_MARKER,
+    list(module.LIBP2P_FALLBACK_MARKER_BLOCKLIST),
+    [],
+    "verified",
+)
+if (policy_outcome, final_decision, status) != ("FAIL", "NO-GO", "fail"):
+    raise SystemExit("expected runtime budget unit check to fail closed")
+if reason_codes != [module.RUNTIME_BUDGET_EXCEEDED_REASON]:
+    raise SystemExit("expected deterministic runtime budget reason code in unit check")
+PY
 
 lane_output="$(
   bash "$LANE_SCRIPT" \
@@ -657,6 +707,24 @@ if ! printf '%s\n' "$fallback_marker_fault_output" | grep -q 'gate_policy_libp2p
   exit 1
 fi
 
+set +e
+readiness_marker_fault_output="$(
+  bash "$LANE_SCRIPT" \
+    --fault-profile readiness_marker_missing \
+    --max-seconds 120 \
+    --output-json "$TMP_READINESS_MARKER_FAULT_REPORT" 2>&1
+)"
+readiness_marker_fault_code=$?
+set -e
+if [ "$readiness_marker_fault_code" -eq 0 ]; then
+  echo "expected go/no-go gate lane readiness marker fault profile to fail closed" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$readiness_marker_fault_output" | grep -q 'gate_required_artifact_status_mismatch:go_no_go_evidence'; then
+  echo "expected go/no-go gate lane readiness marker fault to report deterministic mismatch reason" >&2
+  exit 1
+fi
+
 tampered_manifest="$TMP_DIR/release-evidence-manifest.missing-dr.json"
 python3 - "$RELEASE_MANIFEST_FILE" "$tampered_manifest" <<'PY'
 import json
@@ -931,26 +999,54 @@ if payload.get("observed_reason_codes") != []:
     raise SystemExit("expected fallback marker fault observed_reason_codes to remain empty")
 PY
 
+python3 - "$TMP_READINESS_MARKER_FAULT_REPORT" <<'PY'
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+if payload.get("status") != "fail":
+    raise SystemExit("expected readiness marker fault report status=fail")
+if payload.get("policy_outcome") != "FAIL":
+    raise SystemExit("expected readiness marker fault report policy_outcome=FAIL")
+if payload.get("final_decision") != "NO-GO":
+    raise SystemExit("expected readiness marker fault report final_decision=NO-GO")
+if payload.get("fault_profile") != "readiness_marker_missing":
+    raise SystemExit("expected readiness marker fault report fault_profile=readiness_marker_missing")
+reason_codes = payload.get("reason_codes", [])
+if "gate_required_artifact_status_mismatch:go_no_go_evidence" not in reason_codes:
+    raise SystemExit("expected readiness marker mismatch reason code in readiness fault report")
+if payload.get("observed_reason_codes") != []:
+    raise SystemExit("expected readiness marker fault observed_reason_codes to remain empty")
+PY
+
+set +e
 warn_output="$(
   bash "$LANE_SCRIPT" \
     --fault-profile runtime_budget_warn \
     --max-seconds 120 \
-    --output-json "$TMP_WARN_REPORT"
+    --output-json "$TMP_WARN_REPORT" 2>&1
 )"
-if ! printf '%s\n' "$warn_output" | grep -q '^status=warn$'; then
-  echo "expected go/no-go gate runtime_budget_warn profile to emit status=warn" >&2
+warn_code=$?
+set -e
+if [ "$warn_code" -eq 0 ]; then
+  echo "expected go/no-go gate runtime_budget_warn profile to fail closed" >&2
   exit 1
 fi
-if ! printf '%s\n' "$warn_output" | grep -q '^policy_outcome=WARN$'; then
-  echo "expected go/no-go gate runtime_budget_warn profile to emit policy_outcome=WARN" >&2
+if ! printf '%s\n' "$warn_output" | grep -q '^status=fail$'; then
+  echo "expected go/no-go gate runtime_budget_warn profile to emit status=fail" >&2
   exit 1
 fi
-if ! printf '%s\n' "$warn_output" | grep -q '^final_decision=GO$'; then
-  echo "expected go/no-go gate runtime_budget_warn profile to keep final_decision=GO" >&2
+if ! printf '%s\n' "$warn_output" | grep -q '^policy_outcome=FAIL$'; then
+  echo "expected go/no-go gate runtime_budget_warn profile to emit policy_outcome=FAIL" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$warn_output" | grep -q '^final_decision=NO-GO$'; then
+  echo "expected go/no-go gate runtime_budget_warn profile to emit final_decision=NO-GO" >&2
   exit 1
 fi
 if ! printf '%s\n' "$warn_output" | grep -q '^reason_codes=runtime_budget_exceeded$'; then
-  echo "expected go/no-go gate runtime_budget_warn profile to emit warning reason code" >&2
+  echo "expected go/no-go gate runtime_budget_warn profile to emit deterministic budget reason code" >&2
   exit 1
 fi
 
@@ -960,12 +1056,12 @@ import pathlib
 import sys
 
 payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
-if payload.get("status") != "warn":
-    raise SystemExit("expected runtime_budget_warn report status=warn")
-if payload.get("policy_outcome") != "WARN":
-    raise SystemExit("expected runtime_budget_warn report policy_outcome=WARN")
-if payload.get("final_decision") != "GO":
-    raise SystemExit("expected runtime_budget_warn report final_decision=GO")
+if payload.get("status") != "fail":
+    raise SystemExit("expected runtime_budget_warn report status=fail")
+if payload.get("policy_outcome") != "FAIL":
+    raise SystemExit("expected runtime_budget_warn report policy_outcome=FAIL")
+if payload.get("final_decision") != "NO-GO":
+    raise SystemExit("expected runtime_budget_warn report final_decision=NO-GO")
 if payload.get("policy_evaluator_status") != "verified":
     raise SystemExit("expected runtime_budget_warn report policy_evaluator_status=verified")
 if payload.get("reason_codes") != ["runtime_budget_exceeded"]:

--- a/specs/3891/plan.md
+++ b/specs/3891/plan.md
@@ -1,17 +1,18 @@
 # Issue #3891 Plan
 
 - Issue: #3891
-- Status: Planned
+- Status: Completed
 
 ## Approach
-- Implement issue #3891 using Red->Green->Refactor test-first flow.
-- Keep markers and reason taxonomy deterministic and fail closed where applicable.
-- Preserve CI-fast boundaries by keeping heavy validation lanes explicitly governed.
+- Add RED coverage in the go/no-go lane harness for:
+  - missing activation readiness marker fail-closed behavior
+  - runtime budget overflow fail-closed behavior with deterministic reason code
+- Implement GREEN by extending go/no-go policy evaluation to validate readiness marker completeness and converting `runtime_budget_exceeded` to a fail reason.
+- Preserve CI-fast boundary contracts and update docs for readiness/budget marker policy semantics.
 
 ## Affected Modules
-- scripts/runtime/
-- scripts/ci/
-- scripts/deploy/
+- scripts/runtime/go_no_go_gate_lane_contract.py
+- scripts/runtime/test_run_go_no_go_gate_lane.sh
 - docs/ci/strategy.md
 
 ## Risks and Mitigations
@@ -21,6 +22,7 @@
 ## Interface Contract
 - No protocol or wire-format changes without explicit approval and ADR if needed.
 - Runtime evidence outputs must remain deterministic and machine-checkable.
+- Readiness marker omissions and budget threshold violations both fail closed in go/no-go policy evaluation.
 
 ## ADR
 - No ADR required at planning stage; open ADR if dependency/protocol architecture changes emerge.

--- a/specs/3891/spec.md
+++ b/specs/3891/spec.md
@@ -1,7 +1,7 @@
 # Issue #3891 Spec
 
 - Title: Subtask: add activation readiness and budget marker checks to go-no-go policy
-- Status: Draft
+- Status: Implemented
 - Priority: P1
 - Milestone: specs/milestones/r26-4-native-libp2p-production-activation-and-live-node-validation/index.md
 
@@ -23,12 +23,14 @@ Out:
 ## Conformance Cases
 | Case | AC | Tier | Input | Expected |
 |---|---|---|---|---|
-| C-01 | AC-1 | Unit/Functional/Integration/Regression | TBD in implementation task |  Missing readiness markers fail closed. |
-| C-02 | AC-2 | Unit/Functional/Integration/Regression | TBD in implementation task |  Budget threshold violations fail with deterministic reason codes. |
-| C-03 | AC-3 | Unit/Functional/Integration/Regression | TBD in implementation task |  Unit, Functional, Integration, and Regression tests are present and passing (or justified N/A). |
+| C-01 | AC-1 | Unit | `bash scripts/runtime/test_run_go_no_go_gate_lane.sh` | unit helper checks fail closed when `go_no_go_evidence_status` readiness marker is missing (`gate_required_artifact_status_mismatch:go_no_go_evidence`). |
+| C-02 | AC-1 | Functional/Integration | `bash scripts/runtime/test_run_go_no_go_gate_lane.sh` | readiness-marker fault profile (`--fault-profile readiness_marker_missing`) fails closed with deterministic mismatch reason and `final_decision=NO-GO`. |
+| C-03 | AC-2 | Functional/Integration | `bash scripts/runtime/test_run_go_no_go_gate_lane.sh` | budget fault profile (`--fault-profile runtime_budget_warn`) fails closed with `runtime_budget_exceeded`, `policy_outcome=FAIL`, and `final_decision=NO-GO`. |
+| C-04 | AC-3 | Regression | `cargo test -p kamn-core --test ci_strategy_docs` | CI strategy docs remain synchronized with runtime go/no-go readiness and budget fail-closed marker contracts. |
 
 ## Test Mapping
-- To be completed in implementation phase for issue #3891.
+- `scripts/runtime/test_run_go_no_go_gate_lane.sh`
+- `crates/kamn-core/tests/ci_strategy_docs.rs`
 
 ## Success Metrics
 - All ACs have matching conformance tests and pass in CI/local-heavy lanes as applicable.

--- a/specs/3891/tasks.md
+++ b/specs/3891/tasks.md
@@ -1,15 +1,20 @@
 # Issue #3891 Tasks
 
 - Issue: #3891
-- Status: Planned
+- Status: Completed
 
 ## Ordered Tasks
-- T1 (Red): add failing tests derived from acceptance criteria and conformance cases.
-- T2 (Green): implement minimal code and lane wiring to satisfy ACs deterministically.
-- T3 (Refactor): keep module and lane boundaries clear and reduce drift risk.
-- T4 (Regression): add drift, marker-taxonomy, and docs-parity checks as required.
-- T5 (Docs): update required docs surfaces declared by issue #3891.
-- T6 (Verify): run scoped cargo tests plus relevant runtime/ci/deploy lane scripts for this issue surface.
+- T1 (Red): extended `scripts/runtime/test_run_go_no_go_gate_lane.sh` with failing checks for readiness-marker omission and fail-closed budget behavior.
+- T2 (Green): updated `scripts/runtime/go_no_go_gate_lane_contract.py` to:
+  - enforce readiness marker completeness in policy evaluation
+  - convert `runtime_budget_exceeded` to fail-closed policy behavior
+  - add `readiness_marker_missing` fault profile for deterministic validation
+- T3 (Refactor): centralized readiness marker projection values before policy evaluation and reused them for report/stdout markers.
+- T4 (Regression): added readiness marker fault-profile assertions and runtime-budget fail-closed assertions in script harness (stdout + JSON payload).
+- T5 (Docs): updated `docs/ci/strategy.md` go/no-go marker contract section for readiness marker requirements and budget fail-closed semantics.
+- T6 (Verify): ran:
+  - `bash scripts/runtime/test_run_go_no_go_gate_lane.sh`
+  - `cargo test -p kamn-core --test ci_strategy_docs`
 
 ## Completion Evidence
-- To be filled when implementation lands; include passing commands and AC->test mapping.
+- Go/no-go policy now fails closed for missing readiness markers and runtime budget overflow with deterministic reason codes, and docs-contract coverage remains green.


### PR DESCRIPTION
## Summary
Implement fail-closed go/no-go policy enforcement for activation readiness markers and runtime budget overflow in `#3891`.
This change adds deterministic readiness-marker validation in policy evaluation and promotes `runtime_budget_exceeded` from warn-path to fail-closed decision-path.

## Links
- Milestone: https://github.com/njfio/kamn/milestone/32
- Closes #3891
- Spec: `specs/3891/spec.md`
- Plan: `specs/3891/plan.md`

## Spec Verification (AC -> tests)
| AC | ✅/❌ | Test(s) |
|---|---|---|
| AC-1: Missing readiness markers fail closed | ✅ | `bash scripts/runtime/test_run_go_no_go_gate_lane.sh` (unit helper check + `--fault-profile readiness_marker_missing`) |
| AC-2: Budget threshold violations fail with deterministic reason codes | ✅ | `bash scripts/runtime/test_run_go_no_go_gate_lane.sh` (`--fault-profile runtime_budget_warn` now fails closed with `runtime_budget_exceeded`) |
| AC-3: Unit/Functional/Integration/Regression tests present and passing | ✅ | `bash scripts/runtime/test_run_go_no_go_gate_lane.sh`; `cargo test -p kamn-core --test ci_strategy_docs` |

## TDD Evidence
- RED:
  - Command: `bash scripts/runtime/test_run_go_no_go_gate_lane.sh`
  - Output excerpt: `expected go/no-go gate lane readiness marker fault to report deterministic mismatch reason`
- GREEN:
  - Command: `bash scripts/runtime/test_run_go_no_go_gate_lane.sh`
  - Output excerpt: `go/no-go gate lane script tests passed.`
- REGRESSION:
  - Command: `cargo test -p kamn-core --test ci_strategy_docs`
  - Output excerpt: `test result: ok. 36 passed; 0 failed; ...`

## Test Tiers
| Tier | ✅/❌/N/A | Tests | N/A Why |
|---|---|---|---|
| Unit | ✅ | `bash scripts/runtime/test_run_go_no_go_gate_lane.sh` (inline python unit checks for `_evaluate_go_no_go_policy`) | |
| Property | N/A | | No invariant/proptest surface changed in this subtask scope. |
| Contract/DbC | N/A | | Rust DbC annotations not in scope; behavior guarded by deterministic lane contract tests. |
| Snapshot | N/A | | No snapshot artifacts in this scope. |
| Functional | ✅ | `bash scripts/runtime/test_run_go_no_go_gate_lane.sh` | |
| Conformance | ✅ | `bash scripts/runtime/test_run_go_no_go_gate_lane.sh`; `cargo test -p kamn-core --test ci_strategy_docs` | |
| Integration | ✅ | `bash scripts/runtime/test_run_go_no_go_gate_lane.sh` (report + policy + wrapper integration path checks) | |
| Fuzz | N/A | | No parser/untrusted-input fuzz target changed. |
| Mutation | N/A | | Not a critical-path Rust module mutation campaign; scoped script policy update verified via contract/regression tests. |
| Regression | ✅ | `bash scripts/runtime/test_run_go_no_go_gate_lane.sh`; `cargo test -p kamn-core --test ci_strategy_docs` | |
| Performance | N/A | | No hotspot/perf-sensitive code path change; command budgets remain unchanged. |

## Mutation
- N/A for this scoped script-policy subtask (see Test Tiers table).

## Risks/Rollback
- Risk: runtime budget overrun now exits fail-closed (`NO-GO`) instead of warn/GO in go/no-go gate policy.
- Rollback: revert this PR to restore previous warn semantics.

## Docs/ADR
- Updated: `docs/ci/strategy.md`
- Updated spec artifacts: `specs/3891/spec.md`, `specs/3891/plan.md`, `specs/3891/tasks.md`
- ADR: not required (no dependency/protocol/wire-format change).
