### PR TITLE
feat(kolme): add preflight checker/runbook parity outputs (#4151)

### DIFF
--- a/crates/kamn-core/tests/kolme_devnet_ops_docs.rs
+++ b/crates/kamn-core/tests/kolme_devnet_ops_docs.rs
@@ -263,6 +263,49 @@ fn deploy_compat_contains_rotation_preflight_quorum_parity_and_custody_tamper_ma
 }
 
 #[test]
+fn deploy_compat_contains_deployment_preflight_checker_output_runbook_sync_markers() {
+    assert!(DEPLOY_COMPAT.contains(
+        "## Deployment Preflight Fail-Closed Checker Output and Runbook Marker Synchronization (Issue #4151)"
+    ));
+    assert!(DEPLOY_COMPAT.contains("deployment_preflight_marker_contract_status=verified|failed"));
+    assert!(DEPLOY_COMPAT.contains(
+        "deployment_preflight_marker_contract_version=kamn.kolme.local-live-deployment-preflight-marker-contract.v1"
+    ));
+    assert!(DEPLOY_COMPAT.contains(
+        "deployment_preflight_required_markers_csv=rotation_preflight_reason_taxonomy_version,rotation_preflight_reason_codes_csv,rotation_preflight_reason_codes_value,custody_reason_taxonomy_version,custody_reason_codes_csv,custody_reason_codes_value"
+    ));
+    assert!(DEPLOY_COMPAT.contains("deployment_preflight_schema_parity_status=verified|failed"));
+    assert!(DEPLOY_COMPAT.contains(
+        "deployment_preflight_schema_reason_taxonomy_version=kamn.kolme.local-live-deployment-preflight-schema-parity-reason-taxonomy.v1"
+    ));
+    assert!(DEPLOY_COMPAT.contains(
+        "deployment_preflight_schema_reason_codes_csv=deployment_preflight_required_marker_missing,deployment_preflight_schema_parity_mismatch,deployment_preflight_reason_taxonomy_version_mismatch,deployment_preflight_reason_codes_csv_mismatch,deployment_preflight_reason_codes_value_mismatch"
+    ));
+    assert!(DEPLOY_COMPAT.contains("deployment_preflight_schema_reason_code=none|<reason>"));
+    assert!(
+        DEPLOY_COMPAT.contains("deployment_preflight_runbook_marker_parity_status=verified|failed")
+    );
+    assert!(DEPLOY_COMPAT.contains(
+        "deployment_preflight_runbook_reason_taxonomy_version=kamn.kolme.local-live-deployment-preflight-runbook-reason-taxonomy.v1"
+    ));
+    assert!(DEPLOY_COMPAT.contains(
+        "deployment_preflight_runbook_reason_codes_csv=deployment_preflight_taxonomy_mapping_drift_detected,runbook_marker_parity_mismatch"
+    ));
+    assert!(DEPLOY_COMPAT.contains("deployment_preflight_runbook_reason_code=none|<reason>"));
+    assert!(DEPLOY_COMPAT.contains("deployment_preflight_required_marker_missing"));
+    assert!(DEPLOY_COMPAT.contains("deployment_preflight_schema_parity_mismatch"));
+    assert!(DEPLOY_COMPAT.contains("deployment_preflight_reason_taxonomy_version_mismatch"));
+    assert!(DEPLOY_COMPAT.contains("deployment_preflight_reason_codes_value_mismatch"));
+    assert!(DEPLOY_COMPAT.contains("deployment_preflight_taxonomy_mapping_drift_detected"));
+    assert!(DEPLOY_COMPAT.contains("runbook_marker_parity_mismatch"));
+    assert!(DEPLOY_COMPAT.contains("test_check_local_kolme_live_deployment_preflight_policy.sh"));
+    assert!(DEPLOY_COMPAT.contains(
+        "check_local_kolme_live_deployment_preflight_policy.py --report-file /tmp/kolme-local-live-deployment-preflight-summary.json --expected-final-decision GO --ci-fast-gate PASS --output-json /tmp/kolme-local-live-deployment-preflight-policy.json"
+    ));
+    assert!(DEPLOY_COMPAT.contains("Regression: #4151"));
+}
+
+#[test]
 fn deploy_compat_contains_local_full_stack_harness_taxonomy_runbook_parity_markers() {
     assert!(DEPLOY_COMPAT.contains(
         "## Local Full-Stack Harness Taxonomy and Runbook Marker Parity Contracts (Issue #4197)"

--- a/docs/deploy/kolme_devnet_ops.md
+++ b/docs/deploy/kolme_devnet_ops.md
@@ -62,6 +62,44 @@ Validation commands:
 - `Regression: #4169`
 - `Regression: #4170`
 
+## Deployment Preflight Fail-Closed Checker Output and Runbook Marker Synchronization (Issue #4151)
+
+Deployment preflight policy output and runbook marker declarations must stay synchronized so
+marker/schema drift is surfaced as deterministic `NO-GO`.
+
+Required checker output markers:
+
+- `deployment_preflight_marker_contract_status=verified|failed`
+- `deployment_preflight_marker_contract_version=kamn.kolme.local-live-deployment-preflight-marker-contract.v1`
+- `deployment_preflight_required_markers_csv=rotation_preflight_reason_taxonomy_version,rotation_preflight_reason_codes_csv,rotation_preflight_reason_codes_value,custody_reason_taxonomy_version,custody_reason_codes_csv,custody_reason_codes_value`
+- `deployment_preflight_schema_parity_status=verified|failed`
+- `deployment_preflight_schema_reason_taxonomy_version=kamn.kolme.local-live-deployment-preflight-schema-parity-reason-taxonomy.v1`
+- `deployment_preflight_schema_reason_codes_csv=deployment_preflight_required_marker_missing,deployment_preflight_schema_parity_mismatch,deployment_preflight_reason_taxonomy_version_mismatch,deployment_preflight_reason_codes_csv_mismatch,deployment_preflight_reason_codes_value_mismatch`
+- `deployment_preflight_schema_reason_code=none|<reason>`
+
+Required checker/runbook parity markers:
+
+- `deployment_preflight_runbook_marker_parity_status=verified|failed`
+- `deployment_preflight_runbook_reason_taxonomy_version=kamn.kolme.local-live-deployment-preflight-runbook-reason-taxonomy.v1`
+- `deployment_preflight_runbook_reason_codes_csv=deployment_preflight_taxonomy_mapping_drift_detected,runbook_marker_parity_mismatch`
+- `deployment_preflight_runbook_reason_code=none|<reason>`
+
+Fail-closed drift reasons:
+
+- `deployment_preflight_required_marker_missing`
+- `deployment_preflight_schema_parity_mismatch`
+- `deployment_preflight_reason_taxonomy_version_mismatch`
+- `deployment_preflight_reason_codes_value_mismatch`
+- `deployment_preflight_taxonomy_mapping_drift_detected`
+- `runbook_marker_parity_mismatch`
+
+Validation commands:
+
+- `bash scripts/kolme/test_check_local_kolme_live_deployment_preflight_policy.sh`
+- `python3 scripts/kolme/check_local_kolme_live_deployment_preflight_policy.py --report-file /tmp/kolme-local-live-deployment-preflight-summary.json --expected-final-decision GO --ci-fast-gate PASS --output-json /tmp/kolme-local-live-deployment-preflight-policy.json`
+
+- `Regression: #4151`
+
 ## Kolme Upgrade Compatibility Taxonomy and Runbook Marker Parity Contracts (Issues #4182, #4183)
 
 Kolme upgrade compatibility governance remains deterministic only when compatibility checker

--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -939,6 +939,18 @@ JSON`
     - `contracts.signer_key_source_production_requirement_reason_code=signer_key_source_production_managed_external_required`
     - `contracts.signer_rotation_freshness_max_delta=2`
     - `contracts.signer_rotation_stale_rejected=true`
+  - policy output includes deterministic marker/runbook parity outputs:
+    - `deployment_preflight_marker_contract_status=verified|failed`
+    - `deployment_preflight_marker_contract_version=kamn.kolme.local-live-deployment-preflight-marker-contract.v1`
+    - `deployment_preflight_required_markers_csv=rotation_preflight_reason_taxonomy_version,rotation_preflight_reason_codes_csv,rotation_preflight_reason_codes_value,custody_reason_taxonomy_version,custody_reason_codes_csv,custody_reason_codes_value`
+    - `deployment_preflight_schema_parity_status=verified|failed`
+    - `deployment_preflight_schema_reason_taxonomy_version=kamn.kolme.local-live-deployment-preflight-schema-parity-reason-taxonomy.v1`
+    - `deployment_preflight_schema_reason_codes_csv=deployment_preflight_required_marker_missing,deployment_preflight_schema_parity_mismatch,deployment_preflight_reason_taxonomy_version_mismatch,deployment_preflight_reason_codes_csv_mismatch,deployment_preflight_reason_codes_value_mismatch`
+    - `deployment_preflight_schema_reason_code=none|<reason>`
+    - `deployment_preflight_runbook_marker_parity_status=verified|failed`
+    - `deployment_preflight_runbook_reason_taxonomy_version=kamn.kolme.local-live-deployment-preflight-runbook-reason-taxonomy.v1`
+    - `deployment_preflight_runbook_reason_codes_csv=deployment_preflight_taxonomy_mapping_drift_detected,runbook_marker_parity_mismatch`
+    - `deployment_preflight_runbook_reason_code=none|<reason>`
 - Fail-closed reasons include:
   - `runtime_mode_mismatch`
   - `signer_profile_mismatch`
@@ -981,6 +993,12 @@ JSON`
   - `signer_provenance_missing`
   - `signer_provenance_sha256_invalid`
   - `signer_rotation_epoch_stale`
+  - `deployment_preflight_required_marker_missing`
+  - `deployment_preflight_schema_parity_mismatch`
+  - `deployment_preflight_reason_taxonomy_version_mismatch`
+  - `deployment_preflight_reason_codes_value_mismatch`
+  - `deployment_preflight_taxonomy_mapping_drift_detected`
+  - `runbook_marker_parity_mismatch`
 - Cost policy:
   - lane is lightweight and `ci_fast_gate_eligible=true`.
   - no local-heavy opt-in is required for deployment preflight checks.
@@ -991,6 +1009,7 @@ JSON`
   - signer quorum evidence schema + custody digest parity remains fail-closed (`Regression: #2301`).
   - runtime/deployment shared signer-attestation schema + reason-code parity remains fail-closed (`Regression: #2326`).
   - replay/tamper/stale-signer attestation regression matrix remains fail-closed (`Regression: #2327`).
+  - deployment preflight checker marker/runbook parity remains fail-closed (`Regression: #4151`).
 
 ## Managed Signer Backend SLO Telemetry Lane (Issue #2436)
 

--- a/scripts/kolme/check_local_kolme_live_deployment_preflight_policy.py
+++ b/scripts/kolme/check_local_kolme_live_deployment_preflight_policy.py
@@ -74,6 +74,41 @@ SIGNER_CONFIG_REASON_CODES = (
     "fallback_signer_secret_remediation_missing",
 )
 SIGNER_CONFIG_REASON_CODES_CSV = ",".join(SIGNER_CONFIG_REASON_CODES)
+DEPLOYMENT_PREFLIGHT_MARKER_CONTRACT_VERSION = (
+    "kamn.kolme.local-live-deployment-preflight-marker-contract.v1"
+)
+DEPLOYMENT_PREFLIGHT_REQUIRED_MARKERS = (
+    "rotation_preflight_reason_taxonomy_version",
+    "rotation_preflight_reason_codes_csv",
+    "rotation_preflight_reason_codes_value",
+    "custody_reason_taxonomy_version",
+    "custody_reason_codes_csv",
+    "custody_reason_codes_value",
+)
+DEPLOYMENT_PREFLIGHT_REQUIRED_MARKERS_CSV = ",".join(DEPLOYMENT_PREFLIGHT_REQUIRED_MARKERS)
+DEPLOYMENT_PREFLIGHT_SCHEMA_REASON_TAXONOMY_VERSION = (
+    "kamn.kolme.local-live-deployment-preflight-schema-parity-reason-taxonomy.v1"
+)
+DEPLOYMENT_PREFLIGHT_SCHEMA_REASON_CODES = (
+    "deployment_preflight_required_marker_missing",
+    "deployment_preflight_schema_parity_mismatch",
+    "deployment_preflight_reason_taxonomy_version_mismatch",
+    "deployment_preflight_reason_codes_csv_mismatch",
+    "deployment_preflight_reason_codes_value_mismatch",
+)
+DEPLOYMENT_PREFLIGHT_SCHEMA_REASON_CODES_CSV = ",".join(
+    DEPLOYMENT_PREFLIGHT_SCHEMA_REASON_CODES
+)
+DEPLOYMENT_PREFLIGHT_RUNBOOK_REASON_TAXONOMY_VERSION = (
+    "kamn.kolme.local-live-deployment-preflight-runbook-reason-taxonomy.v1"
+)
+DEPLOYMENT_PREFLIGHT_RUNBOOK_REASON_CODES = (
+    "deployment_preflight_taxonomy_mapping_drift_detected",
+    "runbook_marker_parity_mismatch",
+)
+DEPLOYMENT_PREFLIGHT_RUNBOOK_REASON_CODES_CSV = ",".join(
+    DEPLOYMENT_PREFLIGHT_RUNBOOK_REASON_CODES
+)
 
 
 def observed_rotation_preflight_reason_codes_value(reason_codes: list[str]) -> str:
@@ -105,6 +140,155 @@ def observed_signer_config_reason_codes_value(reason_codes: list[str]) -> str:
     if not observed:
         return "none"
     return ",".join(observed)
+
+
+def read_nested_value(payload: object, path: tuple[str, ...]) -> object | None:
+    current = payload
+    for segment in path:
+        if not isinstance(current, dict) or segment not in current:
+            return None
+        current = current[segment]
+    return current
+
+
+def evaluate_deployment_preflight_marker_contract(report: dict[str, object]) -> list[str]:
+    reason_codes: list[str] = []
+    required_marker_paths = (
+        ("runtime_signer_attestation_schema_version",),
+        ("runtime_signer_drift_telemetry_schema_version",),
+        ("runtime_signer_drift_thresholds_schema_version",),
+        ("signer_key_source_contract_version",),
+        ("contracts", "runtime_signer_attestation_schema_version"),
+        ("contracts", "runtime_signer_drift_telemetry_schema_version"),
+        ("contracts", "runtime_signer_drift_thresholds_schema_version"),
+        ("contracts", "signer_key_source_contract_version"),
+        ("contracts", "required_signer_key_source_for_production"),
+    )
+
+    for marker_path in required_marker_paths:
+        marker_value = read_nested_value(report, marker_path)
+        if marker_value is None:
+            reason_codes.append("deployment_preflight_required_marker_missing")
+            break
+        if isinstance(marker_value, str) and not marker_value.strip():
+            reason_codes.append("deployment_preflight_required_marker_missing")
+            break
+
+    attestation_schema = read_nested_value(
+        report, ("runtime_signer_attestation_schema_version",)
+    )
+    attestation_schema_contract = read_nested_value(
+        report, ("contracts", "runtime_signer_attestation_schema_version")
+    )
+    drift_schema = read_nested_value(report, ("runtime_signer_drift_telemetry_schema_version",))
+    drift_schema_contract = read_nested_value(
+        report, ("contracts", "runtime_signer_drift_telemetry_schema_version")
+    )
+    thresholds_schema = read_nested_value(
+        report, ("runtime_signer_drift_thresholds_schema_version",)
+    )
+    thresholds_schema_contract = read_nested_value(
+        report, ("contracts", "runtime_signer_drift_thresholds_schema_version")
+    )
+    signer_key_source_contract_version = read_nested_value(
+        report, ("signer_key_source_contract_version",)
+    )
+    signer_key_source_contract_version_contract = read_nested_value(
+        report, ("contracts", "signer_key_source_contract_version")
+    )
+
+    parity_pairs = (
+        (attestation_schema, attestation_schema_contract),
+        (drift_schema, drift_schema_contract),
+        (thresholds_schema, thresholds_schema_contract),
+        (
+            signer_key_source_contract_version,
+            signer_key_source_contract_version_contract,
+        ),
+    )
+    for observed_value, contract_value in parity_pairs:
+        if (
+            isinstance(observed_value, str)
+            and observed_value.strip()
+            and isinstance(contract_value, str)
+            and contract_value.strip()
+            and observed_value != contract_value
+        ):
+            reason_codes.append("deployment_preflight_schema_parity_mismatch")
+            break
+
+    expected_versions = (
+        (attestation_schema, RUNTIME_SIGNER_ATTESTATION_SCHEMA_VERSION),
+        (attestation_schema_contract, RUNTIME_SIGNER_ATTESTATION_SCHEMA_VERSION),
+        (drift_schema, RUNTIME_SIGNER_DRIFT_TELEMETRY_SCHEMA_VERSION),
+        (drift_schema_contract, RUNTIME_SIGNER_DRIFT_TELEMETRY_SCHEMA_VERSION),
+        (thresholds_schema, RUNTIME_SIGNER_DRIFT_THRESHOLDS_SCHEMA_VERSION),
+        (thresholds_schema_contract, RUNTIME_SIGNER_DRIFT_THRESHOLDS_SCHEMA_VERSION),
+        (signer_key_source_contract_version, SIGNER_KEY_SOURCE_CONTRACT_VERSION),
+        (
+            signer_key_source_contract_version_contract,
+            SIGNER_KEY_SOURCE_CONTRACT_VERSION,
+        ),
+    )
+    for observed_value, expected_value in expected_versions:
+        if (
+            isinstance(observed_value, str)
+            and observed_value.strip()
+            and observed_value != expected_value
+        ):
+            reason_codes.append("deployment_preflight_reason_taxonomy_version_mismatch")
+            break
+
+    if (
+        ROTATION_PREFLIGHT_REASON_CODES_CSV
+        != ",".join(ROTATION_PREFLIGHT_REASON_CODES)
+        or CUSTODY_REASON_CODES_CSV != ",".join(CUSTODY_REASON_CODES)
+        or SIGNER_CONFIG_REASON_CODES_CSV != ",".join(SIGNER_CONFIG_REASON_CODES)
+    ):
+        reason_codes.append("deployment_preflight_reason_codes_csv_mismatch")
+
+    observed_status = report.get("status")
+    observed_reason_code = report.get("reason_code")
+    if observed_status == "ok" and observed_reason_code not in (
+        "dry_run_no_commands_executed",
+        "deployment_preflight_passed",
+    ):
+        reason_codes.append("deployment_preflight_reason_codes_value_mismatch")
+    if observed_status == "fail" and observed_reason_code in (
+        "dry_run_no_commands_executed",
+        "deployment_preflight_passed",
+    ):
+        reason_codes.append("deployment_preflight_reason_codes_value_mismatch")
+
+    normalized_reason_codes: list[str] = []
+    for reason_code in reason_codes:
+        if reason_code not in normalized_reason_codes:
+            normalized_reason_codes.append(reason_code)
+    return normalized_reason_codes
+
+
+def observed_deployment_preflight_schema_reason_code(reason_codes: list[str]) -> str:
+    for reason_code in DEPLOYMENT_PREFLIGHT_SCHEMA_REASON_CODES:
+        if reason_code in reason_codes:
+            return reason_code
+    return "none"
+
+
+def observed_deployment_preflight_runbook_reason_code(reason_codes: list[str]) -> str:
+    taxonomy_mapping_reasons = {
+        "deployment_preflight_reason_taxonomy_version_mismatch",
+        "deployment_preflight_reason_codes_csv_mismatch",
+    }
+    parity_reasons = {
+        "deployment_preflight_required_marker_missing",
+        "deployment_preflight_schema_parity_mismatch",
+        "deployment_preflight_reason_codes_value_mismatch",
+    }
+    if any(reason in reason_codes for reason in taxonomy_mapping_reasons):
+        return "deployment_preflight_taxonomy_mapping_drift_detected"
+    if any(reason in reason_codes for reason in parity_reasons):
+        return "runbook_marker_parity_mismatch"
+    return "none"
 
 
 def evaluate_runtime_signer_attestation_bundle(
@@ -1032,6 +1216,8 @@ def evaluate(report: dict[str, object], args: argparse.Namespace) -> tuple[str, 
             ):
                 reason_codes.append(matrix_reason_code)
 
+    reason_codes.extend(evaluate_deployment_preflight_marker_contract(report))
+
     for required_reason_code in args.require_reason_code:
         if reason_code != required_reason_code:
             reason_codes.append(f"required_reason_code_missing:{required_reason_code}")
@@ -1072,6 +1258,27 @@ def main() -> int:
         "rotation_preflight_reason_codes_value": observed_rotation_preflight_reason_codes_value(
             reason_codes
         ),
+        "deployment_preflight_marker_contract_status": "verified"
+        if observed_deployment_preflight_schema_reason_code(reason_codes) == "none"
+        else "failed",
+        "deployment_preflight_marker_contract_version": DEPLOYMENT_PREFLIGHT_MARKER_CONTRACT_VERSION,
+        "deployment_preflight_required_markers_csv": DEPLOYMENT_PREFLIGHT_REQUIRED_MARKERS_CSV,
+        "deployment_preflight_schema_parity_status": "verified"
+        if observed_deployment_preflight_schema_reason_code(reason_codes) == "none"
+        else "failed",
+        "deployment_preflight_schema_reason_taxonomy_version": DEPLOYMENT_PREFLIGHT_SCHEMA_REASON_TAXONOMY_VERSION,
+        "deployment_preflight_schema_reason_codes_csv": DEPLOYMENT_PREFLIGHT_SCHEMA_REASON_CODES_CSV,
+        "deployment_preflight_schema_reason_code": observed_deployment_preflight_schema_reason_code(
+            reason_codes
+        ),
+        "deployment_preflight_runbook_marker_parity_status": "verified"
+        if observed_deployment_preflight_runbook_reason_code(reason_codes) == "none"
+        else "failed",
+        "deployment_preflight_runbook_reason_taxonomy_version": DEPLOYMENT_PREFLIGHT_RUNBOOK_REASON_TAXONOMY_VERSION,
+        "deployment_preflight_runbook_reason_codes_csv": DEPLOYMENT_PREFLIGHT_RUNBOOK_REASON_CODES_CSV,
+        "deployment_preflight_runbook_reason_code": observed_deployment_preflight_runbook_reason_code(
+            reason_codes
+        ),
         "custody_reason_taxonomy_version": CUSTODY_REASON_TAXONOMY_VERSION,
         "custody_reason_codes_csv": CUSTODY_REASON_CODES_CSV,
         "custody_reason_codes_value": observed_custody_reason_codes_value(reason_codes),
@@ -1103,6 +1310,50 @@ def main() -> int:
     print(
         "rotation_preflight_reason_codes_value="
         f"{observed_rotation_preflight_reason_codes_value(reason_codes)}"
+    )
+    print(
+        "deployment_preflight_marker_contract_status="
+        f"{output['deployment_preflight_marker_contract_status']}"
+    )
+    print(
+        "deployment_preflight_marker_contract_version="
+        f"{DEPLOYMENT_PREFLIGHT_MARKER_CONTRACT_VERSION}"
+    )
+    print(
+        "deployment_preflight_required_markers_csv="
+        f"{DEPLOYMENT_PREFLIGHT_REQUIRED_MARKERS_CSV}"
+    )
+    print(
+        "deployment_preflight_schema_parity_status="
+        f"{output['deployment_preflight_schema_parity_status']}"
+    )
+    print(
+        "deployment_preflight_schema_reason_taxonomy_version="
+        f"{DEPLOYMENT_PREFLIGHT_SCHEMA_REASON_TAXONOMY_VERSION}"
+    )
+    print(
+        "deployment_preflight_schema_reason_codes_csv="
+        f"{DEPLOYMENT_PREFLIGHT_SCHEMA_REASON_CODES_CSV}"
+    )
+    print(
+        "deployment_preflight_schema_reason_code="
+        f"{output['deployment_preflight_schema_reason_code']}"
+    )
+    print(
+        "deployment_preflight_runbook_marker_parity_status="
+        f"{output['deployment_preflight_runbook_marker_parity_status']}"
+    )
+    print(
+        "deployment_preflight_runbook_reason_taxonomy_version="
+        f"{DEPLOYMENT_PREFLIGHT_RUNBOOK_REASON_TAXONOMY_VERSION}"
+    )
+    print(
+        "deployment_preflight_runbook_reason_codes_csv="
+        f"{DEPLOYMENT_PREFLIGHT_RUNBOOK_REASON_CODES_CSV}"
+    )
+    print(
+        "deployment_preflight_runbook_reason_code="
+        f"{output['deployment_preflight_runbook_reason_code']}"
     )
     print(f"custody_reason_taxonomy_version={CUSTODY_REASON_TAXONOMY_VERSION}")
     print(f"custody_reason_codes_csv={CUSTODY_REASON_CODES_CSV}")

--- a/scripts/kolme/test_check_local_kolme_live_deployment_preflight_policy.sh
+++ b/scripts/kolme/test_check_local_kolme_live_deployment_preflight_policy.sh
@@ -38,6 +38,16 @@ if ! grep -q "check_local_kolme_live_deployment_preflight_policy.py" "$DOC_FILE"
   exit 1
 fi
 
+if ! grep -q "deployment_preflight_marker_contract_status=verified" "$DOC_FILE"; then
+  echo "expected Kolme devnet ops docs to include deployment preflight marker contract status marker" >&2
+  exit 1
+fi
+
+if ! grep -q "deployment_preflight_runbook_marker_parity_status=verified" "$DOC_FILE"; then
+  echo "expected Kolme devnet ops docs to include deployment preflight runbook marker parity status marker" >&2
+  exit 1
+fi
+
 if ! grep -q "check_local_kolme_live_deployment_preflight_policy.py" "$CI_DOC_FILE"; then
   echo "expected CI strategy docs to reference deployment preflight policy checker command" >&2
   exit 1
@@ -331,6 +341,28 @@ if report.get("signer_config_reason_codes_csv") != "signer_secret_missing,signer
     raise SystemExit("expected deterministic signer_config_reason_codes_csv marker")
 if report.get("signer_config_reason_codes_value") != "none":
     raise SystemExit("expected signer_config_reason_codes_value=none for GO deployment preflight report")
+if report.get("deployment_preflight_marker_contract_status") != "verified":
+    raise SystemExit("expected deployment_preflight_marker_contract_status=verified for GO deployment preflight report")
+if report.get("deployment_preflight_marker_contract_version") != "kamn.kolme.local-live-deployment-preflight-marker-contract.v1":
+    raise SystemExit("expected deterministic deployment_preflight_marker_contract_version marker")
+if report.get("deployment_preflight_required_markers_csv") != "rotation_preflight_reason_taxonomy_version,rotation_preflight_reason_codes_csv,rotation_preflight_reason_codes_value,custody_reason_taxonomy_version,custody_reason_codes_csv,custody_reason_codes_value":
+    raise SystemExit("expected deterministic deployment_preflight_required_markers_csv marker")
+if report.get("deployment_preflight_schema_parity_status") != "verified":
+    raise SystemExit("expected deployment_preflight_schema_parity_status=verified for GO deployment preflight report")
+if report.get("deployment_preflight_schema_reason_taxonomy_version") != "kamn.kolme.local-live-deployment-preflight-schema-parity-reason-taxonomy.v1":
+    raise SystemExit("expected deterministic deployment_preflight_schema_reason_taxonomy_version marker")
+if report.get("deployment_preflight_schema_reason_codes_csv") != "deployment_preflight_required_marker_missing,deployment_preflight_schema_parity_mismatch,deployment_preflight_reason_taxonomy_version_mismatch,deployment_preflight_reason_codes_csv_mismatch,deployment_preflight_reason_codes_value_mismatch":
+    raise SystemExit("expected deterministic deployment_preflight_schema_reason_codes_csv marker")
+if report.get("deployment_preflight_schema_reason_code") != "none":
+    raise SystemExit("expected deployment_preflight_schema_reason_code=none for GO deployment preflight report")
+if report.get("deployment_preflight_runbook_marker_parity_status") != "verified":
+    raise SystemExit("expected deployment_preflight_runbook_marker_parity_status=verified for GO deployment preflight report")
+if report.get("deployment_preflight_runbook_reason_taxonomy_version") != "kamn.kolme.local-live-deployment-preflight-runbook-reason-taxonomy.v1":
+    raise SystemExit("expected deterministic deployment_preflight_runbook_reason_taxonomy_version marker")
+if report.get("deployment_preflight_runbook_reason_codes_csv") != "deployment_preflight_taxonomy_mapping_drift_detected,runbook_marker_parity_mismatch":
+    raise SystemExit("expected deterministic deployment_preflight_runbook_reason_codes_csv marker")
+if report.get("deployment_preflight_runbook_reason_code") != "none":
+    raise SystemExit("expected deployment_preflight_runbook_reason_code=none for GO deployment preflight report")
 PY
 
 python3 - "$TMP_REPORT_OK" "$TMP_REPORT_MATRIX_WARN" "$TMP_REPORT_MATRIX_FAIL" "$TMP_REPORT_BUDGET_BYPASS" "$TMP_REPORT_BUDGET_REASON_MISMATCH" <<'PY'
@@ -1194,6 +1226,41 @@ if ! grep -q "runtime_signer_drift_telemetry_missing" "$TMP_ERR"; then
   echo "expected runtime signer drift telemetry missing reason for deployment preflight policy failure" >&2
   exit 1
 fi
+
+if ! grep -q "deployment_preflight_required_marker_missing" "$TMP_ERR"; then
+  echo "expected deployment preflight required marker missing reason for deployment preflight policy failure" >&2
+  exit 1
+fi
+
+if ! grep -q "deployment_preflight_schema_parity_mismatch" "$TMP_ERR"; then
+  echo "expected deployment preflight schema parity mismatch reason for deployment preflight policy failure" >&2
+  exit 1
+fi
+
+python3 - "$TMP_POLICY_OUT" <<'PY'
+import json
+import pathlib
+import sys
+
+report = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+if report.get("deployment_preflight_marker_contract_status") != "failed":
+    raise SystemExit("expected deployment_preflight_marker_contract_status=failed for mismatched deployment preflight report")
+if report.get("deployment_preflight_schema_parity_status") != "failed":
+    raise SystemExit("expected deployment_preflight_schema_parity_status=failed for mismatched deployment preflight report")
+if report.get("deployment_preflight_schema_reason_code") not in (
+    "deployment_preflight_required_marker_missing",
+    "deployment_preflight_schema_parity_mismatch",
+    "deployment_preflight_reason_taxonomy_version_mismatch",
+    "deployment_preflight_reason_codes_csv_mismatch",
+    "deployment_preflight_reason_codes_value_mismatch",
+):
+    raise SystemExit("expected deterministic deployment preflight schema reason code for mismatch failure")
+if report.get("deployment_preflight_runbook_reason_code") not in (
+    "deployment_preflight_taxonomy_mapping_drift_detected",
+    "runbook_marker_parity_mismatch",
+):
+    raise SystemExit("expected deterministic deployment_preflight_runbook_reason_code for mismatch failure")
+PY
 
 if [ ! -x "$RUNNER" ]; then
   echo "expected local Kolme live deployment preflight lane runner to be executable" >&2

--- a/specs/4151/plan.md
+++ b/specs/4151/plan.md
@@ -1,0 +1,39 @@
+# Issue #4151 Plan
+
+- Issue: #4151
+- Status: Implemented
+
+## Approach
+1. Extend deployment preflight policy checker output with deterministic marker-contract and runbook-parity fields.
+2. Add fail-closed marker/schema mismatch classification in checker evaluation.
+3. Update shell contract lane assertions to validate new fields in GO and mismatch NO-GO paths.
+4. Synchronize runbook markers in deploy/planning docs and enforce with Rust docs-contract tests.
+
+## Affected Modules
+- `scripts/kolme/check_local_kolme_live_deployment_preflight_policy.py`
+- `scripts/kolme/test_check_local_kolme_live_deployment_preflight_policy.sh`
+- `docs/deploy/kolme_devnet_ops.md`
+- `docs/planning/kolme-devnet-ops.md`
+- `crates/kamn-core/tests/kolme_devnet_ops_docs.rs`
+- `specs/4151/spec.md`
+- `specs/4151/plan.md`
+- `specs/4151/tasks.md`
+
+## Risks and Mitigations
+- Risk level: medium
+- Mitigations:
+  - Keep reason-taxonomy constants explicit and deterministic.
+  - Restrict scope to checker/docs/tests to avoid runtime behavior drift.
+  - Validate both GO and mismatch NO-GO fixture paths in shell contract lane.
+
+## Interface Contract
+- Additive checker output fields only.
+- No dependency/protocol/wire-format changes.
+
+## ADR
+- Not required for this scoped subtask.
+
+## Verification Summary
+- `bash scripts/kolme/test_check_local_kolme_live_deployment_preflight_policy.sh` (pass)
+- `cargo test -p kamn-core --test kolme_devnet_ops_docs` (pass)
+- `cargo test -p kamn-core --test release_gonogo_checklist_docs` (pass)

--- a/specs/4151/spec.md
+++ b/specs/4151/spec.md
@@ -1,0 +1,50 @@
+# Issue #4151 Spec
+
+- Title: Subtask: implement preflight fail-closed checker outputs and runbook marker synchronization
+- Status: Implemented
+- Type: subtask
+- Priority: P1
+- Milestone: specs/milestones/r27-19-live-deployment-rehearsal-and-rollback-governance-hardening/index.md
+
+## Problem Statement
+Deployment preflight checker output and runbook marker contracts can drift, creating ambiguous remediation outcomes and weakening deterministic GO/NO-GO enforcement.
+
+## Acceptance Criteria
+- AC-1: Deployment preflight checker emits deterministic fail-closed marker contract outputs and reason-code taxonomy fields for marker/schema mismatches.
+- AC-2: Runbook parity markers for deployment preflight checker output remain synchronized in `docs/deploy/kolme_devnet_ops.md` and `docs/planning/kolme-devnet-ops.md`.
+- AC-3: Integration validation confirms stable output behavior across GO and NO-GO fixture paths.
+
+## Scope
+In scope:
+- `scripts/kolme/check_local_kolme_live_deployment_preflight_policy.py` output + fail-closed reason classification updates.
+- `scripts/kolme/test_check_local_kolme_live_deployment_preflight_policy.sh` validation updates for new marker/runbook outputs.
+- Docs/runbook marker synchronization updates in deploy/planning docs plus Rust docs-contract tests.
+- Lifecycle artifacts for issue `#4151`.
+
+Out of scope:
+- Deployment lane runtime orchestration redesign.
+- New dependencies or protocol/wire-format changes.
+
+## Conformance Cases
+| Case | AC | Tier | Input | Expected |
+|---|---|---|---|---|
+| C-01 | AC-1 | Functional | Run preflight policy checker GO fixture | Deterministic marker-contract + schema/runbook parity outputs are emitted with `verified` status |
+| C-02 | AC-1 | Regression | Run preflight policy checker NO-GO mismatch fixtures | Deterministic fail-closed marker/schema mismatch reason codes are emitted |
+| C-03 | AC-2 | Conformance | Validate deploy/planning docs parity markers | Runbook marker contract strings remain synchronized with checker output |
+| C-04 | AC-3 | Integration | Run shell contract lane + Rust docs tests | Stable pass/fail behavior remains deterministic end-to-end |
+
+## Test Mapping
+- `bash scripts/kolme/test_check_local_kolme_live_deployment_preflight_policy.sh`
+- `cargo test -p kamn-core --test kolme_devnet_ops_docs`
+- `cargo test -p kamn-core --test release_gonogo_checklist_docs`
+
+## AC Verification
+| AC | ✅/❌ | Test(s) |
+|---|---|---|
+| AC-1 | ✅ | preflight checker shell contract lane + GO/NO-GO fixture assertions |
+| AC-2 | ✅ | deploy/planning docs markers + `kolme_devnet_ops_docs` assertions |
+| AC-3 | ✅ | shell contract lane + Rust docs suites pass deterministically |
+
+## Success Metrics
+- Issue `#4151` closes with deterministic preflight marker/schema/runbook outputs enforced by tests.
+- Deploy and planning runbooks remain synchronized with checker output marker contract.

--- a/specs/4151/tasks.md
+++ b/specs/4151/tasks.md
@@ -1,0 +1,12 @@
+# Issue #4151 Tasks
+
+- Issue: #4151
+- Status: Done
+
+## Ordered Tasks
+- [x] T1 (Red): define checker/runbook marker parity and fail-closed mismatch assertions in shell and docs-contract tests.
+- [x] T2 (Green): implement deterministic checker output fields and mismatch reason classification for deployment preflight markers/schema parity.
+- [x] T3 (Refactor): normalize reason-code mapping helpers and output projection for readability/determinism.
+- [x] T4 (Regression): run shell contract lane and Rust docs suites.
+- [x] T5 (Governance): maintain shell-surface neutrality expectations with bounded checker/test updates and no new workflow/template files.
+- [x] T6 (Verify): set lifecycle artifacts to implemented/done and close issue with verification evidence.


### PR DESCRIPTION
## Summary
Implement deterministic deployment preflight checker output markers for marker/schema mismatch fail-closed behavior, and synchronize runbook marker contracts across deploy/planning docs with test enforcement.

## Links
- Milestone: `specs/milestones/r27-19-live-deployment-rehearsal-and-rollback-governance-hardening/index.md`
- Closes #4151
- Parent task: #4146
- Spec: `specs/4151/spec.md`
- Plan: `specs/4151/plan.md`
- Tasks: `specs/4151/tasks.md`

## Spec Verification (AC -> tests)
| AC | ✅/❌ | Test(s) |
|---|---|---|
| AC-1 checker emits deterministic fail-closed marker outputs | ✅ | `bash scripts/kolme/test_check_local_kolme_live_deployment_preflight_policy.sh` |
| AC-2 runbook markers synchronized with checker expectations | ✅ | `cargo test -p kamn-core --test kolme_devnet_ops_docs` |
| AC-3 stable integration behavior across GO/NO-GO fixtures | ✅ | shell contract lane + docs suites (`release_gonogo_checklist_docs`, `kolme_devnet_ops_docs`) |

## TDD Evidence
- RED: new parity assertions fail when deployment-preflight marker/runbook fields are absent or mismatch.
- GREEN: `bash scripts/kolme/test_check_local_kolme_live_deployment_preflight_policy.sh` -> pass.
- REGRESSION: `cargo fmt --check`; `cargo test -p kamn-core --test kolme_devnet_ops_docs`; `cargo test -p kamn-core --test release_gonogo_checklist_docs` -> pass.

## Test Tiers
| Tier | ✅/❌/N/A | Tests | N/A Why |
|---|---|---|---|
| Unit | ✅ | checker fixture/path assertions in shell lane | |
| Property | N/A | | no property generators added |
| Contract/DbC | N/A | | no DbC annotations changed |
| Snapshot | N/A | | no snapshot tests |
| Functional | ✅ | preflight checker shell lane | |
| Conformance | ✅ | docs-contract assertions in `kolme_devnet_ops_docs` | |
| Integration | ✅ | shell lane + Rust docs suites compose checker/docs parity | |
| Fuzz | N/A | | no fuzz surface added |
| Mutation | N/A | | scoped checker/docs work; no mutation campaign in this PR |
| Regression | ✅ | `release_gonogo_checklist_docs` + `kolme_devnet_ops_docs` | |
| Performance | N/A | | no perf-sensitive code paths changed |

## Mutation
N/A for this scoped checker/docs parity update.

## Risks/Rollback
Low. Rollback by reverting this commit.

## Docs/ADR
Updated:
- `docs/deploy/kolme_devnet_ops.md`
- `docs/planning/kolme-devnet-ops.md`
- `specs/4151/spec.md`
- `specs/4151/plan.md`
- `specs/4151/tasks.md`

ADR not required.
