### PR TITLE
Spec status sync: mark closed R27.46 specs Implemented

### DIFF
--- a/specs/5177/spec.md
+++ b/specs/5177/spec.md
@@ -1,7 +1,7 @@
 # Issue #5177 Spec
 
 - Title: Story: remediate R42 immediate stability and hygiene findings
-- Status: Reviewed
+- Status: Implemented
 - Priority: P1
 - Milestone: specs/milestones/r27-46-r42-gap-remediation-and-maintainability-closure/index.md
 

--- a/specs/5179/spec.md
+++ b/specs/5179/spec.md
@@ -1,7 +1,7 @@
 # Issue #5179 Spec
 
 - Title: Task: implement R42 immediate fixes (signer lock poisoning, ignored-test debt, PRD relocation, draft-spec review)
-- Status: Reviewed
+- Status: Implemented
 - Priority: P1
 - Milestone: specs/milestones/r27-46-r42-gap-remediation-and-maintainability-closure/index.md
 

--- a/specs/5183/spec.md
+++ b/specs/5183/spec.md
@@ -1,7 +1,7 @@
 # Issue #5183 Spec
 
 - Title: Task: automate merged-branch cleanup with safe retention policy
-- Status: Reviewed
+- Status: Implemented
 - Priority: P2
 - Milestone: specs/milestones/r27-46-r42-gap-remediation-and-maintainability-closure/index.md
 


### PR DESCRIPTION
## Summary
Metadata-only follow-up to align closed issue specs with AGENTS.md closure contract by marking statuses as `Implemented`.

## Links
- Follow-up to PR #5185
- Spec updates:
  - `specs/5177/spec.md`
  - `specs/5179/spec.md`
  - `specs/5183/spec.md`

## Verification
- `rg -n "Status: Implemented" specs/5177/spec.md specs/5179/spec.md specs/5183/spec.md`

## Risks / Rollback
- None (spec metadata only).
