### PR TITLE
feat(kamn-core): implement M11 hardening readiness contracts (#5027)

### DIFF
--- a/crates/kamn-core/src/data_layer_m11_hardening_readiness.rs
+++ b/crates/kamn-core/src/data_layer_m11_hardening_readiness.rs
@@ -1,0 +1,319 @@
+//! M11 hardening matrix contracts for security, chaos, performance, and operator readiness.
+//!
+//! This module provides deterministic contracts for scenario registration,
+//! outcome recording, and fail-closed operator readiness decisions.
+
+use std::collections::BTreeMap;
+use std::fmt;
+
+/// Stable reason marker when readiness evaluates to GO.
+pub const DATA_LAYER_M11_READINESS_GO_REASON_CODE: &str = "m11_operator_readiness_go";
+/// Stable reason marker when readiness is blocked by critical failures.
+pub const DATA_LAYER_M11_BLOCK_CRITICAL_FAILURE_REASON_CODE: &str = "m11_blocking_critical_failure";
+/// Stable reason marker when readiness is blocked by missing/incomplete required scenarios.
+pub const DATA_LAYER_M11_BLOCK_REQUIRED_INCOMPLETE_REASON_CODE: &str =
+    "m11_blocking_required_incomplete";
+/// Stable reason marker for illegal scenario status transitions.
+pub const DATA_LAYER_M11_INVALID_TRANSITION_REASON_CODE: &str = "m11_invalid_status_transition";
+
+/// Hardening scenario domain categories for M11.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum DataLayerM11ScenarioDomain {
+    /// Security and authorization/cryptography checks.
+    Security,
+    /// Chaos and resilience/fault-injection checks.
+    Chaos,
+    /// Performance and latency/throughput checks.
+    Performance,
+    /// Operator and runbook/process readiness checks.
+    Operations,
+}
+
+/// Hardening scenario severity level.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum DataLayerM11ScenarioSeverity {
+    /// Critical severity blocks production readiness on failure.
+    Critical,
+    /// High severity should be addressed before production rollout.
+    High,
+    /// Medium severity indicates bounded but material risk.
+    Medium,
+    /// Low severity indicates non-blocking risk.
+    Low,
+}
+
+/// Execution status for one hardening scenario.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum DataLayerM11ScenarioStatus {
+    /// Scenario completed successfully.
+    Passed,
+    /// Scenario failed and requires remediation.
+    Failed,
+    /// Scenario was skipped and must be treated as incomplete if required.
+    Skipped,
+}
+
+/// Scenario registration input/definition.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DataLayerM11ScenarioDefinition {
+    /// Stable scenario identifier.
+    pub scenario_id: String,
+    /// Scenario domain.
+    pub domain: DataLayerM11ScenarioDomain,
+    /// Scenario severity.
+    pub severity: DataLayerM11ScenarioSeverity,
+    /// Whether this scenario is required for operator readiness.
+    pub required: bool,
+}
+
+/// Scenario outcome recording input.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DataLayerM11ScenarioOutcomeInput {
+    /// Stable scenario identifier.
+    pub scenario_id: String,
+    /// Result status for the scenario execution.
+    pub status: DataLayerM11ScenarioStatus,
+    /// Deterministic evidence marker/path.
+    pub evidence_marker: String,
+}
+
+/// Persisted scenario outcome record.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DataLayerM11ScenarioOutcomeRecord {
+    /// Stable scenario identifier.
+    pub scenario_id: String,
+    /// Result status for the scenario execution.
+    pub status: DataLayerM11ScenarioStatus,
+    /// Deterministic evidence marker/path.
+    pub evidence_marker: String,
+}
+
+/// Operator readiness decision outcome.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DataLayerM11OperatorReadinessDecision {
+    /// Ready for operator rollout.
+    Go,
+    /// Not ready for operator rollout.
+    NoGo,
+}
+
+/// Readiness projection with deterministic reasons.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DataLayerM11OperatorReadinessReport {
+    /// Final readiness decision.
+    pub decision: DataLayerM11OperatorReadinessDecision,
+    /// Deterministic reason markers driving the decision.
+    pub reason_codes: Vec<&'static str>,
+    /// Required scenario ids with missing outcomes.
+    pub missing_required_scenario_ids: Vec<String>,
+    /// Critical-severity scenarios that reported failure.
+    pub failing_critical_scenario_ids: Vec<String>,
+    /// Number of required scenarios in the registry.
+    pub total_required_scenarios: u16,
+    /// Number of required scenarios with `Passed` outcomes.
+    pub passed_required_scenarios: u16,
+}
+
+/// Fail-closed error taxonomy for M11 hardening matrix contracts.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DataLayerM11HardeningMatrixError {
+    /// Required field is empty.
+    EmptyField(&'static str),
+    /// Duplicate scenario identifier.
+    DuplicateScenarioId(String),
+    /// Scenario identifier does not exist in the matrix.
+    ScenarioNotFound(String),
+    /// Matrix has no registered scenarios.
+    EmptyScenarioCatalog,
+    /// Illegal status transition for an already-recorded scenario outcome.
+    InvalidStatusTransition {
+        /// Scenario identifier.
+        scenario_id: String,
+        /// Existing status.
+        from_status: DataLayerM11ScenarioStatus,
+        /// Requested status.
+        to_status: DataLayerM11ScenarioStatus,
+        /// Stable transition reason marker.
+        reason_code: &'static str,
+    },
+}
+
+impl fmt::Display for DataLayerM11HardeningMatrixError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyField(field_name) => write!(formatter, "{field_name} must not be empty"),
+            Self::DuplicateScenarioId(scenario_id) => {
+                write!(formatter, "duplicate scenario id {scenario_id}")
+            }
+            Self::ScenarioNotFound(scenario_id) => write!(formatter, "scenario not found: {scenario_id}"),
+            Self::EmptyScenarioCatalog => write!(formatter, "scenario catalog must not be empty"),
+            Self::InvalidStatusTransition {
+                scenario_id,
+                from_status,
+                to_status,
+                reason_code,
+            } => write!(
+                formatter,
+                "invalid status transition for {scenario_id}: {from_status:?}->{to_status:?} ({reason_code})"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for DataLayerM11HardeningMatrixError {}
+
+/// Deterministic in-memory registry for M11 hardening scenario contracts.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct DataLayerM11HardeningMatrix {
+    scenario_catalog: BTreeMap<String, DataLayerM11ScenarioDefinition>,
+    scenario_outcomes: BTreeMap<String, DataLayerM11ScenarioOutcomeRecord>,
+}
+
+impl DataLayerM11HardeningMatrix {
+    /// Creates an empty hardening matrix.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Registers one hardening scenario definition.
+    pub fn register_scenario(
+        &mut self,
+        definition: DataLayerM11ScenarioDefinition,
+    ) -> Result<DataLayerM11ScenarioDefinition, DataLayerM11HardeningMatrixError> {
+        validate_non_empty(definition.scenario_id.as_str(), "scenario_id")?;
+        if self
+            .scenario_catalog
+            .contains_key(definition.scenario_id.as_str())
+        {
+            return Err(DataLayerM11HardeningMatrixError::DuplicateScenarioId(
+                definition.scenario_id,
+            ));
+        }
+        self.scenario_catalog
+            .insert(definition.scenario_id.clone(), definition.clone());
+        Ok(definition)
+    }
+
+    /// Lists registered scenarios in deterministic identifier order.
+    pub fn list_scenarios(&self) -> Vec<DataLayerM11ScenarioDefinition> {
+        self.scenario_catalog.values().cloned().collect()
+    }
+
+    /// Records one scenario outcome.
+    pub fn record_outcome(
+        &mut self,
+        input: DataLayerM11ScenarioOutcomeInput,
+    ) -> Result<DataLayerM11ScenarioOutcomeRecord, DataLayerM11HardeningMatrixError> {
+        validate_non_empty(input.scenario_id.as_str(), "scenario_id")?;
+        validate_non_empty(input.evidence_marker.as_str(), "evidence_marker")?;
+
+        if !self
+            .scenario_catalog
+            .contains_key(input.scenario_id.as_str())
+        {
+            return Err(DataLayerM11HardeningMatrixError::ScenarioNotFound(
+                input.scenario_id,
+            ));
+        }
+
+        if let Some(existing) = self.scenario_outcomes.get(input.scenario_id.as_str()) {
+            if existing.status != input.status {
+                return Err(DataLayerM11HardeningMatrixError::InvalidStatusTransition {
+                    scenario_id: input.scenario_id,
+                    from_status: existing.status,
+                    to_status: input.status,
+                    reason_code: DATA_LAYER_M11_INVALID_TRANSITION_REASON_CODE,
+                });
+            }
+        }
+
+        let record = DataLayerM11ScenarioOutcomeRecord {
+            scenario_id: input.scenario_id.clone(),
+            status: input.status,
+            evidence_marker: input.evidence_marker,
+        };
+        self.scenario_outcomes
+            .insert(input.scenario_id, record.clone());
+        Ok(record)
+    }
+
+    /// Evaluates overall operator readiness from required scenario outcomes.
+    pub fn evaluate_operator_readiness(
+        &self,
+    ) -> Result<DataLayerM11OperatorReadinessReport, DataLayerM11HardeningMatrixError> {
+        if self.scenario_catalog.is_empty() {
+            return Err(DataLayerM11HardeningMatrixError::EmptyScenarioCatalog);
+        }
+
+        let required_scenarios: Vec<&DataLayerM11ScenarioDefinition> = self
+            .scenario_catalog
+            .values()
+            .filter(|scenario| scenario.required)
+            .collect();
+
+        let mut missing_required_scenario_ids = Vec::new();
+        let mut failing_critical_scenario_ids = Vec::new();
+        let mut passed_required_scenarios = 0u16;
+
+        for scenario in &required_scenarios {
+            match self.scenario_outcomes.get(scenario.scenario_id.as_str()) {
+                Some(outcome) => {
+                    if outcome.status == DataLayerM11ScenarioStatus::Passed {
+                        passed_required_scenarios = passed_required_scenarios.saturating_add(1);
+                    }
+                    if scenario.severity == DataLayerM11ScenarioSeverity::Critical
+                        && outcome.status == DataLayerM11ScenarioStatus::Failed
+                    {
+                        failing_critical_scenario_ids.push(scenario.scenario_id.clone());
+                    }
+                }
+                None => missing_required_scenario_ids.push(scenario.scenario_id.clone()),
+            }
+        }
+
+        let total_required_scenarios = u16::try_from(required_scenarios.len()).unwrap_or(u16::MAX);
+
+        if !failing_critical_scenario_ids.is_empty() {
+            return Ok(DataLayerM11OperatorReadinessReport {
+                decision: DataLayerM11OperatorReadinessDecision::NoGo,
+                reason_codes: vec![DATA_LAYER_M11_BLOCK_CRITICAL_FAILURE_REASON_CODE],
+                missing_required_scenario_ids,
+                failing_critical_scenario_ids,
+                total_required_scenarios,
+                passed_required_scenarios,
+            });
+        }
+
+        if !missing_required_scenario_ids.is_empty()
+            || passed_required_scenarios != total_required_scenarios
+        {
+            return Ok(DataLayerM11OperatorReadinessReport {
+                decision: DataLayerM11OperatorReadinessDecision::NoGo,
+                reason_codes: vec![DATA_LAYER_M11_BLOCK_REQUIRED_INCOMPLETE_REASON_CODE],
+                missing_required_scenario_ids,
+                failing_critical_scenario_ids,
+                total_required_scenarios,
+                passed_required_scenarios,
+            });
+        }
+
+        Ok(DataLayerM11OperatorReadinessReport {
+            decision: DataLayerM11OperatorReadinessDecision::Go,
+            reason_codes: vec![DATA_LAYER_M11_READINESS_GO_REASON_CODE],
+            missing_required_scenario_ids,
+            failing_critical_scenario_ids,
+            total_required_scenarios,
+            passed_required_scenarios,
+        })
+    }
+}
+
+fn validate_non_empty(
+    value: &str,
+    field_name: &'static str,
+) -> Result<(), DataLayerM11HardeningMatrixError> {
+    if value.trim().is_empty() {
+        return Err(DataLayerM11HardeningMatrixError::EmptyField(field_name));
+    }
+    Ok(())
+}

--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -44,6 +44,8 @@ pub mod data_layer_m0;
 pub mod data_layer_m1;
 /// M10 partition contracts for scaling controls, archival index, and re-attachment lifecycle.
 pub mod data_layer_m10_partition_archival;
+/// M11 hardening contracts for security/chaos/performance matrix and operator readiness synthesis.
+pub mod data_layer_m11_hardening_readiness;
 /// M2 access-gateway contracts for DID authn/authz, RLS templates, and audit chains.
 pub mod data_layer_m2_gateway_access;
 /// M3 search contracts for owner-scoped blind-index and metadata query APIs.
@@ -266,6 +268,15 @@ pub use data_layer_m10_partition_archival::{
     DATA_LAYER_M10_ARCHIVE_FORMAT_PARQUET_ZSTD, DATA_LAYER_M10_ARCHIVE_REASON_CODE,
     DATA_LAYER_M10_INVALID_TRANSITION_REASON_CODE, DATA_LAYER_M10_PARTITION_PREFIX,
     DATA_LAYER_M10_REATTACH_REASON_CODE,
+};
+pub use data_layer_m11_hardening_readiness::{
+    DataLayerM11HardeningMatrix, DataLayerM11HardeningMatrixError,
+    DataLayerM11OperatorReadinessDecision, DataLayerM11OperatorReadinessReport,
+    DataLayerM11ScenarioDefinition, DataLayerM11ScenarioDomain, DataLayerM11ScenarioOutcomeInput,
+    DataLayerM11ScenarioOutcomeRecord, DataLayerM11ScenarioSeverity, DataLayerM11ScenarioStatus,
+    DATA_LAYER_M11_BLOCK_CRITICAL_FAILURE_REASON_CODE,
+    DATA_LAYER_M11_BLOCK_REQUIRED_INCOMPLETE_REASON_CODE,
+    DATA_LAYER_M11_INVALID_TRANSITION_REASON_CODE, DATA_LAYER_M11_READINESS_GO_REASON_CODE,
 };
 pub use data_layer_m2_gateway_access::{
     data_layer_m2_default_rls_policies, DataLayerM2AbacEngine, DataLayerM2AccessAuditInput,

--- a/crates/kamn-core/tests/data_layer_m11_hardening_readiness.rs
+++ b/crates/kamn-core/tests/data_layer_m11_hardening_readiness.rs
@@ -1,0 +1,252 @@
+use kamn_core::{
+    DataLayerM11HardeningMatrix, DataLayerM11HardeningMatrixError,
+    DataLayerM11OperatorReadinessDecision, DataLayerM11ScenarioDefinition,
+    DataLayerM11ScenarioDomain, DataLayerM11ScenarioOutcomeInput, DataLayerM11ScenarioSeverity,
+    DataLayerM11ScenarioStatus, DATA_LAYER_M11_BLOCK_CRITICAL_FAILURE_REASON_CODE,
+    DATA_LAYER_M11_BLOCK_REQUIRED_INCOMPLETE_REASON_CODE,
+    DATA_LAYER_M11_INVALID_TRANSITION_REASON_CODE, DATA_LAYER_M11_READINESS_GO_REASON_CODE,
+};
+
+fn scenario(
+    scenario_id: &str,
+    domain: DataLayerM11ScenarioDomain,
+    severity: DataLayerM11ScenarioSeverity,
+    required: bool,
+) -> DataLayerM11ScenarioDefinition {
+    DataLayerM11ScenarioDefinition {
+        scenario_id: scenario_id.to_owned(),
+        domain,
+        severity,
+        required,
+    }
+}
+
+fn outcome(
+    scenario_id: &str,
+    status: DataLayerM11ScenarioStatus,
+) -> DataLayerM11ScenarioOutcomeInput {
+    DataLayerM11ScenarioOutcomeInput {
+        scenario_id: scenario_id.to_owned(),
+        status,
+        evidence_marker: format!("evidence:{scenario_id}:{status:?}"),
+    }
+}
+
+#[test]
+fn spec_c01_registration_catalog_is_deterministic_and_sorted() {
+    let mut matrix = DataLayerM11HardeningMatrix::new();
+    matrix
+        .register_scenario(scenario(
+            "performance.p95-latency",
+            DataLayerM11ScenarioDomain::Performance,
+            DataLayerM11ScenarioSeverity::High,
+            true,
+        ))
+        .expect("performance scenario should register");
+    matrix
+        .register_scenario(scenario(
+            "chaos.partition-heal",
+            DataLayerM11ScenarioDomain::Chaos,
+            DataLayerM11ScenarioSeverity::High,
+            true,
+        ))
+        .expect("chaos scenario should register");
+    matrix
+        .register_scenario(scenario(
+            "security.authz-negative-matrix",
+            DataLayerM11ScenarioDomain::Security,
+            DataLayerM11ScenarioSeverity::Critical,
+            true,
+        ))
+        .expect("security scenario should register");
+
+    let catalog = matrix.list_scenarios();
+    let scenario_ids: Vec<&str> = catalog
+        .iter()
+        .map(|entry| entry.scenario_id.as_str())
+        .collect();
+    assert_eq!(
+        scenario_ids,
+        vec![
+            "chaos.partition-heal",
+            "performance.p95-latency",
+            "security.authz-negative-matrix",
+        ]
+    );
+}
+
+#[test]
+fn spec_c02_all_required_pass_results_in_operator_readiness_go() {
+    let mut matrix = DataLayerM11HardeningMatrix::new();
+    matrix
+        .register_scenario(scenario(
+            "security.authz-negative-matrix",
+            DataLayerM11ScenarioDomain::Security,
+            DataLayerM11ScenarioSeverity::Critical,
+            true,
+        ))
+        .expect("security scenario should register");
+    matrix
+        .register_scenario(scenario(
+            "chaos.partition-heal",
+            DataLayerM11ScenarioDomain::Chaos,
+            DataLayerM11ScenarioSeverity::High,
+            true,
+        ))
+        .expect("chaos scenario should register");
+    matrix
+        .register_scenario(scenario(
+            "operations.runbook-signoff",
+            DataLayerM11ScenarioDomain::Operations,
+            DataLayerM11ScenarioSeverity::Medium,
+            true,
+        ))
+        .expect("operations scenario should register");
+
+    matrix
+        .record_outcome(outcome(
+            "security.authz-negative-matrix",
+            DataLayerM11ScenarioStatus::Passed,
+        ))
+        .expect("security outcome should record");
+    matrix
+        .record_outcome(outcome(
+            "chaos.partition-heal",
+            DataLayerM11ScenarioStatus::Passed,
+        ))
+        .expect("chaos outcome should record");
+    matrix
+        .record_outcome(outcome(
+            "operations.runbook-signoff",
+            DataLayerM11ScenarioStatus::Passed,
+        ))
+        .expect("operations outcome should record");
+
+    let readiness = matrix
+        .evaluate_operator_readiness()
+        .expect("readiness evaluation should succeed");
+    assert_eq!(
+        readiness.decision,
+        DataLayerM11OperatorReadinessDecision::Go
+    );
+    assert_eq!(
+        readiness.reason_codes,
+        vec![DATA_LAYER_M11_READINESS_GO_REASON_CODE]
+    );
+}
+
+#[test]
+fn spec_c03_critical_failure_for_required_scenario_blocks_readiness() {
+    let mut matrix = DataLayerM11HardeningMatrix::new();
+    matrix
+        .register_scenario(scenario(
+            "security.authz-negative-matrix",
+            DataLayerM11ScenarioDomain::Security,
+            DataLayerM11ScenarioSeverity::Critical,
+            true,
+        ))
+        .expect("security scenario should register");
+    matrix
+        .record_outcome(outcome(
+            "security.authz-negative-matrix",
+            DataLayerM11ScenarioStatus::Failed,
+        ))
+        .expect("security outcome should record");
+
+    let readiness = matrix
+        .evaluate_operator_readiness()
+        .expect("readiness evaluation should succeed");
+    assert_eq!(
+        readiness.decision,
+        DataLayerM11OperatorReadinessDecision::NoGo
+    );
+    assert_eq!(
+        readiness.reason_codes,
+        vec![DATA_LAYER_M11_BLOCK_CRITICAL_FAILURE_REASON_CODE]
+    );
+}
+
+#[test]
+fn spec_c04_duplicate_scenario_registration_fails_closed() {
+    let mut matrix = DataLayerM11HardeningMatrix::new();
+    matrix
+        .register_scenario(scenario(
+            "security.authz-negative-matrix",
+            DataLayerM11ScenarioDomain::Security,
+            DataLayerM11ScenarioSeverity::Critical,
+            true,
+        ))
+        .expect("scenario should register");
+
+    let duplicate = matrix.register_scenario(scenario(
+        "security.authz-negative-matrix",
+        DataLayerM11ScenarioDomain::Security,
+        DataLayerM11ScenarioSeverity::Critical,
+        true,
+    ));
+    assert!(matches!(
+        duplicate,
+        Err(DataLayerM11HardeningMatrixError::DuplicateScenarioId(id))
+        if id == "security.authz-negative-matrix"
+    ));
+}
+
+#[test]
+fn spec_c05_missing_required_scenario_outcomes_are_blocking() {
+    let mut matrix = DataLayerM11HardeningMatrix::new();
+    matrix
+        .register_scenario(scenario(
+            "chaos.partition-heal",
+            DataLayerM11ScenarioDomain::Chaos,
+            DataLayerM11ScenarioSeverity::High,
+            true,
+        ))
+        .expect("scenario should register");
+
+    let readiness = matrix
+        .evaluate_operator_readiness()
+        .expect("readiness evaluation should succeed");
+    assert_eq!(
+        readiness.decision,
+        DataLayerM11OperatorReadinessDecision::NoGo
+    );
+    assert_eq!(
+        readiness.reason_codes,
+        vec![DATA_LAYER_M11_BLOCK_REQUIRED_INCOMPLETE_REASON_CODE]
+    );
+    assert_eq!(
+        readiness.missing_required_scenario_ids,
+        vec!["chaos.partition-heal"]
+    );
+}
+
+#[test]
+fn spec_c06_invalid_status_transition_fails_closed() {
+    let mut matrix = DataLayerM11HardeningMatrix::new();
+    matrix
+        .register_scenario(scenario(
+            "performance.p95-latency",
+            DataLayerM11ScenarioDomain::Performance,
+            DataLayerM11ScenarioSeverity::High,
+            true,
+        ))
+        .expect("scenario should register");
+    matrix
+        .record_outcome(outcome(
+            "performance.p95-latency",
+            DataLayerM11ScenarioStatus::Passed,
+        ))
+        .expect("first outcome should record");
+
+    let invalid_transition = matrix.record_outcome(outcome(
+        "performance.p95-latency",
+        DataLayerM11ScenarioStatus::Failed,
+    ));
+    assert!(matches!(
+        invalid_transition,
+        Err(DataLayerM11HardeningMatrixError::InvalidStatusTransition {
+            reason_code: DATA_LAYER_M11_INVALID_TRANSITION_REASON_CODE,
+            ..
+        })
+    ));
+}

--- a/specs/5027/plan.md
+++ b/specs/5027/plan.md
@@ -1,26 +1,45 @@
 # Issue #5027 Plan
 
 - Issue: #5027
-- Status: Draft
+- Status: Implemented
 
 ## Approach
-1. Create red tests and conformance assertions for issue scope.
-2. Implement minimal behavior to satisfy ACs.
-3. Refactor for maintainability while preserving deterministic outputs.
-4. Run scoped regression + governance gates before PR.
+1. Add RED conformance tests (`spec_c01`..`spec_c06`) for:
+   - deterministic hardening scenario registration and ordering,
+   - readiness `Go` evaluation when all required scenarios pass,
+   - readiness `NoGo` for critical failures and missing required outcomes,
+   - duplicate scenario fail-closed guards and stable reason markers.
+2. Implement `data_layer_m11_hardening_readiness` module with:
+   - scenario domain/severity/status models,
+   - deterministic registry and outcome recorder,
+   - operator readiness evaluator and blocking reason projection.
+3. Re-export M11 APIs in `crates/kamn-core/src/lib.rs`.
+4. Run format/lint/targeted/full regression and shell guardrail evidence capture.
 
 ## Affected Modules
-- To be refined during implementation based on issue scope.
+- `crates/kamn-core/src/data_layer_m11_hardening_readiness.rs` (new)
+- `crates/kamn-core/src/lib.rs` (module + exports)
+- `crates/kamn-core/tests/data_layer_m11_hardening_readiness.rs` (new)
+- `specs/5027/spec.md`
+- `specs/5027/plan.md`
+- `specs/5027/tasks.md`
 
 ## Risks and Mitigations
-- Risk level: medium
+- Risk level: high
 - Mitigations:
-  - Keep diffs scoped to issue boundaries.
-  - Prefer Rust-native tests/harnesses to avoid shell-surface growth.
-  - Enforce shell budget and ratio checks when shell surfaces are touched.
+  - Enforce required-scenario and severity contracts with typed fail-closed errors.
+  - Keep outputs deterministic (stable ordering + reason-code markers).
+  - Keep implementation Rust-only to avoid shell-surface growth.
 
 ## Interface Contract
-- No dependency/protocol/wire-format change without explicit approval and ADR.
+- Additive public API under `kamn_core::data_layer_m11_hardening_readiness::*`.
+- No new dependencies.
+- No protocol/wire-format changes.
 
 ## ADR
-- TBD per implementation decisions.
+- Not required for this scoped additive implementation.
+
+## Verification Summary
+- RED: `cargo test -p kamn-core --test data_layer_m11_hardening_readiness` (failed before implementation with unresolved `DataLayerM11*` symbols).
+- GREEN: `cargo test -p kamn-core --test data_layer_m11_hardening_readiness` (6 passed, 0 failed).
+- Regression: `cargo test -p kamn-core` (pass), `cargo clippy -p kamn-core -- -D warnings` (pass), `cargo fmt --check` (pass).

--- a/specs/5027/spec.md
+++ b/specs/5027/spec.md
@@ -1,41 +1,76 @@
 # Issue #5027 Spec
 
 - Title: Task: M11 execute hardening matrix (security, chaos, perf) and operator readiness
-- Status: Draft
+- Status: Implemented
 - Type: task
 - Priority: P1
 - Milestone: specs/milestones/r27-45-kamn-data-layer-prd-implementation-and-validation/index.md
 
 ## Problem Statement
-Implement, integrate, test, and validate the parent-story delivery scope with strict spec-driven + TDD gates.
+PRD M11 requires deterministic hardening closure evidence across security,
+chaos, performance, and operator readiness checks. The codebase has many
+independent tests and docs but lacks a unified Rust contract that composes
+scenario outcomes into a fail-closed operator readiness decision with stable
+reason markers.
+
+PRD mapping:
+- Section 15 (security architecture and audit controls)
+- Section 17 (performance constraints and observability closure)
+- Section 18 (test strategy including chaos and resilience scenarios)
+- Milestone table M11 deliverables (security matrix + chaos + perf + ops closure)
 
 ## Acceptance Criteria
-- AC-1: Scope for issue #5027 is decomposed into explicit implementation/integration/validation outcomes with deterministic test evidence.
-- AC-2: The issue maps to PRD sections and conformance scenarios with clear test commands and result expectations.
-- AC-3: Shell-surface impact remains neutral by default (net shell LOC delta <= 0) unless explicitly waived with mitigation issue linkage.
+- AC-1: Hardening matrix contract deterministically tracks required scenario
+  outcomes across security, chaos, performance, and operator-readiness domains.
+- AC-2: Operator readiness evaluation returns deterministic GO/NO-GO output and
+  stable reason markers based on scenario pass/fail and severity.
+- AC-3: Fail-closed behavior rejects duplicate scenario IDs, missing required
+  scenario results, and invalid severity/status transitions.
+- AC-4: Public M11 API is exported from `kamn_core` for downstream report and
+  runbook integration.
+- AC-5: Shell/workflow/python/template LOC remains unchanged
+  (`shell_loc_delta_actual = 0`).
 
 ## Scope
 In scope:
-- Issue-specific delivery for Task: M11 execute hardening matrix (security, chaos, perf) and operator readiness.
-- Contract-driven lifecycle artifacts (`spec.md`, `plan.md`, `tasks.md`).
-- Test-tier mapping and conformance evidence capture.
+- New Rust M11 module in `kamn-core` for hardening scenario registration,
+  execution outcome recording, and operator readiness decision synthesis.
+- Conformance tests for deterministic ordering, fail-closed guards, and
+  readiness reason-marker stability.
+- Public API exports for downstream subtask `#5040` closure evidence reporting.
 
 Out of scope:
-- Unapproved dependency/protocol changes.
-- Work outside the parent milestone scope.
+- New shell/python/workflow orchestration.
+- External benchmark harness changes.
+- New dependencies or wire/protocol format changes.
 
 ## Conformance Cases
 | Case | AC | Tier | Input | Expected |
 |---|---|---|---|---|
-| C-01 | AC-1 | Functional | Execute issue task plan for #5027 | Planned implementation/integration steps are completed with evidence |
-| C-02 | AC-2 | Conformance | Run mapped test commands for #5027 | All mapped conformance checks pass and produce deterministic markers |
-| C-03 | AC-3 | Regression | Run shell-surface and ratio governance checks | No net shell-surface regression without waiver |
+| C-01 | AC-1 | Functional | Register required scenarios across all M11 domains | Deterministic scenario catalog projection and ordering |
+| C-02 | AC-2 | Conformance | Record passing outcomes for all required scenarios | Readiness evaluates `Go` with stable positive reason marker |
+| C-03 | AC-2/AC-3 | Regression | Record at least one critical failure outcome | Readiness evaluates `NoGo` with deterministic blocking reason marker |
+| C-04 | AC-3 | Regression | Register duplicate scenario IDs | Fail-closed typed error with stable reason marker |
+| C-05 | AC-3 | Regression | Evaluate readiness with missing required outcomes | Fail-closed `NoGo`/error path with deterministic missing-scenario marker |
+| C-06 | AC-4 | Conformance | Import M11 API from `kamn_core` root export | Module symbols available without direct module-path fallback |
+| C-07 | AC-5 | Regression | Inspect issue diff paths and run shell guardrails | No shell/workflow/python/template path changes; ratio/ceiling remain GO |
 
 ## Test Mapping
-- `cargo test -p kamn-core` (scoped by issue-specific suites)
-- `bash scripts/ci/check_shell_loc_hard_ceiling.sh` (when shell/python/workflow surface is touched)
-- `bash scripts/ci/check_shell_rust_ratio_guardrail.sh` (when shell/python/workflow surface is touched)
+- `cargo test -p kamn-core --test data_layer_m11_hardening_readiness`
+- `cargo test -p kamn-core`
+- `bash scripts/ci/check_shell_rust_ratio_guardrail.sh --repo-root . --output-json /tmp/shell-rust-ratio-guardrail-5027.json`
+- `bash scripts/ci/check_shell_loc_hard_ceiling.sh --repo-root . --output-json /tmp/shell-loc-hard-ceiling-5027.json`
+
+## AC Verification
+| AC | ✅/❌ | Test(s) |
+|---|---|---|
+| AC-1 | ✅ | `spec_c01_registration_catalog_is_deterministic_and_sorted` |
+| AC-2 | ✅ | `spec_c02_all_required_pass_results_in_operator_readiness_go`, `spec_c03_critical_failure_for_required_scenario_blocks_readiness` |
+| AC-3 | ✅ | `spec_c04_duplicate_scenario_registration_fails_closed`, `spec_c05_missing_required_scenario_outcomes_are_blocking`, `spec_c06_invalid_status_transition_fails_closed` |
+| AC-4 | ✅ | `cargo test -p kamn-core --test data_layer_m11_hardening_readiness` imports M11 symbols from `kamn_core` root exports |
+| AC-5 | ✅ | `bash scripts/ci/check_shell_rust_ratio_guardrail.sh ...` and `bash scripts/ci/check_shell_loc_hard_ceiling.sh ...` with Rust-only diff |
 
 ## Success Metrics
-- Issue #5027 reaches `Status: Implemented` with ACs mapped to passing conformance evidence.
-- Shell-to-Rust ratio guardrails remain within thresholds.
+- M11 hardening readiness contracts are exported through `kamn_core`.
+- All ACs map to passing `spec_c0x_*` tests with deterministic reason markers.
+- Shell-to-Rust ratio direction remains improved/neutral through Rust-only changes.

--- a/specs/5027/tasks.md
+++ b/specs/5027/tasks.md
@@ -1,12 +1,12 @@
 # Issue #5027 Tasks
 
 - Issue: #5027
-- Status: Draft
+- Status: Done
 
 ## Ordered Tasks
-- [ ] T1 (Red): add failing tests derived from spec conformance cases.
-- [ ] T2 (Green): implement minimum code path to satisfy ACs.
-- [ ] T3 (Refactor): improve structure/readability while preserving behavior.
-- [ ] T4 (Regression): run scoped functional/integration/regression checks.
-- [ ] T5 (Governance): if shell/python/workflow/template changed, run shell budget + ratio guardrails and report deltas.
-- [ ] T6 (Verify): finalize AC mapping and set lifecycle status markers.
+- [x] T1 (Red): add `spec_c01`..`spec_c06` tests for scenario registration, readiness GO/NO-GO, and fail-closed duplicate/missing-scenario paths.
+- [x] T2 (Green): implement `data_layer_m11_hardening_readiness` contracts to satisfy the red suite.
+- [x] T3 (Refactor): tighten deterministic ordering and stable reason-marker taxonomy.
+- [x] T4 (Regression): run `cargo fmt --check`, `cargo clippy -p kamn-core -- -D warnings`, `cargo test -p kamn-core --test data_layer_m11_hardening_readiness`, and `cargo test -p kamn-core`.
+- [x] T5 (Governance): confirm zero shell/python/workflow/template delta and record shell guardrail evidence.
+- [x] T6 (Verify): set spec lifecycle status to `Implemented`, map ACs to tests, and post issue closure evidence.


### PR DESCRIPTION
## Summary
- Implemented PRD M11 hardening contracts in `kamn-core` with a deterministic matrix for security/chaos/performance/operations scenario registration, outcome recording, and operator readiness evaluation.
- Added conformance-focused M11 tests (`spec_c01`..`spec_c06`) covering readiness GO/NO-GO decisions, fail-closed duplicate/missing/transition paths, and stable reason markers.
- Finalized `specs/5027/{spec,plan,tasks}.md` to `Implemented` with AC-to-test verification.

## Linked Issues
- Closes #5027
- Milestone: `specs/milestones/r27-45-kamn-data-layer-prd-implementation-and-validation/index.md`
- Spec: `specs/5027/spec.md`
- Plan: `specs/5027/plan.md`
- Tasks: `specs/5027/tasks.md`

## Validation
- [x] Relevant local checks passed.
- [x] CI fast-gate checks expected to pass.

Commands run:
- `cargo test -p kamn-core --test data_layer_m11_hardening_readiness` (RED then GREEN)
- `cargo fmt --check`
- `cargo clippy -p kamn-core -- -D warnings`
- `cargo test -p kamn-core`
- `bash scripts/ci/check_shell_rust_ratio_guardrail.sh --repo-root . --output-json /tmp/shell-rust-ratio-guardrail-5027.json`
- `bash scripts/ci/check_shell_loc_hard_ceiling.sh --repo-root . --output-json /tmp/shell-loc-hard-ceiling-5027.json`

## CI Impact Declaration
- [x] No CI scope impact.
- [ ] CI scope impact present (explain below).

## Shell-Surface Impact Declaration
- [x] No shell-surface impact.
- [ ] Shell-surface impact present (explain below).

Shell-surface impact details:
- shell_loc_delta_actual: 0
- rust_loc_delta_actual: 582
- shell_to_rust_ratio_delta_actual: -0.003956
- shell_surface_ratio_target_status: improved
- shell_surface_mitigation_issue: None

## Spec Verification (AC -> tests)
| AC | ✅/❌ | Test(s) |
|---|---|---|
| AC-1 deterministic hardening matrix tracking | ✅ | `spec_c01_registration_catalog_is_deterministic_and_sorted` |
| AC-2 deterministic operator readiness GO/NO-GO | ✅ | `spec_c02_all_required_pass_results_in_operator_readiness_go`, `spec_c03_critical_failure_for_required_scenario_blocks_readiness` |
| AC-3 fail-closed duplicate/missing/transition behavior | ✅ | `spec_c04_duplicate_scenario_registration_fails_closed`, `spec_c05_missing_required_scenario_outcomes_are_blocking`, `spec_c06_invalid_status_transition_fails_closed` |
| AC-4 M11 API exported from `kamn_core` | ✅ | integration test imports M11 symbols from crate root (`cargo test -p kamn-core --test data_layer_m11_hardening_readiness`) |
| AC-5 shell/workflow/python/template unchanged | ✅ | no shell/workflow/python/template files changed + guardrail scripts pass |

## TDD Evidence
- RED:
  - `cargo test -p kamn-core --test data_layer_m11_hardening_readiness`
  - failed before implementation with unresolved `DataLayerM11*` imports (`E0432`).
- GREEN:
  - `cargo test -p kamn-core --test data_layer_m11_hardening_readiness`
  - `6 passed; 0 failed`.
- REGRESSION:
  - `cargo test -p kamn-core` passed.

## Test Tiers
| Tier | ✅/❌/N/A | Tests | N/A Why |
|---|---|---|---|
| Unit | ✅ | `spec_c01`..`spec_c06` on public M11 APIs and fail-closed edges | |
| Property | N/A | | No randomized invariant surface introduced for this scoped deterministic matrix |
| Contract/DbC | N/A | | No `contracts` annotations are used in this module; conformance suite enforces fail-closed behavior |
| Snapshot | N/A | | No snapshot artifact in this change |
| Functional | ✅ | `spec_c01`, `spec_c02`, `spec_c03` | |
| Conformance | ✅ | `spec_c01`..`spec_c06` | |
| Integration | ✅ | `cargo test -p kamn-core` | |
| Fuzz | N/A | | No untrusted parser/input boundary introduced |
| Mutation | N/A | `cargo mutants --in-diff` attempted | `cargo-mutants` not installed in environment (`no such command: mutants`) |
| Regression | ✅ | `spec_c04`, `spec_c05`, `spec_c06`, full crate regression | |
| Performance | N/A | | No hotspot/perf-sensitive path changed |

## Mutation
- `cargo mutants --in-diff` attempted; tool unavailable in environment (`error: no such command: mutants`).

## Risks/Rollback
- Risk: low; additive module and exports only.
- Rollback: revert this PR to remove M11 module/tests and public exports.

## Docs/ADR
- Updated: `specs/5027/spec.md`, `specs/5027/plan.md`, `specs/5027/tasks.md`
- ADR: not required (scoped additive implementation, no new dependency/protocol change).
