### PR TITLE
feat(kamn-core): implement M9 realtime delivery contracts (#5025)

### DIFF
--- a/crates/kamn-core/src/data_layer_m9_realtime_delivery.rs
+++ b/crates/kamn-core/src/data_layer_m9_realtime_delivery.rs
@@ -1,0 +1,486 @@
+//! M9 realtime delivery contracts for presence and deterministic backpressure.
+//!
+//! This module models PRD M9 behavior as deterministic Rust contracts:
+//! owner-scoped dispatch acknowledgements, scoped presence visibility, and
+//! queue-cap backpressure escalation markers.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+
+/// Maximum pending messages per recipient queue before full backpressure mode.
+pub const DATA_LAYER_M9_MAX_PENDING_PER_AGENT_MESSAGES: usize = 1_000;
+/// Full-queue duration threshold (seconds) after which warning events are emitted.
+pub const DATA_LAYER_M9_BACKPRESSURE_WARNING_AFTER_SECONDS: u64 = 300;
+/// Full-queue duration threshold (seconds) after which escrow timeout extension is recommended.
+pub const DATA_LAYER_M9_BACKPRESSURE_ESCROW_EXTENSION_AFTER_SECONDS: u64 = 3_600;
+/// Stable reason marker for delivered acknowledgements.
+pub const DATA_LAYER_M9_ACK_DELIVERED_REASON_CODE: &str = "m9_realtime_ack_delivered";
+/// Stable reason marker for queued acknowledgements (queue not yet full).
+pub const DATA_LAYER_M9_ACK_QUEUED_REASON_CODE: &str = "m9_realtime_ack_queued";
+/// Stable reason marker for queued acknowledgements when queue is full.
+pub const DATA_LAYER_M9_ACK_QUEUED_QUEUE_FULL_REASON_CODE: &str =
+    "m9_realtime_ack_queued_queue_full";
+/// Stable reason marker for owner-scope authorization denials.
+pub const DATA_LAYER_M9_OWNER_SCOPE_DENIED_REASON_CODE: &str = "m9_realtime_owner_scope_denied";
+/// Stable reason marker for scoped-presence visibility denials.
+pub const DATA_LAYER_M9_PRESENCE_VISIBILITY_DENIED_REASON_CODE: &str =
+    "m9_realtime_presence_visibility_denied";
+
+/// Dispatch acknowledgement status.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DataLayerM9DispatchAckStatus {
+    /// Recipient was connected with no backlog, so immediate delivery ACK is emitted.
+    Delivered,
+    /// Delivery was deferred and sender receives queued ACK.
+    Queued,
+}
+
+/// Dispatch request envelope.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DataLayerM9DispatchRequest {
+    /// Requester owner DID.
+    pub requester_owner_did: String,
+    /// Target owner DID.
+    pub owner_did: String,
+    /// Sender agent DID.
+    pub sender_agent_did: String,
+    /// Recipient agent DID.
+    pub recipient_agent_did: String,
+    /// Stable message identifier.
+    pub message_id: String,
+    /// Dispatch timestamp in epoch seconds.
+    pub dispatched_at_epoch_seconds: u64,
+}
+
+/// Dispatch outcome projection.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DataLayerM9DispatchOutcome {
+    /// Message identifier.
+    pub message_id: String,
+    /// Delivery acknowledgement status.
+    pub ack_status: DataLayerM9DispatchAckStatus,
+    /// Pending queue depth for the recipient after processing this dispatch.
+    pub pending_queue_depth: usize,
+    /// Deferred message count beyond full queue cap.
+    pub deferred_count: usize,
+    /// Stable decision reason marker.
+    pub reason_code: &'static str,
+    /// True when persistent backpressure warning threshold is crossed.
+    pub backpressure_warning_event: bool,
+    /// True when sustained backpressure threshold is crossed and escrow extension is recommended.
+    pub escrow_timeout_extension_recommended: bool,
+}
+
+/// Presence-connect request.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DataLayerM9PresenceConnectRequest {
+    /// Requester owner DID.
+    pub requester_owner_did: String,
+    /// Target owner DID.
+    pub owner_did: String,
+    /// Connected agent DID.
+    pub agent_did: String,
+    /// Connection start timestamp.
+    pub connected_since_epoch_seconds: u64,
+    /// Last heartbeat timestamp.
+    pub last_heartbeat_epoch_seconds: u64,
+    /// Gateway node identifier holding the active connection.
+    pub gateway_node: String,
+    /// Currently active capabilities.
+    pub capabilities_active: Vec<String>,
+}
+
+/// Presence query envelope.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DataLayerM9PresenceQuery {
+    /// Requester owner DID.
+    pub requester_owner_did: String,
+    /// Target owner DID.
+    pub owner_did: String,
+    /// Requesting agent DID.
+    pub requester_agent_did: String,
+    /// Target agent DID.
+    pub target_agent_did: String,
+}
+
+/// Relationship-link request used for scoped presence visibility.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DataLayerM9PresenceRelationshipRequest {
+    /// Requester owner DID.
+    pub requester_owner_did: String,
+    /// Target owner DID.
+    pub owner_did: String,
+    /// Requesting agent DID.
+    pub requester_agent_did: String,
+    /// Counterparty agent DID.
+    pub counterparty_agent_did: String,
+}
+
+/// Presence projection row.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DataLayerM9PresenceRecord {
+    /// Owner DID scope.
+    pub owner_did: String,
+    /// Agent DID.
+    pub agent_did: String,
+    /// Connection start timestamp.
+    pub connected_since_epoch_seconds: u64,
+    /// Last heartbeat timestamp.
+    pub last_heartbeat_epoch_seconds: u64,
+    /// Gateway node identifier.
+    pub gateway_node: String,
+    /// Sorted active capabilities.
+    pub capabilities_active: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+struct DataLayerM9RecipientQueueState {
+    pending_message_ids: Vec<String>,
+    deferred_message_ids: Vec<String>,
+    first_full_at_epoch_seconds: Option<u64>,
+}
+
+/// M9 realtime delivery registry.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct DataLayerM9RealtimeDeliveryRegistry {
+    presence_by_agent: BTreeMap<String, DataLayerM9PresenceRecord>,
+    queue_by_recipient: BTreeMap<String, DataLayerM9RecipientQueueState>,
+    interaction_pairs: BTreeSet<(String, String)>,
+    shared_escrow_pairs: BTreeSet<(String, String)>,
+}
+
+impl DataLayerM9RealtimeDeliveryRegistry {
+    /// Creates an empty realtime delivery registry.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Registers or refreshes active presence for one agent.
+    pub fn connect_presence(
+        &mut self,
+        request: DataLayerM9PresenceConnectRequest,
+    ) -> Result<DataLayerM9PresenceRecord, DataLayerM9RealtimeDeliveryError> {
+        authorize_owner_scope(
+            request.requester_owner_did.as_str(),
+            request.owner_did.as_str(),
+        )?;
+        validate_kamn_did(request.agent_did.as_str())?;
+        validate_non_empty(request.gateway_node.as_str(), "gateway_node")?;
+        if request.connected_since_epoch_seconds == 0 {
+            return Err(DataLayerM9RealtimeDeliveryError::EmptyField(
+                "connected_since_epoch_seconds",
+            ));
+        }
+        if request.last_heartbeat_epoch_seconds < request.connected_since_epoch_seconds {
+            return Err(DataLayerM9RealtimeDeliveryError::InvalidTimestampOrder {
+                connected_since_epoch_seconds: request.connected_since_epoch_seconds,
+                last_heartbeat_epoch_seconds: request.last_heartbeat_epoch_seconds,
+            });
+        }
+
+        let mut capabilities_active = request.capabilities_active;
+        capabilities_active.sort();
+        capabilities_active.dedup();
+        if capabilities_active
+            .iter()
+            .any(|value| value.trim().is_empty())
+        {
+            return Err(DataLayerM9RealtimeDeliveryError::EmptyField(
+                "capabilities_active",
+            ));
+        }
+
+        let record = DataLayerM9PresenceRecord {
+            owner_did: request.owner_did,
+            agent_did: request.agent_did.clone(),
+            connected_since_epoch_seconds: request.connected_since_epoch_seconds,
+            last_heartbeat_epoch_seconds: request.last_heartbeat_epoch_seconds,
+            gateway_node: request.gateway_node,
+            capabilities_active,
+        };
+        self.presence_by_agent
+            .insert(request.agent_did, record.clone());
+        Ok(record)
+    }
+
+    /// Registers prior-interaction linkage for scoped presence visibility.
+    pub fn record_interaction_link(
+        &mut self,
+        request: DataLayerM9PresenceRelationshipRequest,
+    ) -> Result<(), DataLayerM9RealtimeDeliveryError> {
+        authorize_owner_scope(
+            request.requester_owner_did.as_str(),
+            request.owner_did.as_str(),
+        )?;
+        validate_kamn_did(request.requester_agent_did.as_str())?;
+        validate_kamn_did(request.counterparty_agent_did.as_str())?;
+        if request.requester_agent_did == request.counterparty_agent_did {
+            return Err(DataLayerM9RealtimeDeliveryError::SameAgentRelationship);
+        }
+        self.interaction_pairs.insert(normalize_pair(
+            request.requester_agent_did.as_str(),
+            request.counterparty_agent_did.as_str(),
+        ));
+        Ok(())
+    }
+
+    /// Registers shared-escrow linkage for scoped presence visibility.
+    pub fn record_shared_escrow_link(
+        &mut self,
+        request: DataLayerM9PresenceRelationshipRequest,
+    ) -> Result<(), DataLayerM9RealtimeDeliveryError> {
+        authorize_owner_scope(
+            request.requester_owner_did.as_str(),
+            request.owner_did.as_str(),
+        )?;
+        validate_kamn_did(request.requester_agent_did.as_str())?;
+        validate_kamn_did(request.counterparty_agent_did.as_str())?;
+        if request.requester_agent_did == request.counterparty_agent_did {
+            return Err(DataLayerM9RealtimeDeliveryError::SameAgentRelationship);
+        }
+        self.shared_escrow_pairs.insert(normalize_pair(
+            request.requester_agent_did.as_str(),
+            request.counterparty_agent_did.as_str(),
+        ));
+        Ok(())
+    }
+
+    /// Queries target presence with scoped visibility controls.
+    pub fn query_presence(
+        &self,
+        query: DataLayerM9PresenceQuery,
+    ) -> Result<Option<DataLayerM9PresenceRecord>, DataLayerM9RealtimeDeliveryError> {
+        authorize_owner_scope(query.requester_owner_did.as_str(), query.owner_did.as_str())?;
+        validate_kamn_did(query.requester_agent_did.as_str())?;
+        validate_kamn_did(query.target_agent_did.as_str())?;
+
+        let has_visibility = if query.requester_agent_did == query.target_agent_did {
+            true
+        } else {
+            let pair = normalize_pair(
+                query.requester_agent_did.as_str(),
+                query.target_agent_did.as_str(),
+            );
+            self.interaction_pairs.contains(&pair) || self.shared_escrow_pairs.contains(&pair)
+        };
+
+        if !has_visibility {
+            return Err(DataLayerM9RealtimeDeliveryError::PresenceVisibilityDenied {
+                reason_code: DATA_LAYER_M9_PRESENCE_VISIBILITY_DENIED_REASON_CODE,
+            });
+        }
+
+        Ok(self.presence_by_agent.get(&query.target_agent_did).cloned())
+    }
+
+    /// Dispatches one message and computes deterministic ACK outcome.
+    pub fn dispatch_message(
+        &mut self,
+        request: DataLayerM9DispatchRequest,
+    ) -> Result<DataLayerM9DispatchOutcome, DataLayerM9RealtimeDeliveryError> {
+        authorize_owner_scope(
+            request.requester_owner_did.as_str(),
+            request.owner_did.as_str(),
+        )?;
+        validate_kamn_did(request.sender_agent_did.as_str())?;
+        validate_kamn_did(request.recipient_agent_did.as_str())?;
+        validate_non_empty(request.message_id.as_str(), "message_id")?;
+        if request.dispatched_at_epoch_seconds == 0 {
+            return Err(DataLayerM9RealtimeDeliveryError::EmptyField(
+                "dispatched_at_epoch_seconds",
+            ));
+        }
+
+        let queue_state = self
+            .queue_by_recipient
+            .entry(request.recipient_agent_did.clone())
+            .or_default();
+        if queue_state
+            .pending_message_ids
+            .contains(&request.message_id)
+            || queue_state
+                .deferred_message_ids
+                .contains(&request.message_id)
+        {
+            return Err(DataLayerM9RealtimeDeliveryError::DuplicateMessageId(
+                request.message_id,
+            ));
+        }
+
+        let recipient_connected = self
+            .presence_by_agent
+            .contains_key(&request.recipient_agent_did);
+        if recipient_connected && queue_state.pending_message_ids.is_empty() {
+            return Ok(DataLayerM9DispatchOutcome {
+                message_id: request.message_id,
+                ack_status: DataLayerM9DispatchAckStatus::Delivered,
+                pending_queue_depth: 0,
+                deferred_count: queue_state.deferred_message_ids.len(),
+                reason_code: DATA_LAYER_M9_ACK_DELIVERED_REASON_CODE,
+                backpressure_warning_event: false,
+                escrow_timeout_extension_recommended: false,
+            });
+        }
+
+        if queue_state.pending_message_ids.len() < DATA_LAYER_M9_MAX_PENDING_PER_AGENT_MESSAGES {
+            queue_state
+                .pending_message_ids
+                .push(request.message_id.clone());
+            if queue_state.pending_message_ids.len() == DATA_LAYER_M9_MAX_PENDING_PER_AGENT_MESSAGES
+                && queue_state.first_full_at_epoch_seconds.is_none()
+            {
+                queue_state.first_full_at_epoch_seconds = Some(request.dispatched_at_epoch_seconds);
+            }
+            let (warning, extension) = queue_escalation(
+                queue_state.first_full_at_epoch_seconds,
+                request.dispatched_at_epoch_seconds,
+            );
+            return Ok(DataLayerM9DispatchOutcome {
+                message_id: request.message_id,
+                ack_status: DataLayerM9DispatchAckStatus::Queued,
+                pending_queue_depth: queue_state.pending_message_ids.len(),
+                deferred_count: queue_state.deferred_message_ids.len(),
+                reason_code: DATA_LAYER_M9_ACK_QUEUED_REASON_CODE,
+                backpressure_warning_event: warning,
+                escrow_timeout_extension_recommended: extension,
+            });
+        }
+
+        if queue_state.first_full_at_epoch_seconds.is_none() {
+            queue_state.first_full_at_epoch_seconds = Some(request.dispatched_at_epoch_seconds);
+        }
+        queue_state
+            .deferred_message_ids
+            .push(request.message_id.clone());
+        let (warning, extension) = queue_escalation(
+            queue_state.first_full_at_epoch_seconds,
+            request.dispatched_at_epoch_seconds,
+        );
+        Ok(DataLayerM9DispatchOutcome {
+            message_id: request.message_id,
+            ack_status: DataLayerM9DispatchAckStatus::Queued,
+            pending_queue_depth: DATA_LAYER_M9_MAX_PENDING_PER_AGENT_MESSAGES,
+            deferred_count: queue_state.deferred_message_ids.len(),
+            reason_code: DATA_LAYER_M9_ACK_QUEUED_QUEUE_FULL_REASON_CODE,
+            backpressure_warning_event: warning,
+            escrow_timeout_extension_recommended: extension,
+        })
+    }
+}
+
+/// Error taxonomy for M9 realtime delivery contracts.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DataLayerM9RealtimeDeliveryError {
+    /// Required field was empty.
+    EmptyField(&'static str),
+    /// DID failed validation.
+    InvalidDid(String),
+    /// Owner-scope authorization failed.
+    OwnerScopeViolation {
+        /// Stable reason marker.
+        reason_code: &'static str,
+    },
+    /// Presence visibility policy denied the query.
+    PresenceVisibilityDenied {
+        /// Stable reason marker.
+        reason_code: &'static str,
+    },
+    /// Connected-since and heartbeat timestamps were ordered incorrectly.
+    InvalidTimestampOrder {
+        /// Connection start timestamp.
+        connected_since_epoch_seconds: u64,
+        /// Last heartbeat timestamp.
+        last_heartbeat_epoch_seconds: u64,
+    },
+    /// Request attempted to link one agent to itself.
+    SameAgentRelationship,
+    /// Duplicate message id in recipient queue/deferred state.
+    DuplicateMessageId(String),
+}
+
+impl fmt::Display for DataLayerM9RealtimeDeliveryError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyField(field) => write!(f, "field must not be empty: {field}"),
+            Self::InvalidDid(value) => write!(f, "invalid did: {value}"),
+            Self::OwnerScopeViolation { reason_code } => {
+                write!(f, "owner scope violation: {reason_code}")
+            }
+            Self::PresenceVisibilityDenied { reason_code } => {
+                write!(f, "presence visibility denied: {reason_code}")
+            }
+            Self::InvalidTimestampOrder {
+                connected_since_epoch_seconds,
+                last_heartbeat_epoch_seconds,
+            } => write!(
+                f,
+                "invalid timestamp order: connected_since={connected_since_epoch_seconds}, last_heartbeat={last_heartbeat_epoch_seconds}"
+            ),
+            Self::SameAgentRelationship => {
+                write!(f, "relationship requester and counterparty must differ")
+            }
+            Self::DuplicateMessageId(value) => write!(f, "duplicate message id: {value}"),
+        }
+    }
+}
+
+impl std::error::Error for DataLayerM9RealtimeDeliveryError {}
+
+fn queue_escalation(first_full_at: Option<u64>, now_epoch_seconds: u64) -> (bool, bool) {
+    let Some(first_full_at_epoch_seconds) = first_full_at else {
+        return (false, false);
+    };
+    let full_duration_seconds = now_epoch_seconds.saturating_sub(first_full_at_epoch_seconds);
+    let warning = full_duration_seconds > DATA_LAYER_M9_BACKPRESSURE_WARNING_AFTER_SECONDS;
+    let extension =
+        full_duration_seconds > DATA_LAYER_M9_BACKPRESSURE_ESCROW_EXTENSION_AFTER_SECONDS;
+    (warning, extension)
+}
+
+fn validate_non_empty(
+    value: &str,
+    field: &'static str,
+) -> Result<(), DataLayerM9RealtimeDeliveryError> {
+    if value.trim().is_empty() {
+        return Err(DataLayerM9RealtimeDeliveryError::EmptyField(field));
+    }
+    Ok(())
+}
+
+fn validate_kamn_did(value: &str) -> Result<(), DataLayerM9RealtimeDeliveryError> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() || !trimmed.starts_with("kamn:did:") {
+        return Err(DataLayerM9RealtimeDeliveryError::InvalidDid(
+            value.to_owned(),
+        ));
+    }
+    let segments = trimmed.split(':').collect::<Vec<_>>();
+    if segments.len() < 4 || segments.iter().any(|segment| segment.is_empty()) {
+        return Err(DataLayerM9RealtimeDeliveryError::InvalidDid(
+            value.to_owned(),
+        ));
+    }
+    Ok(())
+}
+
+fn authorize_owner_scope(
+    requester_owner_did: &str,
+    owner_did: &str,
+) -> Result<(), DataLayerM9RealtimeDeliveryError> {
+    validate_kamn_did(requester_owner_did)?;
+    validate_kamn_did(owner_did)?;
+    if requester_owner_did != owner_did {
+        return Err(DataLayerM9RealtimeDeliveryError::OwnerScopeViolation {
+            reason_code: DATA_LAYER_M9_OWNER_SCOPE_DENIED_REASON_CODE,
+        });
+    }
+    Ok(())
+}
+
+fn normalize_pair(left: &str, right: &str) -> (String, String) {
+    if left <= right {
+        (left.to_owned(), right.to_owned())
+    } else {
+        (right.to_owned(), left.to_owned())
+    }
+}

--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -56,6 +56,8 @@ pub mod data_layer_m6_graph_integration;
 pub mod data_layer_m7_timeseries_telemetry;
 /// M8 compliance contracts for retention policy, legal hold, and crypto-shredding lifecycle.
 pub mod data_layer_m8_compliance_lifecycle;
+/// M9 realtime contracts for dispatch acknowledgements, scoped presence, and backpressure markers.
+pub mod data_layer_m9_realtime_delivery;
 /// DID document canonicalization and federated trust-handshake contracts.
 pub mod did;
 /// DID registry lifecycle and chain-submission finality contracts.
@@ -308,6 +310,17 @@ pub use data_layer_m8_compliance_lifecycle::{
     DATA_LAYER_M8_CRYPTO_SHRED_REASON_CODE, DATA_LAYER_M8_EPHEMERAL_RETENTION_SECONDS,
     DATA_LAYER_M8_EXTENDED_RETENTION_SECONDS, DATA_LAYER_M8_OWNER_SCOPE_DENIED_REASON_CODE,
     DATA_LAYER_M8_RETENTION_DUE_REASON_CODE, DATA_LAYER_M8_STANDARD_RETENTION_SECONDS,
+};
+pub use data_layer_m9_realtime_delivery::{
+    DataLayerM9DispatchAckStatus, DataLayerM9DispatchOutcome, DataLayerM9DispatchRequest,
+    DataLayerM9PresenceConnectRequest, DataLayerM9PresenceQuery, DataLayerM9PresenceRecord,
+    DataLayerM9PresenceRelationshipRequest, DataLayerM9RealtimeDeliveryError,
+    DataLayerM9RealtimeDeliveryRegistry, DATA_LAYER_M9_ACK_DELIVERED_REASON_CODE,
+    DATA_LAYER_M9_ACK_QUEUED_QUEUE_FULL_REASON_CODE, DATA_LAYER_M9_ACK_QUEUED_REASON_CODE,
+    DATA_LAYER_M9_BACKPRESSURE_ESCROW_EXTENSION_AFTER_SECONDS,
+    DATA_LAYER_M9_BACKPRESSURE_WARNING_AFTER_SECONDS, DATA_LAYER_M9_MAX_PENDING_PER_AGENT_MESSAGES,
+    DATA_LAYER_M9_OWNER_SCOPE_DENIED_REASON_CODE,
+    DATA_LAYER_M9_PRESENCE_VISIBILITY_DENIED_REASON_CODE,
 };
 pub use did::{
     canonical_did_document, canonical_service_endpoint,

--- a/crates/kamn-core/tests/data_layer_m9_realtime_delivery.rs
+++ b/crates/kamn-core/tests/data_layer_m9_realtime_delivery.rs
@@ -1,0 +1,268 @@
+use kamn_core::{
+    DataLayerM9DispatchAckStatus, DataLayerM9DispatchRequest, DataLayerM9PresenceConnectRequest,
+    DataLayerM9PresenceQuery, DataLayerM9PresenceRelationshipRequest,
+    DataLayerM9RealtimeDeliveryError, DataLayerM9RealtimeDeliveryRegistry,
+    DATA_LAYER_M9_ACK_DELIVERED_REASON_CODE, DATA_LAYER_M9_ACK_QUEUED_QUEUE_FULL_REASON_CODE,
+    DATA_LAYER_M9_ACK_QUEUED_REASON_CODE, DATA_LAYER_M9_MAX_PENDING_PER_AGENT_MESSAGES,
+    DATA_LAYER_M9_OWNER_SCOPE_DENIED_REASON_CODE,
+    DATA_LAYER_M9_PRESENCE_VISIBILITY_DENIED_REASON_CODE,
+};
+
+fn dispatch_request(
+    requester_owner_did: &str,
+    owner_did: &str,
+    sender_agent_did: &str,
+    recipient_agent_did: &str,
+    message_id: &str,
+    dispatched_at_epoch_seconds: u64,
+) -> DataLayerM9DispatchRequest {
+    DataLayerM9DispatchRequest {
+        requester_owner_did: requester_owner_did.to_owned(),
+        owner_did: owner_did.to_owned(),
+        sender_agent_did: sender_agent_did.to_owned(),
+        recipient_agent_did: recipient_agent_did.to_owned(),
+        message_id: message_id.to_owned(),
+        dispatched_at_epoch_seconds,
+    }
+}
+
+#[test]
+fn spec_c01_connected_recipient_without_backlog_receives_delivered_ack() {
+    let mut registry = DataLayerM9RealtimeDeliveryRegistry::new();
+    registry
+        .connect_presence(DataLayerM9PresenceConnectRequest {
+            requester_owner_did: "kamn:did:owner:alpha".to_owned(),
+            owner_did: "kamn:did:owner:alpha".to_owned(),
+            agent_did: "kamn:did:agent:alpha-recipient".to_owned(),
+            connected_since_epoch_seconds: 1_708_560_100,
+            last_heartbeat_epoch_seconds: 1_708_560_100,
+            gateway_node: "gateway-a".to_owned(),
+            capabilities_active: vec!["ws".to_owned(), "notify".to_owned()],
+        })
+        .expect("presence connection should succeed");
+
+    let outcome = registry
+        .dispatch_message(dispatch_request(
+            "kamn:did:owner:alpha",
+            "kamn:did:owner:alpha",
+            "kamn:did:agent:alpha-sender",
+            "kamn:did:agent:alpha-recipient",
+            "m9-msg-001",
+            1_708_560_110,
+        ))
+        .expect("dispatch should succeed");
+
+    assert_eq!(outcome.ack_status, DataLayerM9DispatchAckStatus::Delivered);
+    assert_eq!(outcome.reason_code, DATA_LAYER_M9_ACK_DELIVERED_REASON_CODE);
+    assert_eq!(outcome.pending_queue_depth, 0);
+}
+
+#[test]
+fn spec_c02_presence_query_is_denied_until_relationship_linkage_is_registered() {
+    let mut registry = DataLayerM9RealtimeDeliveryRegistry::new();
+    registry
+        .connect_presence(DataLayerM9PresenceConnectRequest {
+            requester_owner_did: "kamn:did:owner:alpha".to_owned(),
+            owner_did: "kamn:did:owner:alpha".to_owned(),
+            agent_did: "kamn:did:agent:alpha-target".to_owned(),
+            connected_since_epoch_seconds: 1_708_560_100,
+            last_heartbeat_epoch_seconds: 1_708_560_100,
+            gateway_node: "gateway-a".to_owned(),
+            capabilities_active: vec!["ws".to_owned()],
+        })
+        .expect("presence connection should succeed");
+
+    let denied = registry.query_presence(DataLayerM9PresenceQuery {
+        requester_owner_did: "kamn:did:owner:alpha".to_owned(),
+        owner_did: "kamn:did:owner:alpha".to_owned(),
+        requester_agent_did: "kamn:did:agent:alpha-requester".to_owned(),
+        target_agent_did: "kamn:did:agent:alpha-target".to_owned(),
+    });
+    assert!(matches!(
+        denied,
+        Err(DataLayerM9RealtimeDeliveryError::PresenceVisibilityDenied {
+            reason_code: DATA_LAYER_M9_PRESENCE_VISIBILITY_DENIED_REASON_CODE,
+        })
+    ));
+
+    registry
+        .record_interaction_link(DataLayerM9PresenceRelationshipRequest {
+            requester_owner_did: "kamn:did:owner:alpha".to_owned(),
+            owner_did: "kamn:did:owner:alpha".to_owned(),
+            requester_agent_did: "kamn:did:agent:alpha-requester".to_owned(),
+            counterparty_agent_did: "kamn:did:agent:alpha-target".to_owned(),
+        })
+        .expect("interaction linkage should register");
+
+    let visible = registry
+        .query_presence(DataLayerM9PresenceQuery {
+            requester_owner_did: "kamn:did:owner:alpha".to_owned(),
+            owner_did: "kamn:did:owner:alpha".to_owned(),
+            requester_agent_did: "kamn:did:agent:alpha-requester".to_owned(),
+            target_agent_did: "kamn:did:agent:alpha-target".to_owned(),
+        })
+        .expect("presence query should succeed after linkage");
+
+    assert!(visible.is_some());
+    let visible_record = visible.expect("presence should be visible");
+    assert_eq!(visible_record.agent_did, "kamn:did:agent:alpha-target");
+}
+
+#[test]
+fn spec_c03_backpressure_thresholds_emit_warning_and_sustained_escalation_markers() {
+    let mut registry = DataLayerM9RealtimeDeliveryRegistry::new();
+    let base = 1_708_560_100;
+
+    for nonce in 0..DATA_LAYER_M9_MAX_PENDING_PER_AGENT_MESSAGES {
+        let message_id = format!("m9-queued-{nonce:04}");
+        let outcome = registry
+            .dispatch_message(dispatch_request(
+                "kamn:did:owner:alpha",
+                "kamn:did:owner:alpha",
+                "kamn:did:agent:alpha-sender",
+                "kamn:did:agent:alpha-recipient",
+                message_id.as_str(),
+                base,
+            ))
+            .expect("queue fill dispatch should succeed");
+        assert_eq!(outcome.ack_status, DataLayerM9DispatchAckStatus::Queued);
+    }
+
+    let warning = registry
+        .dispatch_message(dispatch_request(
+            "kamn:did:owner:alpha",
+            "kamn:did:owner:alpha",
+            "kamn:did:agent:alpha-sender",
+            "kamn:did:agent:alpha-recipient",
+            "m9-warning-threshold",
+            base + 301,
+        ))
+        .expect("warning-threshold dispatch should succeed");
+    assert_eq!(
+        warning.reason_code,
+        DATA_LAYER_M9_ACK_QUEUED_QUEUE_FULL_REASON_CODE
+    );
+    assert!(warning.backpressure_warning_event);
+    assert!(!warning.escrow_timeout_extension_recommended);
+
+    let sustained = registry
+        .dispatch_message(dispatch_request(
+            "kamn:did:owner:alpha",
+            "kamn:did:owner:alpha",
+            "kamn:did:agent:alpha-sender",
+            "kamn:did:agent:alpha-recipient",
+            "m9-sustained-threshold",
+            base + 3_601,
+        ))
+        .expect("sustained-threshold dispatch should succeed");
+    assert_eq!(
+        sustained.reason_code,
+        DATA_LAYER_M9_ACK_QUEUED_QUEUE_FULL_REASON_CODE
+    );
+    assert!(sustained.backpressure_warning_event);
+    assert!(sustained.escrow_timeout_extension_recommended);
+}
+
+#[test]
+fn spec_c04_cross_owner_dispatch_and_presence_queries_are_denied_fail_closed() {
+    let mut registry = DataLayerM9RealtimeDeliveryRegistry::new();
+    let denied_dispatch = registry.dispatch_message(dispatch_request(
+        "kamn:did:owner:intruder",
+        "kamn:did:owner:alpha",
+        "kamn:did:agent:alpha-sender",
+        "kamn:did:agent:alpha-recipient",
+        "m9-cross-owner",
+        1_708_560_100,
+    ));
+    assert!(matches!(
+        denied_dispatch,
+        Err(DataLayerM9RealtimeDeliveryError::OwnerScopeViolation {
+            reason_code: DATA_LAYER_M9_OWNER_SCOPE_DENIED_REASON_CODE,
+        })
+    ));
+
+    let denied_presence = registry.query_presence(DataLayerM9PresenceQuery {
+        requester_owner_did: "kamn:did:owner:intruder".to_owned(),
+        owner_did: "kamn:did:owner:alpha".to_owned(),
+        requester_agent_did: "kamn:did:agent:alpha-requester".to_owned(),
+        target_agent_did: "kamn:did:agent:alpha-target".to_owned(),
+    });
+    assert!(matches!(
+        denied_presence,
+        Err(DataLayerM9RealtimeDeliveryError::OwnerScopeViolation {
+            reason_code: DATA_LAYER_M9_OWNER_SCOPE_DENIED_REASON_CODE,
+        })
+    ));
+}
+
+#[test]
+fn spec_c05_queue_full_dispatch_keeps_pending_cap_and_increments_deferred_counter() {
+    let mut registry = DataLayerM9RealtimeDeliveryRegistry::new();
+    let base = 1_708_560_100;
+    for nonce in 0..DATA_LAYER_M9_MAX_PENDING_PER_AGENT_MESSAGES {
+        let _ = registry
+            .dispatch_message(dispatch_request(
+                "kamn:did:owner:alpha",
+                "kamn:did:owner:alpha",
+                "kamn:did:agent:alpha-sender",
+                "kamn:did:agent:alpha-recipient",
+                format!("m9-pending-{nonce:04}").as_str(),
+                base,
+            ))
+            .expect("queue fill dispatch should succeed");
+    }
+
+    let first_deferred = registry
+        .dispatch_message(dispatch_request(
+            "kamn:did:owner:alpha",
+            "kamn:did:owner:alpha",
+            "kamn:did:agent:alpha-sender",
+            "kamn:did:agent:alpha-recipient",
+            "m9-deferred-1",
+            base + 30,
+        ))
+        .expect("first deferred dispatch should succeed");
+    assert_eq!(
+        first_deferred.ack_status,
+        DataLayerM9DispatchAckStatus::Queued
+    );
+    assert_eq!(
+        first_deferred.reason_code,
+        DATA_LAYER_M9_ACK_QUEUED_QUEUE_FULL_REASON_CODE
+    );
+    assert_eq!(
+        first_deferred.pending_queue_depth,
+        DATA_LAYER_M9_MAX_PENDING_PER_AGENT_MESSAGES
+    );
+    assert_eq!(first_deferred.deferred_count, 1);
+
+    let second_deferred = registry
+        .dispatch_message(dispatch_request(
+            "kamn:did:owner:alpha",
+            "kamn:did:owner:alpha",
+            "kamn:did:agent:alpha-sender",
+            "kamn:did:agent:alpha-recipient",
+            "m9-deferred-2",
+            base + 31,
+        ))
+        .expect("second deferred dispatch should succeed");
+    assert_eq!(
+        second_deferred.ack_status,
+        DataLayerM9DispatchAckStatus::Queued
+    );
+    assert_eq!(
+        second_deferred.reason_code,
+        DATA_LAYER_M9_ACK_QUEUED_QUEUE_FULL_REASON_CODE
+    );
+    assert_eq!(second_deferred.deferred_count, 2);
+    assert!(!second_deferred.backpressure_warning_event);
+    assert_eq!(
+        second_deferred.pending_queue_depth,
+        DATA_LAYER_M9_MAX_PENDING_PER_AGENT_MESSAGES
+    );
+
+    assert_ne!(
+        DATA_LAYER_M9_ACK_QUEUED_REASON_CODE,
+        DATA_LAYER_M9_ACK_QUEUED_QUEUE_FULL_REASON_CODE
+    );
+}

--- a/specs/5025/plan.md
+++ b/specs/5025/plan.md
@@ -1,26 +1,46 @@
 # Issue #5025 Plan
 
 - Issue: #5025
-- Status: Draft
+- Status: Implemented
 
 ## Approach
-1. Create red tests and conformance assertions for issue scope.
-2. Implement minimal behavior to satisfy ACs.
-3. Refactor for maintainability while preserving deterministic outputs.
-4. Run scoped regression + governance gates before PR.
+1. Add RED conformance tests (`spec_c01`..`spec_c05`) for:
+   - connected-recipient delivered ACK behavior,
+   - scoped presence visibility checks,
+   - deterministic queue-cap backpressure escalation markers,
+   - owner-scope fail-closed controls.
+2. Implement `data_layer_m9_realtime_delivery` module with:
+   - owner-scoped presence registry + linkage gates,
+   - dispatch ACK decision engine (Delivered vs Queued),
+   - per-recipient queue cap and sustained-pressure escalation flags.
+3. Re-export M9 API in `crates/kamn-core/src/lib.rs`.
+4. Run format/lint/targeted/full regression and finalize evidence markers.
 
 ## Affected Modules
-- To be refined during implementation based on issue scope.
+- `crates/kamn-core/src/data_layer_m9_realtime_delivery.rs` (new)
+- `crates/kamn-core/src/lib.rs` (module + exports)
+- `crates/kamn-core/tests/data_layer_m9_realtime_delivery.rs` (new)
+- `specs/5025/spec.md`
+- `specs/5025/plan.md`
+- `specs/5025/tasks.md`
 
 ## Risks and Mitigations
-- Risk level: medium
+- Risk level: high
 - Mitigations:
-  - Keep diffs scoped to issue boundaries.
-  - Prefer Rust-native tests/harnesses to avoid shell-surface growth.
-  - Enforce shell budget and ratio checks when shell surfaces are touched.
+  - Keep queue/backpressure policies deterministic with explicit constants.
+  - Enforce owner-scope authorization at every mutation/query entrypoint.
+  - Use stable reason markers and sorted outputs for reproducible checks.
+  - Keep implementation Rust-only to avoid shell-surface growth.
 
 ## Interface Contract
-- No dependency/protocol/wire-format change without explicit approval and ADR.
+- Additive public API under `kamn_core::data_layer_m9_realtime_delivery::*`.
+- No new dependencies.
+- No protocol/wire-format changes.
 
 ## ADR
-- TBD per implementation decisions.
+- Not required for this scoped additive implementation.
+
+## Outcome
+- Added `data_layer_m9_realtime_delivery` contracts for owner-scoped dispatch ACK behavior, presence visibility gating, and queue-cap backpressure escalation markers.
+- Re-exported full M9 API through `kamn_core`.
+- Landed and passed conformance suite `spec_c01`..`spec_c05` plus full `kamn-core` regression.

--- a/specs/5025/spec.md
+++ b/specs/5025/spec.md
@@ -1,41 +1,83 @@
 # Issue #5025 Spec
 
 - Title: Task: M9 deliver realtime delivery pipeline, presence, and deterministic backpressure
-- Status: Draft
+- Status: Implemented
 - Type: task
 - Priority: P1
 - Milestone: specs/milestones/r27-45-kamn-data-layer-prd-implementation-and-validation/index.md
 
 ## Problem Statement
-Implement, integrate, test, and validate the parent-story delivery scope with strict spec-driven + TDD gates.
+PRD M9 requires deterministic contracts for realtime delivery acknowledgements,
+presence visibility scoping, and backpressure escalation markers. Existing
+runtime code contains queue/backpressure internals, but there is no dedicated
+owner-scoped M9 contract surface that unifies delivery ACK semantics, presence
+policy checks, and sustained backpressure escalation outcomes.
+
+PRD mapping:
+- Section 10.1 (WebSocket/SSE delivery + ACK/requeue contract)
+- Section 10.2 (presence system and scoped visibility)
+- Section 10.4 (backpressure queue cap, warning after 5m, sustained after 1h)
+- Milestone table M9 deliverables (delivery pipeline + presence + queue behavior)
 
 ## Acceptance Criteria
-- AC-1: Scope for issue #5025 is decomposed into explicit implementation/integration/validation outcomes with deterministic test evidence.
-- AC-2: The issue maps to PRD sections and conformance scenarios with clear test commands and result expectations.
-- AC-3: Shell-surface impact remains neutral by default (net shell LOC delta <= 0) unless explicitly waived with mitigation issue linkage.
+- AC-1: Realtime dispatch contract deterministically returns `Delivered` ACK for
+  connected recipients without backlog and `Queued` ACK when delivery must be
+  deferred.
+- AC-2: Presence visibility contract is fail-closed and only allows requester
+  visibility for counterparties with prior interaction or shared escrow linkage.
+- AC-3: Backpressure contract enforces deterministic per-recipient queue cap and
+  emits escalation markers at >5m (warning) and >1h (escrow timeout extension).
+- AC-4: Cross-owner dispatch and presence operations are denied fail-closed with
+  stable reason markers.
+- AC-5: Shell/workflow/python/template LOC remains unchanged
+  (`shell_loc_delta_actual = 0`).
 
 ## Scope
 In scope:
-- Issue-specific delivery for Task: M9 deliver realtime delivery pipeline, presence, and deterministic backpressure.
-- Contract-driven lifecycle artifacts (`spec.md`, `plan.md`, `tasks.md`).
-- Test-tier mapping and conformance evidence capture.
+- New Rust M9 module in `kamn-core` for owner-scoped dispatch ACKs,
+  presence visibility queries, and deterministic backpressure escalation.
+- Conformance tests for ACK behavior, scoped presence access, queue-cap
+  saturation behavior, and sustained-pressure markers.
+- Public API exports for downstream M10/M11 integration lanes.
 
 Out of scope:
-- Unapproved dependency/protocol changes.
-- Work outside the parent milestone scope.
+- Live websocket/SSE runtime wiring and gateway network transport.
+- New shell/python/workflow/template orchestration.
+- New dependencies or wire/protocol format changes.
 
 ## Conformance Cases
 | Case | AC | Tier | Input | Expected |
 |---|---|---|---|---|
-| C-01 | AC-1 | Functional | Execute issue task plan for #5025 | Planned implementation/integration steps are completed with evidence |
-| C-02 | AC-2 | Conformance | Run mapped test commands for #5025 | All mapped conformance checks pass and produce deterministic markers |
-| C-03 | AC-3 | Regression | Run shell-surface and ratio governance checks | No net shell-surface regression without waiver |
+| C-01 | AC-1 | Functional | Dispatch to connected recipient with empty backlog | `Delivered` ACK with stable reason marker and zero queue depth |
+| C-02 | AC-2 | Conformance | Query target presence before/after prior interaction registration | Query is denied before linkage and allowed after linkage |
+| C-03 | AC-3 | Conformance | Saturate recipient queue and dispatch beyond 5m and 1h thresholds | Deterministic warning + escalation flags at policy boundaries |
+| C-04 | AC-4 | Regression | Dispatch/presence queries with mismatched owner scope | Owner-scope violation returned with stable reason marker |
+| C-05 | AC-3/AC-4 | Regression | Queue-full dispatch while disconnected | `Queued` ACK persists and deferred counters remain deterministic |
+| C-06 | AC-5 | Regression | Inspect issue diff paths | No shell/python/workflow/template path changes |
 
 ## Test Mapping
-- `cargo test -p kamn-core` (scoped by issue-specific suites)
-- `bash scripts/ci/check_shell_loc_hard_ceiling.sh` (when shell/python/workflow surface is touched)
-- `bash scripts/ci/check_shell_rust_ratio_guardrail.sh` (when shell/python/workflow surface is touched)
+- `cargo test -p kamn-core --test data_layer_m9_realtime_delivery`
+- `cargo test -p kamn-core spec_c0`
+- `cargo test -p kamn-core`
+- Shell governance scripts are not required because shell/workflow surfaces are unchanged.
 
 ## Success Metrics
-- Issue #5025 reaches `Status: Implemented` with ACs mapped to passing conformance evidence.
-- Shell-to-Rust ratio guardrails remain within thresholds.
+- M9 contracts are exported via `kamn_core` for downstream integration lanes.
+- All ACs map to passing `spec_c0x_*` conformance tests.
+- Shell-to-Rust ratio direction remains improved/neutral through Rust-only changes.
+
+## Verification
+| AC | Result | Tests/Evidence |
+|---|---|---|
+| AC-1 | ✅ | `spec_c01_connected_recipient_without_backlog_receives_delivered_ack`, `spec_c05_queue_full_dispatch_keeps_pending_cap_and_increments_deferred_counter` |
+| AC-2 | ✅ | `spec_c02_presence_query_is_denied_until_relationship_linkage_is_registered` |
+| AC-3 | ✅ | `spec_c03_backpressure_thresholds_emit_warning_and_sustained_escalation_markers` |
+| AC-4 | ✅ | `spec_c04_cross_owner_dispatch_and_presence_queries_are_denied_fail_closed` |
+| AC-5 | ✅ | `git diff --name-only` confirms no shell/python/workflow/template path changes |
+
+Executed commands:
+- `cargo fmt --check`
+- `cargo clippy -p kamn-core -- -D warnings`
+- `cargo test -p kamn-core --test data_layer_m9_realtime_delivery`
+- `cargo test -p kamn-core spec_c0`
+- `cargo test -p kamn-core`

--- a/specs/5025/tasks.md
+++ b/specs/5025/tasks.md
@@ -1,12 +1,12 @@
 # Issue #5025 Tasks
 
 - Issue: #5025
-- Status: Draft
+- Status: Implemented
 
 ## Ordered Tasks
-- [ ] T1 (Red): add failing tests derived from spec conformance cases.
-- [ ] T2 (Green): implement minimum code path to satisfy ACs.
-- [ ] T3 (Refactor): improve structure/readability while preserving behavior.
-- [ ] T4 (Regression): run scoped functional/integration/regression checks.
-- [ ] T5 (Governance): if shell/python/workflow/template changed, run shell budget + ratio guardrails and report deltas.
-- [ ] T6 (Verify): finalize AC mapping and set lifecycle status markers.
+- [x] T1 (Red): add `spec_c01`..`spec_c05` tests for delivery ACK semantics, scoped presence visibility, and deterministic backpressure escalation.
+- [x] T2 (Green): implement `data_layer_m9_realtime_delivery` contracts to satisfy the red suite.
+- [x] T3 (Refactor): tighten deterministic ordering and stable reason-marker taxonomy.
+- [x] T4 (Regression): run `cargo fmt --check`, `cargo clippy -p kamn-core -- -D warnings`, `cargo test -p kamn-core --test data_layer_m9_realtime_delivery`, and `cargo test -p kamn-core`.
+- [x] T5 (Governance): confirm zero shell/python/workflow/template delta and record `shell_loc_delta_actual=0`.
+- [x] T6 (Verify): set spec lifecycle status to `Implemented`, map ACs to tests, and post issue closure evidence.


### PR DESCRIPTION
## Summary
Implements PRD M9 realtime delivery contracts in `kamn-core`: deterministic dispatch ACK outcomes (`Delivered` vs `Queued`), scoped presence visibility controls, and queue-cap backpressure escalation markers for warning (>5m) and sustained pressure (>1h). Adds conformance tests `spec_c01`..`spec_c05` and exports the M9 API from `kamn_core`.

- shell_loc_delta_actual: 0
- rust_loc_delta_actual: +774
- shell_to_rust_ratio_delta_actual: -0.005370
- shell_surface_ratio_target_status: improved

## Links
- Milestone: `specs/milestones/r27-45-kamn-data-layer-prd-implementation-and-validation/index.md`
- Closes #5025
- Spec: `specs/5025/spec.md`
- Plan: `specs/5025/plan.md`
- Tasks: `specs/5025/tasks.md`

## Spec Verification (AC -> tests)
| AC | ✅/❌ | Test(s) |
|---|---|---|
| AC-1: deterministic delivered/queued ACK behavior | ✅ | `spec_c01_connected_recipient_without_backlog_receives_delivered_ack`, `spec_c05_queue_full_dispatch_keeps_pending_cap_and_increments_deferred_counter` |
| AC-2: scoped presence visibility is fail-closed | ✅ | `spec_c02_presence_query_is_denied_until_relationship_linkage_is_registered` |
| AC-3: deterministic queue cap + 5m/1h escalation markers | ✅ | `spec_c03_backpressure_thresholds_emit_warning_and_sustained_escalation_markers` |
| AC-4: cross-owner operations denied fail-closed | ✅ | `spec_c04_cross_owner_dispatch_and_presence_queries_are_denied_fail_closed` |
| AC-5: shell/workflow/python/template LOC unchanged | ✅ | `git diff --name-only origin/main...HEAD` (no shell-surface paths changed) |

## TDD Evidence
RED command + excerpt:
```bash
cargo test -p kamn-core --test data_layer_m9_realtime_delivery
```
```text
error[E0432]: unresolved imports `kamn_core::DataLayerM9*`
```

GREEN command + excerpt:
```bash
cargo test -p kamn-core --test data_layer_m9_realtime_delivery
```
```text
running 5 tests
... spec_c01..spec_c05 ... ok
test result: ok. 5 passed; 0 failed
```

Regression summary:
- `cargo fmt --check`
- `cargo clippy -p kamn-core -- -D warnings`
- `cargo test -p kamn-core --test data_layer_m9_realtime_delivery`
- `cargo test -p kamn-core spec_c0`
- `cargo test -p kamn-core`

## Test Tiers
| Tier | ✅/❌/N/A | Tests | N/A Why |
|---|---|---|---|
| Unit | ✅ | `spec_c05_queue_full_dispatch_keeps_pending_cap_and_increments_deferred_counter` | |
| Property | N/A | | No new parser/invariant property generator in this scope |
| Contract/DbC | N/A | | `contracts` instrumentation not used for this module; fail-closed behavior covered via conformance tests |
| Snapshot | N/A | | Structured snapshots are not used for this contract surface |
| Functional | ✅ | `spec_c01_...`, `spec_c02_...` | |
| Conformance | ✅ | `spec_c01`..`spec_c05` in `data_layer_m9_realtime_delivery.rs` | |
| Integration | ✅ | `cargo test -p kamn-core` | |
| Fuzz | N/A | | No untrusted parser boundary introduced in this issue |
| Mutation | N/A | `cargo mutants --in-diff` (attempted) | Tool unavailable in environment (`error: no such command: mutants`) |
| Regression | ✅ | `spec_c04_...`, `spec_c05_...`, `cargo test -p kamn-core` | |
| Performance | N/A | | No benchmark-targeted hotspot modified in this issue |

## Mutation
`cargo mutants --in-diff` attempted; environment does not have `cargo-mutants` installed (`error: no such command: mutants`).

## Risks/Rollback
Low-to-medium risk additive change in `kamn-core` only. Rollback is clean by reverting commit `f8d89a63`.

## Docs/ADR
Updated:
- `specs/5025/spec.md`
- `specs/5025/plan.md`
- `specs/5025/tasks.md`

ADR not required for this scoped additive contract implementation.
