### PR TITLE
feat(kamn-core): implement M10 partition archival lifecycle contracts (#5026)

### DIFF
--- a/crates/kamn-core/src/data_layer_m10_partition_archival.rs
+++ b/crates/kamn-core/src/data_layer_m10_partition_archival.rs
@@ -1,0 +1,354 @@
+//! M10 partition lifecycle contracts for scaling and archival export controls.
+//!
+//! This module models PRD M10 behavior as deterministic Rust contracts:
+//! monthly partition naming/planning, retention-window archival eligibility,
+//! archival index metadata projection, and archived-partition re-attachment.
+
+use std::collections::BTreeMap;
+use std::fmt;
+
+/// Partition prefix for monthly message partitions.
+pub const DATA_LAYER_M10_PARTITION_PREFIX: &str = "messages_";
+/// Archive format marker for exported partition artifacts.
+pub const DATA_LAYER_M10_ARCHIVE_FORMAT_PARQUET_ZSTD: &str = "parquet-zstd";
+/// Stable reason marker for archived lifecycle transitions.
+pub const DATA_LAYER_M10_ARCHIVE_REASON_CODE: &str = "m10_partition_archived";
+/// Stable reason marker for archived -> reattached transitions.
+pub const DATA_LAYER_M10_REATTACH_REASON_CODE: &str = "m10_partition_reattached";
+/// Stable reason marker for invalid lifecycle transitions.
+pub const DATA_LAYER_M10_INVALID_TRANSITION_REASON_CODE: &str = "m10_partition_transition_invalid";
+
+/// Partition lifecycle status.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DataLayerM10PartitionStatus {
+    /// Active partition in primary query path.
+    Active,
+    /// Archived partition with export metadata in archival index.
+    Archived,
+    /// Archived partition reattached for historical query access.
+    Reattached,
+}
+
+/// Partition registration input.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DataLayerM10PartitionRecordInput {
+    /// Partition month identifier as `YYYYMM`.
+    pub partition_month_id: u32,
+    /// True when all rows in partition are shred-complete and eligible for archival export.
+    pub all_messages_shredded: bool,
+}
+
+/// Partition lifecycle record.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DataLayerM10PartitionRecord {
+    /// Partition month identifier as `YYYYMM`.
+    pub partition_month_id: u32,
+    /// Canonical partition name `messages_YYYY_MM`.
+    pub partition_name: String,
+    /// Shred-complete marker for archival eligibility checks.
+    pub all_messages_shredded: bool,
+    /// Current lifecycle status.
+    pub lifecycle_status: DataLayerM10PartitionStatus,
+    /// Archived object URI when partition is archived.
+    pub archived_object_uri: Option<String>,
+    /// Archive format marker when partition is archived.
+    pub archive_format_marker: Option<&'static str>,
+    /// Deterministic checksum marker when partition is archived.
+    pub checksum_marker: Option<String>,
+    /// Last lifecycle transition reason marker.
+    pub last_reason_code: Option<&'static str>,
+}
+
+/// Archive evaluation request envelope.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DataLayerM10ArchiveDueRequest {
+    /// Current month identifier as `YYYYMM`.
+    pub now_month_id: u32,
+    /// Active retention window in months.
+    pub active_retention_months: u16,
+    /// Object-storage prefix used for archived artifacts.
+    pub object_storage_prefix: String,
+}
+
+/// Archival index projection row.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DataLayerM10ArchivalIndexEntry {
+    /// Partition month identifier as `YYYYMM`.
+    pub partition_month_id: u32,
+    /// Canonical partition name `messages_YYYY_MM`.
+    pub partition_name: String,
+    /// Archived object URI.
+    pub archived_object_uri: String,
+    /// Archive format marker.
+    pub archive_format_marker: &'static str,
+    /// Deterministic checksum marker.
+    pub checksum_marker: String,
+    /// Lifecycle status after archive transition.
+    pub lifecycle_status: DataLayerM10PartitionStatus,
+}
+
+/// M10 partition lifecycle registry.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct DataLayerM10PartitionLifecycleRegistry {
+    partitions: BTreeMap<u32, DataLayerM10PartitionRecord>,
+}
+
+impl DataLayerM10PartitionLifecycleRegistry {
+    /// Creates an empty partition lifecycle registry.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Registers one monthly partition lifecycle record.
+    pub fn register_partition(
+        &mut self,
+        input: DataLayerM10PartitionRecordInput,
+    ) -> Result<DataLayerM10PartitionRecord, DataLayerM10PartitionLifecycleError> {
+        validate_partition_month_id(input.partition_month_id)?;
+        if self.partitions.contains_key(&input.partition_month_id) {
+            return Err(
+                DataLayerM10PartitionLifecycleError::DuplicatePartitionMonthId(
+                    input.partition_month_id,
+                ),
+            );
+        }
+
+        let record = DataLayerM10PartitionRecord {
+            partition_month_id: input.partition_month_id,
+            partition_name: data_layer_m10_format_partition_name(input.partition_month_id)?,
+            all_messages_shredded: input.all_messages_shredded,
+            lifecycle_status: DataLayerM10PartitionStatus::Active,
+            archived_object_uri: None,
+            archive_format_marker: None,
+            checksum_marker: None,
+            last_reason_code: None,
+        };
+        self.partitions
+            .insert(input.partition_month_id, record.clone());
+        Ok(record)
+    }
+
+    /// Plans future partition names for `months_ahead` months after `reference_month_id`.
+    pub fn plan_future_partition_names(
+        &self,
+        reference_month_id: u32,
+        months_ahead: u8,
+    ) -> Result<Vec<String>, DataLayerM10PartitionLifecycleError> {
+        validate_partition_month_id(reference_month_id)?;
+        let mut result = Vec::with_capacity(months_ahead as usize);
+        for offset in 1..=u32::from(months_ahead) {
+            let month_id = add_months(reference_month_id, offset)?;
+            result.push(data_layer_m10_format_partition_name(month_id)?);
+        }
+        Ok(result)
+    }
+
+    /// Archives all due partitions and returns archival-index projections.
+    pub fn archive_due_partitions(
+        &mut self,
+        request: DataLayerM10ArchiveDueRequest,
+    ) -> Result<Vec<DataLayerM10ArchivalIndexEntry>, DataLayerM10PartitionLifecycleError> {
+        validate_partition_month_id(request.now_month_id)?;
+        validate_non_empty(
+            request.object_storage_prefix.as_str(),
+            "object_storage_prefix",
+        )?;
+
+        let mut entries = Vec::new();
+        for record in self.partitions.values_mut() {
+            if record.lifecycle_status != DataLayerM10PartitionStatus::Active {
+                continue;
+            }
+            if !record.all_messages_shredded {
+                continue;
+            }
+            if record.partition_month_id > request.now_month_id {
+                continue;
+            }
+
+            let age_months = month_distance(record.partition_month_id, request.now_month_id)?;
+            if age_months <= u32::from(request.active_retention_months) {
+                continue;
+            }
+
+            let archived_object_uri = format!(
+                "{}/{}.parquet.zst",
+                request.object_storage_prefix.trim_end_matches('/'),
+                record.partition_name
+            );
+            let checksum_marker = deterministic_checksum_marker(
+                record.partition_name.as_str(),
+                record.partition_month_id,
+            );
+
+            record.lifecycle_status = DataLayerM10PartitionStatus::Archived;
+            record.archived_object_uri = Some(archived_object_uri.clone());
+            record.archive_format_marker = Some(DATA_LAYER_M10_ARCHIVE_FORMAT_PARQUET_ZSTD);
+            record.checksum_marker = Some(checksum_marker.clone());
+            record.last_reason_code = Some(DATA_LAYER_M10_ARCHIVE_REASON_CODE);
+
+            entries.push(DataLayerM10ArchivalIndexEntry {
+                partition_month_id: record.partition_month_id,
+                partition_name: record.partition_name.clone(),
+                archived_object_uri,
+                archive_format_marker: DATA_LAYER_M10_ARCHIVE_FORMAT_PARQUET_ZSTD,
+                checksum_marker,
+                lifecycle_status: record.lifecycle_status,
+            });
+        }
+
+        entries.sort_by(|left, right| {
+            left.partition_month_id
+                .cmp(&right.partition_month_id)
+                .then(left.partition_name.cmp(&right.partition_name))
+        });
+        Ok(entries)
+    }
+
+    /// Re-attaches one archived partition for historical query access.
+    pub fn reattach_partition(
+        &mut self,
+        partition_name: &str,
+    ) -> Result<DataLayerM10PartitionRecord, DataLayerM10PartitionLifecycleError> {
+        validate_non_empty(partition_name, "partition_name")?;
+        let record = self
+            .partitions
+            .values_mut()
+            .find(|entry| entry.partition_name == partition_name)
+            .ok_or_else(|| {
+                DataLayerM10PartitionLifecycleError::PartitionNotFound(partition_name.to_owned())
+            })?;
+
+        if record.lifecycle_status != DataLayerM10PartitionStatus::Archived {
+            return Err(
+                DataLayerM10PartitionLifecycleError::InvalidLifecycleTransition {
+                    partition_name: record.partition_name.clone(),
+                    from_status: record.lifecycle_status,
+                    to_status: DataLayerM10PartitionStatus::Reattached,
+                    reason_code: DATA_LAYER_M10_INVALID_TRANSITION_REASON_CODE,
+                },
+            );
+        }
+
+        record.lifecycle_status = DataLayerM10PartitionStatus::Reattached;
+        record.last_reason_code = Some(DATA_LAYER_M10_REATTACH_REASON_CODE);
+        Ok(record.clone())
+    }
+}
+
+/// Formats partition month id (`YYYYMM`) as `messages_YYYY_MM`.
+pub fn data_layer_m10_format_partition_name(
+    partition_month_id: u32,
+) -> Result<String, DataLayerM10PartitionLifecycleError> {
+    let (year, month) = split_month_id(partition_month_id)?;
+    Ok(format!(
+        "{DATA_LAYER_M10_PARTITION_PREFIX}{year:04}_{month:02}"
+    ))
+}
+
+/// Error taxonomy for M10 partition lifecycle contracts.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DataLayerM10PartitionLifecycleError {
+    /// Required field was empty.
+    EmptyField(&'static str),
+    /// Partition month id failed `YYYYMM` validation.
+    InvalidPartitionMonthId(u32),
+    /// Duplicate partition month id registration.
+    DuplicatePartitionMonthId(u32),
+    /// Named partition does not exist in registry.
+    PartitionNotFound(String),
+    /// Lifecycle transition was not allowed from current state.
+    InvalidLifecycleTransition {
+        /// Partition name.
+        partition_name: String,
+        /// Current lifecycle status.
+        from_status: DataLayerM10PartitionStatus,
+        /// Requested lifecycle status.
+        to_status: DataLayerM10PartitionStatus,
+        /// Stable reason marker.
+        reason_code: &'static str,
+    },
+}
+
+impl fmt::Display for DataLayerM10PartitionLifecycleError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyField(field) => write!(f, "field must not be empty: {field}"),
+            Self::InvalidPartitionMonthId(value) => {
+                write!(f, "invalid partition month id: {value}")
+            }
+            Self::DuplicatePartitionMonthId(value) => {
+                write!(f, "duplicate partition month id: {value}")
+            }
+            Self::PartitionNotFound(value) => write!(f, "partition not found: {value}"),
+            Self::InvalidLifecycleTransition {
+                partition_name,
+                from_status,
+                to_status,
+                reason_code,
+            } => write!(
+                f,
+                "invalid lifecycle transition for {partition_name}: {from_status:?} -> {to_status:?} ({reason_code})"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for DataLayerM10PartitionLifecycleError {}
+
+fn validate_non_empty(
+    value: &str,
+    field: &'static str,
+) -> Result<(), DataLayerM10PartitionLifecycleError> {
+    if value.trim().is_empty() {
+        return Err(DataLayerM10PartitionLifecycleError::EmptyField(field));
+    }
+    Ok(())
+}
+
+fn validate_partition_month_id(
+    partition_month_id: u32,
+) -> Result<(), DataLayerM10PartitionLifecycleError> {
+    let _ = split_month_id(partition_month_id)?;
+    Ok(())
+}
+
+fn split_month_id(
+    partition_month_id: u32,
+) -> Result<(u32, u32), DataLayerM10PartitionLifecycleError> {
+    let year = partition_month_id / 100;
+    let month = partition_month_id % 100;
+    if year < 1970 || !(1..=12).contains(&month) {
+        return Err(
+            DataLayerM10PartitionLifecycleError::InvalidPartitionMonthId(partition_month_id),
+        );
+    }
+    Ok((year, month))
+}
+
+fn add_months(
+    partition_month_id: u32,
+    months_to_add: u32,
+) -> Result<u32, DataLayerM10PartitionLifecycleError> {
+    let (year, month) = split_month_id(partition_month_id)?;
+    let base = year * 12 + (month - 1);
+    let future = base + months_to_add;
+    let future_year = future / 12;
+    let future_month = (future % 12) + 1;
+    Ok(future_year * 100 + future_month)
+}
+
+fn month_distance(
+    older_partition_month_id: u32,
+    newer_partition_month_id: u32,
+) -> Result<u32, DataLayerM10PartitionLifecycleError> {
+    let (older_year, older_month) = split_month_id(older_partition_month_id)?;
+    let (newer_year, newer_month) = split_month_id(newer_partition_month_id)?;
+    let older = older_year * 12 + (older_month - 1);
+    let newer = newer_year * 12 + (newer_month - 1);
+    Ok(newer.saturating_sub(older))
+}
+
+fn deterministic_checksum_marker(partition_name: &str, partition_month_id: u32) -> String {
+    format!("sha256:{partition_name}:{partition_month_id}")
+}

--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -42,6 +42,8 @@ pub mod data_classification;
 pub mod data_layer_m0;
 /// M1 trust-anchor contracts for merkle batching, proof APIs, and Kolme anchoring worker flows.
 pub mod data_layer_m1;
+/// M10 partition contracts for scaling controls, archival index, and re-attachment lifecycle.
+pub mod data_layer_m10_partition_archival;
 /// M2 access-gateway contracts for DID authn/authz, RLS templates, and audit chains.
 pub mod data_layer_m2_gateway_access;
 /// M3 search contracts for owner-scoped blind-index and metadata query APIs.
@@ -255,6 +257,15 @@ pub use data_layer_m1::{
     DataLayerM1KolmeAnchoringWorker, DataLayerM1MerkleBatch, DataLayerM1MerkleInclusionProof,
     DataLayerM1MerkleLeaf, DataLayerM1MerkleProofStep, DataLayerM1ProofSiblingSide,
     DATA_LAYER_M1_HASH_ALGORITHM,
+};
+pub use data_layer_m10_partition_archival::{
+    data_layer_m10_format_partition_name, DataLayerM10ArchivalIndexEntry,
+    DataLayerM10ArchiveDueRequest, DataLayerM10PartitionLifecycleError,
+    DataLayerM10PartitionLifecycleRegistry, DataLayerM10PartitionRecord,
+    DataLayerM10PartitionRecordInput, DataLayerM10PartitionStatus,
+    DATA_LAYER_M10_ARCHIVE_FORMAT_PARQUET_ZSTD, DATA_LAYER_M10_ARCHIVE_REASON_CODE,
+    DATA_LAYER_M10_INVALID_TRANSITION_REASON_CODE, DATA_LAYER_M10_PARTITION_PREFIX,
+    DATA_LAYER_M10_REATTACH_REASON_CODE,
 };
 pub use data_layer_m2_gateway_access::{
     data_layer_m2_default_rls_policies, DataLayerM2AbacEngine, DataLayerM2AccessAuditInput,

--- a/crates/kamn-core/tests/data_layer_m10_partition_archival.rs
+++ b/crates/kamn-core/tests/data_layer_m10_partition_archival.rs
@@ -1,0 +1,142 @@
+use kamn_core::{
+    data_layer_m10_format_partition_name, DataLayerM10ArchiveDueRequest,
+    DataLayerM10PartitionLifecycleError, DataLayerM10PartitionLifecycleRegistry,
+    DataLayerM10PartitionRecordInput, DataLayerM10PartitionStatus,
+    DATA_LAYER_M10_ARCHIVE_FORMAT_PARQUET_ZSTD, DATA_LAYER_M10_PARTITION_PREFIX,
+    DATA_LAYER_M10_REATTACH_REASON_CODE,
+};
+
+fn partition_input(
+    partition_month_id: u32,
+    all_messages_shredded: bool,
+) -> DataLayerM10PartitionRecordInput {
+    DataLayerM10PartitionRecordInput {
+        partition_month_id,
+        all_messages_shredded,
+    }
+}
+
+#[test]
+fn spec_c01_partition_naming_and_future_planning_are_deterministic() {
+    let registry = DataLayerM10PartitionLifecycleRegistry::new();
+    assert_eq!(
+        data_layer_m10_format_partition_name(202602).expect("month should format"),
+        "messages_2026_02"
+    );
+
+    let planned = registry
+        .plan_future_partition_names(202602, 3)
+        .expect("future planning should succeed");
+    assert_eq!(
+        planned,
+        vec!["messages_2026_03", "messages_2026_04", "messages_2026_05"]
+    );
+}
+
+#[test]
+fn spec_c02_archival_due_selection_respects_retention_window_and_shred_completeness() {
+    let mut registry = DataLayerM10PartitionLifecycleRegistry::new();
+    registry
+        .register_partition(partition_input(202401, true))
+        .expect("old shred-complete partition should register");
+    registry
+        .register_partition(partition_input(202402, false))
+        .expect("old non-shredded partition should register");
+    registry
+        .register_partition(partition_input(202601, true))
+        .expect("recent partition should register");
+
+    let archived = registry
+        .archive_due_partitions(DataLayerM10ArchiveDueRequest {
+            now_month_id: 202602,
+            active_retention_months: 2,
+            object_storage_prefix: "s3://kamn-archive/messages".to_owned(),
+        })
+        .expect("archive due should succeed");
+
+    assert_eq!(archived.len(), 1);
+    assert_eq!(archived[0].partition_name, "messages_2024_01");
+    assert_eq!(
+        archived[0].lifecycle_status,
+        DataLayerM10PartitionStatus::Archived
+    );
+}
+
+#[test]
+fn spec_c03_archival_index_records_and_reattach_transition_are_deterministic() {
+    let mut registry = DataLayerM10PartitionLifecycleRegistry::new();
+    registry
+        .register_partition(partition_input(202401, true))
+        .expect("old shred-complete partition should register");
+
+    let archived = registry
+        .archive_due_partitions(DataLayerM10ArchiveDueRequest {
+            now_month_id: 202602,
+            active_retention_months: 1,
+            object_storage_prefix: "s3://kamn-archive/messages".to_owned(),
+        })
+        .expect("archive due should succeed");
+    assert_eq!(archived.len(), 1);
+    assert!(archived[0]
+        .archived_object_uri
+        .starts_with("s3://kamn-archive/messages/messages_2024_01"));
+    assert_eq!(
+        archived[0].archive_format_marker,
+        DATA_LAYER_M10_ARCHIVE_FORMAT_PARQUET_ZSTD
+    );
+
+    let reattached = registry
+        .reattach_partition("messages_2024_01")
+        .expect("reattach should succeed");
+    assert_eq!(
+        reattached.lifecycle_status,
+        DataLayerM10PartitionStatus::Reattached
+    );
+    assert_eq!(
+        reattached.last_reason_code,
+        Some(DATA_LAYER_M10_REATTACH_REASON_CODE)
+    );
+}
+
+#[test]
+fn spec_c04_invalid_month_identifiers_and_illegal_transitions_fail_closed() {
+    let mut registry = DataLayerM10PartitionLifecycleRegistry::new();
+    let invalid = registry.register_partition(partition_input(202613, true));
+    assert!(matches!(
+        invalid,
+        Err(DataLayerM10PartitionLifecycleError::InvalidPartitionMonthId(202613))
+    ));
+
+    registry
+        .register_partition(partition_input(202602, true))
+        .expect("valid partition should register");
+    let illegal = registry.reattach_partition("messages_2026_02");
+    assert!(matches!(
+        illegal,
+        Err(
+            DataLayerM10PartitionLifecycleError::InvalidLifecycleTransition {
+                reason_code: "m10_partition_transition_invalid",
+                ..
+            }
+        )
+    ));
+}
+
+#[test]
+fn spec_c05_duplicate_registration_and_partition_prefix_contract_are_enforced() {
+    let mut registry = DataLayerM10PartitionLifecycleRegistry::new();
+    registry
+        .register_partition(partition_input(202512, true))
+        .expect("partition should register");
+    let duplicate = registry.register_partition(partition_input(202512, true));
+    assert!(matches!(
+        duplicate,
+        Err(DataLayerM10PartitionLifecycleError::DuplicatePartitionMonthId(202512))
+    ));
+
+    let planned = registry
+        .plan_future_partition_names(202512, 1)
+        .expect("future planning should succeed");
+    assert_eq!(planned.len(), 1);
+    assert!(planned[0].starts_with(DATA_LAYER_M10_PARTITION_PREFIX));
+}

--- a/specs/5026/plan.md
+++ b/specs/5026/plan.md
@@ -1,26 +1,46 @@
 # Issue #5026 Plan
 
 - Issue: #5026
-- Status: Draft
+- Status: Implemented
 
 ## Approach
-1. Create red tests and conformance assertions for issue scope.
-2. Implement minimal behavior to satisfy ACs.
-3. Refactor for maintainability while preserving deterministic outputs.
-4. Run scoped regression + governance gates before PR.
+1. Add RED conformance tests (`spec_c01`..`spec_c05`) for:
+   - deterministic partition naming and future-horizon planning,
+   - retention-window archival eligibility with shred-complete requirements,
+   - archival-index export metadata and re-attachment transitions,
+   - invalid/illegal transition fail-closed behavior.
+2. Implement `data_layer_m10_partition_archival` module with:
+   - monthly partition registry + naming helpers,
+   - archival candidate planner and archival index records,
+   - re-attachment lifecycle transition enforcement.
+3. Re-export M10 APIs in `crates/kamn-core/src/lib.rs`.
+4. Run format/lint/targeted/full regression and finalize lifecycle evidence.
 
 ## Affected Modules
-- To be refined during implementation based on issue scope.
+- `crates/kamn-core/src/data_layer_m10_partition_archival.rs` (new)
+- `crates/kamn-core/src/lib.rs` (module + exports)
+- `crates/kamn-core/tests/data_layer_m10_partition_archival.rs` (new)
+- `specs/5026/spec.md`
+- `specs/5026/plan.md`
+- `specs/5026/tasks.md`
 
 ## Risks and Mitigations
-- Risk level: medium
+- Risk level: high
 - Mitigations:
-  - Keep diffs scoped to issue boundaries.
-  - Prefer Rust-native tests/harnesses to avoid shell-surface growth.
-  - Enforce shell budget and ratio checks when shell surfaces are touched.
+  - Use deterministic month arithmetic and canonical partition naming utilities.
+  - Enforce lifecycle transition guards (active -> archived -> reattached only).
+  - Validate archival eligibility rules fail-closed for incomplete partitions.
+  - Keep implementation Rust-only to avoid shell-surface growth.
 
 ## Interface Contract
-- No dependency/protocol/wire-format change without explicit approval and ADR.
+- Additive public API under `kamn_core::data_layer_m10_partition_archival::*`.
+- No new dependencies.
+- No protocol/wire-format changes.
 
 ## ADR
-- TBD per implementation decisions.
+- Not required for this scoped additive implementation.
+
+## Verification Summary
+- RED: `cargo test -p kamn-core --test data_layer_m10_partition_archival` (failed before implementation with unresolved `DataLayerM10*` symbols).
+- GREEN: `cargo test -p kamn-core --test data_layer_m10_partition_archival` (5 passed, 0 failed).
+- Regression: `cargo test -p kamn-core` (pass), `cargo clippy -p kamn-core -- -D warnings` (pass), `cargo fmt --check` (pass).

--- a/specs/5026/spec.md
+++ b/specs/5026/spec.md
@@ -1,41 +1,76 @@
 # Issue #5026 Spec
 
 - Title: Task: M10 deliver scaling controls, partition lifecycle, and archival export path
-- Status: Draft
+- Status: Implemented
 - Type: task
 - Priority: P1
 - Milestone: specs/milestones/r27-45-kamn-data-layer-prd-implementation-and-validation/index.md
 
 ## Problem Statement
-Implement, integrate, test, and validate the parent-story delivery scope with strict spec-driven + TDD gates.
+PRD M10 requires deterministic controls for monthly partition lifecycle
+management, archival export indexing, and historical partition re-attachment.
+Current codebase contains runtime/network scaling primitives but no dedicated
+M10 contract surface for partition naming rules, retention-window archival
+eligibility, and archival-index consistency markers.
+
+PRD mapping:
+- Section 5.4 (monthly partitioning and naming convention)
+- Section 13.2 (monthly partition archival to object storage + archival index)
+- Section 13.2 re-attachment workflow for historical queries
+- Milestone table M10 deliverables (partition management + archival pipeline)
 
 ## Acceptance Criteria
-- AC-1: Scope for issue #5026 is decomposed into explicit implementation/integration/validation outcomes with deterministic test evidence.
-- AC-2: The issue maps to PRD sections and conformance scenarios with clear test commands and result expectations.
-- AC-3: Shell-surface impact remains neutral by default (net shell LOC delta <= 0) unless explicitly waived with mitigation issue linkage.
+- AC-1: Partition lifecycle contract produces deterministic monthly partition
+  identifiers (`messages_YYYY_MM`) and planning outputs for future partitions.
+- AC-2: Archival eligibility contract deterministically selects partitions older
+  than the active retention window and only archives shred-complete partitions.
+- AC-3: Archival index contract records deterministic object-storage export
+  metadata and supports partition re-attachment state transitions.
+- AC-4: Invalid month identifiers and illegal lifecycle transitions fail closed
+  with stable error markers.
+- AC-5: Shell/workflow/python/template LOC remains unchanged
+  (`shell_loc_delta_actual = 0`).
 
 ## Scope
 In scope:
-- Issue-specific delivery for Task: M10 deliver scaling controls, partition lifecycle, and archival export path.
-- Contract-driven lifecycle artifacts (`spec.md`, `plan.md`, `tasks.md`).
-- Test-tier mapping and conformance evidence capture.
+- New Rust M10 module in `kamn-core` for monthly partition lifecycle planning,
+  archival eligibility, and archival-index/reattach transitions.
+- Conformance tests for partition naming, archival candidate selection, and
+  archival index integrity markers.
+- Public API exports for downstream M11 and operator-runbook integration lanes.
 
 Out of scope:
-- Unapproved dependency/protocol changes.
-- Work outside the parent milestone scope.
+- Live database DDL/pg_partman orchestration and object-storage network I/O.
+- New shell/python/workflow/template orchestration.
+- New dependencies or wire/protocol format changes.
 
 ## Conformance Cases
 | Case | AC | Tier | Input | Expected |
 |---|---|---|---|---|
-| C-01 | AC-1 | Functional | Execute issue task plan for #5026 | Planned implementation/integration steps are completed with evidence |
-| C-02 | AC-2 | Conformance | Run mapped test commands for #5026 | All mapped conformance checks pass and produce deterministic markers |
-| C-03 | AC-3 | Regression | Run shell-surface and ratio governance checks | No net shell-surface regression without waiver |
+| C-01 | AC-1 | Functional | Plan future partitions from a reference month | Deterministic `messages_YYYY_MM` sequence for configured horizon |
+| C-02 | AC-2 | Conformance | Evaluate archival eligibility with retention window + shred-complete markers | Only eligible partitions become archival candidates in stable order |
+| C-03 | AC-3 | Conformance | Archive eligible partition and inspect archival index projection | Deterministic object-storage URI + format/checksum markers are recorded |
+| C-04 | AC-3/AC-4 | Regression | Re-attach archived partition and inspect lifecycle transition | Transition succeeds only from archived state and becomes queryable |
+| C-05 | AC-4 | Regression | Use invalid month identifiers or duplicate registrations | Fail-closed typed errors with stable reason markers |
+| C-06 | AC-5 | Regression | Inspect issue diff paths | No shell/python/workflow/template path changes |
 
 ## Test Mapping
-- `cargo test -p kamn-core` (scoped by issue-specific suites)
-- `bash scripts/ci/check_shell_loc_hard_ceiling.sh` (when shell/python/workflow surface is touched)
-- `bash scripts/ci/check_shell_rust_ratio_guardrail.sh` (when shell/python/workflow surface is touched)
+- `cargo test -p kamn-core --test data_layer_m10_partition_archival`
+- `cargo test -p kamn-core spec_c0`
+- `cargo test -p kamn-core`
+- `bash scripts/ci/check_shell_rust_ratio_guardrail.sh --repo-root . --output-json /tmp/shell-rust-ratio-guardrail-5026.json`
+- `bash scripts/ci/check_shell_loc_hard_ceiling.sh --repo-root . --output-json /tmp/shell-loc-hard-ceiling-5026.json`
+
+## AC Verification
+| AC | ✅/❌ | Test(s) |
+|---|---|---|
+| AC-1 | ✅ | `spec_c01_partition_naming_and_future_planning_are_deterministic` |
+| AC-2 | ✅ | `spec_c02_archival_due_selection_respects_retention_window_and_shred_completeness` |
+| AC-3 | ✅ | `spec_c03_archival_index_records_and_reattach_transition_are_deterministic` |
+| AC-4 | ✅ | `spec_c04_invalid_month_identifiers_and_illegal_transitions_fail_closed` |
+| AC-5 | ✅ | `bash scripts/ci/check_shell_rust_ratio_guardrail.sh ...` and `bash scripts/ci/check_shell_loc_hard_ceiling.sh ...` with Rust-only diff |
 
 ## Success Metrics
-- Issue #5026 reaches `Status: Implemented` with ACs mapped to passing conformance evidence.
-- Shell-to-Rust ratio guardrails remain within thresholds.
+- M10 contracts are exported via `kamn_core` for downstream integration lanes.
+- All ACs map to passing `spec_c0x_*` conformance tests.
+- Shell-to-Rust ratio direction remains improved/neutral through Rust-only changes.

--- a/specs/5026/tasks.md
+++ b/specs/5026/tasks.md
@@ -1,12 +1,12 @@
 # Issue #5026 Tasks
 
 - Issue: #5026
-- Status: Draft
+- Status: Done
 
 ## Ordered Tasks
-- [ ] T1 (Red): add failing tests derived from spec conformance cases.
-- [ ] T2 (Green): implement minimum code path to satisfy ACs.
-- [ ] T3 (Refactor): improve structure/readability while preserving behavior.
-- [ ] T4 (Regression): run scoped functional/integration/regression checks.
-- [ ] T5 (Governance): if shell/python/workflow/template changed, run shell budget + ratio guardrails and report deltas.
-- [ ] T6 (Verify): finalize AC mapping and set lifecycle status markers.
+- [x] T1 (Red): add `spec_c01`..`spec_c05` tests for partition naming, archival eligibility, archival index, and re-attachment lifecycle guards.
+- [x] T2 (Green): implement `data_layer_m10_partition_archival` contracts to satisfy the red suite.
+- [x] T3 (Refactor): tighten deterministic month arithmetic and stable reason-marker taxonomy.
+- [x] T4 (Regression): run `cargo fmt --check`, `cargo clippy -p kamn-core -- -D warnings`, `cargo test -p kamn-core --test data_layer_m10_partition_archival`, and `cargo test -p kamn-core`.
+- [x] T5 (Governance): confirm zero shell/python/workflow/template delta and record `shell_loc_delta_actual=0`.
+- [x] T6 (Verify): set spec lifecycle status to `Implemented`, map ACs to tests, and post issue closure evidence.


### PR DESCRIPTION
## Summary
- Implemented PRD M10 partition lifecycle contracts in `kamn-core` for deterministic monthly partition planning, archival eligibility, archival index projection, and archived-partition reattachment.
- Added conformance-focused M10 tests (`spec_c01`..`spec_c05`) and exported the new module from `kamn_core` public API.
- Finalized `specs/5026/{spec,plan,tasks}.md` to `Implemented` with AC verification and test evidence.

## Linked Issues
- Closes #5026
- Milestone: `specs/milestones/r27-45-kamn-data-layer-prd-implementation-and-validation/index.md`
- Spec: `specs/5026/spec.md`
- Plan: `specs/5026/plan.md`
- Tasks: `specs/5026/tasks.md`

## Validation
- [x] Relevant local checks passed.
- [x] CI fast-gate checks expected to pass.

Commands run:
- `cargo fmt --check`
- `cargo clippy -p kamn-core -- -D warnings`
- `cargo test -p kamn-core --test data_layer_m10_partition_archival`
- `cargo test -p kamn-core`
- `bash scripts/ci/check_shell_rust_ratio_guardrail.sh --repo-root . --output-json /tmp/shell-rust-ratio-guardrail-5026.json`
- `bash scripts/ci/check_shell_loc_hard_ceiling.sh --repo-root . --output-json /tmp/shell-loc-hard-ceiling-5026.json`

## CI Impact Declaration
- [x] No CI scope impact.
- [ ] CI scope impact present (explain below).

## Shell-Surface Impact Declaration
- [x] No shell-surface impact.
- [ ] Shell-surface impact present (explain below).

Shell-surface impact details:
- shell_loc_delta_actual: 0
- rust_loc_delta_actual: 507
- shell_to_rust_ratio_delta_actual: -0.003470
- shell_surface_ratio_target_status: improved
- shell_surface_mitigation_issue: None

## Spec Verification (AC -> tests)
| AC | ✅/❌ | Test(s) |
|---|---|---|
| AC-1 deterministic partition naming/planning | ✅ | `spec_c01_partition_naming_and_future_planning_are_deterministic` |
| AC-2 archival eligibility determinism | ✅ | `spec_c02_archival_due_selection_respects_retention_window_and_shred_completeness` |
| AC-3 archival index + reattach lifecycle | ✅ | `spec_c03_archival_index_records_and_reattach_transition_are_deterministic` |
| AC-4 fail-closed invalid transitions/month ids | ✅ | `spec_c04_invalid_month_identifiers_and_illegal_transitions_fail_closed` |
| AC-5 shell/workflow/python/template unchanged | ✅ | no shell/workflow/python/template files changed + guardrail scripts pass |

## TDD Evidence
- RED:
  - `cargo test -p kamn-core --test data_layer_m10_partition_archival`
  - failed before implementation with unresolved `DataLayerM10*` imports (`E0432`).
- GREEN:
  - `cargo test -p kamn-core --test data_layer_m10_partition_archival`
  - `5 passed; 0 failed`.
- REGRESSION:
  - `cargo test -p kamn-core` passed.

## Test Tiers
| Tier | ✅/❌/N/A | Tests | N/A Why |
|---|---|---|---|
| Unit | ✅ | `spec_c01`..`spec_c05` cover public API behavior and failure edges | |
| Property | N/A | | No parser/invariant randomization needed for scoped deterministic month lifecycle logic |
| Contract/DbC | N/A | | No `contracts` crate annotations exist in this module; fail-closed behavior covered by conformance tests |
| Snapshot | N/A | | No stable snapshot artifact in this change |
| Functional | ✅ | `spec_c01`, `spec_c02`, `spec_c03` | |
| Conformance | ✅ | `spec_c01`..`spec_c05` | |
| Integration | ✅ | `cargo test -p kamn-core` | |
| Fuzz | N/A | | No untrusted parser/input-surface introduced |
| Mutation | N/A | `cargo mutants --in-diff` attempted | `cargo-mutants` is not installed in this environment (`no such command: mutants`) |
| Regression | ✅ | `spec_c04`, `spec_c05`, full crate regression | |
| Performance | N/A | | No hotspot/performance-sensitive path modified |

## Mutation
- `cargo mutants --in-diff` attempted; tool unavailable in environment (`error: no such command: mutants`).

## Risks/Rollback
- Risk: low; additive module and exports only.
- Rollback: revert this PR to remove M10 module/tests and public exports.

## Docs/ADR
- Updated: `specs/5026/spec.md`, `specs/5026/plan.md`, `specs/5026/tasks.md`
- ADR: not required (scoped additive implementation, no new dependency/protocol change).
