### PR TITLE
feat(kamn-core): add M10 recoverability contract suite (#5039)

### DIFF
--- a/crates/kamn-core/src/data_layer_m10_partition_archival.rs
+++ b/crates/kamn-core/src/data_layer_m10_partition_archival.rs
@@ -17,6 +17,14 @@ pub const DATA_LAYER_M10_ARCHIVE_REASON_CODE: &str = "m10_partition_archived";
 pub const DATA_LAYER_M10_REATTACH_REASON_CODE: &str = "m10_partition_reattached";
 /// Stable reason marker for invalid lifecycle transitions.
 pub const DATA_LAYER_M10_INVALID_TRANSITION_REASON_CODE: &str = "m10_partition_transition_invalid";
+/// Stable reason marker when partition recoverability is ready for historical replay.
+pub const DATA_LAYER_M10_RECOVERY_READY_REASON_CODE: &str = "m10_partition_recovery_ready";
+/// Stable reason marker when partition status is not eligible for historical recovery.
+pub const DATA_LAYER_M10_RECOVERY_STATUS_INELIGIBLE_REASON_CODE: &str =
+    "m10_partition_recovery_status_ineligible";
+/// Stable reason marker when historical partition metadata is incomplete.
+pub const DATA_LAYER_M10_RECOVERY_METADATA_INCOMPLETE_REASON_CODE: &str =
+    "m10_partition_recovery_metadata_incomplete";
 
 /// Partition lifecycle status.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -27,6 +35,15 @@ pub enum DataLayerM10PartitionStatus {
     Archived,
     /// Archived partition reattached for historical query access.
     Reattached,
+}
+
+/// Recoverability decision for one partition.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DataLayerM10RecoveryDecision {
+    /// Partition has complete archival metadata and can be recovered.
+    Ready,
+    /// Partition cannot be recovered under current state/metadata.
+    Blocked,
 }
 
 /// Partition registration input.
@@ -85,6 +102,27 @@ pub struct DataLayerM10ArchivalIndexEntry {
     pub checksum_marker: String,
     /// Lifecycle status after archive transition.
     pub lifecycle_status: DataLayerM10PartitionStatus,
+}
+
+/// Recoverability readiness projection for one partition.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DataLayerM10RecoveryReadinessReport {
+    /// Partition month identifier as `YYYYMM`.
+    pub partition_month_id: u32,
+    /// Canonical partition name `messages_YYYY_MM`.
+    pub partition_name: String,
+    /// Recoverability decision.
+    pub decision: DataLayerM10RecoveryDecision,
+    /// Stable reason marker for the decision.
+    pub reason_code: &'static str,
+    /// Current lifecycle status.
+    pub lifecycle_status: DataLayerM10PartitionStatus,
+    /// Archived object URI.
+    pub archived_object_uri: Option<String>,
+    /// Archive format marker.
+    pub archive_format_marker: Option<&'static str>,
+    /// Deterministic checksum marker.
+    pub checksum_marker: Option<String>,
 }
 
 /// M10 partition lifecycle registry.
@@ -234,6 +272,38 @@ impl DataLayerM10PartitionLifecycleRegistry {
         record.last_reason_code = Some(DATA_LAYER_M10_REATTACH_REASON_CODE);
         Ok(record.clone())
     }
+
+    /// Evaluates recoverability readiness for one partition.
+    pub fn evaluate_partition_recovery_readiness(
+        &self,
+        partition_name: &str,
+    ) -> Result<DataLayerM10RecoveryReadinessReport, DataLayerM10PartitionLifecycleError> {
+        validate_non_empty(partition_name, "partition_name")?;
+        let record = self
+            .partitions
+            .values()
+            .find(|entry| entry.partition_name == partition_name)
+            .ok_or_else(|| {
+                DataLayerM10PartitionLifecycleError::PartitionNotFound(partition_name.to_owned())
+            })?;
+        Ok(project_partition_recovery_readiness(record))
+    }
+
+    /// Lists recoverability readiness for historical partitions in deterministic order.
+    pub fn list_historical_recovery_readiness(&self) -> Vec<DataLayerM10RecoveryReadinessReport> {
+        let mut reports: Vec<DataLayerM10RecoveryReadinessReport> = self
+            .partitions
+            .values()
+            .filter(|record| record.lifecycle_status != DataLayerM10PartitionStatus::Active)
+            .map(project_partition_recovery_readiness)
+            .collect();
+        reports.sort_by(|left, right| {
+            left.partition_month_id
+                .cmp(&right.partition_month_id)
+                .then(left.partition_name.cmp(&right.partition_name))
+        });
+        reports
+    }
 }
 
 /// Formats partition month id (`YYYYMM`) as `messages_YYYY_MM`.
@@ -351,4 +421,49 @@ fn month_distance(
 
 fn deterministic_checksum_marker(partition_name: &str, partition_month_id: u32) -> String {
     format!("sha256:{partition_name}:{partition_month_id}")
+}
+
+fn project_partition_recovery_readiness(
+    record: &DataLayerM10PartitionRecord,
+) -> DataLayerM10RecoveryReadinessReport {
+    let metadata_complete = record
+        .archived_object_uri
+        .as_deref()
+        .is_some_and(|value| !value.trim().is_empty())
+        && record.archive_format_marker == Some(DATA_LAYER_M10_ARCHIVE_FORMAT_PARQUET_ZSTD)
+        && record
+            .checksum_marker
+            .as_deref()
+            .is_some_and(|value| !value.trim().is_empty());
+
+    let (decision, reason_code) = match record.lifecycle_status {
+        DataLayerM10PartitionStatus::Active => (
+            DataLayerM10RecoveryDecision::Blocked,
+            DATA_LAYER_M10_RECOVERY_STATUS_INELIGIBLE_REASON_CODE,
+        ),
+        DataLayerM10PartitionStatus::Archived | DataLayerM10PartitionStatus::Reattached => {
+            if metadata_complete {
+                (
+                    DataLayerM10RecoveryDecision::Ready,
+                    DATA_LAYER_M10_RECOVERY_READY_REASON_CODE,
+                )
+            } else {
+                (
+                    DataLayerM10RecoveryDecision::Blocked,
+                    DATA_LAYER_M10_RECOVERY_METADATA_INCOMPLETE_REASON_CODE,
+                )
+            }
+        }
+    };
+
+    DataLayerM10RecoveryReadinessReport {
+        partition_month_id: record.partition_month_id,
+        partition_name: record.partition_name.clone(),
+        decision,
+        reason_code,
+        lifecycle_status: record.lifecycle_status,
+        archived_object_uri: record.archived_object_uri.clone(),
+        archive_format_marker: record.archive_format_marker,
+        checksum_marker: record.checksum_marker.clone(),
+    }
 }

--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -266,10 +266,13 @@ pub use data_layer_m10_partition_archival::{
     data_layer_m10_format_partition_name, DataLayerM10ArchivalIndexEntry,
     DataLayerM10ArchiveDueRequest, DataLayerM10PartitionLifecycleError,
     DataLayerM10PartitionLifecycleRegistry, DataLayerM10PartitionRecord,
-    DataLayerM10PartitionRecordInput, DataLayerM10PartitionStatus,
-    DATA_LAYER_M10_ARCHIVE_FORMAT_PARQUET_ZSTD, DATA_LAYER_M10_ARCHIVE_REASON_CODE,
-    DATA_LAYER_M10_INVALID_TRANSITION_REASON_CODE, DATA_LAYER_M10_PARTITION_PREFIX,
-    DATA_LAYER_M10_REATTACH_REASON_CODE,
+    DataLayerM10PartitionRecordInput, DataLayerM10PartitionStatus, DataLayerM10RecoveryDecision,
+    DataLayerM10RecoveryReadinessReport, DATA_LAYER_M10_ARCHIVE_FORMAT_PARQUET_ZSTD,
+    DATA_LAYER_M10_ARCHIVE_REASON_CODE, DATA_LAYER_M10_INVALID_TRANSITION_REASON_CODE,
+    DATA_LAYER_M10_PARTITION_PREFIX, DATA_LAYER_M10_REATTACH_REASON_CODE,
+    DATA_LAYER_M10_RECOVERY_METADATA_INCOMPLETE_REASON_CODE,
+    DATA_LAYER_M10_RECOVERY_READY_REASON_CODE,
+    DATA_LAYER_M10_RECOVERY_STATUS_INELIGIBLE_REASON_CODE,
 };
 pub use data_layer_m11_hardening_readiness::{
     DataLayerM11HardeningMatrix, DataLayerM11HardeningMatrixError,

--- a/crates/kamn-core/tests/data_layer_m10_partition_recoverability.rs
+++ b/crates/kamn-core/tests/data_layer_m10_partition_recoverability.rs
@@ -1,0 +1,139 @@
+use kamn_core::{
+    DataLayerM10ArchiveDueRequest, DataLayerM10PartitionLifecycleError,
+    DataLayerM10PartitionLifecycleRegistry, DataLayerM10PartitionRecordInput,
+    DataLayerM10PartitionStatus, DataLayerM10RecoveryDecision,
+    DATA_LAYER_M10_RECOVERY_READY_REASON_CODE,
+    DATA_LAYER_M10_RECOVERY_STATUS_INELIGIBLE_REASON_CODE,
+};
+
+fn partition_input(
+    partition_month_id: u32,
+    all_messages_shredded: bool,
+) -> DataLayerM10PartitionRecordInput {
+    DataLayerM10PartitionRecordInput {
+        partition_month_id,
+        all_messages_shredded,
+    }
+}
+
+#[test]
+fn spec_c01_archived_partition_recovery_readiness_is_ready() {
+    let mut registry = DataLayerM10PartitionLifecycleRegistry::new();
+    registry
+        .register_partition(partition_input(202401, true))
+        .expect("partition should register");
+    registry
+        .archive_due_partitions(DataLayerM10ArchiveDueRequest {
+            now_month_id: 202602,
+            active_retention_months: 2,
+            object_storage_prefix: "s3://kamn-archive/messages".to_owned(),
+        })
+        .expect("archive due should succeed");
+
+    let report = registry
+        .evaluate_partition_recovery_readiness("messages_2024_01")
+        .expect("recovery readiness should evaluate");
+    assert_eq!(report.decision, DataLayerM10RecoveryDecision::Ready);
+    assert_eq!(
+        report.reason_code,
+        DATA_LAYER_M10_RECOVERY_READY_REASON_CODE
+    );
+    assert_eq!(
+        report.lifecycle_status,
+        DataLayerM10PartitionStatus::Archived
+    );
+}
+
+#[test]
+fn spec_c02_reattached_partition_recovery_readiness_remains_ready() {
+    let mut registry = DataLayerM10PartitionLifecycleRegistry::new();
+    registry
+        .register_partition(partition_input(202401, true))
+        .expect("partition should register");
+    registry
+        .archive_due_partitions(DataLayerM10ArchiveDueRequest {
+            now_month_id: 202602,
+            active_retention_months: 2,
+            object_storage_prefix: "s3://kamn-archive/messages".to_owned(),
+        })
+        .expect("archive due should succeed");
+    registry
+        .reattach_partition("messages_2024_01")
+        .expect("reattach should succeed");
+
+    let report = registry
+        .evaluate_partition_recovery_readiness("messages_2024_01")
+        .expect("recovery readiness should evaluate");
+    assert_eq!(report.decision, DataLayerM10RecoveryDecision::Ready);
+    assert_eq!(
+        report.reason_code,
+        DATA_LAYER_M10_RECOVERY_READY_REASON_CODE
+    );
+    assert_eq!(
+        report.lifecycle_status,
+        DataLayerM10PartitionStatus::Reattached
+    );
+}
+
+#[test]
+fn spec_c03_active_partition_is_blocked_for_recoverability() {
+    let mut registry = DataLayerM10PartitionLifecycleRegistry::new();
+    registry
+        .register_partition(partition_input(202602, true))
+        .expect("partition should register");
+
+    let report = registry
+        .evaluate_partition_recovery_readiness("messages_2026_02")
+        .expect("recovery readiness should evaluate");
+    assert_eq!(report.decision, DataLayerM10RecoveryDecision::Blocked);
+    assert_eq!(
+        report.reason_code,
+        DATA_LAYER_M10_RECOVERY_STATUS_INELIGIBLE_REASON_CODE
+    );
+    assert_eq!(report.lifecycle_status, DataLayerM10PartitionStatus::Active);
+}
+
+#[test]
+fn spec_c04_historical_recovery_readiness_catalog_is_deterministic() {
+    let mut registry = DataLayerM10PartitionLifecycleRegistry::new();
+    registry
+        .register_partition(partition_input(202401, true))
+        .expect("partition should register");
+    registry
+        .register_partition(partition_input(202402, true))
+        .expect("partition should register");
+    registry
+        .register_partition(partition_input(202602, true))
+        .expect("active partition should register");
+    registry
+        .archive_due_partitions(DataLayerM10ArchiveDueRequest {
+            now_month_id: 202602,
+            active_retention_months: 2,
+            object_storage_prefix: "s3://kamn-archive/messages".to_owned(),
+        })
+        .expect("archive due should succeed");
+    registry
+        .reattach_partition("messages_2024_02")
+        .expect("reattach should succeed");
+
+    let reports = registry.list_historical_recovery_readiness();
+    let names: Vec<&str> = reports
+        .iter()
+        .map(|report| report.partition_name.as_str())
+        .collect();
+    assert_eq!(names, vec!["messages_2024_01", "messages_2024_02"]);
+    assert!(reports
+        .iter()
+        .all(|report| report.decision == DataLayerM10RecoveryDecision::Ready));
+}
+
+#[test]
+fn spec_c05_unknown_partition_lookup_fails_closed() {
+    let registry = DataLayerM10PartitionLifecycleRegistry::new();
+    let missing = registry.evaluate_partition_recovery_readiness("messages_2024_99");
+    assert!(matches!(
+        missing,
+        Err(DataLayerM10PartitionLifecycleError::PartitionNotFound(name))
+        if name == "messages_2024_99"
+    ));
+}

--- a/specs/5039/plan.md
+++ b/specs/5039/plan.md
@@ -1,26 +1,46 @@
 # Issue #5039 Plan
 
 - Issue: #5039
-- Status: Draft
+- Status: Implemented
 
 ## Approach
-1. Create red tests and conformance assertions for issue scope.
-2. Implement minimal behavior to satisfy ACs.
-3. Refactor for maintainability while preserving deterministic outputs.
-4. Run scoped regression + governance gates before PR.
+1. Add RED conformance tests (`spec_c01`..`spec_c05`) for:
+   - archived and reattached recovery readiness (`Ready`),
+   - active partition readiness block (`Blocked`),
+   - deterministic historical recovery listing,
+   - unknown partition fail-closed lookup.
+2. Extend `data_layer_m10_partition_archival` with recoverability projections:
+   - readiness decision enum + report struct + reason markers,
+   - per-partition readiness evaluator,
+   - deterministic historical readiness listing.
+3. Re-export new APIs in `crates/kamn-core/src/lib.rs`.
+4. Run format/lint/targeted/full regression and shell guardrail evidence.
 
 ## Affected Modules
-- To be refined during implementation based on issue scope.
+- `crates/kamn-core/src/data_layer_m10_partition_archival.rs`
+- `crates/kamn-core/src/lib.rs`
+- `crates/kamn-core/tests/data_layer_m10_partition_recoverability.rs` (new)
+- `specs/5039/spec.md`
+- `specs/5039/plan.md`
+- `specs/5039/tasks.md`
 
 ## Risks and Mitigations
 - Risk level: medium
 - Mitigations:
-  - Keep diffs scoped to issue boundaries.
-  - Prefer Rust-native tests/harnesses to avoid shell-surface growth.
-  - Enforce shell budget and ratio checks when shell surfaces are touched.
+  - Preserve existing M10 lifecycle behavior while adding read-only readiness
+    projections.
+  - Keep recoverability report ordering deterministic.
+  - Keep implementation Rust-only to avoid shell-surface growth.
 
 ## Interface Contract
-- No dependency/protocol/wire-format change without explicit approval and ADR.
+- Additive public API under existing `kamn_core` M10 exports.
+- No new dependencies.
+- No protocol/wire-format changes.
 
 ## ADR
-- TBD per implementation decisions.
+- Not required for this scoped additive implementation.
+
+## Verification Summary
+- RED: `cargo test -p kamn-core --test data_layer_m10_partition_recoverability` (failed before implementation with unresolved recoverability symbols/methods).
+- GREEN: `cargo test -p kamn-core --test data_layer_m10_partition_recoverability` (5 passed, 0 failed).
+- Regression: `cargo test -p kamn-core` (pass), `cargo clippy -p kamn-core -- -D warnings` (pass), `cargo fmt --check` (pass).

--- a/specs/5039/spec.md
+++ b/specs/5039/spec.md
@@ -1,41 +1,72 @@
 # Issue #5039 Spec
 
 - Title: Subtask: M10 partition lifecycle and archival recoverability contract suite
-- Status: Draft
+- Status: Implemented
 - Type: subtask
 - Priority: P1
 - Milestone: specs/milestones/r27-45-kamn-data-layer-prd-implementation-and-validation/index.md
 
 ## Problem Statement
-Deliver the highest-risk validation/conformance sub-scope for parent task
+Parent task `#5026` implemented baseline M10 partition lifecycle and archival
+contracts, but recoverability validation remains shallow. M10 requires
+deterministic recoverability evidence for archived/reattached partitions so
+operator workflows can block unsafe restores and project stable readiness state.
+
+PRD mapping:
+- Section 13.2 archival + historical re-attachment lifecycle
+- M10 scaling deliverables (archival pipeline and recoverability)
+- M11/operator readiness dependencies on recoverability evidence
 
 ## Acceptance Criteria
-- AC-1: Scope for issue #5039 is decomposed into explicit implementation/integration/validation outcomes with deterministic test evidence.
-- AC-2: The issue maps to PRD sections and conformance scenarios with clear test commands and result expectations.
-- AC-3: Shell-surface impact remains neutral by default (net shell LOC delta <= 0) unless explicitly waived with mitigation issue linkage.
+- AC-1: Partition recoverability readiness is deterministically evaluated for
+  archived and reattached partitions.
+- AC-2: Recoverability readiness blocks active/non-historical partitions with
+  stable ineligible-status reason markers.
+- AC-3: Historical recovery readiness listing is deterministic and sorted for
+  archived/reattached partitions only.
+- AC-4: Unknown partition lookups fail closed with typed errors.
+- AC-5: Shell/workflow/python/template LOC remains unchanged
+  (`shell_loc_delta_actual = 0`).
 
 ## Scope
 In scope:
-- Issue-specific delivery for Subtask: M10 partition lifecycle and archival recoverability contract suite.
-- Contract-driven lifecycle artifacts (`spec.md`, `plan.md`, `tasks.md`).
-- Test-tier mapping and conformance evidence capture.
+- Extend existing `data_layer_m10_partition_archival` contracts with
+  recoverability readiness projections.
+- Add conformance tests for readiness outcomes and deterministic historical
+  ordering.
+- Export recoverability API through `kamn_core` root.
 
 Out of scope:
-- Unapproved dependency/protocol changes.
-- Work outside the parent milestone scope.
+- New shell/python/workflow orchestration.
+- New dependencies or wire/protocol format changes.
+- Live DB or object-store integration changes.
 
 ## Conformance Cases
 | Case | AC | Tier | Input | Expected |
 |---|---|---|---|---|
-| C-01 | AC-1 | Functional | Execute issue task plan for #5039 | Planned implementation/integration steps are completed with evidence |
-| C-02 | AC-2 | Conformance | Run mapped test commands for #5039 | All mapped conformance checks pass and produce deterministic markers |
-| C-03 | AC-3 | Regression | Run shell-surface and ratio governance checks | No net shell-surface regression without waiver |
+| C-01 | AC-1 | Functional | Evaluate readiness for archived partition | `Ready` decision with stable ready reason marker |
+| C-02 | AC-1 | Conformance | Evaluate readiness after archived -> reattached transition | `Ready` decision remains stable for historical reattached partition |
+| C-03 | AC-2 | Regression | Evaluate readiness for active partition | `Blocked` decision with stable ineligible-status reason marker |
+| C-04 | AC-3 | Conformance | List historical recovery readiness for mixed partition states | Deterministic ordered list contains archived/reattached partitions only |
+| C-05 | AC-4 | Regression | Evaluate readiness for unknown partition name | Fail-closed `PartitionNotFound` typed error |
+| C-06 | AC-5 | Regression | Inspect diff paths and shell guardrails | No shell/workflow/python/template path changes; ratio/ceiling remain GO |
 
 ## Test Mapping
-- `cargo test -p kamn-core` (scoped by issue-specific suites)
-- `bash scripts/ci/check_shell_loc_hard_ceiling.sh` (when shell/python/workflow surface is touched)
-- `bash scripts/ci/check_shell_rust_ratio_guardrail.sh` (when shell/python/workflow surface is touched)
+- `cargo test -p kamn-core --test data_layer_m10_partition_recoverability`
+- `cargo test -p kamn-core`
+- `bash scripts/ci/check_shell_rust_ratio_guardrail.sh --repo-root . --output-json /tmp/shell-rust-ratio-guardrail-5039.json`
+- `bash scripts/ci/check_shell_loc_hard_ceiling.sh --repo-root . --output-json /tmp/shell-loc-hard-ceiling-5039.json`
+
+## AC Verification
+| AC | ✅/❌ | Test(s) |
+|---|---|---|
+| AC-1 | ✅ | `spec_c01_archived_partition_recovery_readiness_is_ready`, `spec_c02_reattached_partition_recovery_readiness_remains_ready` |
+| AC-2 | ✅ | `spec_c03_active_partition_is_blocked_for_recoverability` |
+| AC-3 | ✅ | `spec_c04_historical_recovery_readiness_catalog_is_deterministic` |
+| AC-4 | ✅ | `spec_c05_unknown_partition_lookup_fails_closed` |
+| AC-5 | ✅ | `bash scripts/ci/check_shell_rust_ratio_guardrail.sh ...` and `bash scripts/ci/check_shell_loc_hard_ceiling.sh ...` with Rust-only diff |
 
 ## Success Metrics
-- Issue #5039 reaches `Status: Implemented` with ACs mapped to passing conformance evidence.
-- Shell-to-Rust ratio guardrails remain within thresholds.
+- Recoverability APIs are exported and consumed from `kamn_core`.
+- All ACs map to passing `spec_c0x_*` tests for recoverability suite.
+- Shell-to-Rust ratio direction remains improved/neutral via Rust-only changes.

--- a/specs/5039/tasks.md
+++ b/specs/5039/tasks.md
@@ -1,12 +1,12 @@
 # Issue #5039 Tasks
 
 - Issue: #5039
-- Status: Draft
+- Status: Done
 
 ## Ordered Tasks
-- [ ] T1 (Red): add failing tests derived from spec conformance cases.
-- [ ] T2 (Green): implement minimum code path to satisfy ACs.
-- [ ] T3 (Refactor): improve structure/readability while preserving behavior.
-- [ ] T4 (Regression): run scoped functional/integration/regression checks.
-- [ ] T5 (Governance): if shell/python/workflow/template changed, run shell budget + ratio guardrails and report deltas.
-- [ ] T6 (Verify): finalize AC mapping and set lifecycle status markers.
+- [x] T1 (Red): add `spec_c01`..`spec_c05` recoverability tests for archived/reattached readiness, active-blocked status, deterministic history listing, and unknown partition fail-closed behavior.
+- [x] T2 (Green): implement M10 recoverability APIs in `data_layer_m10_partition_archival`.
+- [x] T3 (Refactor): tighten deterministic ordering and stable reason markers for readiness reports.
+- [x] T4 (Regression): run `cargo fmt --check`, `cargo clippy -p kamn-core -- -D warnings`, `cargo test -p kamn-core --test data_layer_m10_partition_recoverability`, and `cargo test -p kamn-core`.
+- [x] T5 (Governance): confirm zero shell/python/workflow/template delta and record shell guardrail evidence.
+- [x] T6 (Verify): set spec lifecycle status to `Implemented`, map ACs to tests, and post issue closure evidence.


### PR DESCRIPTION
## Summary
- Extended M10 archival contracts with deterministic recoverability projections for archived/reattached partitions.
- Added `evaluate_partition_recovery_readiness` and `list_historical_recovery_readiness` APIs plus stable reason markers for ready/blocked states.
- Added recoverability conformance tests (`spec_c01`..`spec_c05`) and finalized `specs/5039/{spec,plan,tasks}.md` to `Implemented`.

## Linked Issues
- Closes #5039
- Milestone: `specs/milestones/r27-45-kamn-data-layer-prd-implementation-and-validation/index.md`
- Spec: `specs/5039/spec.md`
- Plan: `specs/5039/plan.md`
- Tasks: `specs/5039/tasks.md`

## Validation
- [x] Relevant local checks passed.
- [x] CI fast-gate checks expected to pass.

Commands run:
- `cargo test -p kamn-core --test data_layer_m10_partition_recoverability` (RED then GREEN)
- `cargo fmt --check`
- `cargo clippy -p kamn-core -- -D warnings`
- `cargo test -p kamn-core`
- `bash scripts/ci/check_shell_rust_ratio_guardrail.sh --repo-root . --output-json /tmp/shell-rust-ratio-guardrail-5039.json`
- `bash scripts/ci/check_shell_loc_hard_ceiling.sh --repo-root . --output-json /tmp/shell-loc-hard-ceiling-5039.json`

## CI Impact Declaration
- [x] No CI scope impact.
- [ ] CI scope impact present (explain below).

## Shell-Surface Impact Declaration
- [x] No shell-surface impact.
- [ ] Shell-surface impact present (explain below).

Shell-surface impact details:
- shell_loc_delta_actual: 0
- rust_loc_delta_actual: 257
- shell_to_rust_ratio_delta_actual: -0.001713
- shell_surface_ratio_target_status: improved
- shell_surface_mitigation_issue: None

## Spec Verification (AC -> tests)
| AC | ✅/❌ | Test(s) |
|---|---|---|
| AC-1 recoverability ready for archived/reattached | ✅ | `spec_c01_archived_partition_recovery_readiness_is_ready`, `spec_c02_reattached_partition_recovery_readiness_remains_ready` |
| AC-2 active partition blocked with stable reason | ✅ | `spec_c03_active_partition_is_blocked_for_recoverability` |
| AC-3 deterministic historical readiness listing | ✅ | `spec_c04_historical_recovery_readiness_catalog_is_deterministic` |
| AC-4 unknown partition fail-closed | ✅ | `spec_c05_unknown_partition_lookup_fails_closed` |
| AC-5 shell/workflow/python/template unchanged | ✅ | no shell/workflow/python/template files changed + guardrail scripts pass |

## TDD Evidence
- RED:
  - `cargo test -p kamn-core --test data_layer_m10_partition_recoverability`
  - failed before implementation with unresolved imports/methods (`DataLayerM10RecoveryDecision`, `evaluate_partition_recovery_readiness`, `list_historical_recovery_readiness`).
- GREEN:
  - `cargo test -p kamn-core --test data_layer_m10_partition_recoverability`
  - `5 passed; 0 failed`.
- REGRESSION:
  - `cargo test -p kamn-core` passed.

## Test Tiers
| Tier | ✅/❌/N/A | Tests | N/A Why |
|---|---|---|---|
| Unit | ✅ | `spec_c01`..`spec_c05` on new recoverability APIs | |
| Property | N/A | | No randomized invariant expansion needed for this scoped recoverability projection |
| Contract/DbC | N/A | | No `contracts` annotations in this module; fail-closed behavior covered by conformance tests |
| Snapshot | N/A | | No snapshot artifact in this change |
| Functional | ✅ | `spec_c01`, `spec_c02`, `spec_c03` | |
| Conformance | ✅ | `spec_c01`..`spec_c05` | |
| Integration | ✅ | `cargo test -p kamn-core` | |
| Fuzz | N/A | | No untrusted parser/input boundary introduced |
| Mutation | N/A | `cargo mutants --in-diff` attempted | `cargo-mutants` not installed in environment (`no such command: mutants`) |
| Regression | ✅ | `spec_c03`, `spec_c04`, `spec_c05`, full crate regression | |
| Performance | N/A | | No hotspot/perf-sensitive path changed |

## Mutation
- `cargo mutants --in-diff` attempted; tool unavailable in environment (`error: no such command: mutants`).

## Risks/Rollback
- Risk: low; additive API surface over existing M10 module.
- Rollback: revert this PR to remove recoverability APIs/tests.

## Docs/ADR
- Updated: `specs/5039/spec.md`, `specs/5039/plan.md`, `specs/5039/tasks.md`
- ADR: not required (scoped additive implementation, no new dependency/protocol change).
