### PR TITLE
feat(kamn-core): add deterministic notifications reconnect pacing (#3793)

### DIFF
--- a/crates/kamn-core/src/kolme_runtime_commit/notifications_consumer.rs
+++ b/crates/kamn-core/src/kolme_runtime_commit/notifications_consumer.rs
@@ -13,6 +13,10 @@ use kamn_kolme::{
     KolmeRuntimeCommitNotificationsConnection, KolmeRuntimeCommitNotificationsConnector,
     KolmeRuntimeCommitProviderError, KolmeRuntimeCommitTransportErrorKind,
 };
+use std::{thread, time::Duration};
+
+const NOTIFICATIONS_RECONNECT_BASE_BACKOFF_MILLIS: u64 = 10;
+const NOTIFICATIONS_RECONNECT_MAX_BACKOFF_MILLIS: u64 = 40;
 
 /// Deterministic notifications consumer for Kolme websocket events with bounded reconnect policy.
 pub struct KolmeRuntimeCommitNotificationsConsumer<C>
@@ -108,6 +112,7 @@ where
                                     ),
                             });
                         }
+                        maybe_sleep_notifications_reconnect_backoff(reconnect_attempts);
                         continue;
                     }
                 }
@@ -122,6 +127,7 @@ where
                         ),
                     });
                 }
+                maybe_sleep_notifications_reconnect_backoff(reconnect_attempts);
                 continue;
             };
             let result = connection.read_text_message();
@@ -144,6 +150,7 @@ where
                             ),
                         });
                     }
+                    maybe_sleep_notifications_reconnect_backoff(reconnect_attempts);
                 }
             }
         }
@@ -159,5 +166,29 @@ where
                 return Ok(receipt);
             }
         }
+    }
+}
+
+fn deterministic_notifications_reconnect_backoff_millis(attempt: u32) -> u64 {
+    let exponent = attempt.saturating_sub(1).min(4);
+    let backoff = NOTIFICATIONS_RECONNECT_BASE_BACKOFF_MILLIS << exponent;
+    backoff.min(NOTIFICATIONS_RECONNECT_MAX_BACKOFF_MILLIS)
+}
+
+fn maybe_sleep_notifications_reconnect_backoff(attempt: u32) {
+    let backoff = deterministic_notifications_reconnect_backoff_millis(attempt);
+    thread::sleep(Duration::from_millis(backoff));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::deterministic_notifications_reconnect_backoff_millis;
+
+    #[test]
+    fn unit_notifications_reconnect_backoff_schedule_is_deterministic_and_bounded() {
+        assert_eq!(deterministic_notifications_reconnect_backoff_millis(1), 10);
+        assert_eq!(deterministic_notifications_reconnect_backoff_millis(2), 20);
+        assert_eq!(deterministic_notifications_reconnect_backoff_millis(3), 40);
+        assert_eq!(deterministic_notifications_reconnect_backoff_millis(8), 40);
     }
 }

--- a/crates/kamn-core/tests/kolme_runtime_commit_notifications.rs
+++ b/crates/kamn-core/tests/kolme_runtime_commit_notifications.rs
@@ -10,7 +10,7 @@ use std::io::{Read, Write};
 use std::net::TcpListener;
 use std::sync::{Arc, Mutex};
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 #[derive(Clone)]
 enum MockStep {
@@ -333,5 +333,47 @@ fn regression_issue_1924_notifications_consumer_reconnect_exhausted_reason_remai
         Err(KolmeRuntimeCommitProviderError::Unavailable {
             reason: "notification reconnect attempts exhausted after 3 retries".to_owned(),
         })
+    );
+}
+
+#[test]
+fn functional_notifications_consumer_reconnect_exhaustion_applies_deterministic_pacing() {
+    let retry_connector = MockConnector::new(vec![
+        Err(KolmeRuntimeCommitProviderError::Unavailable {
+            reason: "dial failed: refused".to_owned(),
+        }),
+        Err(KolmeRuntimeCommitProviderError::Unavailable {
+            reason: "dial failed: refused".to_owned(),
+        }),
+        Err(KolmeRuntimeCommitProviderError::Unavailable {
+            reason: "dial failed: refused".to_owned(),
+        }),
+    ]);
+    let mut retry_consumer = KolmeRuntimeCommitNotificationsConsumer::new(
+        "http://127.0.0.1:3030",
+        "/notifications",
+        "kolme-fork-local",
+        3,
+        retry_connector,
+    )
+    .expect("notifications consumer should build");
+
+    let start = Instant::now();
+    let result = retry_consumer.next_notification_event();
+    let elapsed = start.elapsed();
+
+    assert_eq!(
+        result,
+        Err(KolmeRuntimeCommitProviderError::Unavailable {
+            reason: "notification reconnect attempts exhausted after 3 retries".to_owned(),
+        })
+    );
+    assert!(
+        elapsed >= Duration::from_millis(20),
+        "reconnect pacing should apply deterministic backoff before exhaustion"
+    );
+    assert!(
+        elapsed <= Duration::from_millis(400),
+        "reconnect pacing should remain bounded"
     );
 }

--- a/crates/kamn-node/tests/kolme_runtime_commit_docs.rs
+++ b/crates/kamn-node/tests/kolme_runtime_commit_docs.rs
@@ -35,3 +35,12 @@ fn doc_contains_transient_classifier_and_bounded_retry_schedule_markers() {
     assert!(DOC.contains("timeout"));
     assert!(DOC.contains("unavailable"));
 }
+
+#[test]
+fn doc_contains_notifications_reconnect_pacing_policy_markers() {
+    assert!(DOC.contains("### Notifications Reconnect Pacing Policy"));
+    assert!(DOC.contains("notifications_reconnect_pacing_contract_version=v1"));
+    assert!(DOC.contains("notifications_reconnect_backoff_sequence_ms=10,20,40,40,40"));
+    assert!(DOC.contains("notifications_reconnect_backoff_cap_ms=40"));
+    assert!(DOC.contains("notification reconnect attempts exhausted after <N> retries"));
+}

--- a/docs/architecture/kolme-runtime-commit.md
+++ b/docs/architecture/kolme-runtime-commit.md
@@ -65,6 +65,20 @@ Fail-closed behavior is preserved for continuous and single-cycle modes:
 | `Unavailable` | `unavailable` | retry with deterministic bounded backoff | `attempt_ceiling_reached` |
 | `MalformedResponse` | non-transient | fail closed immediately | `malformed_response_fail_fast` |
 
+### Notifications Reconnect Pacing Policy
+
+- `notifications_reconnect_pacing_contract_version=v1`
+- `notifications_reconnect_backoff_sequence_ms=10,20,40,40,40`
+- `notifications_reconnect_backoff_cap_ms=40`
+- terminal exhaustion reason:
+  - `notification reconnect attempts exhausted after <N> retries`
+
+| Reconnect attempt | Delay before next attempt | Budget behavior |
+|---|---|---|
+| 1 | `10ms` | retry if budget remains |
+| 2 | `20ms` | retry if budget remains |
+| 3+ | `40ms` (capped) | fail closed when attempt budget is exhausted |
+
 ### Signer Provenance Failure Taxonomy
 
 Signer contracts are fail-closed and reason-code stable:

--- a/specs/3793/plan.md
+++ b/specs/3793/plan.md
@@ -1,0 +1,27 @@
+# Issue #3793 Plan
+
+- Issue: #3793
+- Status: Reviewed
+
+## Approach
+1. Add deterministic reconnect pacing helper to notifications consumer reconnect loop.
+2. Keep reconnect attempt budget exhaustion behavior deterministic and unchanged for terminal outcomes.
+3. Add/extend tests for pacing schedule, reconnect-loop behavior, and bounded delay budget.
+4. Add runtime architecture doc markers for reconnect pacing and pin them with docs-contract assertions.
+5. Run targeted tests + lint + shell guardrails, then merge and close issue.
+
+## Risks and Mitigations
+- Risk level: medium
+- Risks:
+  - New reconnect delays can introduce flaky time-based tests.
+  - Overly aggressive delays can regress runtime responsiveness.
+- Mitigations:
+  - Use deterministic bounded backoff with small cap.
+  - Keep timing assertions tolerant and bounded to avoid flaky scheduling noise.
+  - Add explicit performance-bound test for reconnect pacing path.
+
+## Interface Contract
+- No API/protocol changes; internal reconnect-loop behavior only.
+
+## ADR
+- Not required.

--- a/specs/3793/spec.md
+++ b/specs/3793/spec.md
@@ -1,0 +1,54 @@
+# Issue #3793 Spec
+
+- Title: Subtask: implement deterministic reconnect pacing schedule for notifications consumer
+- Status: Reviewed
+- Type: subtask
+- Priority: P1
+- Milestone: specs/milestones/r26-5-observability-and-transport-resilience-hardening/index.md
+
+## Problem Statement
+Kolme notifications consumer reconnect attempts are budget bounded but currently immediate; deterministic reconnect pacing is required to avoid tight-loop retry behavior under endpoint flapping and to keep terminal attempt-budget outcomes deterministic.
+
+## Acceptance Criteria
+- AC-1: Notifications consumer reconnect loop applies deterministic backoff pacing with bounded increments/cap.
+- AC-2: Attempt budget exhaustion remains deterministic and surfaced with stable terminal outcome mapping.
+- AC-3: Unit, Functional, Integration, Regression, and bounded Performance evidence is present and passing.
+- AC-4: Runtime architecture documentation declares reconnect pacing policy markers and remains contract-tested.
+
+## Scope
+In scope:
+- `crates/kamn-core/src/kolme_runtime_commit/notifications_consumer.rs`
+- `crates/kamn-core/tests/kolme_runtime_commit_notifications.rs`
+- `docs/architecture/kolme-runtime-commit.md`
+- `crates/kamn-node/tests/kolme_runtime_commit_docs.rs`
+- `specs/3793/{spec.md,plan.md,tasks.md}`
+
+Out of scope:
+- Websocket protocol feature changes
+- Non-notification transport taxonomy changes (covered by `#3792`)
+- New dependencies
+
+## Conformance Cases
+| Case | AC | Tier | Input | Expected |
+|---|---|---|---|---|
+| C-01 | AC-1 | Unit | deterministic reconnect pacing helper across attempt range | Backoff schedule is deterministic and capped |
+| C-02 | AC-1 | Functional | repeated connection/read failures before exhaustion | Loop applies non-zero reconnect pacing before subsequent attempts |
+| C-03 | AC-2 | Regression | retry exhaustion behavior tests | Terminal exhaustion remains deterministic/stable |
+| C-04 | AC-3 | Integration | websocket connector notification path under reconnect behavior | Consumer still reconnects and decodes valid events correctly |
+| C-05 | AC-3 | Performance | reconnect pacing budget test | Bounded delay and attempt budget remain within expected upper bound |
+| C-06 | AC-4 | Regression | docs-contract assertions over runtime architecture doc markers | Missing pacing markers fail closed |
+
+## Test Mapping
+- `cargo test -p kamn-core --test kolme_runtime_commit_notifications`
+- `cargo test -p kamn-node --test kolme_runtime_commit_docs`
+- `cargo fmt --check`
+- `cargo clippy -p kamn-core --all-targets -- -D warnings`
+- `cargo clippy -p kamn-node --all-targets -- -D warnings`
+- `scripts/ci/check_shell_loc_hard_ceiling.sh --output-json /tmp/shell-loc-hard-ceiling-3793.json`
+- `scripts/ci/check_shell_rust_ratio_guardrail.sh --output-json /tmp/shell-rust-ratio-3793.json`
+- `scripts/ci/check_shell_surface_threshold_ratchet.sh --output-json /tmp/shell-threshold-ratchet-3793.json`
+
+## Success Metrics
+- Notifications reconnect pacing is deterministic, bounded, and test-verified.
+- Retry exhaustion remains deterministic and stable.
+- No shell LOC increase for this issue (`shell_loc_delta_actual=0` target).

--- a/specs/3793/tasks.md
+++ b/specs/3793/tasks.md
@@ -1,0 +1,18 @@
+# Issue #3793 Tasks
+
+- Issue: #3793
+- Status: In Progress
+
+## Ordered Tasks
+- [x] T1 (Red): add failing tests/docs-contract assertions for reconnect pacing policy markers and pacing behavior.
+- [x] T2 (Green): implement deterministic reconnect pacing schedule with bounded cap in notifications consumer loop.
+- [x] T3 (Functional/Integration): verify reconnect loop behavior and websocket integration paths remain green.
+- [x] T4 (Regression/Performance): verify retry exhaustion stability and reconnect pacing budget constraints.
+- [ ] T5 (Verify): run fmt/clippy/shell guardrails, open mergeable PR, and close issue.
+
+## Tier Mapping
+- Unit: reconnect pacing helper schedule checks.
+- Functional: reconnect loop under repeated disconnect/connect failures.
+- Integration: websocket connector notification receipt behavior.
+- Regression: reconnect exhaustion reason stability + docs drift checks.
+- Performance: bounded reconnect pacing upper-budget checks.


### PR DESCRIPTION
## Summary
Implements deterministic reconnect pacing for Kolme notifications consumer with bounded backoff (10ms, 20ms, 40ms cap), while preserving deterministic reconnect exhaustion behavior. Adds red->green test coverage and runtime architecture docs-contract markers, plus `specs/3793` lifecycle artifacts.

## Links
- Milestone: https://github.com/njfio/kamn/milestone/37
- Closes #3793
- Spec: `specs/3793/spec.md`
- Plan: `specs/3793/plan.md`

## Spec Verification (AC -> tests)
| AC | ✅/❌ | Test(s) |
|---|---|---|
| AC-1: Reconnect loop applies deterministic bounded pacing | ✅ | `cargo test -p kamn-core --test kolme_runtime_commit_notifications functional_notifications_consumer_reconnect_exhaustion_applies_deterministic_pacing -- --exact`; `cargo test -p kamn-core --test kolme_runtime_commit_notifications` |
| AC-2: Attempt-budget exhaustion remains deterministic and surfaced | ✅ | `cargo test -p kamn-core --test kolme_runtime_commit_notifications regression_issue_1924_notifications_consumer_reconnect_exhausted_reason_remains_stable -- --exact`; `cargo test -p kamn-core --test kolme_runtime_commit_notifications regression_notifications_consumer_fails_closed_on_decode_and_retry_exhaustion -- --exact` |
| AC-3: Unit/Functional/Integration/Regression/Performance evidence present and passing | ✅ | `cargo test -p kamn-core --test kolme_runtime_commit_notifications`; `cargo test -p kamn-node --test kolme_runtime_commit_docs`; lint/guardrails below |
| AC-4: Runtime docs declare reconnect pacing policy markers and are contract-tested | ✅ | `cargo test -p kamn-node --test kolme_runtime_commit_docs` |

## TDD Evidence
- RED:
  - `cargo test -p kamn-node --test kolme_runtime_commit_docs`
    - failed at `doc_contains_notifications_reconnect_pacing_policy_markers` (missing heading/markers).
  - `cargo test -p kamn-core --test kolme_runtime_commit_notifications functional_notifications_consumer_reconnect_exhaustion_applies_deterministic_pacing -- --exact`
    - failed with `reconnect pacing should apply deterministic backoff before exhaustion`.
- GREEN:
  - same two commands above now pass after reconnect pacing implementation + docs update.
- REGRESSION:
  - `cargo test -p kamn-core --test kolme_runtime_commit_notifications`
  - `cargo test -p kamn-node --test kolme_runtime_commit_docs`
  - `cargo fmt --check`
  - `cargo clippy -p kamn-core --all-targets -- -D warnings`
  - `cargo clippy -p kamn-node --all-targets -- -D warnings`
  - `scripts/ci/check_shell_loc_hard_ceiling.sh --output-json /tmp/shell-loc-hard-ceiling-3793.json`
  - `scripts/ci/check_shell_rust_ratio_guardrail.sh --output-json /tmp/shell-rust-ratio-3793.json`
  - `scripts/ci/check_shell_surface_threshold_ratchet.sh --output-json /tmp/shell-threshold-ratchet-3793.json`

## Test Tiers
| Tier | ✅/❌/N/A | Tests | N/A Why |
|---|---|---|---|
| Unit | ✅ | `unit_notifications_reconnect_backoff_schedule_is_deterministic_and_bounded`; helper paths in notifications tests | |
| Property | N/A | | No randomized invariant parser changes |
| Contract/DbC | N/A | | No DbC macro contracts in this slice |
| Snapshot | N/A | | No snapshot outputs |
| Functional | ✅ | `functional_notifications_consumer_reconnect_exhaustion_applies_deterministic_pacing`; existing reconnect behavior tests | |
| Conformance | ✅ | AC-mapped tests in `specs/3793/spec.md` | |
| Integration | ✅ | `integration_notifications_websocket_connector_receives_kolme_notification` in `kolme_runtime_commit_notifications` suite | |
| Fuzz | N/A | | No new untrusted parser boundary |
| Mutation | N/A | | Not run for this bounded reconnect pacing slice; no critical-path mutation gate requested in this PR |
| Regression | ✅ | reconnect exhaustion stability tests + docs marker drift tests + lint/guardrails | |
| Performance | ✅ | bounded elapsed-time assertion in `functional_notifications_consumer_reconnect_exhaustion_applies_deterministic_pacing` | |

## Mutation
- N/A for this PR (bounded reconnect pacing behavior update without new mutation-gate requirement in this subtask scope).

## Risks/Rollback
- Risks: medium-low; reconnect pacing introduces deterministic sleep in retry path.
- Rollback: revert this PR.
- Breaking changes: None.

## Docs/ADR
- Updated: `docs/architecture/kolme-runtime-commit.md`
- Updated tests: `crates/kamn-node/tests/kolme_runtime_commit_docs.rs`, `crates/kamn-core/tests/kolme_runtime_commit_notifications.rs`
- Updated implementation: `crates/kamn-core/src/kolme_runtime_commit/notifications_consumer.rs`
- Added specs: `specs/3793/spec.md`, `specs/3793/plan.md`, `specs/3793/tasks.md`
- ADR: not required.

## Shell Surface DoD Markers
- `shell_loc_delta_actual: 0`
- `rust_loc_delta_actual: +82`
- `shell_to_rust_ratio_delta_actual: -0.000494`
- `shell_surface_ratio_target_status: improved`

## Review Note
- P1 self-authored spec marked `Reviewed`; human review requested before merge.
