### PR TITLE
fix: enforce transport resilience retry/reconnect marker contract (#3794)

### DIFF
--- a/crates/kamn-node/tests/kolme_devnet_ops_docs.rs
+++ b/crates/kamn-node/tests/kolme_devnet_ops_docs.rs
@@ -9,6 +9,7 @@ fn doc_contains_transport_retry_validation_contract_markers() {
     assert!(DOC.contains("kolme.live.finality.retry.terminal"));
     assert!(DOC.contains("terminal_decision=attempt_ceiling_reached"));
     assert!(DOC.contains("terminal_decision=malformed_response_fail_fast"));
+    assert!(DOC.contains("retry_reconnect_marker_contract_status=verified"));
 }
 
 #[test]

--- a/docs/planning/kolme-devnet-ops.md
+++ b/docs/planning/kolme-devnet-ops.md
@@ -2029,6 +2029,7 @@ Operator checkpoints:
   - `peer_adapter_reason_projection_timeout_code=p2p_live_reconnect_retry_dial_timeout`
   - `peer_adapter_reason_projection_budget_exhausted_code=p2p_live_reconnect_retry_budget_exhausted`
   - `peer_adapter_multi_process_validation_local_heavy_status=required`
+  - `retry_reconnect_marker_contract_status=verified`
 - Drift failure requirements:
   - partition/rejoin tamper must fail closed with `live_transport_fault_matrix_policy_marker_missing:partition_rejoin_status`.
   - unstable reason classification tamper must fail closed with `live_transport_fault_matrix_policy_reason_codes_classification_mismatch`.

--- a/scripts/runtime/live_transport_fault_matrix_live_contract.py
+++ b/scripts/runtime/live_transport_fault_matrix_live_contract.py
@@ -36,6 +36,7 @@ PEER_ADAPTER_REASON_PROJECTION_BUDGET_EXHAUSTED_CODE = (
     "p2p_live_reconnect_retry_budget_exhausted"
 )
 PEER_ADAPTER_MULTI_PROCESS_VALIDATION_LOCAL_HEAVY_STATUS = "required"
+RETRY_RECONNECT_MARKER_CONTRACT_STATUS = "verified"
 POLICY_REASON_CODES_CSV = ",".join(
     [
         "ci_fast_gate_failed",
@@ -208,6 +209,7 @@ def _run_lane(args: argparse.Namespace) -> int:
         "peer_adapter_multi_process_validation_local_heavy_status": (
             PEER_ADAPTER_MULTI_PROCESS_VALIDATION_LOCAL_HEAVY_STATUS
         ),
+        "retry_reconnect_marker_contract_status": RETRY_RECONNECT_MARKER_CONTRACT_STATUS,
         "reason_taxonomy_version": REASON_TAXONOMY_VERSION,
         "reason_taxonomy_status": "verified",
         "reason_codes": ["none"],
@@ -252,6 +254,10 @@ def _run_lane(args: argparse.Namespace) -> int:
     print(
         "peer_adapter_multi_process_validation_local_heavy_status="
         f"{PEER_ADAPTER_MULTI_PROCESS_VALIDATION_LOCAL_HEAVY_STATUS}"
+    )
+    print(
+        "retry_reconnect_marker_contract_status="
+        f"{RETRY_RECONNECT_MARKER_CONTRACT_STATUS}"
     )
     print(f"reason_taxonomy_version={REASON_TAXONOMY_VERSION}")
     print("reason_taxonomy_status=verified")
@@ -298,6 +304,7 @@ def _check_policy(args: argparse.Namespace) -> int:
         "peer_adapter_reason_projection_timeout_code",
         "peer_adapter_reason_projection_budget_exhausted_code",
         "peer_adapter_multi_process_validation_local_heavy_status",
+        "retry_reconnect_marker_contract_status",
         "reason_taxonomy_version",
         "reason_taxonomy_status",
         "reason_codes",
@@ -336,6 +343,7 @@ def _check_policy(args: argparse.Namespace) -> int:
         "peer_churn_recovery_status",
         "reason_taxonomy_status",
         "performance_budget_status",
+        "retry_reconnect_marker_contract_status",
     ):
         decision.reject_if(
             report.get(field_name) != "verified",
@@ -469,6 +477,7 @@ def _check_policy(args: argparse.Namespace) -> int:
         "peer_adapter_multi_process_validation_local_heavy_status": (
             PEER_ADAPTER_MULTI_PROCESS_VALIDATION_LOCAL_HEAVY_STATUS
         ),
+        "retry_reconnect_marker_contract_status": RETRY_RECONNECT_MARKER_CONTRACT_STATUS,
         "ci_fast_gate": ci_fast_gate,
         "source_report_file": str(report_file),
         "generated_at_epoch": int(time.time()),
@@ -500,6 +509,10 @@ def _check_policy(args: argparse.Namespace) -> int:
     print(
         "peer_adapter_multi_process_validation_local_heavy_status="
         f"{PEER_ADAPTER_MULTI_PROCESS_VALIDATION_LOCAL_HEAVY_STATUS}"
+    )
+    print(
+        "retry_reconnect_marker_contract_status="
+        f"{RETRY_RECONNECT_MARKER_CONTRACT_STATUS}"
     )
     if output_json is not None:
         print(f"policy_report_file={output_json}")

--- a/scripts/runtime/test_check_live_transport_fault_matrix_live_policy.sh
+++ b/scripts/runtime/test_check_live_transport_fault_matrix_live_policy.sh
@@ -77,6 +77,10 @@ if ! printf '%s\n' "$policy_output" | grep -q '^peer_adapter_multi_process_valid
   echo "expected deterministic live transport fault matrix policy peer-adapter multi-process local-heavy marker" >&2
   exit 1
 fi
+if ! printf '%s\n' "$policy_output" | grep -q '^retry_reconnect_marker_contract_status=verified$'; then
+  echo "expected deterministic live transport fault matrix policy retry/reconnect marker contract status marker" >&2
+  exit 1
+fi
 
 python3 - "$TMP_POLICY" <<'PY'
 import json
@@ -106,6 +110,8 @@ if payload.get("peer_adapter_reason_projection_budget_exhausted_code") != "p2p_l
     raise SystemExit("expected deterministic peer_adapter_reason_projection_budget_exhausted_code marker in policy report")
 if payload.get("peer_adapter_multi_process_validation_local_heavy_status") != "required":
     raise SystemExit("expected deterministic peer_adapter_multi_process_validation_local_heavy_status marker in policy report")
+if payload.get("retry_reconnect_marker_contract_status") != "verified":
+    raise SystemExit("expected deterministic retry_reconnect_marker_contract_status marker in policy report")
 PY
 
 cp "$TMP_REPORT" "$TMP_TAMPERED"

--- a/scripts/runtime/test_validate_live_transport_fault_matrix_live.sh
+++ b/scripts/runtime/test_validate_live_transport_fault_matrix_live.sh
@@ -66,6 +66,10 @@ if ! printf '%s\n' "$validation_output" | grep -q '^peer_adapter_multi_process_v
   echo "expected live transport fault matrix peer-adapter multi-process local-heavy marker" >&2
   exit 1
 fi
+if ! printf '%s\n' "$validation_output" | grep -q '^retry_reconnect_marker_contract_status=verified$'; then
+  echo "expected live transport fault matrix retry/reconnect marker contract status marker" >&2
+  exit 1
+fi
 if ! printf '%s\n' "$validation_output" | grep -q '^reason_taxonomy_version=kamn.runtime.live-transport-fault-matrix-reason-taxonomy.v1$'; then
   echo "expected live transport fault matrix reason taxonomy version marker" >&2
   exit 1
@@ -99,6 +103,8 @@ if payload.get("peer_adapter_reason_projection_budget_exhausted_code") != "p2p_l
     raise SystemExit("expected deterministic peer_adapter_reason_projection_budget_exhausted_code marker")
 if payload.get("peer_adapter_multi_process_validation_local_heavy_status") != "required":
     raise SystemExit("expected deterministic peer_adapter_multi_process_validation_local_heavy_status marker")
+if payload.get("retry_reconnect_marker_contract_status") != "verified":
+    raise SystemExit("expected deterministic retry_reconnect_marker_contract_status marker")
 if payload.get("reason_taxonomy_version") != "kamn.runtime.live-transport-fault-matrix-reason-taxonomy.v1":
     raise SystemExit("expected deterministic reason taxonomy version marker")
 if payload.get("reason_codes") != ["none"]:

--- a/scripts/runtime/test_validate_live_transport_fault_matrix_live_contract_lane.sh
+++ b/scripts/runtime/test_validate_live_transport_fault_matrix_live_contract_lane.sh
@@ -83,6 +83,10 @@ if ! printf '%s\n' "$lane_output" | grep -q '^peer_adapter_multi_process_validat
   echo "expected live transport fault matrix peer-adapter multi-process local-heavy marker in contract lane output" >&2
   exit 1
 fi
+if ! printf '%s\n' "$lane_output" | grep -q '^retry_reconnect_marker_contract_status=verified$'; then
+  echo "expected live transport fault matrix retry/reconnect marker contract status marker in contract lane output" >&2
+  exit 1
+fi
 if ! printf '%s\n' "$lane_output" | grep -q '^peer_reason_docs_contract_status=verified$'; then
   echo "expected live transport fault matrix peer reason docs contract status marker in contract lane output" >&2
   exit 1
@@ -144,6 +148,8 @@ if lane_payload.get("peer_adapter_reason_projection_budget_exhausted_code") != "
     raise SystemExit("expected deterministic peer_adapter_reason_projection_budget_exhausted_code marker in contract lane report")
 if lane_payload.get("peer_adapter_multi_process_validation_local_heavy_status") != "required":
     raise SystemExit("expected deterministic peer_adapter_multi_process_validation_local_heavy_status marker in contract lane report")
+if lane_payload.get("retry_reconnect_marker_contract_status") != "verified":
+    raise SystemExit("expected deterministic retry_reconnect_marker_contract_status marker in contract lane report")
 if lane_payload.get("peer_reason_docs_contract_status") != "verified":
     raise SystemExit("expected peer_reason_docs_contract_status=verified in contract lane report")
 if lane_payload.get("evidence_convergence_status") != "verified":
@@ -176,6 +182,8 @@ if policy_payload.get("peer_adapter_reason_projection_budget_exhausted_code") !=
     raise SystemExit("expected deterministic peer_adapter_reason_projection_budget_exhausted_code marker in policy report")
 if policy_payload.get("peer_adapter_multi_process_validation_local_heavy_status") != "required":
     raise SystemExit("expected deterministic peer_adapter_multi_process_validation_local_heavy_status marker in policy report")
+if policy_payload.get("retry_reconnect_marker_contract_status") != "verified":
+    raise SystemExit("expected deterministic retry_reconnect_marker_contract_status marker in policy report")
 PY
 
 set +e

--- a/scripts/runtime/validate_live_transport_fault_matrix_live_contract_lane.sh
+++ b/scripts/runtime/validate_live_transport_fault_matrix_live_contract_lane.sh
@@ -236,6 +236,10 @@ if ! printf '%s\n' "$policy_output" | grep -q '^peer_adapter_multi_process_valid
   echo "expected live transport fault matrix policy peer-adapter multi-process local-heavy marker" >&2
   exit 1
 fi
+if ! printf '%s\n' "$policy_output" | grep -q '^retry_reconnect_marker_contract_status=verified$'; then
+  echo "expected live transport fault matrix policy retry/reconnect marker contract status marker" >&2
+  exit 1
+fi
 
 cp "$summary_report" "$tampered_report"
 python3 - "$tampered_report" <<'PY'
@@ -427,6 +431,9 @@ lane_report = {
     "peer_adapter_multi_process_validation_local_heavy_status": policy_report.get(
         "peer_adapter_multi_process_validation_local_heavy_status"
     ),
+    "retry_reconnect_marker_contract_status": policy_report.get(
+        "retry_reconnect_marker_contract_status"
+    ),
     "peer_reason_docs_contract_status": "verified",
     "fail_closed_status": "verified",
     "convergence_fail_closed_reason_code": "live_transport_fault_matrix_contract_evidence_convergence_mismatch",
@@ -466,6 +473,7 @@ echo "peer_integrity_fail_closed_reason_code=p2p_transport_unknown_sender_peer"
 echo "peer_adapter_reason_projection_timeout_code=p2p_live_reconnect_retry_dial_timeout"
 echo "peer_adapter_reason_projection_budget_exhausted_code=p2p_live_reconnect_retry_budget_exhausted"
 echo "peer_adapter_multi_process_validation_local_heavy_status=required"
+echo "retry_reconnect_marker_contract_status=verified"
 echo "peer_reason_docs_contract_status=verified"
 echo "fail_closed_status=verified"
 echo "convergence_fail_closed_reason_code=live_transport_fault_matrix_contract_evidence_convergence_mismatch"

--- a/specs/3794/plan.md
+++ b/specs/3794/plan.md
@@ -1,0 +1,38 @@
+# Issue #3794 Plan
+
+- Issue: #3794
+- Status: In Progress
+- Spec: `specs/3794/spec.md`
+
+## Implementation Approach
+1. Introduce a deterministic retry/reconnect marker contract status field in the transport resilience lane run report and policy report.
+2. Require and validate the field in policy checks so drift fails closed.
+3. Propagate the marker through the contract-lane summary report and emitted markers.
+4. Update transport resilience test harnesses and docs marker references.
+
+## Affected Modules
+- `scripts/runtime/live_transport_fault_matrix_live_contract.py`
+- `scripts/runtime/validate_live_transport_fault_matrix_live_contract_lane.sh`
+- `scripts/runtime/test_validate_live_transport_fault_matrix_live.sh`
+- `scripts/runtime/test_check_live_transport_fault_matrix_live_policy.sh`
+- `scripts/runtime/test_validate_live_transport_fault_matrix_live_contract_lane.sh`
+- `docs/planning/kolme-devnet-ops.md`
+
+## Risks and Mitigations
+- Risk: marker propagation drift between run-lane, policy, and contract-lane reports.
+  - Mitigation: enforce marker presence and value in all three existing contract test suites.
+- Risk: shell-surface growth.
+  - Mitigation: keep changes minimal and focused on existing scripts/tests; run shell LOC/ratio/ratchet guardrails before PR.
+
+## Contracts and Interfaces
+- Run-lane report contract (`kamn.runtime.live-transport-fault-matrix-report.v1`) includes:
+  - `retry_reconnect_marker_contract_status=verified`
+- Policy report contract (`kamn.runtime.live-transport-fault-matrix-policy-report.v1`) includes:
+  - `retry_reconnect_marker_contract_status=verified`
+- Contract-lane report contract (`kamn.runtime.live-transport-fault-matrix-contract-lane-report.v1`) propagates:
+  - `retry_reconnect_marker_contract_status=verified`
+
+## Verification Strategy
+- Execute RED by adding marker assertions before implementation.
+- Execute GREEN by adding marker emission/validation/propagation.
+- Execute regression lane and shell guardrail checks listed in `specs/3794/spec.md`.

--- a/specs/3794/spec.md
+++ b/specs/3794/spec.md
@@ -1,0 +1,54 @@
+# Issue #3794 Spec
+
+- Title: Subtask: implement transport resilience local-heavy lane artifact and policy checker
+- Status: Reviewed
+- Type: subtask
+- Priority: P1
+- Milestone: specs/milestones/r26-5-observability-and-transport-resilience-hardening/index.md
+
+## Problem Statement
+The transport resilience local-heavy lane already validates retry/reconnect behavior, but it lacks an explicit deterministic retry/reconnect marker contract status field that can be consumed by downstream policy and docs drift contracts.
+
+## Acceptance Criteria
+- AC-1: Local-heavy transport resilience run-lane summary emits a deterministic retry/reconnect marker contract status field.
+- AC-2: Local-heavy transport resilience policy checker fails closed when retry/reconnect marker contract status is missing or mismatched.
+- AC-3: Contract-lane aggregation and docs references include the deterministic retry/reconnect marker contract status.
+- AC-4: Unit/Functional/Integration/Regression evidence for this marker contract is present and passing.
+
+## Scope
+In scope:
+- `scripts/runtime/live_transport_fault_matrix_live_contract.py`
+- `scripts/runtime/validate_live_transport_fault_matrix_live_contract_lane.sh`
+- `scripts/runtime/test_validate_live_transport_fault_matrix_live.sh`
+- `scripts/runtime/test_check_live_transport_fault_matrix_live_policy.sh`
+- `scripts/runtime/test_validate_live_transport_fault_matrix_live_contract_lane.sh`
+- `docs/planning/kolme-devnet-ops.md`
+- `specs/3794/{spec.md,plan.md,tasks.md}`
+
+Out of scope:
+- CI-fast exclusion policy wiring for this lane (tracked in `#3795`)
+- New transport protocol behavior
+- New dependencies
+
+## Conformance Cases
+| Case | AC | Tier | Input | Expected |
+|---|---|---|---|---|
+| C-01 | AC-1 | Functional | dry-run transport resilience lane execution | output includes `retry_reconnect_marker_contract_status=verified` and report JSON field |
+| C-02 | AC-2 | Regression | policy checker against lane report | policy output/report include deterministic retry/reconnect marker contract status; mismatch fails closed |
+| C-03 | AC-3 | Integration | contract-lane runner output aggregation | lane output/report include propagated retry/reconnect marker contract status from policy surface |
+| C-04 | AC-3 | Regression | docs contract checks | Kolme devnet ops docs include retry/reconnect marker contract status declaration for the transport resilience lane |
+| C-05 | AC-4 | Regression | shell guardrails | no shell/rust ratio or hard-ceiling regression introduced by this change |
+
+## Test Mapping
+- `bash scripts/runtime/test_validate_live_transport_fault_matrix_live.sh`
+- `bash scripts/runtime/test_check_live_transport_fault_matrix_live_policy.sh`
+- `bash scripts/runtime/test_validate_live_transport_fault_matrix_live_contract_lane.sh`
+- `cargo test -p kamn-node --test kolme_devnet_ops_docs`
+- `scripts/ci/check_shell_loc_hard_ceiling.sh --output-json /tmp/shell-loc-hard-ceiling-3794.json`
+- `scripts/ci/check_shell_rust_ratio_guardrail.sh --output-json /tmp/shell-rust-ratio-3794.json`
+- `scripts/ci/check_shell_surface_threshold_ratchet.sh --output-json /tmp/shell-threshold-ratchet-3794.json`
+
+## Success Metrics
+- Retry/reconnect marker contract status is deterministic and visible in lane, policy, and contract-lane outputs.
+- Policy and docs checks fail closed on drift.
+- Shell-surface guardrails remain green.

--- a/specs/3794/tasks.md
+++ b/specs/3794/tasks.md
@@ -1,0 +1,18 @@
+# Issue #3794 Tasks
+
+- Issue: #3794
+- Status: In Progress
+
+## Ordered Tasks
+- [x] T1 (Red): add failing retry/reconnect marker contract assertions across transport resilience lane/policy/contract-lane tests.
+- [x] T2 (Green): emit and validate deterministic `retry_reconnect_marker_contract_status=verified` marker in run-lane + policy contracts.
+- [x] T3 (Integration): propagate marker through contract-lane aggregation output and report payload.
+- [x] T4 (Regression): update docs marker references and rerun transport resilience/test-contract suites.
+- [ ] T5 (Verify): run shell guardrails, open mergeable PR, and close issue with DoD markers.
+
+## Tier Mapping
+- Unit: policy required-field/value checks for retry/reconnect marker contract status.
+- Functional: lane dry-run marker emission checks.
+- Integration: contract-lane output/report marker propagation checks.
+- Regression: tamper/missing marker fail-closed behavior and docs marker parity.
+- Performance: N/A (no new command path or runtime workload introduced).


### PR DESCRIPTION
## Summary
Adds an explicit deterministic `retry_reconnect_marker_contract_status=verified` contract marker across the live transport fault-matrix run-lane, policy checker, and contract-lane aggregation surfaces. Tightens docs/test contracts so retry/reconnect marker drift fails closed and records issue lineage under `specs/3794/`.

## Links
- Milestone: `specs/milestones/r26-5-observability-and-transport-resilience-hardening/index.md`
- Closes #3794
- Spec: `specs/3794/spec.md`
- Plan: `specs/3794/plan.md`
- Tasks: `specs/3794/tasks.md`

## Spec Verification (AC → tests)
| AC | ✅/❌ | Test(s) |
|---|---|---|
| AC-1: run-lane summary emits deterministic retry/reconnect marker contract status | ✅ | `bash scripts/runtime/test_validate_live_transport_fault_matrix_live.sh` |
| AC-2: policy checker fails closed on missing/mismatched retry/reconnect marker contract status | ✅ | `bash scripts/runtime/test_check_live_transport_fault_matrix_live_policy.sh` |
| AC-3: contract-lane aggregation and docs references include marker | ✅ | `bash scripts/runtime/test_validate_live_transport_fault_matrix_live_contract_lane.sh`; `cargo test -p kamn-node --test kolme_devnet_ops_docs` |
| AC-4: Unit/Functional/Integration/Regression evidence present and passing | ✅ | Commands in TDD + Test Tier sections |

## TDD Evidence
- RED:
  - `bash scripts/runtime/test_validate_live_transport_fault_matrix_live.sh`
  - Failing excerpt: `expected live transport fault matrix retry/reconnect marker contract status marker`
  - `cargo test -p kamn-node --test kolme_devnet_ops_docs`
  - Failing excerpt: `assertion failed: DOC.contains("retry_reconnect_marker_contract_status=verified")`
- GREEN:
  - `bash scripts/runtime/test_validate_live_transport_fault_matrix_live.sh`
  - `bash scripts/runtime/test_check_live_transport_fault_matrix_live_policy.sh`
  - `bash scripts/runtime/test_validate_live_transport_fault_matrix_live_contract_lane.sh`
  - `cargo test -p kamn-node --test kolme_devnet_ops_docs`
  - `cargo fmt --check`
  - `cargo clippy -p kamn-node --test kolme_devnet_ops_docs -- -D warnings`
  - `scripts/ci/check_shell_loc_hard_ceiling.sh --output-json /tmp/shell-loc-hard-ceiling-3794.json`
  - `scripts/ci/check_shell_rust_ratio_guardrail.sh --output-json /tmp/shell-rust-ratio-3794.json`
  - `scripts/ci/check_shell_surface_threshold_ratchet.sh --output-json /tmp/shell-threshold-ratchet-3794.json`
- REGRESSION:
  - Existing tamper/fail-closed policy and contract-lane tests now include retry/reconnect marker contract status expectations.

## Test Tiers
| Tier | ✅/❌/N/A | Tests | N/A Why |
|---|---|---|---|
| Unit | ✅ | `bash scripts/runtime/test_check_live_transport_fault_matrix_live_policy.sh` | |
| Property | N/A | | No randomized invariant/parser behavior added. |
| Contract/DbC | N/A | | No new DbC annotation surface in Rust APIs. |
| Snapshot | N/A | | No snapshot artifacts introduced. |
| Functional | ✅ | `bash scripts/runtime/test_validate_live_transport_fault_matrix_live.sh` | |
| Conformance | ✅ | `bash scripts/runtime/test_validate_live_transport_fault_matrix_live.sh`; `bash scripts/runtime/test_check_live_transport_fault_matrix_live_policy.sh`; `bash scripts/runtime/test_validate_live_transport_fault_matrix_live_contract_lane.sh`; `cargo test -p kamn-node --test kolme_devnet_ops_docs` | |
| Integration | ✅ | `bash scripts/runtime/test_validate_live_transport_fault_matrix_live_contract_lane.sh` | |
| Fuzz | N/A | | No new untrusted parser/input boundary introduced. |
| Mutation | N/A | | This subtask extends deterministic marker contracts on existing lane/policy surfaces; no new critical algorithmic branch introduced. |
| Regression | ✅ | Existing tamper-path checks in policy/contract-lane tests + docs marker parity test | |
| Performance | N/A | | No new command path or runtime workload introduced. |

## Mutation
- caught/total: N/A (see Test Tier justification)

## Risks/Rollback
- Risk: Low. Change is additive marker contract propagation/validation on existing local-heavy lane outputs.
- Rollback: revert this PR commit to remove the added marker contract surface.

## Docs/ADR
- Updated docs:
  - `docs/planning/kolme-devnet-ops.md`
- ADR: N/A (no architectural/protocol/dependency change)
