### PR TITLE
feat(kamn-core): canonicalize M2 agent DID validation via AgentDid parser (#5091)

### DIFF
--- a/crates/kamn-core/src/data_layer_m2_gateway_access.rs
+++ b/crates/kamn-core/src/data_layer_m2_gateway_access.rs
@@ -4,6 +4,7 @@
 //! DID-authenticated session issuance, ABAC message visibility checks, RLS policy
 //! template emission, and append-only audit logging with hash-chain verification.
 
+use crate::AgentDid;
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 
@@ -94,7 +95,7 @@ impl DataLayerM2DidSessionService {
             });
         }
 
-        validate_kamn_did(request.requester_did.as_str())?;
+        validate_agent_did(request.requester_did.as_str())?;
         let expected_credential = format!("sig:{}:{}", request.requester_did, request.challenge);
         if request.credential != expected_credential {
             return Err(DataLayerM2GatewayError::InvalidCredential(
@@ -279,7 +280,12 @@ impl DataLayerM2AbacEngine {
         scope: &DataLayerM2MessageScope,
     ) -> Result<DataLayerM2AuthorizationDecision, DataLayerM2GatewayError> {
         validate_message_scope(scope)?;
-        validate_kamn_did(requester_did)?;
+        match requester_role {
+            DataLayerM2ActorRole::Agent => validate_agent_did(requester_did)?,
+            DataLayerM2ActorRole::Owner
+            | DataLayerM2ActorRole::EscrowAuditor
+            | DataLayerM2ActorRole::PlatformOperator => validate_kamn_did(requester_did)?,
+        }
 
         let decision = match requester_role {
             DataLayerM2ActorRole::Agent => {
@@ -636,16 +642,24 @@ fn validate_message_scope(scope: &DataLayerM2MessageScope) -> Result<(), DataLay
     if scope.message_id.trim().is_empty() {
         return Err(DataLayerM2GatewayError::EmptyField("message_id"));
     }
-    for (field, value) in [
-        ("sender_did", scope.sender_did.as_str()),
-        ("recipient_did", scope.recipient_did.as_str()),
-        ("owner_sender_did", scope.owner_sender_did.as_str()),
-        ("owner_recipient_did", scope.owner_recipient_did.as_str()),
+    for (field, value, requires_agent_did) in [
+        ("sender_did", scope.sender_did.as_str(), true),
+        ("recipient_did", scope.recipient_did.as_str(), true),
+        ("owner_sender_did", scope.owner_sender_did.as_str(), false),
+        (
+            "owner_recipient_did",
+            scope.owner_recipient_did.as_str(),
+            false,
+        ),
     ] {
         if value.trim().is_empty() {
             return Err(DataLayerM2GatewayError::EmptyField(field));
         }
-        validate_kamn_did(value)?;
+        if requires_agent_did {
+            validate_agent_did(value)?;
+        } else {
+            validate_kamn_did(value)?;
+        }
     }
     Ok(())
 }
@@ -681,6 +695,11 @@ fn validate_kamn_did(value: &str) -> Result<(), DataLayerM2GatewayError> {
     if segments.len() < 4 || segments.iter().any(|segment| segment.is_empty()) {
         return Err(DataLayerM2GatewayError::InvalidDid(value.to_owned()));
     }
+    Ok(())
+}
+
+fn validate_agent_did(value: &str) -> Result<(), DataLayerM2GatewayError> {
+    AgentDid::parse(value).map_err(|_| DataLayerM2GatewayError::InvalidDid(value.to_owned()))?;
     Ok(())
 }
 

--- a/crates/kamn-core/tests/data_layer_m2_gateway_access.rs
+++ b/crates/kamn-core/tests/data_layer_m2_gateway_access.rs
@@ -81,6 +81,23 @@ fn spec_c02_did_authentication_rejects_invalid_identity_or_credential_inputs() {
 }
 
 #[test]
+fn spec_c02b_did_authentication_rejects_non_canonical_agent_did_shapes() {
+    let service = DataLayerM2DidSessionService::new(900).expect("service should initialize");
+
+    let uppercase_agent_segment = service.authenticate(DataLayerM2DidAuthRequest {
+        requester_did: "kamn:did:agent:Sender-1".to_owned(),
+        challenge: "nonce-123".to_owned(),
+        credential: "sig:kamn:did:agent:Sender-1:nonce-123".to_owned(),
+        issued_at_epoch_seconds: 1_708_160_000,
+        ttl_seconds: 300,
+    });
+    assert!(matches!(
+        uppercase_agent_segment,
+        Err(DataLayerM2GatewayError::InvalidDid(_))
+    ));
+}
+
+#[test]
 fn spec_c03_abac_message_visibility_matrix_is_fail_closed_for_unrelated_requesters() {
     let abac = seeded_abac();
 
@@ -139,6 +156,33 @@ fn spec_c03_abac_message_visibility_matrix_is_fail_closed_for_unrelated_requeste
             reason_code: DATA_LAYER_M2_REASON_ABAC_SCOPE_DENIED,
         }
     );
+}
+
+#[test]
+fn spec_c03b_abac_rejects_non_canonical_agent_did_fields() {
+    let abac = seeded_abac();
+    let mut invalid_scope = message_scope(None);
+    invalid_scope.sender_did = "kamn:did:agent:Sender-1".to_owned();
+
+    let invalid_sender = abac.authorize_message_visibility(
+        "kamn:did:agent:recipient-1",
+        DataLayerM2ActorRole::Agent,
+        &invalid_scope,
+    );
+    assert!(matches!(
+        invalid_sender,
+        Err(DataLayerM2GatewayError::InvalidDid(_))
+    ));
+
+    let invalid_agent_requester = abac.authorize_message_visibility(
+        "kamn:did:owner:sender",
+        DataLayerM2ActorRole::Agent,
+        &message_scope(None),
+    );
+    assert!(matches!(
+        invalid_agent_requester,
+        Err(DataLayerM2GatewayError::InvalidDid(_))
+    ));
 }
 
 #[test]

--- a/specs/5091/plan.md
+++ b/specs/5091/plan.md
@@ -1,0 +1,34 @@
+# Issue #5091 Plan
+
+- Issue: #5091
+- Status: Implemented
+
+## Approach
+1. Replace M2 local agent DID checks with `AgentDid::parse` in:
+   - DID session authentication requester validation.
+   - Message-scope sender/recipient validation.
+   - Agent-role requester validation path.
+2. Preserve generic DID checks for non-agent role paths to avoid widening
+   behavior changes in owner/auditor/platform role handling.
+3. Add/adjust conformance tests for parser-specific malformed agent DID
+   rejection and role-preserving behavior.
+4. Run scoped and crate-level regression gates.
+
+## Risks and Mitigations
+- Risk level: high
+- Risks:
+  - Tightening parser checks can reject values that previously passed local
+    format checks.
+  - Over-tightening requester validation for non-agent roles can break existing
+    owner/auditor deny-path expectations.
+- Mitigations:
+  - Apply `AgentDid` parsing only to explicit agent DID fields/paths.
+  - Keep non-agent role behavior unchanged.
+  - Lock behavior with deterministic tests.
+
+## Interface Contract
+- Additive/internal validation-path change.
+- No dependency, protocol, or wire-format changes.
+
+## ADR
+- Not required for this scoped validation integration.

--- a/specs/5091/spec.md
+++ b/specs/5091/spec.md
@@ -1,0 +1,87 @@
+# Issue #5091 Spec
+
+- Title: Task: integrate M2 gateway DID validation with canonical AgentDid parser
+- Status: Implemented
+- Type: task
+- Priority: P1
+- Milestone: specs/milestones/r27-45-kamn-data-layer-prd-implementation-and-validation/index.md
+
+## Problem Statement
+`data_layer_m2_gateway_access.rs` currently validates DIDs with a local
+`validate_kamn_did()` helper and raw string checks. This duplicates identity
+validation logic from `did.rs` and allows M2-specific drift from canonical
+`AgentDid` parsing behavior.
+
+## Acceptance Criteria
+- AC-1: M2 DID-auth session issuance validates requester identity through
+  `AgentDid::parse` rather than local format-only checks.
+- AC-2: M2 message-scope validation uses canonical `AgentDid` parsing for
+  `sender_did` and `recipient_did`.
+- AC-3: M2 ABAC agent-role authorization validates requester identity through
+  `AgentDid::parse` while preserving fail-closed deterministic denials for
+  non-agent roles.
+- AC-4: M2 tests cover parser-backed accept/reject behavior, including malformed
+  agent DID inputs that previously bypassed strict parser checks.
+- AC-5: Shell/workflow/python/template LOC remains unchanged
+  (`shell_loc_delta_actual = 0`).
+
+## Scope
+In scope:
+- `crates/kamn-core/src/data_layer_m2_gateway_access.rs`
+- `crates/kamn-core/tests/data_layer_m2_gateway_access.rs`
+- `specs/5091/{spec.md,plan.md,tasks.md}`
+
+Out of scope:
+- Protocol/wire-format changes.
+- New dependencies.
+- M3/M7/M9/M10 integration-gap work.
+
+## Conformance Cases
+| Case | AC | Tier | Input | Expected |
+|---|---|---|---|---|
+| C-01 | AC-1 | Functional | Authenticate request with canonical agent DID | Session token issued deterministically |
+| C-02 | AC-1 | Regression | Authenticate request with malformed agent DID (`kamn:did:agent:Bad`) | Fail-closed `InvalidDid` |
+| C-03 | AC-2 | Conformance | Authorize scope with malformed sender/recipient agent DID | Fail-closed `InvalidDid` |
+| C-04 | AC-3 | Conformance | Agent-role authorization with non-agent requester DID | Fail-closed `InvalidDid`; owner/auditor role behavior unchanged |
+| C-05 | AC-4 | Regression | Run full M2 suite and crate regression | Deterministic pass with canonical parse enforcement |
+| C-06 | AC-5 | Regression | Diff path audit | Zero shell/workflow/python/template changes |
+
+## Test Mapping
+- `cargo test -p kamn-core --test data_layer_m2_gateway_access`
+- `cargo test -p kamn-core`
+- `cargo fmt --check`
+- `cargo clippy -p kamn-core -- -D warnings`
+
+## Success Metrics
+- M2 uses canonical parser for agent DID validation paths.
+- M2 suite demonstrates parser-backed strict rejection for malformed agent DIDs.
+- Shell-to-Rust posture is improved/neutral with zero shell delta.
+
+## Verification Evidence
+- RED: `cargo test -p kamn-core --test data_layer_m2_gateway_access` failed with:
+  - `spec_c02b_did_authentication_rejects_non_canonical_agent_did_shapes`
+  - `spec_c03b_abac_rejects_non_canonical_agent_did_fields`
+- GREEN: `cargo test -p kamn-core --test data_layer_m2_gateway_access` passed after
+  integrating canonical parser checks.
+- REGRESSION:
+  - `cargo fmt --check` passed.
+  - `cargo clippy -p kamn-core -- -D warnings` passed.
+  - `cargo test -p kamn-core` passed.
+  - `bash scripts/ci/check_shell_rust_ratio_guardrail.sh --repo-root . --output-json /tmp/shell-rust-ratio-guardrail-5091.json` -> `final_decision=GO`.
+  - `bash scripts/ci/check_shell_loc_hard_ceiling.sh --repo-root . --output-json /tmp/shell-loc-hard-ceiling-5091.json` -> `final_decision=GO`.
+
+## AC Verification
+| AC | Result | Tests |
+|---|---|---|
+| AC-1 | ✅ | `spec_c01_did_authentication_issues_deterministic_bounded_session`; `spec_c02b_did_authentication_rejects_non_canonical_agent_did_shapes` |
+| AC-2 | ✅ | `spec_c03b_abac_rejects_non_canonical_agent_did_fields` |
+| AC-3 | ✅ | `spec_c03_abac_message_visibility_matrix_is_fail_closed_for_unrelated_requesters`; `spec_c03b_abac_rejects_non_canonical_agent_did_fields` |
+| AC-4 | ✅ | `cargo test -p kamn-core --test data_layer_m2_gateway_access`; `cargo test -p kamn-core` |
+| AC-5 | ✅ | `git diff --name-only` shows Rust + spec files only; shell guardrail checks `GO` |
+
+## Shell Surface Markers
+- shell_loc_delta_actual: 0
+- rust_loc_delta_actual: +67
+- shell_to_rust_ratio_delta_actual: improved
+- shell_surface_ratio_target_status: improved
+- shell_surface_mitigation_issue: None

--- a/specs/5091/tasks.md
+++ b/specs/5091/tasks.md
@@ -1,0 +1,20 @@
+# Issue #5091 Tasks
+
+- Issue: #5091
+- Status: Done
+
+## Ordered Tasks
+- [x] T1 (Red): add failing tests for malformed agent DID rejection on auth,
+  scope validation, and agent-role authorization paths.
+- [x] T2 (Green): integrate `AgentDid::parse` into M2 validation paths for
+  requester/sender/recipient agent DID checks.
+- [x] T3 (Refactor): keep non-agent role validation behavior stable while
+  removing duplicate agent-format logic in affected code paths.
+- [x] T4 (Regression): run `cargo fmt --check`,
+  `cargo clippy -p kamn-core -- -D warnings`,
+  `cargo test -p kamn-core --test data_layer_m2_gateway_access`, and
+  `cargo test -p kamn-core`.
+- [x] T5 (Governance): confirm shell/workflow/python/template delta is zero and
+  record DoD shell markers.
+- [x] T6 (Verify): set lifecycle markers to Implemented/Done and post issue
+  closure evidence.


### PR DESCRIPTION
## Summary
Integrates M2 agent-identity validation with canonical `AgentDid::parse` instead of local agent-format checks. This hardens DID strictness for auth and agent-scope authorization paths while preserving owner/auditor/platform behavior. Adds parser-backed conformance tests and updates issue lifecycle artifacts.

## Links
- Milestone: `specs/milestones/r27-45-kamn-data-layer-prd-implementation-and-validation/index.md`
- Closes #5091
- Spec: `specs/5091/spec.md`
- Plan: `specs/5091/plan.md`
- Tasks: `specs/5091/tasks.md`

## Shell-Surface Declaration
- [x] No shell-surface impact.
- [ ] Shell-surface impact present.

shell_loc_delta_actual: 0
rust_loc_delta_actual: +63
shell_to_rust_ratio_delta_actual: improved
shell_surface_ratio_target_status: improved
shell_surface_mitigation_issue: None

## Spec Verification (AC -> tests)
| AC | ✅/❌ | Test(s) |
|---|---|---|
| AC-1: auth requester validation uses canonical parser | ✅ | `spec_c01_did_authentication_issues_deterministic_bounded_session`, `spec_c02b_did_authentication_rejects_non_canonical_agent_did_shapes` |
| AC-2: sender/recipient scope validation uses canonical parser | ✅ | `spec_c03b_abac_rejects_non_canonical_agent_did_fields` |
| AC-3: agent-role requester validation uses canonical parser, non-agent roles preserved | ✅ | `spec_c03_abac_message_visibility_matrix_is_fail_closed_for_unrelated_requesters`, `spec_c03b_abac_rejects_non_canonical_agent_did_fields` |
| AC-4: parser-backed malformed DID regression coverage | ✅ | `cargo test -p kamn-core --test data_layer_m2_gateway_access`, `cargo test -p kamn-core` |
| AC-5: shell/workflow/python/template unchanged | ✅ | `git diff --name-only`, shell guardrails below |

## TDD Evidence
- RED cmd + output excerpt:
```bash
cargo test -p kamn-core --test data_layer_m2_gateway_access
```
```text
FAILED spec_c02b_did_authentication_rejects_non_canonical_agent_did_shapes
FAILED spec_c03b_abac_rejects_non_canonical_agent_did_fields
```
- GREEN cmd + output excerpt:
```bash
cargo test -p kamn-core --test data_layer_m2_gateway_access
```
```text
test result: ok. 10 passed; 0 failed
```
- REGRESSION summary:
  - `cargo fmt --check`
  - `cargo clippy -p kamn-core -- -D warnings`
  - `cargo test -p kamn-core`
  - `bash scripts/ci/check_shell_rust_ratio_guardrail.sh --repo-root . --output-json /tmp/shell-rust-ratio-guardrail-5091.json`
  - `bash scripts/ci/check_shell_loc_hard_ceiling.sh --repo-root . --output-json /tmp/shell-loc-hard-ceiling-5091.json`

## Test Tiers
| Tier | ✅/❌/N/A | Tests | N/A Why |
|---|---|---|---|
| Unit | ✅ | `spec_c02_*`, `spec_c02b_*`, `spec_c03b_*` in `data_layer_m2_gateway_access` | |
| Property | N/A | N/A | No property/invariant harness added in this scoped validation-path change |
| Contract/DbC | N/A | N/A | No `contracts` DbC annotations introduced/changed |
| Snapshot | N/A | N/A | No snapshot artifacts in scope |
| Functional | ✅ | `spec_c01_*`, `spec_c03_*`, `spec_c04_*`, `spec_c05_*` | |
| Conformance | ✅ | `cargo test -p kamn-core --test data_layer_m2_gateway_access` | |
| Integration | ✅ | `cargo test -p kamn-core` | |
| Fuzz | N/A | N/A | No new parser entrypoint or fuzz harness added |
| Mutation | N/A | N/A | `cargo mutants` unavailable in this environment |
| Regression | ✅ | full M2 suite + crate regression + shell guardrails | |
| Performance | N/A | N/A | No perf hotspot or budget-sensitive path changes |

## Mutation
- caught/total: N/A
- rationale: `cargo mutants` unavailable in this environment.

## Risks/Rollback
- Risk: low-medium; validation strictness increased for agent DID fields only.
- Rollback: revert commit `7fcf7ae3`.

## Docs/ADR
- Updated: `specs/5091/spec.md`, `specs/5091/plan.md`, `specs/5091/tasks.md`
- ADR: not required.

## Review Note
Issue `#5091` is P1; requesting human review per AGENTS contract.
