### PR TITLE
feat(kamn-core): implement PRD critical scenario conformance contracts (#5028)

### DIFF
--- a/crates/kamn-core/src/data_layer_prd_critical_scenario_conformance.rs
+++ b/crates/kamn-core/src/data_layer_prd_critical_scenario_conformance.rs
@@ -1,0 +1,294 @@
+//! PRD critical-scenario conformance contracts (`18.2`, scenarios `62..71`).
+//!
+//! This module provides a deterministic, fail-closed contract for recording
+//! scenario outcomes and evaluating whether the critical scenario matrix is
+//! conformant under shell-neutral orchestration policy.
+
+use std::collections::BTreeMap;
+use std::fmt;
+
+/// Stable reason marker for fully conformant critical scenario matrix.
+pub const DATA_LAYER_PRD_CRITICAL_SCENARIO_CONFORMANT_REASON_CODE: &str =
+    "prd_critical_scenario_matrix_conformant";
+/// Stable reason marker when at least one required scenario failed.
+pub const DATA_LAYER_PRD_CRITICAL_SCENARIO_FAILED_REASON_CODE: &str =
+    "prd_critical_scenario_failed";
+/// Stable reason marker when required scenario outcomes are missing.
+pub const DATA_LAYER_PRD_CRITICAL_SCENARIO_MISSING_REASON_CODE: &str =
+    "prd_critical_scenario_missing";
+/// Stable reason marker when non-rust orchestration mode is detected.
+pub const DATA_LAYER_PRD_CRITICAL_SCENARIO_SHELL_POLICY_REASON_CODE: &str =
+    "prd_critical_scenario_shell_policy_violation";
+/// Stable reason marker for invalid/mutating scenario record updates.
+pub const DATA_LAYER_PRD_CRITICAL_SCENARIO_INVALID_MUTATION_REASON_CODE: &str =
+    "prd_critical_scenario_invalid_mutation";
+
+const DATA_LAYER_PRD_REQUIRED_CRITICAL_SCENARIO_IDS: [u8; 10] =
+    [62, 63, 64, 65, 66, 67, 68, 69, 70, 71];
+
+/// Orchestration mode used to execute a scenario.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DataLayerPrdCriticalScenarioMode {
+    /// Rust-first orchestration policy-compliant mode.
+    RustOnly,
+    /// Shell-assisted mode; policy violation for critical scenarios.
+    ShellHybrid,
+}
+
+/// Scenario result input payload.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DataLayerPrdCriticalScenarioResultInput {
+    /// PRD scenario identifier (`62..71`).
+    pub scenario_id: u8,
+    /// Scenario pass/fail result.
+    pub passed: bool,
+    /// Scenario orchestration mode.
+    pub orchestration_mode: DataLayerPrdCriticalScenarioMode,
+    /// Deterministic evidence marker/path.
+    pub evidence_marker: String,
+}
+
+/// Recorded scenario result row.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DataLayerPrdCriticalScenarioResultRecord {
+    /// PRD scenario identifier (`62..71`).
+    pub scenario_id: u8,
+    /// Scenario pass/fail result.
+    pub passed: bool,
+    /// Scenario orchestration mode.
+    pub orchestration_mode: DataLayerPrdCriticalScenarioMode,
+    /// Deterministic evidence marker/path.
+    pub evidence_marker: String,
+}
+
+/// Conformance decision output.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DataLayerPrdCriticalScenarioConformanceDecision {
+    /// Matrix satisfies completeness/pass/policy constraints.
+    Conformant,
+    /// Matrix does not satisfy one or more constraints.
+    NonConformant,
+}
+
+/// Conformance evaluation projection.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DataLayerPrdCriticalScenarioConformanceReport {
+    /// Final conformance decision.
+    pub decision: DataLayerPrdCriticalScenarioConformanceDecision,
+    /// Deterministic reason markers explaining the decision.
+    pub reason_codes: Vec<&'static str>,
+    /// Required scenario IDs with no recorded result.
+    pub missing_scenario_ids: Vec<u8>,
+    /// Required scenario IDs with `passed=false`.
+    pub failed_scenario_ids: Vec<u8>,
+    /// Required scenario IDs with non-rust orchestration mode.
+    pub shell_policy_violation_scenario_ids: Vec<u8>,
+    /// Number of required scenarios.
+    pub total_required_scenarios: u8,
+    /// Number of required scenarios with `passed=true`.
+    pub passed_required_scenarios: u8,
+}
+
+/// Fail-closed error taxonomy for critical-scenario conformance contracts.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DataLayerPrdCriticalScenarioConformanceError {
+    /// Required field was empty.
+    EmptyField(&'static str),
+    /// Scenario id is not within required set (`62..71`).
+    InvalidScenarioId(u8),
+    /// Attempted update mutates a previously recorded result.
+    InvalidResultMutation {
+        /// Scenario identifier being updated.
+        scenario_id: u8,
+        /// Existing `passed` value.
+        existing_passed: bool,
+        /// Requested `passed` value.
+        requested_passed: bool,
+        /// Existing mode.
+        existing_mode: DataLayerPrdCriticalScenarioMode,
+        /// Requested mode.
+        requested_mode: DataLayerPrdCriticalScenarioMode,
+        /// Stable reason marker.
+        reason_code: &'static str,
+    },
+}
+
+impl fmt::Display for DataLayerPrdCriticalScenarioConformanceError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyField(field_name) => write!(formatter, "{field_name} must not be empty"),
+            Self::InvalidScenarioId(scenario_id) => {
+                write!(formatter, "invalid PRD critical scenario id: {scenario_id}")
+            }
+            Self::InvalidResultMutation {
+                scenario_id,
+                existing_passed,
+                requested_passed,
+                existing_mode,
+                requested_mode,
+                reason_code,
+            } => write!(
+                formatter,
+                "invalid result mutation for scenario {scenario_id}: passed({existing_passed}->{requested_passed}) mode({existing_mode:?}->{requested_mode:?}) ({reason_code})"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for DataLayerPrdCriticalScenarioConformanceError {}
+
+/// In-memory deterministic registry for PRD critical scenario conformance.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct DataLayerPrdCriticalScenarioConformanceMatrix {
+    scenario_results: BTreeMap<u8, DataLayerPrdCriticalScenarioResultRecord>,
+}
+
+impl DataLayerPrdCriticalScenarioConformanceMatrix {
+    /// Creates an empty conformance matrix.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Returns required PRD critical scenario IDs in deterministic order.
+    pub fn required_scenario_ids(&self) -> Vec<u8> {
+        DATA_LAYER_PRD_REQUIRED_CRITICAL_SCENARIO_IDS.to_vec()
+    }
+
+    /// Records one critical scenario result.
+    pub fn record_result(
+        &mut self,
+        input: DataLayerPrdCriticalScenarioResultInput,
+    ) -> Result<
+        DataLayerPrdCriticalScenarioResultRecord,
+        DataLayerPrdCriticalScenarioConformanceError,
+    > {
+        validate_required_scenario_id(input.scenario_id)?;
+        validate_non_empty(input.evidence_marker.as_str(), "evidence_marker")?;
+
+        if let Some(existing) = self.scenario_results.get(&input.scenario_id) {
+            if existing.passed != input.passed
+                || existing.orchestration_mode != input.orchestration_mode
+            {
+                return Err(
+                    DataLayerPrdCriticalScenarioConformanceError::InvalidResultMutation {
+                        scenario_id: input.scenario_id,
+                        existing_passed: existing.passed,
+                        requested_passed: input.passed,
+                        existing_mode: existing.orchestration_mode,
+                        requested_mode: input.orchestration_mode,
+                        reason_code: DATA_LAYER_PRD_CRITICAL_SCENARIO_INVALID_MUTATION_REASON_CODE,
+                    },
+                );
+            }
+            return Ok(existing.clone());
+        }
+
+        let record = DataLayerPrdCriticalScenarioResultRecord {
+            scenario_id: input.scenario_id,
+            passed: input.passed,
+            orchestration_mode: input.orchestration_mode,
+            evidence_marker: input.evidence_marker,
+        };
+        self.scenario_results
+            .insert(input.scenario_id, record.clone());
+        Ok(record)
+    }
+
+    /// Evaluates matrix conformance against required scenario completeness + policy.
+    pub fn evaluate_conformance(
+        &self,
+    ) -> Result<
+        DataLayerPrdCriticalScenarioConformanceReport,
+        DataLayerPrdCriticalScenarioConformanceError,
+    > {
+        let mut missing_scenario_ids = Vec::new();
+        let mut failed_scenario_ids = Vec::new();
+        let mut shell_policy_violation_scenario_ids = Vec::new();
+        let mut passed_required_scenarios = 0u8;
+
+        for scenario_id in self.required_scenario_ids() {
+            match self.scenario_results.get(&scenario_id) {
+                Some(record) => {
+                    if record.passed {
+                        passed_required_scenarios = passed_required_scenarios.saturating_add(1);
+                    } else {
+                        failed_scenario_ids.push(scenario_id);
+                    }
+                    if record.orchestration_mode != DataLayerPrdCriticalScenarioMode::RustOnly {
+                        shell_policy_violation_scenario_ids.push(scenario_id);
+                    }
+                }
+                None => missing_scenario_ids.push(scenario_id),
+            }
+        }
+
+        let total_required_scenarios = DATA_LAYER_PRD_REQUIRED_CRITICAL_SCENARIO_IDS.len() as u8;
+
+        if !shell_policy_violation_scenario_ids.is_empty() {
+            return Ok(DataLayerPrdCriticalScenarioConformanceReport {
+                decision: DataLayerPrdCriticalScenarioConformanceDecision::NonConformant,
+                reason_codes: vec![DATA_LAYER_PRD_CRITICAL_SCENARIO_SHELL_POLICY_REASON_CODE],
+                missing_scenario_ids,
+                failed_scenario_ids,
+                shell_policy_violation_scenario_ids,
+                total_required_scenarios,
+                passed_required_scenarios,
+            });
+        }
+
+        if !failed_scenario_ids.is_empty() {
+            return Ok(DataLayerPrdCriticalScenarioConformanceReport {
+                decision: DataLayerPrdCriticalScenarioConformanceDecision::NonConformant,
+                reason_codes: vec![DATA_LAYER_PRD_CRITICAL_SCENARIO_FAILED_REASON_CODE],
+                missing_scenario_ids,
+                failed_scenario_ids,
+                shell_policy_violation_scenario_ids,
+                total_required_scenarios,
+                passed_required_scenarios,
+            });
+        }
+
+        if !missing_scenario_ids.is_empty() {
+            return Ok(DataLayerPrdCriticalScenarioConformanceReport {
+                decision: DataLayerPrdCriticalScenarioConformanceDecision::NonConformant,
+                reason_codes: vec![DATA_LAYER_PRD_CRITICAL_SCENARIO_MISSING_REASON_CODE],
+                missing_scenario_ids,
+                failed_scenario_ids,
+                shell_policy_violation_scenario_ids,
+                total_required_scenarios,
+                passed_required_scenarios,
+            });
+        }
+
+        Ok(DataLayerPrdCriticalScenarioConformanceReport {
+            decision: DataLayerPrdCriticalScenarioConformanceDecision::Conformant,
+            reason_codes: vec![DATA_LAYER_PRD_CRITICAL_SCENARIO_CONFORMANT_REASON_CODE],
+            missing_scenario_ids,
+            failed_scenario_ids,
+            shell_policy_violation_scenario_ids,
+            total_required_scenarios,
+            passed_required_scenarios,
+        })
+    }
+}
+
+fn validate_required_scenario_id(
+    scenario_id: u8,
+) -> Result<(), DataLayerPrdCriticalScenarioConformanceError> {
+    if !DATA_LAYER_PRD_REQUIRED_CRITICAL_SCENARIO_IDS.contains(&scenario_id) {
+        return Err(DataLayerPrdCriticalScenarioConformanceError::InvalidScenarioId(scenario_id));
+    }
+    Ok(())
+}
+
+fn validate_non_empty(
+    value: &str,
+    field_name: &'static str,
+) -> Result<(), DataLayerPrdCriticalScenarioConformanceError> {
+    if value.trim().is_empty() {
+        return Err(DataLayerPrdCriticalScenarioConformanceError::EmptyField(
+            field_name,
+        ));
+    }
+    Ok(())
+}

--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -62,6 +62,8 @@ pub mod data_layer_m7_timeseries_telemetry;
 pub mod data_layer_m8_compliance_lifecycle;
 /// M9 realtime contracts for dispatch acknowledgements, scoped presence, and backpressure markers.
 pub mod data_layer_m9_realtime_delivery;
+/// PRD critical-scenario conformance contracts for shell-neutral validation (`62..71`).
+pub mod data_layer_prd_critical_scenario_conformance;
 /// DID document canonicalization and federated trust-handshake contracts.
 pub mod did;
 /// DID registry lifecycle and chain-submission finality contracts.
@@ -343,6 +345,17 @@ pub use data_layer_m9_realtime_delivery::{
     DATA_LAYER_M9_BACKPRESSURE_WARNING_AFTER_SECONDS, DATA_LAYER_M9_MAX_PENDING_PER_AGENT_MESSAGES,
     DATA_LAYER_M9_OWNER_SCOPE_DENIED_REASON_CODE,
     DATA_LAYER_M9_PRESENCE_VISIBILITY_DENIED_REASON_CODE,
+};
+pub use data_layer_prd_critical_scenario_conformance::{
+    DataLayerPrdCriticalScenarioConformanceDecision, DataLayerPrdCriticalScenarioConformanceError,
+    DataLayerPrdCriticalScenarioConformanceMatrix, DataLayerPrdCriticalScenarioConformanceReport,
+    DataLayerPrdCriticalScenarioMode, DataLayerPrdCriticalScenarioResultInput,
+    DataLayerPrdCriticalScenarioResultRecord,
+    DATA_LAYER_PRD_CRITICAL_SCENARIO_CONFORMANT_REASON_CODE,
+    DATA_LAYER_PRD_CRITICAL_SCENARIO_FAILED_REASON_CODE,
+    DATA_LAYER_PRD_CRITICAL_SCENARIO_INVALID_MUTATION_REASON_CODE,
+    DATA_LAYER_PRD_CRITICAL_SCENARIO_MISSING_REASON_CODE,
+    DATA_LAYER_PRD_CRITICAL_SCENARIO_SHELL_POLICY_REASON_CODE,
 };
 pub use did::{
     canonical_did_document, canonical_service_endpoint,

--- a/crates/kamn-core/tests/data_layer_prd_critical_scenario_conformance.rs
+++ b/crates/kamn-core/tests/data_layer_prd_critical_scenario_conformance.rs
@@ -1,0 +1,178 @@
+use kamn_core::{
+    DataLayerPrdCriticalScenarioConformanceDecision, DataLayerPrdCriticalScenarioConformanceError,
+    DataLayerPrdCriticalScenarioConformanceMatrix, DataLayerPrdCriticalScenarioMode,
+    DataLayerPrdCriticalScenarioResultInput,
+    DATA_LAYER_PRD_CRITICAL_SCENARIO_CONFORMANT_REASON_CODE,
+    DATA_LAYER_PRD_CRITICAL_SCENARIO_FAILED_REASON_CODE,
+    DATA_LAYER_PRD_CRITICAL_SCENARIO_INVALID_MUTATION_REASON_CODE,
+    DATA_LAYER_PRD_CRITICAL_SCENARIO_MISSING_REASON_CODE,
+    DATA_LAYER_PRD_CRITICAL_SCENARIO_SHELL_POLICY_REASON_CODE,
+};
+
+fn result_input(
+    scenario_id: u8,
+    passed: bool,
+    mode: DataLayerPrdCriticalScenarioMode,
+) -> DataLayerPrdCriticalScenarioResultInput {
+    DataLayerPrdCriticalScenarioResultInput {
+        scenario_id,
+        passed,
+        orchestration_mode: mode,
+        evidence_marker: format!("evidence:prd-critical:{scenario_id}"),
+    }
+}
+
+#[test]
+fn spec_c01_required_scenario_catalog_is_deterministic() {
+    let matrix = DataLayerPrdCriticalScenarioConformanceMatrix::new();
+    assert_eq!(
+        matrix.required_scenario_ids(),
+        vec![62, 63, 64, 65, 66, 67, 68, 69, 70, 71]
+    );
+}
+
+#[test]
+fn spec_c02_all_required_scenarios_pass_with_rust_only_orchestration() {
+    let mut matrix = DataLayerPrdCriticalScenarioConformanceMatrix::new();
+    for scenario_id in matrix.required_scenario_ids() {
+        matrix
+            .record_result(result_input(
+                scenario_id,
+                true,
+                DataLayerPrdCriticalScenarioMode::RustOnly,
+            ))
+            .expect("scenario result should record");
+    }
+
+    let report = matrix
+        .evaluate_conformance()
+        .expect("conformance evaluation should succeed");
+    assert_eq!(
+        report.decision,
+        DataLayerPrdCriticalScenarioConformanceDecision::Conformant
+    );
+    assert_eq!(
+        report.reason_codes,
+        vec![DATA_LAYER_PRD_CRITICAL_SCENARIO_CONFORMANT_REASON_CODE]
+    );
+}
+
+#[test]
+fn spec_c03_failed_required_scenario_is_non_conformant() {
+    let mut matrix = DataLayerPrdCriticalScenarioConformanceMatrix::new();
+    for scenario_id in matrix.required_scenario_ids() {
+        let passed = scenario_id != 66;
+        matrix
+            .record_result(result_input(
+                scenario_id,
+                passed,
+                DataLayerPrdCriticalScenarioMode::RustOnly,
+            ))
+            .expect("scenario result should record");
+    }
+
+    let report = matrix
+        .evaluate_conformance()
+        .expect("conformance evaluation should succeed");
+    assert_eq!(
+        report.decision,
+        DataLayerPrdCriticalScenarioConformanceDecision::NonConformant
+    );
+    assert_eq!(
+        report.reason_codes,
+        vec![DATA_LAYER_PRD_CRITICAL_SCENARIO_FAILED_REASON_CODE]
+    );
+    assert_eq!(report.failed_scenario_ids, vec![66]);
+}
+
+#[test]
+fn spec_c04_missing_required_scenario_is_non_conformant() {
+    let mut matrix = DataLayerPrdCriticalScenarioConformanceMatrix::new();
+    for scenario_id in 62..=70 {
+        matrix
+            .record_result(result_input(
+                scenario_id,
+                true,
+                DataLayerPrdCriticalScenarioMode::RustOnly,
+            ))
+            .expect("scenario result should record");
+    }
+
+    let report = matrix
+        .evaluate_conformance()
+        .expect("conformance evaluation should succeed");
+    assert_eq!(
+        report.decision,
+        DataLayerPrdCriticalScenarioConformanceDecision::NonConformant
+    );
+    assert_eq!(
+        report.reason_codes,
+        vec![DATA_LAYER_PRD_CRITICAL_SCENARIO_MISSING_REASON_CODE]
+    );
+    assert_eq!(report.missing_scenario_ids, vec![71]);
+}
+
+#[test]
+fn spec_c05_shell_hybrid_orchestration_is_policy_violation() {
+    let mut matrix = DataLayerPrdCriticalScenarioConformanceMatrix::new();
+    for scenario_id in matrix.required_scenario_ids() {
+        let mode = if scenario_id == 68 {
+            DataLayerPrdCriticalScenarioMode::ShellHybrid
+        } else {
+            DataLayerPrdCriticalScenarioMode::RustOnly
+        };
+        matrix
+            .record_result(result_input(scenario_id, true, mode))
+            .expect("scenario result should record");
+    }
+
+    let report = matrix
+        .evaluate_conformance()
+        .expect("conformance evaluation should succeed");
+    assert_eq!(
+        report.decision,
+        DataLayerPrdCriticalScenarioConformanceDecision::NonConformant
+    );
+    assert_eq!(
+        report.reason_codes,
+        vec![DATA_LAYER_PRD_CRITICAL_SCENARIO_SHELL_POLICY_REASON_CODE]
+    );
+    assert_eq!(report.shell_policy_violation_scenario_ids, vec![68]);
+}
+
+#[test]
+fn spec_c06_invalid_scenario_ids_and_mutating_records_fail_closed() {
+    let mut matrix = DataLayerPrdCriticalScenarioConformanceMatrix::new();
+    let invalid = matrix.record_result(result_input(
+        72,
+        true,
+        DataLayerPrdCriticalScenarioMode::RustOnly,
+    ));
+    assert!(matches!(
+        invalid,
+        Err(DataLayerPrdCriticalScenarioConformanceError::InvalidScenarioId(72))
+    ));
+
+    matrix
+        .record_result(result_input(
+            62,
+            true,
+            DataLayerPrdCriticalScenarioMode::RustOnly,
+        ))
+        .expect("scenario result should record");
+
+    let mutation = matrix.record_result(result_input(
+        62,
+        false,
+        DataLayerPrdCriticalScenarioMode::RustOnly,
+    ));
+    assert!(matches!(
+        mutation,
+        Err(
+            DataLayerPrdCriticalScenarioConformanceError::InvalidResultMutation {
+                reason_code: DATA_LAYER_PRD_CRITICAL_SCENARIO_INVALID_MUTATION_REASON_CODE,
+                ..
+            }
+        )
+    ));
+}

--- a/specs/5028/plan.md
+++ b/specs/5028/plan.md
@@ -1,26 +1,45 @@
 # Issue #5028 Plan
 
 - Issue: #5028
-- Status: Draft
+- Status: Implemented
 
 ## Approach
-1. Create red tests and conformance assertions for issue scope.
-2. Implement minimal behavior to satisfy ACs.
-3. Refactor for maintainability while preserving deterministic outputs.
-4. Run scoped regression + governance gates before PR.
+1. Add RED conformance tests (`spec_c01`..`spec_c05`) for:
+   - deterministic required-scenario catalog (`62..71`),
+   - fully passing matrix -> `Conformant`,
+   - scenario failure/shell-policy violation -> `NonConformant`,
+   - invalid scenario id + record mutation fail-closed errors.
+2. Implement `data_layer_prd_critical_scenario_conformance` module with:
+   - required scenario catalog and result registry,
+   - deterministic conformance evaluator with stable reason markers,
+   - shell-neutral orchestration mode policy enforcement.
+3. Re-export APIs in `crates/kamn-core/src/lib.rs`.
+4. Run format/lint/targeted/full regression and shell guardrail evidence capture.
 
 ## Affected Modules
-- To be refined during implementation based on issue scope.
+- `crates/kamn-core/src/data_layer_prd_critical_scenario_conformance.rs` (new)
+- `crates/kamn-core/src/lib.rs` (module + exports)
+- `crates/kamn-core/tests/data_layer_prd_critical_scenario_conformance.rs` (new)
+- `specs/5028/spec.md`
+- `specs/5028/plan.md`
+- `specs/5028/tasks.md`
 
 ## Risks and Mitigations
-- Risk level: medium
+- Risk level: high
 - Mitigations:
-  - Keep diffs scoped to issue boundaries.
-  - Prefer Rust-native tests/harnesses to avoid shell-surface growth.
-  - Enforce shell budget and ratio checks when shell surfaces are touched.
+  - Hard-code required scenario catalog and keep output ordering deterministic.
+  - Fail-closed on invalid IDs/duplicate mutation attempts.
+  - Keep implementation Rust-only to avoid shell-surface growth.
 
 ## Interface Contract
-- No dependency/protocol/wire-format change without explicit approval and ADR.
+- Additive public API under `kamn_core::data_layer_prd_critical_scenario_conformance::*`.
+- No new dependencies.
+- No protocol/wire-format changes.
 
 ## ADR
-- TBD per implementation decisions.
+- Not required for this scoped additive implementation.
+
+## Verification Summary
+- RED: `cargo test -p kamn-core --test data_layer_prd_critical_scenario_conformance` (failed before implementation with unresolved `DataLayerPrdCriticalScenario*` symbols).
+- GREEN: `cargo test -p kamn-core --test data_layer_prd_critical_scenario_conformance` (6 passed, 0 failed).
+- Regression: `cargo test -p kamn-core` (pass), `cargo clippy -p kamn-core -- -D warnings` (pass), `cargo fmt --check` (pass).

--- a/specs/5028/spec.md
+++ b/specs/5028/spec.md
@@ -1,41 +1,73 @@
 # Issue #5028 Spec
 
 - Title: Task: enforce PRD critical-scenario conformance matrix with shell-neutral test orchestration
-- Status: Draft
+- Status: Implemented
 - Type: task
 - Priority: P1
 - Milestone: specs/milestones/r27-45-kamn-data-layer-prd-implementation-and-validation/index.md
 
 ## Problem Statement
-Implement, integrate, test, and validate the parent-story delivery scope with strict spec-driven + TDD gates.
+PRD Section 18.2 defines critical validation scenarios `62..71` as release
+gates. The repository lacks one deterministic Rust contract that verifies all
+required scenarios are present, passed, and executed through shell-neutral
+orchestration policy (Rust-first by default).
+
+PRD mapping:
+- Section 18.2 critical scenarios (`62..71`)
+- M11 cross-cutting validation and acceptance gates
+- Shell-surface guardrail policy from milestone execution plan
 
 ## Acceptance Criteria
-- AC-1: Scope for issue #5028 is decomposed into explicit implementation/integration/validation outcomes with deterministic test evidence.
-- AC-2: The issue maps to PRD sections and conformance scenarios with clear test commands and result expectations.
-- AC-3: Shell-surface impact remains neutral by default (net shell LOC delta <= 0) unless explicitly waived with mitigation issue linkage.
+- AC-1: Contract surface deterministically tracks PRD critical scenarios
+  `62..71` and validates matrix completeness.
+- AC-2: Conformance evaluation deterministically reports `Conformant` only when
+  all required scenarios pass.
+- AC-3: Shell-neutral orchestration policy is enforced in conformance
+  evaluation (Rust-only mode required by default for critical scenarios).
+- AC-4: Invalid scenario IDs and duplicate/mutating records fail closed with
+  stable reason markers.
+- AC-5: Shell/workflow/python/template LOC remains unchanged
+  (`shell_loc_delta_actual = 0`).
 
 ## Scope
 In scope:
-- Issue-specific delivery for Task: enforce PRD critical-scenario conformance matrix with shell-neutral test orchestration.
-- Contract-driven lifecycle artifacts (`spec.md`, `plan.md`, `tasks.md`).
-- Test-tier mapping and conformance evidence capture.
+- New Rust module in `kamn-core` for PRD critical scenario result recording,
+  conformance evaluation, and shell-neutral orchestration enforcement.
+- Conformance tests covering completeness, failure states, shell-policy
+  violations, and fail-closed invalid inputs.
+- Public API exports for downstream `#5041` integration and release evidence.
 
 Out of scope:
-- Unapproved dependency/protocol changes.
-- Work outside the parent milestone scope.
+- New shell/python/workflow orchestration scripts.
+- Changes to CI workflow structure.
+- New dependencies or wire/protocol format changes.
 
 ## Conformance Cases
 | Case | AC | Tier | Input | Expected |
 |---|---|---|---|---|
-| C-01 | AC-1 | Functional | Execute issue task plan for #5028 | Planned implementation/integration steps are completed with evidence |
-| C-02 | AC-2 | Conformance | Run mapped test commands for #5028 | All mapped conformance checks pass and produce deterministic markers |
-| C-03 | AC-3 | Regression | Run shell-surface and ratio governance checks | No net shell-surface regression without waiver |
+| C-01 | AC-1 | Functional | Inspect required scenario catalog | Deterministic ordered list of scenario IDs `62..71` |
+| C-02 | AC-2 | Conformance | Record all scenarios as passed | Conformance report returns `Conformant` with stable pass reason marker |
+| C-03 | AC-2 | Regression | Record one scenario as failed | Conformance report returns `NonConformant` with failed-scenario reason marker |
+| C-04 | AC-3 | Regression | Record scenario execution with shell-hybrid orchestration mode | Conformance report returns `NonConformant` with shell-neutral policy reason marker |
+| C-05 | AC-4 | Regression | Record invalid scenario ID or mutate existing scenario record | Fail-closed typed error with stable reason marker |
+| C-06 | AC-5 | Regression | Inspect issue diff paths and run shell guardrails | No shell/workflow/python/template path changes; ratio/ceiling remain GO |
 
 ## Test Mapping
-- `cargo test -p kamn-core` (scoped by issue-specific suites)
-- `bash scripts/ci/check_shell_loc_hard_ceiling.sh` (when shell/python/workflow surface is touched)
-- `bash scripts/ci/check_shell_rust_ratio_guardrail.sh` (when shell/python/workflow surface is touched)
+- `cargo test -p kamn-core --test data_layer_prd_critical_scenario_conformance`
+- `cargo test -p kamn-core`
+- `bash scripts/ci/check_shell_rust_ratio_guardrail.sh --repo-root . --output-json /tmp/shell-rust-ratio-guardrail-5028.json`
+- `bash scripts/ci/check_shell_loc_hard_ceiling.sh --repo-root . --output-json /tmp/shell-loc-hard-ceiling-5028.json`
+
+## AC Verification
+| AC | ✅/❌ | Test(s) |
+|---|---|---|
+| AC-1 | ✅ | `spec_c01_required_scenario_catalog_is_deterministic` |
+| AC-2 | ✅ | `spec_c02_all_required_scenarios_pass_with_rust_only_orchestration` |
+| AC-3 | ✅ | `spec_c05_shell_hybrid_orchestration_is_policy_violation` |
+| AC-4 | ✅ | `spec_c06_invalid_scenario_ids_and_mutating_records_fail_closed` |
+| AC-5 | ✅ | `bash scripts/ci/check_shell_rust_ratio_guardrail.sh ...` and `bash scripts/ci/check_shell_loc_hard_ceiling.sh ...` with Rust-only diff |
 
 ## Success Metrics
-- Issue #5028 reaches `Status: Implemented` with ACs mapped to passing conformance evidence.
-- Shell-to-Rust ratio guardrails remain within thresholds.
+- PRD critical scenario contract surface is exported through `kamn_core`.
+- All ACs map to passing `spec_c0x_*` tests with deterministic reason markers.
+- Shell-to-Rust ratio direction remains improved/neutral through Rust-only changes.

--- a/specs/5028/tasks.md
+++ b/specs/5028/tasks.md
@@ -1,12 +1,12 @@
 # Issue #5028 Tasks
 
 - Issue: #5028
-- Status: Draft
+- Status: Done
 
 ## Ordered Tasks
-- [ ] T1 (Red): add failing tests derived from spec conformance cases.
-- [ ] T2 (Green): implement minimum code path to satisfy ACs.
-- [ ] T3 (Refactor): improve structure/readability while preserving behavior.
-- [ ] T4 (Regression): run scoped functional/integration/regression checks.
-- [ ] T5 (Governance): if shell/python/workflow/template changed, run shell budget + ratio guardrails and report deltas.
-- [ ] T6 (Verify): finalize AC mapping and set lifecycle status markers.
+- [x] T1 (Red): add `spec_c01`..`spec_c05` tests for critical scenario completeness, failure handling, shell-neutral policy, and fail-closed invalid inputs.
+- [x] T2 (Green): implement `data_layer_prd_critical_scenario_conformance` contracts to satisfy the red suite.
+- [x] T3 (Refactor): tighten deterministic ordering and stable reason-marker taxonomy.
+- [x] T4 (Regression): run `cargo fmt --check`, `cargo clippy -p kamn-core -- -D warnings`, `cargo test -p kamn-core --test data_layer_prd_critical_scenario_conformance`, and `cargo test -p kamn-core`.
+- [x] T5 (Governance): confirm zero shell/python/workflow/template delta and record shell guardrail evidence.
+- [x] T6 (Verify): set spec lifecycle status to `Implemented`, map ACs to tests, and post issue closure evidence.


### PR DESCRIPTION
## Summary
- Implemented PRD critical-scenario (`18.2`, scenarios `62..71`) conformance contracts in `kamn-core` with deterministic result recording, completeness checks, and conformance decisioning.
- Added shell-neutral orchestration policy enforcement to the conformance evaluator, including stable fail-closed reason markers.
- Added `spec_c01`..`spec_c06` conformance tests and finalized `specs/5028/{spec,plan,tasks}.md` to `Implemented`.

## Linked Issues
- Closes #5028
- Milestone: `specs/milestones/r27-45-kamn-data-layer-prd-implementation-and-validation/index.md`
- Spec: `specs/5028/spec.md`
- Plan: `specs/5028/plan.md`
- Tasks: `specs/5028/tasks.md`

## Validation
- [x] Relevant local checks passed.
- [x] CI fast-gate checks expected to pass.

Commands run:
- `cargo test -p kamn-core --test data_layer_prd_critical_scenario_conformance` (RED then GREEN)
- `cargo fmt --check`
- `cargo clippy -p kamn-core -- -D warnings`
- `cargo test -p kamn-core`
- `bash scripts/ci/check_shell_rust_ratio_guardrail.sh --repo-root . --output-json /tmp/shell-rust-ratio-guardrail-5028.json`
- `bash scripts/ci/check_shell_loc_hard_ceiling.sh --repo-root . --output-json /tmp/shell-loc-hard-ceiling-5028.json`

## CI Impact Declaration
- [x] No CI scope impact.
- [ ] CI scope impact present (explain below).

## Shell-Surface Impact Declaration
- [x] No shell-surface impact.
- [ ] Shell-surface impact present (explain below).

Shell-surface impact details:
- shell_loc_delta_actual: 0
- rust_loc_delta_actual: 485
- shell_to_rust_ratio_delta_actual: -0.003266
- shell_surface_ratio_target_status: improved
- shell_surface_mitigation_issue: None

## Spec Verification (AC -> tests)
| AC | ✅/❌ | Test(s) |
|---|---|---|
| AC-1 deterministic `62..71` scenario catalog/completeness | ✅ | `spec_c01_required_scenario_catalog_is_deterministic`, `spec_c04_missing_required_scenario_is_non_conformant` |
| AC-2 deterministic conformant/non-conformant decisions | ✅ | `spec_c02_all_required_scenarios_pass_with_rust_only_orchestration`, `spec_c03_failed_required_scenario_is_non_conformant` |
| AC-3 shell-neutral orchestration policy enforcement | ✅ | `spec_c05_shell_hybrid_orchestration_is_policy_violation` |
| AC-4 fail-closed invalid ID + mutating updates | ✅ | `spec_c06_invalid_scenario_ids_and_mutating_records_fail_closed` |
| AC-5 shell/workflow/python/template unchanged | ✅ | no shell/workflow/python/template files changed + guardrail scripts pass |

## TDD Evidence
- RED:
  - `cargo test -p kamn-core --test data_layer_prd_critical_scenario_conformance`
  - failed before implementation with unresolved `DataLayerPrdCriticalScenario*` imports (`E0432`).
- GREEN:
  - `cargo test -p kamn-core --test data_layer_prd_critical_scenario_conformance`
  - `6 passed; 0 failed`.
- REGRESSION:
  - `cargo test -p kamn-core` passed.

## Test Tiers
| Tier | ✅/❌/N/A | Tests | N/A Why |
|---|---|---|---|
| Unit | ✅ | `spec_c01`..`spec_c06` on public conformance APIs | |
| Property | N/A | | No randomized invariant expansion required for this scoped deterministic matrix |
| Contract/DbC | N/A | | No `contracts` annotations in this module; fail-closed behavior is covered by conformance tests |
| Snapshot | N/A | | No snapshot artifact in this change |
| Functional | ✅ | `spec_c01`, `spec_c02`, `spec_c03` | |
| Conformance | ✅ | `spec_c01`..`spec_c06` | |
| Integration | ✅ | `cargo test -p kamn-core` | |
| Fuzz | N/A | | No untrusted parser/input boundary introduced |
| Mutation | N/A | `cargo mutants --in-diff` attempted | `cargo-mutants` not installed in environment (`no such command: mutants`) |
| Regression | ✅ | `spec_c04`, `spec_c05`, `spec_c06`, full crate regression | |
| Performance | N/A | | No hotspot/perf-sensitive path changed |

## Mutation
- `cargo mutants --in-diff` attempted; tool unavailable in environment (`error: no such command: mutants`).

## Risks/Rollback
- Risk: low; additive module and exports only.
- Rollback: revert this PR to remove PRD critical-scenario module/tests and exports.

## Docs/ADR
- Updated: `specs/5028/spec.md`, `specs/5028/plan.md`, `specs/5028/tasks.md`
- ADR: not required (scoped additive implementation, no new dependency/protocol change).
