### PR TITLE
feat: typed DID migration wave-B for operator/governance surfaces (#5229)

### DIFF
--- a/crates/kamn-core/src/governance_workflow.rs
+++ b/crates/kamn-core/src/governance_workflow.rs
@@ -4,6 +4,13 @@ use crate::AgentDid;
 use std::collections::BTreeMap;
 use std::fmt;
 
+const GOVERNANCE_WORKFLOW_INVALID_PROPOSER_DID_REASON_CODE: &str =
+    "governance_workflow_invalid_proposer_did";
+const GOVERNANCE_WORKFLOW_INVALID_VOTER_DID_REASON_CODE: &str =
+    "governance_workflow_invalid_voter_did";
+const GOVERNANCE_WORKFLOW_INVALID_EXECUTOR_DID_REASON_CODE: &str =
+    "governance_workflow_invalid_executor_did";
+
 /// Draft proposal submitted into the governance workflow.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GovernanceProposalDraft {
@@ -219,7 +226,11 @@ impl GovernanceWorkflow {
         require_non_empty("proposal_id", &draft.proposal_id)?;
         require_non_empty("title", &draft.title)?;
         require_non_empty("description", &draft.description)?;
-        validate_did(&draft.proposer_did)?;
+        let proposer_did = parse_agent_did(
+            draft.proposer_did.as_str(),
+            "proposer_did",
+            GOVERNANCE_WORKFLOW_INVALID_PROPOSER_DID_REASON_CODE,
+        )?;
         if draft.created_at_unix == 0 {
             return Err(GovernanceWorkflowError::InvalidTimestamp("created_at_unix"));
         }
@@ -248,7 +259,7 @@ impl GovernanceWorkflow {
                     proposal_id: draft.proposal_id,
                     title: draft.title,
                     description: draft.description,
-                    proposer_did: draft.proposer_did,
+                    proposer_did: proposer_did.as_str().to_owned(),
                     created_at_unix: draft.created_at_unix,
                     voting_deadline_unix: draft.voting_deadline_unix,
                     quorum_threshold: draft.quorum_threshold,
@@ -281,7 +292,11 @@ impl GovernanceWorkflow {
         if cast_at_unix == 0 {
             return Err(GovernanceWorkflowError::InvalidTimestamp("cast_at_unix"));
         }
-        validate_did(voter_did)?;
+        let voter_did = parse_agent_did(
+            voter_did,
+            "voter_did",
+            GOVERNANCE_WORKFLOW_INVALID_VOTER_DID_REASON_CODE,
+        )?;
         if state.record.status != GovernanceProposalStatus::Voting {
             return Err(GovernanceWorkflowError::ProposalClosed {
                 proposal_id: proposal_id.to_owned(),
@@ -295,20 +310,20 @@ impl GovernanceWorkflow {
                 status: state.record.status,
             });
         }
-        if state.votes.contains_key(voter_did) {
+        if state.votes.contains_key(voter_did.as_str()) {
             return Err(GovernanceWorkflowError::DuplicateVote {
                 proposal_id: proposal_id.to_owned(),
-                voter_did: voter_did.to_owned(),
+                voter_did: voter_did.as_str().to_owned(),
             });
         }
 
         let vote = GovernanceVoteRecord {
             proposal_id: proposal_id.to_owned(),
-            voter_did: voter_did.to_owned(),
+            voter_did: voter_did.as_str().to_owned(),
             choice,
             cast_at_unix,
         };
-        state.votes.insert(voter_did.to_owned(), vote);
+        state.votes.insert(voter_did.as_str().to_owned(), vote);
         match choice {
             GovernanceVoteChoice::Yes => state.record.yes_votes += 1,
             GovernanceVoteChoice::No => state.record.no_votes += 1,
@@ -351,7 +366,11 @@ impl GovernanceWorkflow {
                 "executed_at_unix",
             ));
         }
-        validate_did(executed_by)?;
+        let executed_by = parse_agent_did(
+            executed_by,
+            "executed_by",
+            GOVERNANCE_WORKFLOW_INVALID_EXECUTOR_DID_REASON_CODE,
+        )?;
         require_non_empty("operation_hash", operation_hash)?;
 
         let state = self
@@ -377,7 +396,7 @@ impl GovernanceWorkflow {
         state.record.executed_at_unix = Some(executed_at_unix);
         let record = GovernanceExecutionRecord {
             proposal_id: proposal_id.to_owned(),
-            executed_by: executed_by.to_owned(),
+            executed_by: executed_by.as_str().to_owned(),
             executed_at_unix,
             operation_hash: operation_hash.to_owned(),
         };
@@ -416,7 +435,14 @@ pub enum GovernanceWorkflowError {
     /// Required string field is empty.
     EmptyField(&'static str),
     /// DID failed canonical parsing/validation.
-    InvalidDid(String),
+    InvalidDid {
+        /// Input field carrying the DID value.
+        field: &'static str,
+        /// Stable reason marker.
+        reason_code: &'static str,
+        /// Canonical parser detail.
+        detail: String,
+    },
     /// Timestamp field must be positive.
     InvalidTimestamp(&'static str),
     /// Voting deadline does not occur after creation timestamp.
@@ -507,7 +533,11 @@ impl fmt::Display for GovernanceWorkflowError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::EmptyField(field) => write!(f, "field must not be empty: {field}"),
-            Self::InvalidDid(value) => write!(f, "invalid did: {value}"),
+            Self::InvalidDid {
+                field,
+                reason_code,
+                detail,
+            } => write!(f, "invalid did field {field}: {reason_code} ({detail})"),
             Self::InvalidTimestamp(field) => write!(f, "timestamp must be > 0: {field}"),
             Self::InvalidDeadline {
                 created_at_unix,
@@ -601,10 +631,47 @@ fn require_non_empty(field: &'static str, value: &str) -> Result<(), GovernanceW
     Ok(())
 }
 
-fn validate_did(value: &str) -> Result<(), GovernanceWorkflowError> {
-    AgentDid::parse(value)
-        .map_err(|error| GovernanceWorkflowError::InvalidDid(error.to_string()))?;
-    Ok(())
+impl GovernanceWorkflowError {
+    /// Stable reason taxonomy for governance workflow failures.
+    pub fn reason_code(&self) -> &'static str {
+        match self {
+            Self::EmptyField(_) => "governance_workflow_empty_field",
+            Self::InvalidDid { reason_code, .. } => reason_code,
+            Self::InvalidTimestamp(_) => "governance_workflow_invalid_timestamp",
+            Self::InvalidDeadline { .. } => "governance_workflow_invalid_deadline",
+            Self::InvalidQuorum(_) => "governance_workflow_invalid_quorum",
+            Self::InvalidParameterTargetVersion(_) => {
+                "governance_workflow_invalid_parameter_target_version"
+            }
+            Self::InvalidParameterRange { .. } => "governance_workflow_invalid_parameter_range",
+            Self::UnknownParameterKey(_) => "governance_workflow_unknown_parameter_key",
+            Self::ParameterRangeOutsidePolicy { .. } => {
+                "governance_workflow_parameter_range_outside_policy"
+            }
+            Self::ParameterUnsupportedForVersion { .. } => {
+                "governance_workflow_parameter_unsupported_for_version"
+            }
+            Self::ParameterOutOfBounds { .. } => "governance_workflow_parameter_out_of_bounds",
+            Self::DuplicateProposal(_) => "governance_workflow_duplicate_proposal",
+            Self::ProposalNotFound(_) => "governance_workflow_proposal_not_found",
+            Self::DuplicateVote { .. } => "governance_workflow_duplicate_vote",
+            Self::ProposalClosed { .. } => "governance_workflow_proposal_closed",
+            Self::ProposalNotApproved { .. } => "governance_workflow_proposal_not_approved",
+            Self::AlreadyExecuted(_) => "governance_workflow_already_executed",
+        }
+    }
+}
+
+fn parse_agent_did(
+    value: &str,
+    field: &'static str,
+    reason_code: &'static str,
+) -> Result<AgentDid, GovernanceWorkflowError> {
+    AgentDid::parse(value).map_err(|error| GovernanceWorkflowError::InvalidDid {
+        field,
+        reason_code,
+        detail: error.to_string(),
+    })
 }
 
 fn validate_parameter_change(

--- a/crates/kamn-core/src/operator_actions.rs
+++ b/crates/kamn-core/src/operator_actions.rs
@@ -80,7 +80,7 @@ impl PermissionedOperatorActionService {
                 requested_at_unix,
                 outcome: OperatorActionOutcome::Denied,
             });
-            return Err(OperatorActionServiceError::Binding(error.to_string()));
+            return Err(OperatorActionServiceError::Binding(error));
         }
 
         self.settings.insert(
@@ -132,7 +132,7 @@ impl PermissionedOperatorActionService {
                     requested_at_unix,
                     outcome: OperatorActionOutcome::Denied,
                 });
-                Err(OperatorActionServiceError::Binding(error.to_string()))
+                Err(OperatorActionServiceError::Binding(error))
             }
         }
     }
@@ -161,7 +161,7 @@ impl PermissionedOperatorActionService {
                 requested_at_unix,
                 outcome: OperatorActionOutcome::Denied,
             });
-            return Err(OperatorActionServiceError::Binding(error.to_string()));
+            return Err(OperatorActionServiceError::Binding(error));
         }
 
         self.push_audit(OperatorActionAuditRecord {
@@ -199,14 +199,14 @@ pub enum OperatorActionServiceError {
     /// Required input field was empty.
     EmptyField(&'static str),
     /// Binding authorization or binding mutation failed.
-    Binding(String),
+    Binding(OperatorBindingError),
 }
 
 impl fmt::Display for OperatorActionServiceError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::EmptyField(field) => write!(f, "field must not be empty: {field}"),
-            Self::Binding(message) => write!(f, "operator binding error: {message}"),
+            Self::Binding(error) => write!(f, "operator binding error: {error}"),
         }
     }
 }
@@ -215,7 +215,17 @@ impl std::error::Error for OperatorActionServiceError {}
 
 impl From<OperatorBindingError> for OperatorActionServiceError {
     fn from(value: OperatorBindingError) -> Self {
-        Self::Binding(value.to_string())
+        Self::Binding(value)
+    }
+}
+
+impl OperatorActionServiceError {
+    /// Stable reason taxonomy for permissioned operator action failures.
+    pub fn reason_code(&self) -> &'static str {
+        match self {
+            Self::EmptyField(_) => "operator_actions_empty_field",
+            Self::Binding(error) => error.reason_code(),
+        }
     }
 }
 

--- a/crates/kamn-core/src/operator_binding.rs
+++ b/crates/kamn-core/src/operator_binding.rs
@@ -4,6 +4,9 @@ use std::fmt;
 
 const HUMAN_DID_PREFIX: &str = "kamn:did:human:";
 const CANONICAL_PROOF_TYPE: &str = "Ed25519Signature2020";
+const OPERATOR_BINDING_INVALID_AGENT_DID_REASON_CODE: &str = "operator_binding_invalid_agent_did";
+const OPERATOR_BINDING_INVALID_OPERATOR_DID_REASON_CODE: &str =
+    "operator_binding_invalid_operator_did";
 
 /// Permissioned actions that an operator binding may authorize.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -50,6 +53,71 @@ pub struct OperatorBindingEngine {
     bindings: BTreeMap<(String, String), OperatorBindingRecord>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct OperatorBindingPrincipals {
+    agent_did: AgentDid,
+    operator_did: OperatorHumanDid,
+}
+
+impl OperatorBindingPrincipals {
+    fn parse(agent_did: &str, operator_did: &str) -> Result<Self, OperatorBindingError> {
+        Ok(Self {
+            agent_did: parse_agent_did(
+                agent_did,
+                "agent_did",
+                OPERATOR_BINDING_INVALID_AGENT_DID_REASON_CODE,
+            )?,
+            operator_did: parse_operator_did(
+                operator_did,
+                "operator_did",
+                OPERATOR_BINDING_INVALID_OPERATOR_DID_REASON_CODE,
+            )?,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct OperatorHumanDid(String);
+
+impl OperatorHumanDid {
+    fn parse(
+        value: &str,
+        field: &'static str,
+        reason_code: &'static str,
+    ) -> Result<Self, OperatorBindingError> {
+        if !value.starts_with(HUMAN_DID_PREFIX) {
+            return Err(OperatorBindingError::InvalidOperatorDid {
+                field,
+                reason_code,
+                detail: format!("invalid human did prefix: {value}"),
+            });
+        }
+        let method_specific_id = &value[HUMAN_DID_PREFIX.len()..];
+        if method_specific_id.is_empty() {
+            return Err(OperatorBindingError::InvalidOperatorDid {
+                field,
+                reason_code,
+                detail: "human did method-specific id must not be empty".to_owned(),
+            });
+        }
+        if !method_specific_id
+            .chars()
+            .all(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '-' || ch == '_')
+        {
+            return Err(OperatorBindingError::InvalidOperatorDid {
+                field,
+                reason_code,
+                detail: format!("human did has invalid characters: {method_specific_id}"),
+            });
+        }
+        Ok(Self(value.to_owned()))
+    }
+
+    fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
 impl OperatorBindingEngine {
     /// Creates an empty operator binding engine.
     pub fn new() -> Self {
@@ -64,29 +132,31 @@ impl OperatorBindingEngine {
         proof: Option<OperatorBindingProof>,
         permissions: BTreeSet<OperatorBindingAction>,
     ) -> Result<(), OperatorBindingError> {
-        validate_agent_did(agent_did)?;
-        validate_operator_did(operator_did)?;
+        let principals = OperatorBindingPrincipals::parse(agent_did, operator_did)?;
         if permissions.is_empty() {
             return Err(OperatorBindingError::EmptyPermissions);
         }
 
         if let Some(proof_value) = &proof {
-            validate_proof(proof_value, operator_did)?;
+            validate_proof(proof_value, principals.operator_did.as_str())?;
         }
 
-        let key = (agent_did.to_owned(), operator_did.to_owned());
+        let key = (
+            principals.agent_did.as_str().to_owned(),
+            principals.operator_did.as_str().to_owned(),
+        );
         if self.bindings.contains_key(&key) {
             return Err(OperatorBindingError::DuplicateBinding {
-                agent_did: agent_did.to_owned(),
-                operator_did: operator_did.to_owned(),
+                agent_did: principals.agent_did.as_str().to_owned(),
+                operator_did: principals.operator_did.as_str().to_owned(),
             });
         }
 
         self.bindings.insert(
             key,
             OperatorBindingRecord {
-                agent_did: agent_did.to_owned(),
-                operator_did: operator_did.to_owned(),
+                agent_did: principals.agent_did.as_str().to_owned(),
+                operator_did: principals.operator_did.as_str().to_owned(),
                 proof,
                 permissions,
                 revoked: false,
@@ -102,19 +172,21 @@ impl OperatorBindingEngine {
         operator_did: &str,
         action: OperatorBindingAction,
     ) -> Result<(), OperatorBindingError> {
-        validate_agent_did(agent_did)?;
-        validate_operator_did(operator_did)?;
+        let principals = OperatorBindingPrincipals::parse(agent_did, operator_did)?;
 
-        let record = self.lookup(agent_did, operator_did)?;
+        let record = self.lookup(
+            principals.agent_did.as_str(),
+            principals.operator_did.as_str(),
+        )?;
         if record.revoked {
             return Err(OperatorBindingError::RevokedBinding {
-                agent_did: agent_did.to_owned(),
-                operator_did: operator_did.to_owned(),
+                agent_did: principals.agent_did.as_str().to_owned(),
+                operator_did: principals.operator_did.as_str().to_owned(),
             });
         }
         if !record.permissions.contains(&action) {
             return Err(OperatorBindingError::UnauthorizedAction {
-                operator_did: operator_did.to_owned(),
+                operator_did: principals.operator_did.as_str().to_owned(),
                 action,
             });
         }
@@ -127,28 +199,30 @@ impl OperatorBindingEngine {
         agent_did: &str,
         operator_did: &str,
     ) -> Result<(), OperatorBindingError> {
-        validate_agent_did(agent_did)?;
-        validate_operator_did(operator_did)?;
+        let principals = OperatorBindingPrincipals::parse(agent_did, operator_did)?;
 
-        let key = (agent_did.to_owned(), operator_did.to_owned());
+        let key = (
+            principals.agent_did.as_str().to_owned(),
+            principals.operator_did.as_str().to_owned(),
+        );
         let record =
             self.bindings
                 .get_mut(&key)
                 .ok_or_else(|| OperatorBindingError::MissingBinding {
-                    agent_did: agent_did.to_owned(),
-                    operator_did: operator_did.to_owned(),
+                    agent_did: principals.agent_did.as_str().to_owned(),
+                    operator_did: principals.operator_did.as_str().to_owned(),
                 })?;
 
         if record.revoked {
             return Err(OperatorBindingError::RevokedBinding {
-                agent_did: agent_did.to_owned(),
-                operator_did: operator_did.to_owned(),
+                agent_did: principals.agent_did.as_str().to_owned(),
+                operator_did: principals.operator_did.as_str().to_owned(),
             });
         }
 
         if !record.permissions.contains(&OperatorBindingAction::Revoke) {
             return Err(OperatorBindingError::UnauthorizedAction {
-                operator_did: operator_did.to_owned(),
+                operator_did: principals.operator_did.as_str().to_owned(),
                 action: OperatorBindingAction::Revoke,
             });
         }
@@ -163,9 +237,11 @@ impl OperatorBindingEngine {
         agent_did: &str,
         operator_did: &str,
     ) -> Result<&OperatorBindingRecord, OperatorBindingError> {
-        validate_agent_did(agent_did)?;
-        validate_operator_did(operator_did)?;
-        self.lookup(agent_did, operator_did)
+        let principals = OperatorBindingPrincipals::parse(agent_did, operator_did)?;
+        self.lookup(
+            principals.agent_did.as_str(),
+            principals.operator_did.as_str(),
+        )
     }
 
     fn lookup(
@@ -190,9 +266,23 @@ pub enum OperatorBindingError {
     /// Proof field was empty.
     EmptyProofField(&'static str),
     /// Agent DID failed validation.
-    InvalidAgentDid(String),
+    InvalidAgentDid {
+        /// Input field carrying the DID value.
+        field: &'static str,
+        /// Stable reason marker.
+        reason_code: &'static str,
+        /// Canonical parser detail.
+        detail: String,
+    },
     /// Operator DID failed validation.
-    InvalidOperatorDid(String),
+    InvalidOperatorDid {
+        /// Input field carrying the DID value.
+        field: &'static str,
+        /// Stable reason marker.
+        reason_code: &'static str,
+        /// Canonical parser detail.
+        detail: String,
+    },
     /// Proof type did not match required canonical type.
     InvalidProofType(String),
     /// Proof verification method prefix did not match operator DID.
@@ -237,8 +327,16 @@ impl fmt::Display for OperatorBindingError {
         match self {
             Self::EmptyPermissions => write!(f, "permissions must not be empty"),
             Self::EmptyProofField(field) => write!(f, "proof field must not be empty: {field}"),
-            Self::InvalidAgentDid(value) => write!(f, "invalid agent did: {value}"),
-            Self::InvalidOperatorDid(value) => write!(f, "invalid operator did: {value}"),
+            Self::InvalidAgentDid {
+                field,
+                reason_code,
+                detail,
+            } => write!(f, "invalid did field {field}: {reason_code} ({detail})"),
+            Self::InvalidOperatorDid {
+                field,
+                reason_code,
+                detail,
+            } => write!(f, "invalid did field {field}: {reason_code} ({detail})"),
             Self::InvalidProofType(value) => write!(f, "invalid proof type: {value}"),
             Self::ProofVerificationMethodMismatch {
                 expected_prefix,
@@ -272,33 +370,44 @@ impl fmt::Display for OperatorBindingError {
 
 impl std::error::Error for OperatorBindingError {}
 
-fn validate_agent_did(value: &str) -> Result<(), OperatorBindingError> {
-    AgentDid::parse(value)
-        .map_err(|error| OperatorBindingError::InvalidAgentDid(error.to_string()))?;
-    Ok(())
+impl OperatorBindingError {
+    /// Stable reason taxonomy for operator binding errors.
+    pub fn reason_code(&self) -> &'static str {
+        match self {
+            Self::EmptyPermissions => "operator_binding_empty_permissions",
+            Self::EmptyProofField(_) => "operator_binding_empty_proof_field",
+            Self::InvalidAgentDid { reason_code, .. } => reason_code,
+            Self::InvalidOperatorDid { reason_code, .. } => reason_code,
+            Self::InvalidProofType(_) => "operator_binding_invalid_proof_type",
+            Self::ProofVerificationMethodMismatch { .. } => {
+                "operator_binding_proof_verification_method_mismatch"
+            }
+            Self::DuplicateBinding { .. } => "operator_binding_duplicate_binding",
+            Self::MissingBinding { .. } => "operator_binding_missing_binding",
+            Self::RevokedBinding { .. } => "operator_binding_revoked_binding",
+            Self::UnauthorizedAction { .. } => "operator_binding_unauthorized_action",
+        }
+    }
 }
 
-fn validate_operator_did(value: &str) -> Result<(), OperatorBindingError> {
-    if !value.starts_with(HUMAN_DID_PREFIX) {
-        return Err(OperatorBindingError::InvalidOperatorDid(format!(
-            "invalid human did prefix: {value}"
-        )));
-    }
-    let method_specific_id = &value[HUMAN_DID_PREFIX.len()..];
-    if method_specific_id.is_empty() {
-        return Err(OperatorBindingError::InvalidOperatorDid(
-            "human did method-specific id must not be empty".to_owned(),
-        ));
-    }
-    if !method_specific_id
-        .chars()
-        .all(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '-' || ch == '_')
-    {
-        return Err(OperatorBindingError::InvalidOperatorDid(format!(
-            "human did has invalid characters: {method_specific_id}"
-        )));
-    }
-    Ok(())
+fn parse_agent_did(
+    value: &str,
+    field: &'static str,
+    reason_code: &'static str,
+) -> Result<AgentDid, OperatorBindingError> {
+    AgentDid::parse(value).map_err(|error| OperatorBindingError::InvalidAgentDid {
+        field,
+        reason_code,
+        detail: error.to_string(),
+    })
+}
+
+fn parse_operator_did(
+    value: &str,
+    field: &'static str,
+    reason_code: &'static str,
+) -> Result<OperatorHumanDid, OperatorBindingError> {
+    OperatorHumanDid::parse(value, field, reason_code)
 }
 
 fn validate_non_empty(field: &'static str, value: &str) -> Result<(), OperatorBindingError> {
@@ -363,9 +472,11 @@ mod tests {
                 None,
                 permissions(&[OperatorBindingAction::Configure]),
             ),
-            Err(OperatorBindingError::InvalidOperatorDid(
-                "invalid human did prefix: did:example:operator".to_owned()
-            ))
+            Err(OperatorBindingError::InvalidOperatorDid {
+                field: "operator_did",
+                reason_code: "operator_binding_invalid_operator_did",
+                detail: "invalid human did prefix: did:example:operator".to_owned(),
+            })
         );
     }
 

--- a/crates/kamn-core/src/operator_dashboard_api.rs
+++ b/crates/kamn-core/src/operator_dashboard_api.rs
@@ -7,6 +7,23 @@ use crate::{
 use std::collections::BTreeMap;
 use std::fmt;
 
+const OPERATOR_DASHBOARD_API_INVALID_AGENT_DID_REASON_CODE: &str =
+    "operator_dashboard_api_invalid_agent_did";
+const OPERATOR_DASHBOARD_API_INVALID_TASK_REQUESTER_DID_REASON_CODE: &str =
+    "operator_dashboard_api_invalid_task_requester_did";
+const OPERATOR_DASHBOARD_API_INVALID_TASK_ASSIGNEE_DID_REASON_CODE: &str =
+    "operator_dashboard_api_invalid_task_assignee_did";
+const OPERATOR_DASHBOARD_API_INVALID_MESSAGE_SENDER_DID_REASON_CODE: &str =
+    "operator_dashboard_api_invalid_message_sender_did";
+const OPERATOR_DASHBOARD_API_INVALID_MESSAGE_RECIPIENT_DID_REASON_CODE: &str =
+    "operator_dashboard_api_invalid_message_recipient_did";
+const OPERATOR_DASHBOARD_API_INVALID_ESCROW_PAYER_DID_REASON_CODE: &str =
+    "operator_dashboard_api_invalid_escrow_payer_did";
+const OPERATOR_DASHBOARD_API_INVALID_ESCROW_PAYEE_DID_REASON_CODE: &str =
+    "operator_dashboard_api_invalid_escrow_payee_did";
+const OPERATOR_DASHBOARD_API_INVALID_REPUTATION_AGENT_DID_REASON_CODE: &str =
+    "operator_dashboard_api_invalid_reputation_agent_did";
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 /// Pagination request contract for dashboard list endpoints.
 pub struct DashboardPageRequest {
@@ -149,7 +166,11 @@ impl OperatorDashboardApi {
         agent_did: &str,
         hierarchy: &AgentKeyHierarchy,
     ) -> Result<(), OperatorDashboardApiError> {
-        validate_did(agent_did)?;
+        let agent_did = parse_agent_did(
+            agent_did,
+            "agent_did",
+            OPERATOR_DASHBOARD_API_INVALID_AGENT_DID_REASON_CODE,
+        )?;
         let identity_key_id = hierarchy
             .current_key(KeyRole::Identity)
             .map_err(|error| OperatorDashboardApiError::Hierarchy(error.to_string()))?
@@ -164,9 +185,9 @@ impl OperatorDashboardApi {
             .to_owned();
 
         self.agents.insert(
-            agent_did.to_owned(),
+            agent_did.as_str().to_owned(),
             OperatorAgentView {
-                agent_did: agent_did.to_owned(),
+                agent_did: agent_did.as_str().to_owned(),
                 identity_key_id,
                 signing_key_id,
                 agreement_key_id,
@@ -183,16 +204,29 @@ impl OperatorDashboardApi {
         if task.task_id.trim().is_empty() {
             return Err(OperatorDashboardApiError::EmptyField("task_id"));
         }
-        validate_did(&task.requester)?;
-        if let Some(assignee) = task.assignee.as_deref() {
-            validate_did(assignee)?;
-        }
+        let requester = parse_agent_did(
+            task.requester.as_str(),
+            "task.requester",
+            OPERATOR_DASHBOARD_API_INVALID_TASK_REQUESTER_DID_REASON_CODE,
+        )?;
+        let assignee = task
+            .assignee
+            .as_deref()
+            .map(|value| {
+                parse_agent_did(
+                    value,
+                    "task.assignee",
+                    OPERATOR_DASHBOARD_API_INVALID_TASK_ASSIGNEE_DID_REASON_CODE,
+                )
+                .map(|did| did.as_str().to_owned())
+            })
+            .transpose()?;
         self.tasks.insert(
             task.task_id.clone(),
             OperatorTaskView {
                 task_id: task.task_id.clone(),
-                requester: task.requester.clone(),
-                assignee: task.assignee.clone(),
+                requester: requester.as_str().to_owned(),
+                assignee,
                 state: task.lifecycle.state(),
             },
         );
@@ -211,17 +245,29 @@ impl OperatorDashboardApi {
         let (sender, recipients) = store
             .participants(message_id)
             .map_err(|error| OperatorDashboardApiError::Message(error.to_string()))?;
-        validate_did(sender)?;
-        for recipient in recipients {
-            validate_did(recipient)?;
-        }
+        let sender = parse_agent_did(
+            sender,
+            "message.sender",
+            OPERATOR_DASHBOARD_API_INVALID_MESSAGE_SENDER_DID_REASON_CODE,
+        )?;
+        let recipients = recipients
+            .iter()
+            .map(|recipient| {
+                parse_agent_did(
+                    recipient,
+                    "message.recipients[]",
+                    OPERATOR_DASHBOARD_API_INVALID_MESSAGE_RECIPIENT_DID_REASON_CODE,
+                )
+                .map(|did| did.as_str().to_owned())
+            })
+            .collect::<Result<Vec<_>, _>>()?;
 
         self.messages.insert(
             message_id.to_owned(),
             OperatorMessageView {
                 message_id: message_id.to_owned(),
-                sender: sender.to_owned(),
-                recipients: recipients.to_vec(),
+                sender: sender.as_str().to_owned(),
+                recipients,
                 status,
             },
         );
@@ -239,15 +285,23 @@ impl OperatorDashboardApi {
         if escrow_id.trim().is_empty() {
             return Err(OperatorDashboardApiError::EmptyField("escrow_id"));
         }
-        validate_did(payer)?;
-        validate_did(payee)?;
+        let payer = parse_agent_did(
+            payer,
+            "escrow.payer",
+            OPERATOR_DASHBOARD_API_INVALID_ESCROW_PAYER_DID_REASON_CODE,
+        )?;
+        let payee = parse_agent_did(
+            payee,
+            "escrow.payee",
+            OPERATOR_DASHBOARD_API_INVALID_ESCROW_PAYEE_DID_REASON_CODE,
+        )?;
 
         self.escrows.insert(
             escrow_id.to_owned(),
             OperatorEscrowView {
                 escrow_id: escrow_id.to_owned(),
-                payer: payer.to_owned(),
-                payee: payee.to_owned(),
+                payer: payer.as_str().to_owned(),
+                payee: payee.as_str().to_owned(),
                 status: escrow.status(),
                 remaining_amount: escrow.remaining_amount(),
             },
@@ -260,11 +314,15 @@ impl OperatorDashboardApi {
         &mut self,
         reputation: &crate::AgentReputation,
     ) -> Result<(), OperatorDashboardApiError> {
-        validate_did(&reputation.agent_did)?;
+        let agent_did = parse_agent_did(
+            reputation.agent_did.as_str(),
+            "reputation.agent_did",
+            OPERATOR_DASHBOARD_API_INVALID_REPUTATION_AGENT_DID_REASON_CODE,
+        )?;
         self.reputation.insert(
-            reputation.agent_did.clone(),
+            agent_did.as_str().to_owned(),
             OperatorReputationView {
-                agent_did: reputation.agent_did.clone(),
+                agent_did: agent_did.as_str().to_owned(),
                 trust_score: reputation.trust_score,
                 delivery_rate: reputation.delivery_rate,
                 dispute_rate: reputation.dispute_rate,
@@ -338,7 +396,14 @@ pub enum OperatorDashboardApiError {
     /// Required field is empty.
     EmptyField(&'static str),
     /// DID value is invalid.
-    InvalidDid(String),
+    InvalidDid {
+        /// Input field carrying the DID value.
+        field: &'static str,
+        /// Stable reason marker.
+        reason_code: &'static str,
+        /// Canonical parser detail.
+        detail: String,
+    },
     /// Agent key hierarchy lookup failed.
     Hierarchy(String),
     /// Message lifecycle lookup failed.
@@ -359,7 +424,11 @@ impl fmt::Display for OperatorDashboardApiError {
                 write!(f, "invalid pagination cursor: {cursor}")
             }
             Self::EmptyField(field) => write!(f, "field must not be empty: {field}"),
-            Self::InvalidDid(value) => write!(f, "invalid did: {value}"),
+            Self::InvalidDid {
+                field,
+                reason_code,
+                detail,
+            } => write!(f, "invalid did field {field}: {reason_code} ({detail})"),
             Self::Hierarchy(value) => write!(f, "key hierarchy error: {value}"),
             Self::Message(value) => write!(f, "message lifecycle error: {value}"),
             Self::Task(value) => write!(f, "task operation error: {value}"),
@@ -382,10 +451,32 @@ impl From<ReputationError> for OperatorDashboardApiError {
     }
 }
 
-fn validate_did(value: &str) -> Result<(), OperatorDashboardApiError> {
-    AgentDid::parse(value)
-        .map_err(|error| OperatorDashboardApiError::InvalidDid(error.to_string()))?;
-    Ok(())
+impl OperatorDashboardApiError {
+    /// Stable reason taxonomy for dashboard API failures.
+    pub fn reason_code(&self) -> &'static str {
+        match self {
+            Self::InvalidPageLimit(_) => "operator_dashboard_api_invalid_page_limit",
+            Self::InvalidPaginationCursor(_) => "operator_dashboard_api_invalid_pagination_cursor",
+            Self::EmptyField(_) => "operator_dashboard_api_empty_field",
+            Self::InvalidDid { reason_code, .. } => reason_code,
+            Self::Hierarchy(_) => "operator_dashboard_api_hierarchy_error",
+            Self::Message(_) => "operator_dashboard_api_message_error",
+            Self::Task(_) => "operator_dashboard_api_task_error",
+            Self::Reputation(_) => "operator_dashboard_api_reputation_error",
+        }
+    }
+}
+
+fn parse_agent_did(
+    value: &str,
+    field: &'static str,
+    reason_code: &'static str,
+) -> Result<AgentDid, OperatorDashboardApiError> {
+    AgentDid::parse(value).map_err(|error| OperatorDashboardApiError::InvalidDid {
+        field,
+        reason_code,
+        detail: error.to_string(),
+    })
 }
 
 fn paginate_map<T: Clone>(

--- a/crates/kamn-core/src/operator_dashboard_ui.rs
+++ b/crates/kamn-core/src/operator_dashboard_ui.rs
@@ -1,10 +1,32 @@
 //! Operator dashboard UI projection contracts for human-facing control surfaces.
 
 use crate::{
-    EscrowStatus, MessageStatus, OperatorActionAuditRecord, OperatorActionOutcome,
+    AgentDid, EscrowStatus, MessageStatus, OperatorActionAuditRecord, OperatorActionOutcome,
     OperatorBindingAction, OperatorDashboardSnapshot, TaskState,
 };
 use std::fmt;
+
+const HUMAN_DID_PREFIX: &str = "kamn:did:human:";
+const OPERATOR_DASHBOARD_UI_INVALID_AGENT_DID_REASON_CODE: &str =
+    "operator_dashboard_ui_invalid_agent_did";
+const OPERATOR_DASHBOARD_UI_INVALID_TASK_REQUESTER_DID_REASON_CODE: &str =
+    "operator_dashboard_ui_invalid_task_requester_did";
+const OPERATOR_DASHBOARD_UI_INVALID_TASK_ASSIGNEE_DID_REASON_CODE: &str =
+    "operator_dashboard_ui_invalid_task_assignee_did";
+const OPERATOR_DASHBOARD_UI_INVALID_MESSAGE_SENDER_DID_REASON_CODE: &str =
+    "operator_dashboard_ui_invalid_message_sender_did";
+const OPERATOR_DASHBOARD_UI_INVALID_MESSAGE_RECIPIENT_DID_REASON_CODE: &str =
+    "operator_dashboard_ui_invalid_message_recipient_did";
+const OPERATOR_DASHBOARD_UI_INVALID_ESCROW_PAYER_DID_REASON_CODE: &str =
+    "operator_dashboard_ui_invalid_escrow_payer_did";
+const OPERATOR_DASHBOARD_UI_INVALID_ESCROW_PAYEE_DID_REASON_CODE: &str =
+    "operator_dashboard_ui_invalid_escrow_payee_did";
+const OPERATOR_DASHBOARD_UI_INVALID_REPUTATION_AGENT_DID_REASON_CODE: &str =
+    "operator_dashboard_ui_invalid_reputation_agent_did";
+const OPERATOR_DASHBOARD_UI_INVALID_AUDIT_AGENT_DID_REASON_CODE: &str =
+    "operator_dashboard_ui_invalid_audit_agent_did";
+const OPERATOR_DASHBOARD_UI_INVALID_AUDIT_OPERATOR_DID_REASON_CODE: &str =
+    "operator_dashboard_ui_invalid_audit_operator_did";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 /// UI attention severity used for triage highlighting.
@@ -176,6 +198,11 @@ impl OperatorDashboardUi {
     ) -> Result<OperatorDashboardUiModel, OperatorDashboardUiError> {
         let mut agent_list = Vec::with_capacity(snapshot.agents.items.len());
         for agent in &snapshot.agents.items {
+            let agent_did = parse_agent_did(
+                agent.agent_did.as_str(),
+                "snapshot.agents[].agent_did",
+                OPERATOR_DASHBOARD_UI_INVALID_AGENT_DID_REASON_CODE,
+            )?;
             if agent.identity_key_id.trim().is_empty() {
                 return Err(OperatorDashboardUiError::EmptyAgentKey {
                     agent_did: agent.agent_did.clone(),
@@ -196,7 +223,7 @@ impl OperatorDashboardUi {
             }
 
             agent_list.push(OperatorAgentListRow {
-                agent_did: agent.agent_did.clone(),
+                agent_did: agent_did.as_str().to_owned(),
                 key_summary: format!(
                     "{}/{}/{}",
                     agent.identity_key_id, agent.signing_key_id, agent.agreement_key_id
@@ -207,12 +234,26 @@ impl OperatorDashboardUi {
 
         let mut task_timeline = Vec::with_capacity(snapshot.tasks.items.len());
         for task in &snapshot.tasks.items {
+            let requester = parse_agent_did(
+                task.requester.as_str(),
+                "snapshot.tasks[].requester",
+                OPERATOR_DASHBOARD_UI_INVALID_TASK_REQUESTER_DID_REASON_CODE,
+            )?;
+            let assignee = task
+                .assignee
+                .as_deref()
+                .map(|value| {
+                    parse_agent_did(
+                        value,
+                        "snapshot.tasks[].assignee",
+                        OPERATOR_DASHBOARD_UI_INVALID_TASK_ASSIGNEE_DID_REASON_CODE,
+                    )
+                    .map(|did| did.as_str().to_owned())
+                })
+                .transpose()?;
             task_timeline.push(OperatorTaskTimelineEntry {
                 task_id: task.task_id.clone(),
-                owner: task
-                    .assignee
-                    .clone()
-                    .unwrap_or_else(|| task.requester.clone()),
+                owner: assignee.unwrap_or_else(|| requester.as_str().to_owned()),
                 state: task.state,
                 attention: task_attention(task.state),
             });
@@ -226,10 +267,22 @@ impl OperatorDashboardUi {
                     message.message_id.clone(),
                 ));
             }
+            let sender = parse_agent_did(
+                message.sender.as_str(),
+                "snapshot.messages[].sender",
+                OPERATOR_DASHBOARD_UI_INVALID_MESSAGE_SENDER_DID_REASON_CODE,
+            )?;
+            for recipient in &message.recipients {
+                parse_agent_did(
+                    recipient.as_str(),
+                    "snapshot.messages[].recipients[]",
+                    OPERATOR_DASHBOARD_UI_INVALID_MESSAGE_RECIPIENT_DID_REASON_CODE,
+                )?;
+            }
 
             message_traces.push(OperatorMessageTraceEntry {
                 message_id: message.message_id.clone(),
-                sender: message.sender.clone(),
+                sender: sender.as_str().to_owned(),
                 recipient_count: message.recipients.len(),
                 status: message.status,
                 attention: message_attention(message.status),
@@ -239,10 +292,20 @@ impl OperatorDashboardUi {
 
         let mut escrow_status = Vec::with_capacity(snapshot.escrows.items.len());
         for escrow in &snapshot.escrows.items {
+            let payer = parse_agent_did(
+                escrow.payer.as_str(),
+                "snapshot.escrows[].payer",
+                OPERATOR_DASHBOARD_UI_INVALID_ESCROW_PAYER_DID_REASON_CODE,
+            )?;
+            let payee = parse_agent_did(
+                escrow.payee.as_str(),
+                "snapshot.escrows[].payee",
+                OPERATOR_DASHBOARD_UI_INVALID_ESCROW_PAYEE_DID_REASON_CODE,
+            )?;
             escrow_status.push(OperatorEscrowStatusEntry {
                 escrow_id: escrow.escrow_id.clone(),
-                payer: escrow.payer.clone(),
-                payee: escrow.payee.clone(),
+                payer: payer.as_str().to_owned(),
+                payee: payee.as_str().to_owned(),
                 status: escrow.status.clone(),
                 remaining_amount: escrow.remaining_amount,
                 attention: escrow_attention(&escrow.status),
@@ -252,18 +315,19 @@ impl OperatorDashboardUi {
 
         let mut reputation_overview = Vec::with_capacity(snapshot.reputation.items.len());
         for reputation in &snapshot.reputation.items {
+            let agent_did = parse_agent_did(
+                reputation.agent_did.as_str(),
+                "snapshot.reputation[].agent_did",
+                OPERATOR_DASHBOARD_UI_INVALID_REPUTATION_AGENT_DID_REASON_CODE,
+            )?;
             validate_rate(
                 "delivery_rate",
-                &reputation.agent_did,
+                agent_did.as_str(),
                 reputation.delivery_rate,
             )?;
-            validate_rate(
-                "dispute_rate",
-                &reputation.agent_did,
-                reputation.dispute_rate,
-            )?;
+            validate_rate("dispute_rate", agent_did.as_str(), reputation.dispute_rate)?;
             reputation_overview.push(OperatorReputationOverviewEntry {
-                agent_did: reputation.agent_did.clone(),
+                agent_did: agent_did.as_str().to_owned(),
                 trust_score: reputation.trust_score,
                 delivery_rate: reputation.delivery_rate,
                 dispute_rate: reputation.dispute_rate,
@@ -274,15 +338,25 @@ impl OperatorDashboardUi {
 
         let mut audit_traces = Vec::with_capacity(audit_log.len());
         for record in audit_log {
+            let agent_did = parse_agent_did(
+                record.agent_did.as_str(),
+                "audit_log[].agent_did",
+                OPERATOR_DASHBOARD_UI_INVALID_AUDIT_AGENT_DID_REASON_CODE,
+            )?;
+            let operator_did = parse_operator_did(
+                record.operator_did.as_str(),
+                "audit_log[].operator_did",
+                OPERATOR_DASHBOARD_UI_INVALID_AUDIT_OPERATOR_DID_REASON_CODE,
+            )?;
             if record.requested_at_unix == 0 {
                 return Err(OperatorDashboardUiError::InvalidAuditTimestamp {
-                    operator_did: record.operator_did.clone(),
+                    operator_did: operator_did.clone(),
                 });
             }
 
             audit_traces.push(OperatorAuditTraceEntry {
-                agent_did: record.agent_did.clone(),
-                operator_did: record.operator_did.clone(),
+                agent_did: agent_did.as_str().to_owned(),
+                operator_did: operator_did.clone(),
                 action: record.action,
                 target: record.target.clone(),
                 value: record.value.clone(),
@@ -364,6 +438,15 @@ pub enum OperatorDashboardUiError {
     },
     /// Message projection is missing recipients.
     EmptyMessageRecipients(String),
+    /// DID value is invalid.
+    InvalidDid {
+        /// Input field carrying the DID value.
+        field: &'static str,
+        /// Stable reason marker.
+        reason_code: &'static str,
+        /// Canonical parser detail.
+        detail: String,
+    },
     /// Reputation rate is outside the supported range.
     InvalidReputationRate {
         /// Agent DID associated with invalid rate.
@@ -395,6 +478,11 @@ impl fmt::Display for OperatorDashboardUiError {
                     "message trace must include at least one recipient: {message_id}"
                 )
             }
+            Self::InvalidDid {
+                field,
+                reason_code,
+                detail,
+            } => write!(f, "invalid did field {field}: {reason_code} ({detail})"),
             Self::InvalidReputationRate {
                 agent_did,
                 field,
@@ -415,6 +503,19 @@ impl fmt::Display for OperatorDashboardUiError {
 
 impl std::error::Error for OperatorDashboardUiError {}
 
+impl OperatorDashboardUiError {
+    /// Stable reason taxonomy for dashboard UI validation failures.
+    pub fn reason_code(&self) -> &'static str {
+        match self {
+            Self::EmptyAgentKey { .. } => "operator_dashboard_ui_empty_agent_key",
+            Self::EmptyMessageRecipients(_) => "operator_dashboard_ui_empty_message_recipients",
+            Self::InvalidDid { reason_code, .. } => reason_code,
+            Self::InvalidReputationRate { .. } => "operator_dashboard_ui_invalid_reputation_rate",
+            Self::InvalidAuditTimestamp { .. } => "operator_dashboard_ui_invalid_audit_timestamp",
+        }
+    }
+}
+
 fn validate_rate(
     field: &'static str,
     agent_did: &str,
@@ -428,6 +529,51 @@ fn validate_rate(
         });
     }
     Ok(())
+}
+
+fn parse_agent_did(
+    value: &str,
+    field: &'static str,
+    reason_code: &'static str,
+) -> Result<AgentDid, OperatorDashboardUiError> {
+    AgentDid::parse(value).map_err(|error| OperatorDashboardUiError::InvalidDid {
+        field,
+        reason_code,
+        detail: error.to_string(),
+    })
+}
+
+fn parse_operator_did(
+    value: &str,
+    field: &'static str,
+    reason_code: &'static str,
+) -> Result<String, OperatorDashboardUiError> {
+    if !value.starts_with(HUMAN_DID_PREFIX) {
+        return Err(OperatorDashboardUiError::InvalidDid {
+            field,
+            reason_code,
+            detail: format!("invalid human did prefix: {value}"),
+        });
+    }
+    let method_specific_id = &value[HUMAN_DID_PREFIX.len()..];
+    if method_specific_id.is_empty() {
+        return Err(OperatorDashboardUiError::InvalidDid {
+            field,
+            reason_code,
+            detail: "human did method-specific id must not be empty".to_owned(),
+        });
+    }
+    if !method_specific_id
+        .chars()
+        .all(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '-' || ch == '_')
+    {
+        return Err(OperatorDashboardUiError::InvalidDid {
+            field,
+            reason_code,
+            detail: format!("human did has invalid characters: {method_specific_id}"),
+        });
+    }
+    Ok(value.to_owned())
 }
 
 fn task_attention(state: TaskState) -> DashboardAttentionLevel {

--- a/crates/kamn-core/src/task_payment.rs
+++ b/crates/kamn-core/src/task_payment.rs
@@ -5,6 +5,10 @@ use crate::{
 use std::collections::BTreeMap;
 use std::fmt;
 
+const TASK_PAYMENT_INVALID_PAYER_DID_REASON_CODE: &str = "task_payment_invalid_payer_did";
+const TASK_PAYMENT_INVALID_PAYEE_DID_REASON_CODE: &str = "task_payment_invalid_payee_did";
+const TASK_PAYMENT_INVALID_CONFIRMER_DID_REASON_CODE: &str = "task_payment_invalid_confirmer_did";
+
 /// Payment offer submitted for a completed task.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PaymentOffer {
@@ -37,6 +41,50 @@ struct PendingOffer {
     confirmed: bool,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PaymentOfferValidated {
+    payer_did: AgentDid,
+    payee_did: AgentDid,
+}
+
+impl TryFrom<&PaymentOffer> for PaymentOfferValidated {
+    type Error = TaskPaymentError;
+
+    fn try_from(offer: &PaymentOffer) -> Result<Self, Self::Error> {
+        Ok(Self {
+            payer_did: parse_agent_did(
+                offer.payer_did.as_str(),
+                "payer_did",
+                TASK_PAYMENT_INVALID_PAYER_DID_REASON_CODE,
+            )?,
+            payee_did: parse_agent_did(
+                offer.payee_did.as_str(),
+                "payee_did",
+                TASK_PAYMENT_INVALID_PAYEE_DID_REASON_CODE,
+            )?,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PaymentConfirmValidated {
+    confirmer_did: AgentDid,
+}
+
+impl TryFrom<&PaymentConfirm> for PaymentConfirmValidated {
+    type Error = TaskPaymentError;
+
+    fn try_from(confirm: &PaymentConfirm) -> Result<Self, Self::Error> {
+        Ok(Self {
+            confirmer_did: parse_agent_did(
+                confirm.confirmer_did.as_str(),
+                "confirmer_did",
+                TASK_PAYMENT_INVALID_CONFIRMER_DID_REASON_CODE,
+            )?,
+        })
+    }
+}
+
 /// Task payment workflow that validates and tracks escrow-backed offers.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct TaskPaymentWorkflow {
@@ -57,8 +105,7 @@ impl TaskPaymentWorkflow {
         escrow: &EscrowLifecycle,
     ) -> Result<(), TaskPaymentError> {
         validate_offer_shape(&offer)?;
-        validate_did(&offer.payer_did)?;
-        validate_did(&offer.payee_did)?;
+        let validated_offer = PaymentOfferValidated::try_from(&offer)?;
 
         if self.offers_by_task.contains_key(&offer.task_id) {
             return Err(TaskPaymentError::DuplicateOffer(offer.task_id));
@@ -74,7 +121,13 @@ impl TaskPaymentWorkflow {
                 state,
             });
         }
-        validate_offer_participants(&offer, &task.requester, task.assignee.as_deref())?;
+        validate_offer_participants(
+            offer.task_id.as_str(),
+            validated_offer.payer_did.as_str(),
+            validated_offer.payee_did.as_str(),
+            task.requester.as_str(),
+            task.assignee.as_deref(),
+        )?;
 
         let remaining = escrow.remaining_amount();
         if offer.amount > remaining {
@@ -106,7 +159,7 @@ impl TaskPaymentWorkflow {
         if confirm.escrow_id.trim().is_empty() {
             return Err(TaskPaymentError::EmptyField("escrow_id"));
         }
-        validate_did(&confirm.confirmer_did)?;
+        let validated_confirm = PaymentConfirmValidated::try_from(&confirm)?;
 
         let pending = self
             .offers_by_task
@@ -124,7 +177,7 @@ impl TaskPaymentWorkflow {
         if pending.offer.payer_did != confirm.confirmer_did {
             return Err(TaskPaymentError::UnauthorizedConfirmer {
                 expected: pending.offer.payer_did.clone(),
-                found: confirm.confirmer_did,
+                found: validated_confirm.confirmer_did.as_str().to_owned(),
             });
         }
 
@@ -155,7 +208,14 @@ pub enum TaskPaymentError {
         found: String,
     },
     /// DID failed validation.
-    InvalidDid(String),
+    InvalidDid {
+        /// Input field carrying the DID value.
+        field: &'static str,
+        /// Stable reason marker.
+        reason_code: &'static str,
+        /// Canonical parser detail.
+        detail: String,
+    },
     /// Offer amount is invalid.
     InvalidOfferAmount(u128),
     /// Payer DID does not match task requester.
@@ -216,7 +276,11 @@ impl fmt::Display for TaskPaymentError {
                 f,
                 "escrow reference mismatch, expected {expected}, found {found}"
             ),
-            Self::InvalidDid(error) => write!(f, "invalid did: {error}"),
+            Self::InvalidDid {
+                field,
+                reason_code,
+                detail,
+            } => write!(f, "invalid did field {field}: {reason_code} ({detail})"),
             Self::InvalidOfferAmount(amount) => {
                 write!(f, "offer amount must be greater than zero, found {amount}")
             }
@@ -266,29 +330,61 @@ fn validate_offer_shape(offer: &PaymentOffer) -> Result<(), TaskPaymentError> {
     Ok(())
 }
 
-fn validate_did(value: &str) -> Result<(), TaskPaymentError> {
-    AgentDid::parse(value).map_err(|error| TaskPaymentError::InvalidDid(error.to_string()))?;
-    Ok(())
+impl TaskPaymentError {
+    /// Stable reason taxonomy for task payment failures.
+    pub fn reason_code(&self) -> &'static str {
+        match self {
+            Self::DuplicateConfirm(_) => "task_payment_duplicate_confirm",
+            Self::DuplicateOffer(_) => "task_payment_duplicate_offer",
+            Self::EmptyField(_) => "task_payment_empty_field",
+            Self::Escrow(_) => "task_payment_escrow_error",
+            Self::EscrowMismatch { .. } => "task_payment_escrow_mismatch",
+            Self::InvalidDid { reason_code, .. } => reason_code,
+            Self::InvalidOfferAmount(_) => "task_payment_invalid_offer_amount",
+            Self::PayerRequesterMismatch { .. } => "task_payment_payer_requester_mismatch",
+            Self::PayeeAssigneeMismatch { .. } => "task_payment_payee_assignee_mismatch",
+            Self::OfferExceedsEscrow { .. } => "task_payment_offer_exceeds_escrow",
+            Self::TaskLookup(_) => "task_payment_task_lookup_error",
+            Self::TaskMissingAssignee(_) => "task_payment_task_missing_assignee",
+            Self::TaskNotCompleted { .. } => "task_payment_task_not_completed",
+            Self::UnauthorizedConfirmer { .. } => "task_payment_unauthorized_confirmer",
+            Self::UnknownOffer(_) => "task_payment_unknown_offer",
+        }
+    }
+}
+
+fn parse_agent_did(
+    value: &str,
+    field: &'static str,
+    reason_code: &'static str,
+) -> Result<AgentDid, TaskPaymentError> {
+    AgentDid::parse(value).map_err(|error| TaskPaymentError::InvalidDid {
+        field,
+        reason_code,
+        detail: error.to_string(),
+    })
 }
 
 fn validate_offer_participants(
-    offer: &PaymentOffer,
+    task_id: &str,
+    payer_did: &str,
+    payee_did: &str,
     task_requester: &str,
     task_assignee: Option<&str>,
 ) -> Result<(), TaskPaymentError> {
-    if offer.payer_did != task_requester {
+    if payer_did != task_requester {
         return Err(TaskPaymentError::PayerRequesterMismatch {
             expected: task_requester.to_owned(),
-            found: offer.payer_did.clone(),
+            found: payer_did.to_owned(),
         });
     }
 
-    let assignee = task_assignee
-        .ok_or_else(|| TaskPaymentError::TaskMissingAssignee(offer.task_id.clone()))?;
-    if offer.payee_did != assignee {
+    let assignee =
+        task_assignee.ok_or_else(|| TaskPaymentError::TaskMissingAssignee(task_id.to_owned()))?;
+    if payee_did != assignee {
         return Err(TaskPaymentError::PayeeAssigneeMismatch {
             expected: assignee.to_owned(),
-            found: offer.payee_did.clone(),
+            found: payee_did.to_owned(),
         });
     }
 
@@ -309,23 +405,15 @@ impl From<EscrowLifecycleError> for TaskPaymentError {
 
 #[cfg(test)]
 mod tests {
-    use super::{validate_offer_participants, PaymentOffer, TaskPaymentError};
-
-    fn offer(payer: &str, payee: &str) -> PaymentOffer {
-        PaymentOffer {
-            task_id: "task-pay-unit".to_owned(),
-            escrow_id: "escrow-unit".to_owned(),
-            payer_did: payer.to_owned(),
-            payee_did: payee.to_owned(),
-            amount: 10,
-        }
-    }
+    use super::{validate_offer_participants, TaskPaymentError};
 
     #[test]
     fn participant_check_rejects_payer_requester_mismatch() {
         assert_eq!(
             validate_offer_participants(
-                &offer("kamn:did:agent:observer-9", "kamn:did:agent:worker-1"),
+                "task-pay-unit",
+                "kamn:did:agent:observer-9",
+                "kamn:did:agent:worker-1",
                 "kamn:did:agent:requester-1",
                 Some("kamn:did:agent:worker-1")
             ),
@@ -340,7 +428,9 @@ mod tests {
     fn participant_check_rejects_payee_assignee_mismatch() {
         assert_eq!(
             validate_offer_participants(
-                &offer("kamn:did:agent:requester-1", "kamn:did:agent:observer-9"),
+                "task-pay-unit",
+                "kamn:did:agent:requester-1",
+                "kamn:did:agent:observer-9",
                 "kamn:did:agent:requester-1",
                 Some("kamn:did:agent:worker-1")
             ),
@@ -355,7 +445,9 @@ mod tests {
     fn participant_check_requires_task_assignee() {
         assert_eq!(
             validate_offer_participants(
-                &offer("kamn:did:agent:requester-1", "kamn:did:agent:worker-1"),
+                "task-pay-unit",
+                "kamn:did:agent:requester-1",
+                "kamn:did:agent:worker-1",
                 "kamn:did:agent:requester-1",
                 None
             ),

--- a/crates/kamn-core/tests/governance_workflow.rs
+++ b/crates/kamn-core/tests/governance_workflow.rs
@@ -382,3 +382,25 @@ fn governance_workflow_functional_executes_valid_parameter_change_proposal() {
         })
     );
 }
+
+#[test]
+fn invalid_proposer_did_surfaces_reason_code_contract() {
+    let mut workflow = GovernanceWorkflow::new();
+    assert_eq!(
+        workflow.submit_proposal(GovernanceProposalDraft {
+            proposal_id: "gov-proposal-invalid-did".to_owned(),
+            title: "Invalid proposer".to_owned(),
+            description: "Should fail deterministically".to_owned(),
+            proposer_did: "bad-did".to_owned(),
+            created_at_unix: 1_716_309_000,
+            voting_deadline_unix: 1_716_310_000,
+            quorum_threshold: 2,
+            parameter_change: None,
+        }),
+        Err(GovernanceWorkflowError::InvalidDid {
+            field: "proposer_did",
+            reason_code: "governance_workflow_invalid_proposer_did",
+            detail: "invalid agent did prefix: bad-did".to_owned(),
+        })
+    );
+}

--- a/crates/kamn-core/tests/operator_binding_permissions.rs
+++ b/crates/kamn-core/tests/operator_binding_permissions.rs
@@ -120,3 +120,22 @@ fn regression_unbound_operator_cannot_read_history() {
         })
     );
 }
+
+#[test]
+fn invalid_operator_did_surfaces_reason_code_contract() {
+    let mut engine = OperatorBindingEngine::new();
+
+    assert_eq!(
+        engine.register_binding(
+            "kamn:did:agent:agent-11",
+            "bad-did",
+            Some(valid_proof("kamn:did:human:operator-11")),
+            permission_set(&[OperatorBindingAction::Configure]),
+        ),
+        Err(OperatorBindingError::InvalidOperatorDid {
+            field: "operator_did",
+            reason_code: "operator_binding_invalid_operator_did",
+            detail: "invalid human did prefix: bad-did".to_owned(),
+        })
+    );
+}

--- a/crates/kamn-core/tests/operator_dashboard_api.rs
+++ b/crates/kamn-core/tests/operator_dashboard_api.rs
@@ -135,3 +135,19 @@ fn operator_dashboard_api_regression_rejects_tampered_cursor_tokens() {
         ))
     );
 }
+
+#[test]
+fn invalid_agent_did_surfaces_reason_code_contract() {
+    let mut api = OperatorDashboardApi::new();
+    let hierarchy =
+        AgentKeyHierarchy::new("id-4", "sig-4", "agr-4").expect("hierarchy should initialize");
+
+    assert_eq!(
+        api.upsert_agent_from_hierarchy("bad-did", &hierarchy),
+        Err(OperatorDashboardApiError::InvalidDid {
+            field: "agent_did",
+            reason_code: "operator_dashboard_api_invalid_agent_did",
+            detail: "invalid agent did prefix: bad-did".to_owned(),
+        })
+    );
+}

--- a/crates/kamn-core/tests/operator_dashboard_ui.rs
+++ b/crates/kamn-core/tests/operator_dashboard_ui.rs
@@ -220,3 +220,29 @@ fn operator_dashboard_ui_regression_orders_audit_traces_newest_first() {
         .collect();
     assert_eq!(ordered, vec![9, 6, 3]);
 }
+
+#[test]
+fn invalid_snapshot_agent_did_surfaces_reason_code_contract() {
+    let snapshot = OperatorDashboardSnapshot {
+        agents: page(vec![kamn_core::OperatorAgentView {
+            agent_did: "bad-did".to_owned(),
+            identity_key_id: "id-alpha".to_owned(),
+            signing_key_id: "sig-alpha".to_owned(),
+            agreement_key_id: "agr-alpha".to_owned(),
+        }]),
+        tasks: page(vec![]),
+        messages: page(vec![]),
+        escrows: page(vec![]),
+        reputation: page(vec![]),
+    };
+
+    let ui = OperatorDashboardUi::new();
+    assert_eq!(
+        ui.compose(&snapshot, &[]),
+        Err(OperatorDashboardUiError::InvalidDid {
+            field: "snapshot.agents[].agent_did",
+            reason_code: "operator_dashboard_ui_invalid_agent_did",
+            detail: "invalid agent did prefix: bad-did".to_owned(),
+        })
+    );
+}

--- a/crates/kamn-core/tests/operator_permissioned_actions.rs
+++ b/crates/kamn-core/tests/operator_permissioned_actions.rs
@@ -1,6 +1,6 @@
 use kamn_core::{
-    OperatorActionServiceError, OperatorBindingAction, OperatorBindingEngine, OperatorBindingProof,
-    PermissionedOperatorActionService,
+    OperatorActionServiceError, OperatorBindingAction, OperatorBindingEngine, OperatorBindingError,
+    OperatorBindingProof, PermissionedOperatorActionService,
 };
 use std::collections::BTreeSet;
 
@@ -172,5 +172,36 @@ fn operator_actions_regression_unauthorized_operator_cannot_mutate_settings() {
     assert_eq!(
         service.setting("kamn:did:agent:ops-5", "maintenance_mode"),
         None
+    );
+}
+
+#[test]
+fn invalid_agent_did_surfaces_reason_code_contract() {
+    let mut bindings = OperatorBindingEngine::new();
+    bindings
+        .register_binding(
+            "kamn:did:agent:ops-6",
+            "kamn:did:human:alice-6",
+            Some(proof_for("kamn:did:human:alice-6")),
+            permissions(&[OperatorBindingAction::Configure]),
+        )
+        .expect("binding should register");
+    let mut service = PermissionedOperatorActionService::new(bindings);
+
+    assert_eq!(
+        service.configure(
+            "bad-did",
+            "kamn:did:human:alice-6",
+            "maintenance_mode",
+            "enabled",
+            1_716_100_500,
+        ),
+        Err(OperatorActionServiceError::Binding(
+            OperatorBindingError::InvalidAgentDid {
+                field: "agent_did",
+                reason_code: "operator_binding_invalid_agent_did",
+                detail: "invalid agent did prefix: bad-did".to_owned(),
+            }
+        ))
     );
 }

--- a/crates/kamn-core/tests/task_payment_workflow.rs
+++ b/crates/kamn-core/tests/task_payment_workflow.rs
@@ -258,3 +258,31 @@ fn integration_timeout_refund_recovers_remaining_escrow_after_confirm() {
     assert_eq!(escrow.released_amount(), 60);
     assert_eq!(escrow.refunded_amount(), 40);
 }
+
+#[test]
+fn invalid_payer_did_surfaces_reason_code_contract() {
+    let mut workflow = TaskPaymentWorkflow::new();
+    let tasks = completed_task_engine("task-pay-invalid-payer-did");
+    let escrow = EscrowLifecycle::new(100).expect("escrow should initialize");
+
+    let result = workflow.submit_offer(
+        PaymentOffer {
+            task_id: "task-pay-invalid-payer-did".to_owned(),
+            escrow_id: "escrow-invalid-payer-did".to_owned(),
+            payer_did: "bad-did".to_owned(),
+            payee_did: "kamn:did:agent:worker-1".to_owned(),
+            amount: 60,
+        },
+        &tasks,
+        &escrow,
+    );
+
+    assert_eq!(
+        result,
+        Err(TaskPaymentError::InvalidDid {
+            field: "payer_did",
+            reason_code: "task_payment_invalid_payer_did",
+            detail: "invalid agent did prefix: bad-did".to_owned(),
+        })
+    );
+}

--- a/specs/5229/plan.md
+++ b/specs/5229/plan.md
@@ -1,0 +1,35 @@
+# Issue #5229 Plan
+
+- Issue: #5229
+- Milestone: specs/milestones/r27-47-r43-gap-remediation-and-delivery-rebalancing/index.md
+
+## Approach
+1. Introduce typed DID boundary wrappers across wave-B modules while preserving existing public string-based data contracts where required.
+2. Normalize DID validation errors to structured deterministic markers (`field`, `reason_code`, `detail`) for all wave-B surfaces.
+3. Replace stringly propagation from operator binding into operator actions with typed error passthrough.
+4. Add deterministic invalid-DID regression coverage for operator binding/actions, dashboard API/UI, governance workflow, and task payment workflow.
+5. Run targeted wave-B suites, formatting/lint gates, and shell-ratio guardrail check.
+
+## Affected Modules
+- `operator_binding.rs`: validated agent/operator DID wrappers and deterministic invalid-DID errors.
+- `operator_actions.rs`: preserve API shape but use typed binding errors and deterministic invalid-DID outcomes.
+- `operator_dashboard_api.rs`: validated DID boundaries for agent/task/message/escrow/reputation upserts and structured invalid-DID taxonomy.
+- `operator_dashboard_ui.rs`: add DID boundary checks for rendered snapshot/audit records and deterministic invalid-DID taxonomy.
+- `governance_workflow.rs`: typed proposer/voter/executor DID boundary conversions and structured invalid-DID errors.
+- `task_payment.rs`: typed payer/payee/confirmer DID boundary conversions and structured invalid-DID errors.
+
+## Risks and Mitigations
+- Risk: Broad error-enum updates break existing tests and call sites.
+  - Mitigation: preserve non-DID variants and update tests in one commit with clear reason-code assertions.
+- Risk: UI/API behavior drift from new validation points.
+  - Mitigation: keep validation scoped to existing DID fields and maintain existing success-path behavior.
+- Risk: shell ratio regression.
+  - Mitigation: rust-only implementation and run `scripts/ci/test_check_shell_rust_ratio_guardrail.sh`.
+
+## Interfaces / Contracts
+- Invalid DID variants in wave-B modules expose:
+  - `field`: failing input field name
+  - `reason_code`: deterministic parser marker
+  - `detail`: parser detail text
+- Typed conversion boundaries use `TryFrom<&RawType>` wrappers where input structs must remain string-based.
+- Operator actions retain external signatures and map authorization failures through typed `OperatorBindingError` instead of opaque string payloads.

--- a/specs/5229/spec.md
+++ b/specs/5229/spec.md
@@ -1,0 +1,60 @@
+# Issue #5229 Spec
+
+- Title: Subtask: Typed-DID migration wave B for operator and governance surfaces
+- Status: Implemented
+- Priority: P2
+- Milestone: specs/milestones/r27-47-r43-gap-remediation-and-delivery-rebalancing/index.md
+
+## Problem Statement
+Operator and governance modules still accept raw DID `String` values across core authorization and workflow boundaries. This permits unchecked DID values to flow into privileged paths and produces inconsistent validation error formats.
+
+## Scope
+In:
+- `crates/kamn-core/src/operator_binding.rs`
+- `crates/kamn-core/src/operator_actions.rs`
+- `crates/kamn-core/src/operator_dashboard_api.rs`
+- `crates/kamn-core/src/operator_dashboard_ui.rs`
+- `crates/kamn-core/src/governance_workflow.rs`
+- `crates/kamn-core/src/task_payment.rs`
+- Targeted wave-B tests in `crates/kamn-core/tests/**`
+
+Out:
+- Wave-A bridge/marketplace modules (`#5228`)
+- Wave-C runtime/proof/reputation modules (`#5230`)
+- Shell/python/workflow/template changes
+
+## Shell-Surface Estimates
+- shell_loc_delta_estimate: 0
+- rust_loc_delta_estimate: 220
+- shell_to_rust_ratio_delta_estimate: -0.0011
+- shell_surface_mitigation_issue: None
+
+## Acceptance Criteria
+- AC-1: Scoped wave-B module identity boundaries use typed DID conversions (`AgentDid` plus validated human/operator DID wrappers) in core interfaces.
+- AC-2: Public/API compatibility is preserved where required by introducing validated conversion wrappers rather than removing existing String-based contracts.
+- AC-3: Invalid DID failures emit deterministic error markers (field + reason code + parser detail) and are covered by tests.
+- AC-4: Shell LOC remains unchanged.
+
+## Conformance Cases
+| Case | AC | Tier | Input | Expected |
+|---|---|---|---|---|
+| C-01 | AC-1 | Functional | Valid DID-bound operator/governance requests | Core logic uses validated typed DID wrappers before authorization/workflow actions |
+| C-02 | AC-2 | Integration | Existing operator/governance API inputs | Existing call sites continue to function through conversion boundaries |
+| C-03 | AC-3 | Regression | Invalid DID in proposer/voter/operator/payer/payee boundaries | Structured deterministic invalid-DID errors with reason markers |
+| C-04 | AC-4 | Conformance | diff-level shell/rust accounting + guardrail | shell delta stays zero |
+
+## Test Mapping
+- C-01/C-02/C-03:
+  - `cargo test -p kamn-core --test operator_permissioned_actions`
+  - `cargo test -p kamn-core --test operator_dashboard_api`
+  - `cargo test -p kamn-core --test operator_dashboard_ui`
+  - `cargo test -p kamn-core --test governance_workflow`
+  - `cargo test -p kamn-core --test task_payment_workflow`
+  - targeted module unit tests in `src/*`
+- C-04:
+  - `bash scripts/ci/test_check_shell_rust_ratio_guardrail.sh`
+
+## Success Metrics
+- Wave-B authorization and governance execution paths reject malformed DID inputs before state mutation.
+- Invalid DID errors are deterministic and machine-parsable.
+- Existing wave-B behavioral tests remain green without shell-surface growth.

--- a/specs/5229/tasks.md
+++ b/specs/5229/tasks.md
@@ -1,0 +1,22 @@
+# Issue #5229 Tasks
+
+- Issue: #5229
+- Milestone: specs/milestones/r27-47-r43-gap-remediation-and-delivery-rebalancing/index.md
+
+## Ordered Tasks
+- T1 (Tests/RED): add wave-B deterministic invalid-DID regression tests for operator binding/actions, dashboard API/UI, governance workflow, and task payment workflows.
+- T2 (Implementation/GREEN): migrate `operator_binding.rs` DID validation to typed wrappers with structured invalid-DID errors.
+- T3 (Implementation/GREEN): migrate `operator_actions.rs` to typed binding error propagation with deterministic invalid-DID passthrough.
+- T4 (Implementation/GREEN): migrate `operator_dashboard_api.rs` and `operator_dashboard_ui.rs` to validated DID boundaries + structured invalid-DID taxonomy.
+- T5 (Implementation/GREEN): migrate `governance_workflow.rs` and `task_payment.rs` DID boundaries + structured invalid-DID taxonomy.
+- T6 (Regression): update affected wave-B integration tests and module unit tests to assert reason-code contracts and preserve existing behavior.
+- T7 (Verification): run targeted wave-B suites, `cargo fmt --check`, `cargo clippy -p kamn-core --tests -- -D warnings`, and shell-ratio guardrail.
+- T8 (Process): set `specs/5229/spec.md` to `Implemented`, update issue/PR AC mapping, and record shell-surface actual markers.
+
+## Test Tier Mapping
+| Tier | Planned Coverage |
+|---|---|
+| Unit | DID conversion helpers and field-level validation checks in each wave-B module |
+| Functional | operator/governance/task-payment boundaries with valid and invalid DIDs |
+| Integration | operator dashboard, permissioned actions, governance workflow, and task payment suites |
+| Regression | deterministic invalid-DID reason-code assertions across all wave-B modules |


### PR DESCRIPTION
## Summary
- Migrated wave-B operator/governance surfaces to typed DID boundary conversions while preserving existing string-based public contracts.
- Replaced tuple-style invalid DID errors with deterministic structured markers (`field`, `reason_code`, `detail`) across operator binding/actions, dashboard API/UI, governance workflow, and task payment workflow.
- Added regression tests for deterministic invalid DID contracts in each wave-B test surface.

## Linked Issues
- Closes #5229
- Milestone: `specs/milestones/r27-47-r43-gap-remediation-and-delivery-rebalancing/index.md`
- Spec: `specs/5229/spec.md`
- Plan: `specs/5229/plan.md`
- Tasks: `specs/5229/tasks.md`

## Spec Verification (AC -> tests)
| AC | ✅/❌ | Test(s) |
|---|---|---|
| AC-1 typed DID boundaries in wave-B modules | ✅ | `cargo test -p kamn-core --test operator_binding_permissions`; `cargo test -p kamn-core --test operator_permissioned_actions`; `cargo test -p kamn-core --test operator_dashboard_api`; `cargo test -p kamn-core --test operator_dashboard_ui`; `cargo test -p kamn-core --test governance_workflow`; `cargo test -p kamn-core --test task_payment_workflow` |
| AC-2 compatibility via conversion wrappers | ✅ | `cargo test -p kamn-core --test operator_dashboard_api`; `cargo test -p kamn-core --test operator_dashboard_ui`; `cargo test -p kamn-core --test governance_workflow`; `cargo test -p kamn-core --test task_payment_workflow` |
| AC-3 deterministic invalid-DID markers | ✅ | `invalid_operator_did_surfaces_reason_code_contract`; `invalid_agent_did_surfaces_reason_code_contract`; `invalid_snapshot_agent_did_surfaces_reason_code_contract`; `invalid_proposer_did_surfaces_reason_code_contract`; `invalid_payer_did_surfaces_reason_code_contract` |
| AC-4 shell LOC unchanged | ✅ | `bash scripts/ci/test_check_shell_rust_ratio_guardrail.sh`; `bash scripts/ci/check_shell_rust_ratio_guardrail.sh --repo-root . --output-json /tmp/shell-rust-ratio-5229.json` |

## TDD Evidence
- RED:
  - Command: `cargo test -p kamn-core --test operator_dashboard_api invalid_agent_did_surfaces_reason_code_contract`
  - Output excerpt: `variant OperatorDashboardApiError::InvalidDid has no field named field/reason_code/detail` (expected failure before enum migration)
- GREEN:
  - `cargo test -p kamn-core --test operator_binding_permissions`
  - `cargo test -p kamn-core --test operator_permissioned_actions`
  - `cargo test -p kamn-core --test operator_dashboard_api`
  - `cargo test -p kamn-core --test operator_dashboard_ui`
  - `cargo test -p kamn-core --test governance_workflow`
  - `cargo test -p kamn-core --test task_payment_workflow`
  - `cargo fmt --check`
  - `cargo clippy -p kamn-core --tests -- -D warnings`
  - `bash scripts/ci/test_check_shell_rust_ratio_guardrail.sh`

## Test Tiers
| Tier | ✅/❌/N/A | Tests | N/A Why |
|---|---|---|---|
| Unit | ✅ | module-local tests in `operator_binding.rs`, `operator_dashboard_ui.rs`, `task_payment.rs` | |
| Property | N/A | | no parser/invariant property harness added in this wave |
| Contract/DbC | N/A | | no `contracts` instrumentation used in this crate path |
| Snapshot | N/A | | no snapshot outputs touched |
| Functional | ✅ | `operator_binding_permissions`, `operator_permissioned_actions`, `operator_dashboard_api`, `operator_dashboard_ui`, `governance_workflow`, `task_payment_workflow` | |
| Conformance | ✅ | deterministic invalid-DID reason-code tests added per wave-B module | |
| Integration | ✅ | `operator_dashboard_api`, `operator_dashboard_ui`, `governance_workflow`, `task_payment_workflow` | |
| Fuzz | N/A | | no untrusted parser fuzz target changed in this issue |
| Mutation | N/A | | not required for this non-critical-path subtask |
| Regression | ✅ | `invalid_*_surfaces_reason_code_contract` cases across 6 suites | |
| Performance | N/A | | no hotspot/perf-sensitive change |

## Mutation
- N/A for this subtask; no critical-path mutation gate requested.

## Risks/Rollback
- Risk: downstream callers pattern-matching old tuple `InvalidDid(String)` variants.
- Rollback: revert commit `3862025a` to restore previous error shapes.

## Docs/ADR
- Updated spec lifecycle artifacts:
  - `specs/5229/spec.md`
  - `specs/5229/plan.md`
  - `specs/5229/tasks.md`
- ADR: not required (no new dependency/protocol/wire-format change).

## Validation
- [x] Relevant local checks passed.
- [x] CI fast-gate checks expected to pass.

## CI Impact Declaration
- [x] No CI scope impact.
- [ ] CI scope impact present (explain below).

CI scope impact details (required when CI scope impact is present):
- Workflow(s) touched:
- Expected runtime delta:
- Expected runner-minute delta:
- Rollback plan if CI cost/runtime regresses:

## Shell-Surface Impact Declaration
- [x] No shell-surface impact.
- [ ] Shell-surface impact present (explain below).

Shell-surface impact details (required when shell-surface impact is present):
- shell_loc_delta_actual: 0
- rust_loc_delta_actual: 659
- shell_to_rust_ratio_delta_actual: -0.003511
- shell_surface_ratio_target_status: improved
- shell_surface_mitigation_issue: None
- regressed_with_waiver requires shell_surface_mitigation_issue to link #<issue-id>
