### PR TITLE
feat(kamn-core): add M11 closure evidence acceptance report contracts (#5040)

### DIFF
--- a/crates/kamn-core/src/data_layer_m11_closure_evidence.rs
+++ b/crates/kamn-core/src/data_layer_m11_closure_evidence.rs
@@ -1,0 +1,127 @@
+//! M11 closure evidence contracts for deterministic release acceptance decisions.
+//!
+//! This module composes existing hardening and critical-scenario conformance
+//! reports into one closure acceptance report with stable reason markers.
+
+use crate::{
+    DataLayerM11OperatorReadinessDecision, DataLayerM11OperatorReadinessReport,
+    DataLayerPrdCriticalScenarioConformanceDecision, DataLayerPrdCriticalScenarioConformanceReport,
+};
+
+/// Stable reason marker when closure evidence satisfies all release gates.
+pub const DATA_LAYER_M11_CLOSURE_ACCEPTED_REASON_CODE: &str = "m11_closure_accepted";
+/// Stable reason marker when hardening readiness blocks closure.
+pub const DATA_LAYER_M11_CLOSURE_BLOCK_HARDENING_REASON_CODE: &str = "m11_closure_block_hardening";
+/// Stable reason marker when critical scenario conformance blocks closure.
+pub const DATA_LAYER_M11_CLOSURE_BLOCK_CRITICAL_SCENARIO_REASON_CODE: &str =
+    "m11_closure_block_critical_scenario";
+/// Stable reason marker when performance/signoff evidence is incomplete.
+pub const DATA_LAYER_M11_CLOSURE_BLOCK_EVIDENCE_GAP_REASON_CODE: &str =
+    "m11_closure_block_evidence_gap";
+
+/// Acceptance decision for M11 closure evidence.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DataLayerM11ClosureAcceptanceDecision {
+    /// Release closure is accepted.
+    Accepted,
+    /// Release closure is rejected.
+    Rejected,
+}
+
+/// Input envelope for closure evidence evaluation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DataLayerM11ClosureEvidenceInput {
+    /// Release marker for the closure report.
+    pub release_marker: String,
+    /// M11 hardening readiness report.
+    pub hardening_report: DataLayerM11OperatorReadinessReport,
+    /// PRD critical scenario conformance report.
+    pub critical_scenario_report: DataLayerPrdCriticalScenarioConformanceReport,
+    /// Performance budget closure gate.
+    pub performance_budget_met: bool,
+    /// Security signoff closure gate.
+    pub security_signoff_complete: bool,
+    /// Chaos signoff closure gate.
+    pub chaos_signoff_complete: bool,
+}
+
+/// Deterministic closure acceptance report.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DataLayerM11ClosureEvidenceReport {
+    /// Release marker for this report.
+    pub release_marker: String,
+    /// Final acceptance decision.
+    pub decision: DataLayerM11ClosureAcceptanceDecision,
+    /// Stable reason markers for the decision.
+    pub reason_codes: Vec<&'static str>,
+    /// Projected hardening decision.
+    pub hardening_decision: DataLayerM11OperatorReadinessDecision,
+    /// Projected critical scenario conformance decision.
+    pub critical_scenario_decision: DataLayerPrdCriticalScenarioConformanceDecision,
+    /// Performance gate marker.
+    pub performance_budget_met: bool,
+    /// Security signoff gate marker.
+    pub security_signoff_complete: bool,
+    /// Chaos signoff gate marker.
+    pub chaos_signoff_complete: bool,
+}
+
+/// Fail-closed error taxonomy for closure evidence contracts.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DataLayerM11ClosureEvidenceError {
+    /// Release marker is empty.
+    EmptyReleaseMarker,
+}
+
+impl std::fmt::Display for DataLayerM11ClosureEvidenceError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::EmptyReleaseMarker => write!(formatter, "release_marker must not be empty"),
+        }
+    }
+}
+
+impl std::error::Error for DataLayerM11ClosureEvidenceError {}
+
+/// Evaluates closure evidence and projects deterministic acceptance output.
+pub fn data_layer_m11_evaluate_closure_evidence(
+    input: DataLayerM11ClosureEvidenceInput,
+) -> Result<DataLayerM11ClosureEvidenceReport, DataLayerM11ClosureEvidenceError> {
+    if input.release_marker.trim().is_empty() {
+        return Err(DataLayerM11ClosureEvidenceError::EmptyReleaseMarker);
+    }
+
+    let mut reason_codes = Vec::new();
+    if input.hardening_report.decision != DataLayerM11OperatorReadinessDecision::Go {
+        reason_codes.push(DATA_LAYER_M11_CLOSURE_BLOCK_HARDENING_REASON_CODE);
+    }
+    if input.critical_scenario_report.decision
+        != DataLayerPrdCriticalScenarioConformanceDecision::Conformant
+    {
+        reason_codes.push(DATA_LAYER_M11_CLOSURE_BLOCK_CRITICAL_SCENARIO_REASON_CODE);
+    }
+    if !input.performance_budget_met
+        || !input.security_signoff_complete
+        || !input.chaos_signoff_complete
+    {
+        reason_codes.push(DATA_LAYER_M11_CLOSURE_BLOCK_EVIDENCE_GAP_REASON_CODE);
+    }
+
+    let decision = if reason_codes.is_empty() {
+        reason_codes.push(DATA_LAYER_M11_CLOSURE_ACCEPTED_REASON_CODE);
+        DataLayerM11ClosureAcceptanceDecision::Accepted
+    } else {
+        DataLayerM11ClosureAcceptanceDecision::Rejected
+    };
+
+    Ok(DataLayerM11ClosureEvidenceReport {
+        release_marker: input.release_marker,
+        decision,
+        reason_codes,
+        hardening_decision: input.hardening_report.decision,
+        critical_scenario_decision: input.critical_scenario_report.decision,
+        performance_budget_met: input.performance_budget_met,
+        security_signoff_complete: input.security_signoff_complete,
+        chaos_signoff_complete: input.chaos_signoff_complete,
+    })
+}

--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -44,6 +44,8 @@ pub mod data_layer_m0;
 pub mod data_layer_m1;
 /// M10 partition contracts for scaling controls, archival index, and re-attachment lifecycle.
 pub mod data_layer_m10_partition_archival;
+/// M11 closure evidence contracts for release acceptance decision synthesis.
+pub mod data_layer_m11_closure_evidence;
 /// M11 hardening contracts for security/chaos/performance matrix and operator readiness synthesis.
 pub mod data_layer_m11_hardening_readiness;
 /// M2 access-gateway contracts for DID authn/authz, RLS templates, and audit chains.
@@ -273,6 +275,14 @@ pub use data_layer_m10_partition_archival::{
     DATA_LAYER_M10_RECOVERY_METADATA_INCOMPLETE_REASON_CODE,
     DATA_LAYER_M10_RECOVERY_READY_REASON_CODE,
     DATA_LAYER_M10_RECOVERY_STATUS_INELIGIBLE_REASON_CODE,
+};
+pub use data_layer_m11_closure_evidence::{
+    data_layer_m11_evaluate_closure_evidence, DataLayerM11ClosureAcceptanceDecision,
+    DataLayerM11ClosureEvidenceError, DataLayerM11ClosureEvidenceInput,
+    DataLayerM11ClosureEvidenceReport, DATA_LAYER_M11_CLOSURE_ACCEPTED_REASON_CODE,
+    DATA_LAYER_M11_CLOSURE_BLOCK_CRITICAL_SCENARIO_REASON_CODE,
+    DATA_LAYER_M11_CLOSURE_BLOCK_EVIDENCE_GAP_REASON_CODE,
+    DATA_LAYER_M11_CLOSURE_BLOCK_HARDENING_REASON_CODE,
 };
 pub use data_layer_m11_hardening_readiness::{
     DataLayerM11HardeningMatrix, DataLayerM11HardeningMatrixError,

--- a/crates/kamn-core/tests/data_layer_m11_closure_evidence.rs
+++ b/crates/kamn-core/tests/data_layer_m11_closure_evidence.rs
@@ -1,0 +1,188 @@
+use kamn_core::{
+    data_layer_m11_evaluate_closure_evidence, DataLayerM11ClosureAcceptanceDecision,
+    DataLayerM11ClosureEvidenceError, DataLayerM11ClosureEvidenceInput,
+    DataLayerM11HardeningMatrix, DataLayerM11ScenarioDefinition, DataLayerM11ScenarioDomain,
+    DataLayerM11ScenarioOutcomeInput, DataLayerM11ScenarioSeverity, DataLayerM11ScenarioStatus,
+    DataLayerPrdCriticalScenarioConformanceMatrix, DataLayerPrdCriticalScenarioMode,
+    DataLayerPrdCriticalScenarioResultInput, DATA_LAYER_M11_CLOSURE_ACCEPTED_REASON_CODE,
+    DATA_LAYER_M11_CLOSURE_BLOCK_CRITICAL_SCENARIO_REASON_CODE,
+    DATA_LAYER_M11_CLOSURE_BLOCK_EVIDENCE_GAP_REASON_CODE,
+    DATA_LAYER_M11_CLOSURE_BLOCK_HARDENING_REASON_CODE,
+};
+
+fn build_hardening_report(all_passed: bool) -> kamn_core::DataLayerM11OperatorReadinessReport {
+    let mut matrix = DataLayerM11HardeningMatrix::new();
+    matrix
+        .register_scenario(DataLayerM11ScenarioDefinition {
+            scenario_id: "security.authz-negative-matrix".to_owned(),
+            domain: DataLayerM11ScenarioDomain::Security,
+            severity: DataLayerM11ScenarioSeverity::Critical,
+            required: true,
+        })
+        .expect("security scenario should register");
+    matrix
+        .register_scenario(DataLayerM11ScenarioDefinition {
+            scenario_id: "chaos.partition-heal".to_owned(),
+            domain: DataLayerM11ScenarioDomain::Chaos,
+            severity: DataLayerM11ScenarioSeverity::High,
+            required: true,
+        })
+        .expect("chaos scenario should register");
+    matrix
+        .register_scenario(DataLayerM11ScenarioDefinition {
+            scenario_id: "operations.runbook-signoff".to_owned(),
+            domain: DataLayerM11ScenarioDomain::Operations,
+            severity: DataLayerM11ScenarioSeverity::Medium,
+            required: true,
+        })
+        .expect("operations scenario should register");
+
+    matrix
+        .record_outcome(DataLayerM11ScenarioOutcomeInput {
+            scenario_id: "security.authz-negative-matrix".to_owned(),
+            status: if all_passed {
+                DataLayerM11ScenarioStatus::Passed
+            } else {
+                DataLayerM11ScenarioStatus::Failed
+            },
+            evidence_marker: "evidence:security".to_owned(),
+        })
+        .expect("security result should record");
+    matrix
+        .record_outcome(DataLayerM11ScenarioOutcomeInput {
+            scenario_id: "chaos.partition-heal".to_owned(),
+            status: DataLayerM11ScenarioStatus::Passed,
+            evidence_marker: "evidence:chaos".to_owned(),
+        })
+        .expect("chaos result should record");
+    matrix
+        .record_outcome(DataLayerM11ScenarioOutcomeInput {
+            scenario_id: "operations.runbook-signoff".to_owned(),
+            status: DataLayerM11ScenarioStatus::Passed,
+            evidence_marker: "evidence:ops".to_owned(),
+        })
+        .expect("ops result should record");
+
+    matrix
+        .evaluate_operator_readiness()
+        .expect("hardening report should evaluate")
+}
+
+fn build_critical_report(
+    fail_scenario_id: Option<u8>,
+) -> kamn_core::DataLayerPrdCriticalScenarioConformanceReport {
+    let mut matrix = DataLayerPrdCriticalScenarioConformanceMatrix::new();
+    for scenario_id in matrix.required_scenario_ids() {
+        matrix
+            .record_result(DataLayerPrdCriticalScenarioResultInput {
+                scenario_id,
+                passed: fail_scenario_id != Some(scenario_id),
+                orchestration_mode: DataLayerPrdCriticalScenarioMode::RustOnly,
+                evidence_marker: format!("evidence:critical:{scenario_id}"),
+            })
+            .expect("critical scenario should record");
+    }
+    matrix
+        .evaluate_conformance()
+        .expect("critical conformance should evaluate")
+}
+
+#[test]
+fn spec_c01_conformant_closure_evidence_is_accepted() {
+    let report = data_layer_m11_evaluate_closure_evidence(DataLayerM11ClosureEvidenceInput {
+        release_marker: "release-2026-02-18".to_owned(),
+        hardening_report: build_hardening_report(true),
+        critical_scenario_report: build_critical_report(None),
+        performance_budget_met: true,
+        security_signoff_complete: true,
+        chaos_signoff_complete: true,
+    })
+    .expect("closure evaluation should succeed");
+    assert_eq!(
+        report.decision,
+        DataLayerM11ClosureAcceptanceDecision::Accepted
+    );
+    assert_eq!(
+        report.reason_codes,
+        vec![DATA_LAYER_M11_CLOSURE_ACCEPTED_REASON_CODE]
+    );
+}
+
+#[test]
+fn spec_c02_hardening_nogo_blocks_closure_acceptance() {
+    let report = data_layer_m11_evaluate_closure_evidence(DataLayerM11ClosureEvidenceInput {
+        release_marker: "release-2026-02-18".to_owned(),
+        hardening_report: build_hardening_report(false),
+        critical_scenario_report: build_critical_report(None),
+        performance_budget_met: true,
+        security_signoff_complete: true,
+        chaos_signoff_complete: true,
+    })
+    .expect("closure evaluation should succeed");
+    assert_eq!(
+        report.decision,
+        DataLayerM11ClosureAcceptanceDecision::Rejected
+    );
+    assert_eq!(
+        report.reason_codes,
+        vec![DATA_LAYER_M11_CLOSURE_BLOCK_HARDENING_REASON_CODE]
+    );
+}
+
+#[test]
+fn spec_c03_non_conformant_critical_scenario_blocks_closure_acceptance() {
+    let report = data_layer_m11_evaluate_closure_evidence(DataLayerM11ClosureEvidenceInput {
+        release_marker: "release-2026-02-18".to_owned(),
+        hardening_report: build_hardening_report(true),
+        critical_scenario_report: build_critical_report(Some(68)),
+        performance_budget_met: true,
+        security_signoff_complete: true,
+        chaos_signoff_complete: true,
+    })
+    .expect("closure evaluation should succeed");
+    assert_eq!(
+        report.decision,
+        DataLayerM11ClosureAcceptanceDecision::Rejected
+    );
+    assert_eq!(
+        report.reason_codes,
+        vec![DATA_LAYER_M11_CLOSURE_BLOCK_CRITICAL_SCENARIO_REASON_CODE]
+    );
+}
+
+#[test]
+fn spec_c04_missing_performance_or_signoff_evidence_blocks_closure_acceptance() {
+    let report = data_layer_m11_evaluate_closure_evidence(DataLayerM11ClosureEvidenceInput {
+        release_marker: "release-2026-02-18".to_owned(),
+        hardening_report: build_hardening_report(true),
+        critical_scenario_report: build_critical_report(None),
+        performance_budget_met: false,
+        security_signoff_complete: false,
+        chaos_signoff_complete: true,
+    })
+    .expect("closure evaluation should succeed");
+    assert_eq!(
+        report.decision,
+        DataLayerM11ClosureAcceptanceDecision::Rejected
+    );
+    assert_eq!(
+        report.reason_codes,
+        vec![DATA_LAYER_M11_CLOSURE_BLOCK_EVIDENCE_GAP_REASON_CODE]
+    );
+}
+
+#[test]
+fn spec_c05_empty_release_marker_fails_closed() {
+    let error = data_layer_m11_evaluate_closure_evidence(DataLayerM11ClosureEvidenceInput {
+        release_marker: " ".to_owned(),
+        hardening_report: build_hardening_report(true),
+        critical_scenario_report: build_critical_report(None),
+        performance_budget_met: true,
+        security_signoff_complete: true,
+        chaos_signoff_complete: true,
+    });
+    assert!(matches!(
+        error,
+        Err(DataLayerM11ClosureEvidenceError::EmptyReleaseMarker)
+    ));
+}

--- a/specs/5040/plan.md
+++ b/specs/5040/plan.md
@@ -1,26 +1,45 @@
 # Issue #5040 Plan
 
 - Issue: #5040
-- Status: Draft
+- Status: Implemented
 
 ## Approach
-1. Create red tests and conformance assertions for issue scope.
-2. Implement minimal behavior to satisfy ACs.
-3. Refactor for maintainability while preserving deterministic outputs.
-4. Run scoped regression + governance gates before PR.
+1. Add RED conformance tests (`spec_c01`..`spec_c05`) for:
+   - accepted closure when all gates are satisfied,
+   - rejection when hardening/critical scenario evidence blocks,
+   - rejection when performance/signoff gates are incomplete,
+   - fail-closed error for empty release marker.
+2. Implement `data_layer_m11_closure_evidence` module with:
+   - closure input/report models,
+   - deterministic reason-marker taxonomy,
+   - acceptance decision evaluator over M11 + PRD critical evidence.
+3. Re-export closure report APIs in `crates/kamn-core/src/lib.rs`.
+4. Run format/lint/targeted/full regression and shell guardrail evidence.
 
 ## Affected Modules
-- To be refined during implementation based on issue scope.
+- `crates/kamn-core/src/data_layer_m11_closure_evidence.rs` (new)
+- `crates/kamn-core/src/lib.rs` (module + exports)
+- `crates/kamn-core/tests/data_layer_m11_closure_evidence.rs` (new)
+- `specs/5040/spec.md`
+- `specs/5040/plan.md`
+- `specs/5040/tasks.md`
 
 ## Risks and Mitigations
 - Risk level: medium
 - Mitigations:
-  - Keep diffs scoped to issue boundaries.
-  - Prefer Rust-native tests/harnesses to avoid shell-surface growth.
-  - Enforce shell budget and ratio checks when shell surfaces are touched.
+  - Reuse existing M11/PRD report types to avoid duplicative logic.
+  - Keep reason-code ordering deterministic and stable.
+  - Keep implementation Rust-only to avoid shell-surface growth.
 
 ## Interface Contract
-- No dependency/protocol/wire-format change without explicit approval and ADR.
+- Additive public API under `kamn_core::data_layer_m11_closure_evidence::*`.
+- No new dependencies.
+- No protocol/wire-format changes.
 
 ## ADR
-- TBD per implementation decisions.
+- Not required for this scoped additive implementation.
+
+## Verification Summary
+- RED: `cargo test -p kamn-core --test data_layer_m11_closure_evidence` (failed before implementation with unresolved closure evidence symbols).
+- GREEN: `cargo test -p kamn-core --test data_layer_m11_closure_evidence` (5 passed, 0 failed).
+- Regression: `cargo test -p kamn-core` (pass), `cargo clippy -p kamn-core -- -D warnings` (pass), `cargo fmt --check` (pass).

--- a/specs/5040/spec.md
+++ b/specs/5040/spec.md
@@ -1,41 +1,70 @@
 # Issue #5040 Spec
 
 - Title: Subtask: M11 security-chaos-performance closure evidence and acceptance report
-- Status: Draft
+- Status: Implemented
 - Type: subtask
 - Priority: P1
 - Milestone: specs/milestones/r27-45-kamn-data-layer-prd-implementation-and-validation/index.md
 
 ## Problem Statement
-Deliver the highest-risk validation/conformance sub-scope for parent task
+Parent task `#5027` delivered M11 hardening readiness contracts and `#5028`
+delivered PRD critical-scenario conformance contracts, but there is no
+deterministic acceptance report that composes these artifacts into one
+release-closure decision for operator signoff.
+
+PRD mapping:
+- Section 18 closure criteria (security + chaos + performance gates)
+- M11 hardening acceptance requirements
+- Operator readiness acceptance/reporting dependency
 
 ## Acceptance Criteria
-- AC-1: Scope for issue #5040 is decomposed into explicit implementation/integration/validation outcomes with deterministic test evidence.
-- AC-2: The issue maps to PRD sections and conformance scenarios with clear test commands and result expectations.
-- AC-3: Shell-surface impact remains neutral by default (net shell LOC delta <= 0) unless explicitly waived with mitigation issue linkage.
+- AC-1: M11 closure report contract deterministically composes hardening
+  readiness and PRD critical-scenario conformance evidence into an acceptance
+  decision.
+- AC-2: Acceptance report rejects closure when performance/signoff evidence is
+  missing, with stable reason markers.
+- AC-3: Input validation fails closed for empty release marker values.
+- AC-4: New closure report API is exported from `kamn_core`.
+- AC-5: Shell/workflow/python/template LOC remains unchanged
+  (`shell_loc_delta_actual = 0`).
 
 ## Scope
 In scope:
-- Issue-specific delivery for Subtask: M11 security-chaos-performance closure evidence and acceptance report.
-- Contract-driven lifecycle artifacts (`spec.md`, `plan.md`, `tasks.md`).
-- Test-tier mapping and conformance evidence capture.
+- New Rust closure-report module in `kamn-core`.
+- Conformance tests for accept/reject paths and deterministic reason markers.
+- Root export wiring for downstream runbook/ops report surfaces.
 
 Out of scope:
-- Unapproved dependency/protocol changes.
-- Work outside the parent milestone scope.
+- New shell/python/workflow orchestration.
+- New dependencies or protocol/wire-format changes.
+- CI workflow graph changes.
 
 ## Conformance Cases
 | Case | AC | Tier | Input | Expected |
 |---|---|---|---|---|
-| C-01 | AC-1 | Functional | Execute issue task plan for #5040 | Planned implementation/integration steps are completed with evidence |
-| C-02 | AC-2 | Conformance | Run mapped test commands for #5040 | All mapped conformance checks pass and produce deterministic markers |
-| C-03 | AC-3 | Regression | Run shell-surface and ratio governance checks | No net shell-surface regression without waiver |
+| C-01 | AC-1 | Functional | Submit conformant hardening+critical evidence and complete closure gates | Acceptance report returns `Accepted` with stable accept reason marker |
+| C-02 | AC-1/AC-2 | Conformance | Submit `NoGo` hardening evidence | Acceptance report returns `Rejected` with hardening-block reason marker |
+| C-03 | AC-1/AC-2 | Conformance | Submit non-conformant critical-scenario evidence | Acceptance report returns `Rejected` with critical-scenario-block reason marker |
+| C-04 | AC-2 | Regression | Submit incomplete performance/signoff evidence | Acceptance report returns `Rejected` with stable evidence-gap reason markers |
+| C-05 | AC-3 | Regression | Submit empty release marker | Fail-closed typed error |
+| C-06 | AC-5 | Regression | Inspect diff paths and shell guardrails | No shell/workflow/python/template path changes; ratio/ceiling remain GO |
 
 ## Test Mapping
-- `cargo test -p kamn-core` (scoped by issue-specific suites)
-- `bash scripts/ci/check_shell_loc_hard_ceiling.sh` (when shell/python/workflow surface is touched)
-- `bash scripts/ci/check_shell_rust_ratio_guardrail.sh` (when shell/python/workflow surface is touched)
+- `cargo test -p kamn-core --test data_layer_m11_closure_evidence`
+- `cargo test -p kamn-core`
+- `bash scripts/ci/check_shell_rust_ratio_guardrail.sh --repo-root . --output-json /tmp/shell-rust-ratio-guardrail-5040.json`
+- `bash scripts/ci/check_shell_loc_hard_ceiling.sh --repo-root . --output-json /tmp/shell-loc-hard-ceiling-5040.json`
+
+## AC Verification
+| AC | ✅/❌ | Test(s) |
+|---|---|---|
+| AC-1 | ✅ | `spec_c01_conformant_closure_evidence_is_accepted`, `spec_c02_hardening_nogo_blocks_closure_acceptance`, `spec_c03_non_conformant_critical_scenario_blocks_closure_acceptance` |
+| AC-2 | ✅ | `spec_c04_missing_performance_or_signoff_evidence_blocks_closure_acceptance` |
+| AC-3 | ✅ | `spec_c05_empty_release_marker_fails_closed` |
+| AC-4 | ✅ | `cargo test -p kamn-core --test data_layer_m11_closure_evidence` imports closure API from `kamn_core` root |
+| AC-5 | ✅ | `bash scripts/ci/check_shell_rust_ratio_guardrail.sh ...` and `bash scripts/ci/check_shell_loc_hard_ceiling.sh ...` with Rust-only diff |
 
 ## Success Metrics
-- Issue #5040 reaches `Status: Implemented` with ACs mapped to passing conformance evidence.
-- Shell-to-Rust ratio guardrails remain within thresholds.
+- Closure acceptance API is exported and consumed from `kamn_core`.
+- All ACs map to passing `spec_c0x_*` tests with deterministic reason markers.
+- Shell-to-Rust ratio direction remains improved/neutral through Rust-only changes.

--- a/specs/5040/tasks.md
+++ b/specs/5040/tasks.md
@@ -1,12 +1,12 @@
 # Issue #5040 Tasks
 
 - Issue: #5040
-- Status: Draft
+- Status: Done
 
 ## Ordered Tasks
-- [ ] T1 (Red): add failing tests derived from spec conformance cases.
-- [ ] T2 (Green): implement minimum code path to satisfy ACs.
-- [ ] T3 (Refactor): improve structure/readability while preserving behavior.
-- [ ] T4 (Regression): run scoped functional/integration/regression checks.
-- [ ] T5 (Governance): if shell/python/workflow/template changed, run shell budget + ratio guardrails and report deltas.
-- [ ] T6 (Verify): finalize AC mapping and set lifecycle status markers.
+- [x] T1 (Red): add `spec_c01`..`spec_c05` closure-evidence tests for acceptance/rejection gates and fail-closed input validation.
+- [x] T2 (Green): implement `data_layer_m11_closure_evidence` contracts and report evaluator.
+- [x] T3 (Refactor): tighten deterministic reason-marker ordering and evidence projection consistency.
+- [x] T4 (Regression): run `cargo fmt --check`, `cargo clippy -p kamn-core -- -D warnings`, `cargo test -p kamn-core --test data_layer_m11_closure_evidence`, and `cargo test -p kamn-core`.
+- [x] T5 (Governance): confirm zero shell/python/workflow/template delta and record shell guardrail evidence.
+- [x] T6 (Verify): set spec lifecycle status to `Implemented`, map ACs to tests, and post issue closure evidence.


### PR DESCRIPTION
## Summary
- Implemented M11 closure evidence contracts that deterministically compose hardening readiness, critical-scenario conformance, and signoff/performance gates into one acceptance report.
- Added fail-closed input validation for empty release markers and stable reason-marker taxonomy for accepted/rejected outcomes.
- Added `spec_c01`..`spec_c05` closure conformance tests and finalized `specs/5040/{spec,plan,tasks}.md` to `Implemented`.

## Linked Issues
- Closes #5040
- Milestone: `specs/milestones/r27-45-kamn-data-layer-prd-implementation-and-validation/index.md`
- Spec: `specs/5040/spec.md`
- Plan: `specs/5040/plan.md`
- Tasks: `specs/5040/tasks.md`

## Validation
- [x] Relevant local checks passed.
- [x] CI fast-gate checks expected to pass.

Commands run:
- `cargo test -p kamn-core --test data_layer_m11_closure_evidence` (RED then GREEN)
- `cargo fmt --check`
- `cargo clippy -p kamn-core -- -D warnings`
- `cargo test -p kamn-core`
- `bash scripts/ci/check_shell_rust_ratio_guardrail.sh --repo-root . --output-json /tmp/shell-rust-ratio-guardrail-5040.json`
- `bash scripts/ci/check_shell_loc_hard_ceiling.sh --repo-root . --output-json /tmp/shell-loc-hard-ceiling-5040.json`

## CI Impact Declaration
- [x] No CI scope impact.
- [ ] CI scope impact present (explain below).

## Shell-Surface Impact Declaration
- [x] No shell-surface impact.
- [ ] Shell-surface impact present (explain below).

Shell-surface impact details:
- shell_loc_delta_actual: 0
- rust_loc_delta_actual: 325
- shell_to_rust_ratio_delta_actual: -0.002162
- shell_surface_ratio_target_status: improved
- shell_surface_mitigation_issue: None

## Spec Verification (AC -> tests)
| AC | ✅/❌ | Test(s) |
|---|---|---|
| AC-1 deterministic closure acceptance composition | ✅ | `spec_c01_conformant_closure_evidence_is_accepted`, `spec_c02_hardening_nogo_blocks_closure_acceptance`, `spec_c03_non_conformant_critical_scenario_blocks_closure_acceptance` |
| AC-2 evidence-gap rejection with stable markers | ✅ | `spec_c04_missing_performance_or_signoff_evidence_blocks_closure_acceptance` |
| AC-3 fail-closed empty release marker validation | ✅ | `spec_c05_empty_release_marker_fails_closed` |
| AC-4 closure API exported from `kamn_core` | ✅ | `cargo test -p kamn-core --test data_layer_m11_closure_evidence` imports closure APIs from crate root |
| AC-5 shell/workflow/python/template unchanged | ✅ | no shell/workflow/python/template files changed + guardrail scripts pass |

## TDD Evidence
- RED:
  - `cargo test -p kamn-core --test data_layer_m11_closure_evidence`
  - failed before implementation with unresolved closure evidence imports (`E0432`).
- GREEN:
  - `cargo test -p kamn-core --test data_layer_m11_closure_evidence`
  - `5 passed; 0 failed`.
- REGRESSION:
  - `cargo test -p kamn-core` passed.

## Test Tiers
| Tier | ✅/❌/N/A | Tests | N/A Why |
|---|---|---|---|
| Unit | ✅ | `spec_c01`..`spec_c05` on closure report APIs | |
| Property | N/A | | No randomized invariant expansion needed for this scoped composition evaluator |
| Contract/DbC | N/A | | No `contracts` annotations in this module; fail-closed behavior covered by conformance tests |
| Snapshot | N/A | | No snapshot artifact in this change |
| Functional | ✅ | `spec_c01`, `spec_c02`, `spec_c03` | |
| Conformance | ✅ | `spec_c01`..`spec_c05` | |
| Integration | ✅ | `cargo test -p kamn-core` | |
| Fuzz | N/A | | No untrusted parser/input boundary introduced |
| Mutation | N/A | `cargo mutants --in-diff` attempted | `cargo-mutants` not installed in environment (`no such command: mutants`) |
| Regression | ✅ | `spec_c04`, `spec_c05`, full crate regression | |
| Performance | N/A | | No hotspot/perf-sensitive path changed |

## Mutation
- `cargo mutants --in-diff` attempted; tool unavailable in environment (`error: no such command: mutants`).

## Risks/Rollback
- Risk: low; additive module and exports only.
- Rollback: revert this PR to remove closure evidence module/tests and exports.

## Docs/ADR
- Updated: `specs/5040/spec.md`, `specs/5040/plan.md`, `specs/5040/tasks.md`
- ADR: not required (scoped additive implementation, no new dependency/protocol change).
