### PR TITLE
feat(service-api): request-path authz matrix and docs parity governance (#4057)

### DIFF
--- a/crates/kamn-core/tests/ci_strategy_docs.rs
+++ b/crates/kamn-core/tests/ci_strategy_docs.rs
@@ -3,6 +3,8 @@ const OPS_DOC: &str = include_str!("../../../docs/ops/configuration.md");
 const FAIRNESS_FIXTURE: &str =
     include_str!("../../../fixtures/runtime/starvation_fairness_fixture_matrix.txt");
 const FAIRNESS_POLICY_SOURCE: &str = include_str!("../src/fairness_policy.rs");
+const SERVICE_API_ENDPOINT_SOURCE: &str =
+    include_str!("../../kamn-node/src/service_api_endpoint.rs");
 const OVERLOAD_RUNNER_SOURCE: &str =
     include_str!("../../../scripts/ci/run_daemon_os_signal_stress_matrix.sh");
 
@@ -12,6 +14,13 @@ const FAIRNESS_REASON_CODES_CSV: &str =
 const OVERLOAD_REASON_TAXONOMY_VERSION: &str =
     "kamn.ci.daemon-os-signal-stress-matrix-reason-taxonomy.v1";
 const OVERLOAD_REASON_CODES_CSV: &str = "runtime_budget_exceeded,matrix_failure_threshold_exceeded,quarantine_registry_missing,quarantine_reference_present_without_followup,matrix_failures_within_threshold,stable_success_with_quarantine_followup,stable_success";
+const SERVICE_API_REQUEST_PATH_AUTHZ_REASON_TAXONOMY_VERSION: &str =
+    "kamn.runtime.service-api-auth-reason-taxonomy.v1";
+const SERVICE_API_REQUEST_PATH_AUTHZ_REASON_CODES_CSV: &str = "service_api_auth_sender_did_header_missing,service_api_auth_sender_did_invalid,service_api_auth_nonce_header_missing,service_api_auth_nonce_invalid,service_api_auth_nonce_non_positive,service_api_auth_signature_header_missing,service_api_auth_signature_verification_failed,service_api_auth_replay_nonce_detected";
+const SERVICE_API_REQUEST_PATH_AUTHZ_PUBLIC_ROUTES_CSV: &str = "GET:/healthz,GET:/metrics";
+const SERVICE_API_REQUEST_PATH_AUTHZ_PROTECTED_ROUTES_CSV: &str = "POST:/v1/messages/send,POST:/v1/channels/create,POST:/v1/tasks/create,GET:/v1/messages/{message_id},GET:/v1/channels/{channel_id}/messages,GET:/v1/tasks/{task_id},GET:/v1/agents/{agent_did},GET:/v1/events/ws";
+const SERVICE_API_REQUEST_PATH_AUTHZ_MISSING_HEADER_REASON_CODE: &str =
+    "service_api_auth_sender_did_header_missing";
 
 fn fairness_reason_codes() -> Vec<&'static str> {
     FAIRNESS_REASON_CODES_CSV.split(',').collect()
@@ -19,6 +28,12 @@ fn fairness_reason_codes() -> Vec<&'static str> {
 
 fn overload_reason_codes() -> Vec<&'static str> {
     OVERLOAD_REASON_CODES_CSV.split(',').collect()
+}
+
+fn service_api_request_path_authz_reason_codes() -> Vec<&'static str> {
+    SERVICE_API_REQUEST_PATH_AUTHZ_REASON_CODES_CSV
+        .split(',')
+        .collect()
 }
 
 #[test]
@@ -1520,6 +1535,101 @@ fn doc_contains_quota_policy_checker_taxonomy_contract_markers() {
     assert!(DOC.contains("cargo test -p kamn-core --test quota_policy_checker_contract"));
     assert!(DOC.contains("cargo test -p kamn-core --test quota_policy_fixture_parser_contract"));
     assert!(DOC.contains("Regression: #4091"));
+}
+
+#[test]
+fn doc_contains_service_api_request_path_authz_docs_parity_markers() {
+    assert!(DOC.contains("### Service API Request-Path Authz Matrix and Docs Parity Contract"));
+    assert!(DOC.contains(
+        "service_api_request_path_authz_reason_taxonomy_version=kamn.runtime.service-api-auth-reason-taxonomy.v1"
+    ));
+    assert!(DOC.contains(
+        "service_api_request_path_authz_reason_codes_csv=service_api_auth_sender_did_header_missing,service_api_auth_sender_did_invalid,service_api_auth_nonce_header_missing,service_api_auth_nonce_invalid,service_api_auth_nonce_non_positive,service_api_auth_signature_header_missing,service_api_auth_signature_verification_failed,service_api_auth_replay_nonce_detected"
+    ));
+    assert!(
+        DOC.contains("service_api_request_path_authz_public_routes_csv=GET:/healthz,GET:/metrics")
+    );
+    assert!(DOC.contains("service_api_request_path_authz_protected_routes_csv=POST:/v1/messages/send,POST:/v1/channels/create,POST:/v1/tasks/create,GET:/v1/messages/{message_id},GET:/v1/channels/{channel_id}/messages,GET:/v1/tasks/{task_id},GET:/v1/agents/{agent_did},GET:/v1/events/ws"));
+    assert!(DOC.contains(
+        "service_api_request_path_authz_missing_header_reason_code=service_api_auth_sender_did_header_missing"
+    ));
+    assert!(DOC.contains("service_api_request_path_authz_ops_doc_path=docs/ops/configuration.md"));
+    assert!(DOC.contains("service_api_request_path_authz_strategy_doc_path=docs/ci/strategy.md"));
+    assert!(DOC.contains("service_api_request_path_authz_remediation_map_version=v1"));
+    assert!(DOC.contains(
+        "cargo test -p kamn-node main_tests::service_api_endpoint_tests::unit_service_api_route_authz_matrix_matches_protected_and_public_paths -- --exact"
+    ));
+    assert!(DOC.contains(
+        "cargo test -p kamn-node main_tests::service_api_endpoint_tests::integration_service_api_endpoint_route_authz_matrix_rejects_protected_paths_without_headers -- --exact"
+    ));
+    assert!(DOC.contains(
+        "cargo test -p kamn-core --test ci_strategy_docs doc_enforces_service_api_request_path_authz_docs_parity_matches_source_taxonomy -- --exact"
+    ));
+    assert!(DOC.contains(
+        "cargo test -p kamn-core --test ci_strategy_docs doc_enforces_service_api_request_path_authz_remediation_markers_cover_reason_codes -- --exact"
+    ));
+    assert!(DOC.contains("Regression: #4057"));
+}
+
+#[test]
+fn doc_enforces_service_api_request_path_authz_docs_parity_matches_source_taxonomy() {
+    assert!(SERVICE_API_ENDPOINT_SOURCE
+        .contains("pub(crate) const SERVICE_API_AUTH_REASON_TAXONOMY_VERSION: &str ="));
+    assert!(SERVICE_API_ENDPOINT_SOURCE
+        .contains("pub(crate) const SERVICE_API_AUTH_REASON_CODES_CSV: &str ="));
+    assert!(SERVICE_API_ENDPOINT_SOURCE
+        .contains(SERVICE_API_REQUEST_PATH_AUTHZ_REASON_TAXONOMY_VERSION));
+    assert!(SERVICE_API_ENDPOINT_SOURCE.contains(SERVICE_API_REQUEST_PATH_AUTHZ_REASON_CODES_CSV));
+
+    assert!(DOC.contains(&format!(
+        "service_api_request_path_authz_reason_taxonomy_version={SERVICE_API_REQUEST_PATH_AUTHZ_REASON_TAXONOMY_VERSION}"
+    )));
+    assert!(DOC.contains(&format!(
+        "service_api_request_path_authz_reason_codes_csv={SERVICE_API_REQUEST_PATH_AUTHZ_REASON_CODES_CSV}"
+    )));
+    assert!(DOC.contains(&format!(
+        "service_api_request_path_authz_public_routes_csv={SERVICE_API_REQUEST_PATH_AUTHZ_PUBLIC_ROUTES_CSV}"
+    )));
+    assert!(DOC.contains(&format!(
+        "service_api_request_path_authz_protected_routes_csv={SERVICE_API_REQUEST_PATH_AUTHZ_PROTECTED_ROUTES_CSV}"
+    )));
+    assert!(DOC.contains(&format!(
+        "service_api_request_path_authz_missing_header_reason_code={SERVICE_API_REQUEST_PATH_AUTHZ_MISSING_HEADER_REASON_CODE}"
+    )));
+
+    assert!(OPS_DOC.contains(&format!(
+        "service_api_request_path_authz_reason_taxonomy_version={SERVICE_API_REQUEST_PATH_AUTHZ_REASON_TAXONOMY_VERSION}"
+    )));
+    assert!(OPS_DOC.contains(&format!(
+        "service_api_request_path_authz_reason_codes_csv={SERVICE_API_REQUEST_PATH_AUTHZ_REASON_CODES_CSV}"
+    )));
+    assert!(OPS_DOC.contains(&format!(
+        "service_api_request_path_authz_public_routes_csv={SERVICE_API_REQUEST_PATH_AUTHZ_PUBLIC_ROUTES_CSV}"
+    )));
+    assert!(OPS_DOC.contains(&format!(
+        "service_api_request_path_authz_protected_routes_csv={SERVICE_API_REQUEST_PATH_AUTHZ_PROTECTED_ROUTES_CSV}"
+    )));
+    assert!(OPS_DOC.contains(&format!(
+        "service_api_request_path_authz_missing_header_reason_code={SERVICE_API_REQUEST_PATH_AUTHZ_MISSING_HEADER_REASON_CODE}"
+    )));
+}
+
+#[test]
+fn doc_enforces_service_api_request_path_authz_remediation_markers_cover_reason_codes() {
+    for reason_code in service_api_request_path_authz_reason_codes() {
+        assert!(
+            DOC.contains(&format!(
+                "service_api_request_path_authz_remediation.{reason_code}="
+            )),
+            "missing request-path authz remediation marker for {reason_code}"
+        );
+        assert!(
+            OPS_DOC.contains(&format!(
+                "service_api_request_path_authz_remediation.{reason_code}="
+            )),
+            "ops docs missing request-path authz remediation marker for {reason_code}"
+        );
+    }
 }
 
 #[test]

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests.rs
@@ -4,6 +4,7 @@ use crate::service_api_endpoint::{
     ServiceApiChannelCreateBody, ServiceApiHealthBody, ServiceApiLifecycleRejectionProjection,
     ServiceApiMessageCreateBody, ServiceApiTaskCreateBody, DEFAULT_SERVICE_API_BODY_LIMIT_BYTES,
     DEFAULT_SERVICE_API_CONCURRENCY_LIMIT, DEFAULT_SERVICE_API_RATE_LIMIT_PER_SECOND,
+    SERVICE_API_AUTH_REASON_CODES_CSV, SERVICE_API_AUTH_REASON_TAXONOMY_VERSION,
 };
 use kamn_core::baseline_signature_for_fields;
 use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
@@ -72,6 +73,93 @@ struct ServiceApiErrorEnvelope {
     error: String,
     reason_code: String,
     message: String,
+}
+
+const SERVICE_API_AUTH_MISSING_HEADER_REASON_CODE: &str =
+    "service_api_auth_sender_did_header_missing";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ServiceApiRouteAuthzMatrixRow {
+    method: &'static str,
+    path: &'static str,
+    body: &'static str,
+    requires_auth: bool,
+    expected_status_without_auth: &'static str,
+}
+
+fn service_api_route_authz_matrix_rows() -> Vec<ServiceApiRouteAuthzMatrixRow> {
+    vec![
+        ServiceApiRouteAuthzMatrixRow {
+            method: "GET",
+            path: "/healthz",
+            body: "",
+            requires_auth: false,
+            expected_status_without_auth: "HTTP/1.1 200 OK",
+        },
+        ServiceApiRouteAuthzMatrixRow {
+            method: "GET",
+            path: "/metrics",
+            body: "",
+            requires_auth: false,
+            expected_status_without_auth: "HTTP/1.1 200 OK",
+        },
+        ServiceApiRouteAuthzMatrixRow {
+            method: "POST",
+            path: "/v1/messages/send",
+            body: "{\"message\":\"matrix-message\"}",
+            requires_auth: true,
+            expected_status_without_auth: "HTTP/1.1 401 Unauthorized",
+        },
+        ServiceApiRouteAuthzMatrixRow {
+            method: "POST",
+            path: "/v1/channels/create",
+            body: "{\"name\":\"matrix-channel\"}",
+            requires_auth: true,
+            expected_status_without_auth: "HTTP/1.1 401 Unauthorized",
+        },
+        ServiceApiRouteAuthzMatrixRow {
+            method: "POST",
+            path: "/v1/tasks/create",
+            body: "{\"task\":\"matrix-task\"}",
+            requires_auth: true,
+            expected_status_without_auth: "HTTP/1.1 401 Unauthorized",
+        },
+        ServiceApiRouteAuthzMatrixRow {
+            method: "GET",
+            path: "/v1/messages/msg-matrix",
+            body: "",
+            requires_auth: true,
+            expected_status_without_auth: "HTTP/1.1 401 Unauthorized",
+        },
+        ServiceApiRouteAuthzMatrixRow {
+            method: "GET",
+            path: "/v1/channels/channel-matrix/messages",
+            body: "",
+            requires_auth: true,
+            expected_status_without_auth: "HTTP/1.1 401 Unauthorized",
+        },
+        ServiceApiRouteAuthzMatrixRow {
+            method: "GET",
+            path: "/v1/tasks/task-matrix",
+            body: "",
+            requires_auth: true,
+            expected_status_without_auth: "HTTP/1.1 401 Unauthorized",
+        },
+        ServiceApiRouteAuthzMatrixRow {
+            method: "GET",
+            path: "/v1/agents/kamn:did:agent:matrix",
+            body: "",
+            requires_auth: true,
+            expected_status_without_auth: "HTTP/1.1 401 Unauthorized",
+        },
+        ServiceApiRouteAuthzMatrixRow {
+            method: "GET",
+            path: "/v1/events/ws",
+            body: "",
+            requires_auth: true,
+            expected_status_without_auth: "HTTP/1.1 401 Unauthorized",
+        },
+    ]
 }
 
 #[derive(Debug)]
@@ -1126,6 +1214,111 @@ fn unit_service_api_endpoint_metrics_use_runtime_observability_when_present() {
     assert!(metrics_response
         .body
         .contains("kamn_service_api_observability_health{health=\"healthy\"} 1"));
+}
+
+#[test]
+fn unit_service_api_route_authz_matrix_matches_protected_and_public_paths() {
+    assert_eq!(
+        SERVICE_API_AUTH_REASON_TAXONOMY_VERSION,
+        "kamn.runtime.service-api-auth-reason-taxonomy.v1"
+    );
+    assert!(SERVICE_API_AUTH_REASON_CODES_CSV.contains(SERVICE_API_AUTH_MISSING_HEADER_REASON_CODE));
+    for row in service_api_route_authz_matrix_rows() {
+        assert_eq!(
+            crate::service_api_endpoint::route_requires_auth(row.method, row.path),
+            row.requires_auth,
+            "route authz matrix drift for {} {}",
+            row.method,
+            row.path
+        );
+    }
+}
+
+#[test]
+fn integration_service_api_endpoint_route_authz_matrix_rejects_protected_paths_without_headers() {
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    struct ObservedRouteOutcome {
+        method: String,
+        path: String,
+        status_line: String,
+        reason_code: Option<String>,
+    }
+
+    let _env = acquire_service_api_test_env();
+    let parsed = parse_args(vec![
+        "kamn-node".to_owned(),
+        "--role".to_owned(),
+        "processor".to_owned(),
+        "--runtime-mode".to_owned(),
+        "api".to_owned(),
+        "--api-bind".to_owned(),
+        "127.0.0.1:34074".to_owned(),
+    ])
+    .expect("api args should parse");
+    let report = execute(parsed).expect("api execution should succeed");
+    let snapshot = build_service_api_snapshot(&report);
+
+    let matrix_rows = service_api_route_authz_matrix_rows();
+    let rounds = 2_u64;
+    let bind_addr = reserve_loopback_addr();
+    let endpoint_config = ServiceApiEndpointConfig {
+        bind_addr: bind_addr.clone(),
+        max_requests: rounds * matrix_rows.len() as u64,
+        idle_timeout_ms: 2_500,
+        body_limit_bytes: DEFAULT_SERVICE_API_BODY_LIMIT_BYTES,
+        concurrency_limit: DEFAULT_SERVICE_API_CONCURRENCY_LIMIT,
+        rate_limit_per_second: DEFAULT_SERVICE_API_RATE_LIMIT_PER_SECOND,
+    };
+    let server_snapshot = snapshot.clone();
+    let server =
+        thread::spawn(move || serve_service_api_endpoint(&endpoint_config, &server_snapshot));
+    wait_for_endpoint_ready(bind_addr.as_str());
+
+    let mut baseline_outcomes: Option<Vec<ObservedRouteOutcome>> = None;
+    for _round in 0..rounds {
+        let mut outcomes = Vec::with_capacity(matrix_rows.len());
+        for row in &matrix_rows {
+            let response = send_http_request(bind_addr.as_str(), row.method, row.path, row.body);
+            assert!(
+                response.contains(row.expected_status_without_auth),
+                "unexpected authz matrix status for {} {}: expected {}, response={response}",
+                row.method,
+                row.path,
+                row.expected_status_without_auth
+            );
+            let reason_code = if row.requires_auth {
+                let payload = parse_error_envelope_from_http_response(response.as_str());
+                assert_eq!(payload.error, "unauthorized");
+                assert_eq!(
+                    payload.reason_code,
+                    SERVICE_API_AUTH_MISSING_HEADER_REASON_CODE
+                );
+                Some(payload.reason_code)
+            } else {
+                None
+            };
+            outcomes.push(ObservedRouteOutcome {
+                method: row.method.to_owned(),
+                path: row.path.to_owned(),
+                status_line: row.expected_status_without_auth.to_owned(),
+                reason_code,
+            });
+        }
+        if let Some(baseline) = baseline_outcomes.as_ref() {
+            assert_eq!(
+                outcomes, *baseline,
+                "route authz outcomes must remain deterministic across rounds"
+            );
+        } else {
+            baseline_outcomes = Some(outcomes);
+        }
+    }
+
+    let server_result = server.join().expect("endpoint thread should complete");
+    assert!(
+        server_result.is_ok(),
+        "service api endpoint should stop cleanly after route authz matrix validation"
+    );
 }
 
 #[test]

--- a/crates/kamn-node/src/service_api_endpoint.rs
+++ b/crates/kamn-node/src/service_api_endpoint.rs
@@ -95,6 +95,11 @@ const REASON_CODE_AUTH_SIGNATURE_HEADER_MISSING: &str = "service_api_auth_signat
 const REASON_CODE_AUTH_SIGNATURE_VERIFICATION_FAILED: &str =
     "service_api_auth_signature_verification_failed";
 const REASON_CODE_AUTH_REPLAY_NONCE_DETECTED: &str = "service_api_auth_replay_nonce_detected";
+#[cfg(test)]
+pub(crate) const SERVICE_API_AUTH_REASON_TAXONOMY_VERSION: &str =
+    "kamn.runtime.service-api-auth-reason-taxonomy.v1";
+#[cfg(test)]
+pub(crate) const SERVICE_API_AUTH_REASON_CODES_CSV: &str = "service_api_auth_sender_did_header_missing,service_api_auth_sender_did_invalid,service_api_auth_nonce_header_missing,service_api_auth_nonce_invalid,service_api_auth_nonce_non_positive,service_api_auth_signature_header_missing,service_api_auth_signature_verification_failed,service_api_auth_replay_nonce_detected";
 const REASON_CODE_WS_UPGRADE_HEADER_MISSING: &str = "service_api_ws_upgrade_header_missing";
 const REASON_CODE_WS_CONNECTION_HEADER_MISSING: &str = "service_api_ws_connection_header_missing";
 const REASON_CODE_WS_KEY_HEADER_MISSING: &str = "service_api_ws_key_header_missing";
@@ -478,7 +483,7 @@ async fn handle_service_api_websocket_route(
     middleware_impl::handle_service_api_websocket_route(State(state), Extension(context), upgrade)
         .await
 }
-fn route_requires_auth(method: &str, path: &str) -> bool {
+pub(crate) fn route_requires_auth(method: &str, path: &str) -> bool {
     middleware_impl::route_requires_auth(method, path)
 }
 

--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -4671,9 +4671,38 @@ The runtime go/no-go gate lane enforces a versioned release evidence manifest:
   - `cargo test -p kamn-core --test ci_strategy_docs doc_contains_quota_policy_checker_taxonomy_contract_markers -- --exact`
 - Fail-closed policy:
   - unknown scopes, non-positive windows, non-positive limits, and exceeded limits must reject deterministically.
-  - checker taxonomy must remain a superset of fixture taxonomy reason codes.
-  - docs marker drift fails the docs-contract target.
+- checker taxonomy must remain a superset of fixture taxonomy reason codes.
+- docs marker drift fails the docs-contract target.
 - Regression: #4091
+
+### Service API Request-Path Authz Matrix and Docs Parity Contract
+- `service_api_request_path_authz_reason_taxonomy_version=kamn.runtime.service-api-auth-reason-taxonomy.v1`
+- `service_api_request_path_authz_reason_codes_csv=service_api_auth_sender_did_header_missing,service_api_auth_sender_did_invalid,service_api_auth_nonce_header_missing,service_api_auth_nonce_invalid,service_api_auth_nonce_non_positive,service_api_auth_signature_header_missing,service_api_auth_signature_verification_failed,service_api_auth_replay_nonce_detected`
+- `service_api_request_path_authz_public_routes_csv=GET:/healthz,GET:/metrics`
+- `service_api_request_path_authz_protected_routes_csv=POST:/v1/messages/send,POST:/v1/channels/create,POST:/v1/tasks/create,GET:/v1/messages/{message_id},GET:/v1/channels/{channel_id}/messages,GET:/v1/tasks/{task_id},GET:/v1/agents/{agent_did},GET:/v1/events/ws`
+- `service_api_request_path_authz_missing_header_reason_code=service_api_auth_sender_did_header_missing`
+- `service_api_request_path_authz_ops_doc_path=docs/ops/configuration.md`
+- `service_api_request_path_authz_strategy_doc_path=docs/ci/strategy.md`
+- `service_api_request_path_authz_remediation_map_version=v1`
+- `service_api_request_path_authz_remediation.service_api_auth_sender_did_header_missing=add x-kamn-sender-did header with a valid kamn DID before calling protected routes`
+- `service_api_request_path_authz_remediation.service_api_auth_sender_did_invalid=fix sender DID to kamn:did:<scope>:<id> format`
+- `service_api_request_path_authz_remediation.service_api_auth_nonce_header_missing=add x-kamn-request-nonce header with a positive integer`
+- `service_api_request_path_authz_remediation.service_api_auth_nonce_invalid=use a base-10 u64 nonce value in x-kamn-request-nonce`
+- `service_api_request_path_authz_remediation.service_api_auth_nonce_non_positive=increment nonce to a value greater than zero`
+- `service_api_request_path_authz_remediation.service_api_auth_signature_header_missing=add x-kamn-request-signature over sender_did+nonce+state_hash+body`
+- `service_api_request_path_authz_remediation.service_api_auth_signature_verification_failed=recompute signature with the supported profile and current state hash`
+- `service_api_request_path_authz_remediation.service_api_auth_replay_nonce_detected=use a fresh nonce per sender DID and avoid replaying accepted envelopes`
+- Guard commands:
+  - `cargo test -p kamn-node main_tests::service_api_endpoint_tests::unit_service_api_route_authz_matrix_matches_protected_and_public_paths -- --exact`
+  - `cargo test -p kamn-node main_tests::service_api_endpoint_tests::integration_service_api_endpoint_route_authz_matrix_rejects_protected_paths_without_headers -- --exact`
+  - `cargo test -p kamn-core --test ci_strategy_docs doc_contains_service_api_request_path_authz_docs_parity_markers -- --exact`
+  - `cargo test -p kamn-core --test ci_strategy_docs doc_enforces_service_api_request_path_authz_docs_parity_matches_source_taxonomy -- --exact`
+  - `cargo test -p kamn-core --test ci_strategy_docs doc_enforces_service_api_request_path_authz_remediation_markers_cover_reason_codes -- --exact`
+- Fail-closed policy:
+  - protected-route matrix rows without auth headers reject with `401` and `service_api_auth_sender_did_header_missing`.
+  - source taxonomy, strategy docs, and ops docs markers must remain synchronized.
+  - each auth reason code must have deterministic remediation markers in strategy and ops docs.
+- Regression: #4057
 
 ### Fairness Docs Parity and Remediation Contract
 - `fairness_docs_parity_reason_taxonomy_version=kamn.runtime.fairness-policy-reason-taxonomy.v1`

--- a/docs/ops/configuration.md
+++ b/docs/ops/configuration.md
@@ -280,6 +280,39 @@ Regression marker:
 
 - `Regression: #4315`
 
+## Service API Request-Path Authz Matrix and Docs Parity Contract (Issue #4057)
+
+Deterministic route-level request authorization markers:
+
+- `service_api_request_path_authz_reason_taxonomy_version=kamn.runtime.service-api-auth-reason-taxonomy.v1`
+- `service_api_request_path_authz_reason_codes_csv=service_api_auth_sender_did_header_missing,service_api_auth_sender_did_invalid,service_api_auth_nonce_header_missing,service_api_auth_nonce_invalid,service_api_auth_nonce_non_positive,service_api_auth_signature_header_missing,service_api_auth_signature_verification_failed,service_api_auth_replay_nonce_detected`
+- `service_api_request_path_authz_public_routes_csv=GET:/healthz,GET:/metrics`
+- `service_api_request_path_authz_protected_routes_csv=POST:/v1/messages/send,POST:/v1/channels/create,POST:/v1/tasks/create,GET:/v1/messages/{message_id},GET:/v1/channels/{channel_id}/messages,GET:/v1/tasks/{task_id},GET:/v1/agents/{agent_did},GET:/v1/events/ws`
+- `service_api_request_path_authz_missing_header_reason_code=service_api_auth_sender_did_header_missing`
+
+Deterministic remediation markers:
+
+- `service_api_request_path_authz_remediation_map_version=v1`
+- `service_api_request_path_authz_remediation.service_api_auth_sender_did_header_missing=add x-kamn-sender-did header with a valid kamn DID before calling protected routes`
+- `service_api_request_path_authz_remediation.service_api_auth_sender_did_invalid=fix sender DID to kamn:did:<scope>:<id> format`
+- `service_api_request_path_authz_remediation.service_api_auth_nonce_header_missing=add x-kamn-request-nonce header with a positive integer`
+- `service_api_request_path_authz_remediation.service_api_auth_nonce_invalid=use a base-10 u64 nonce value in x-kamn-request-nonce`
+- `service_api_request_path_authz_remediation.service_api_auth_nonce_non_positive=increment nonce to a value greater than zero`
+- `service_api_request_path_authz_remediation.service_api_auth_signature_header_missing=add x-kamn-request-signature over sender_did+nonce+state_hash+body`
+- `service_api_request_path_authz_remediation.service_api_auth_signature_verification_failed=recompute signature with the supported profile and current state hash`
+- `service_api_request_path_authz_remediation.service_api_auth_replay_nonce_detected=use a fresh nonce per sender DID and avoid replaying accepted envelopes`
+
+Validation commands:
+
+- `cargo test -p kamn-node main_tests::service_api_endpoint_tests::unit_service_api_route_authz_matrix_matches_protected_and_public_paths -- --exact`
+- `cargo test -p kamn-node main_tests::service_api_endpoint_tests::integration_service_api_endpoint_route_authz_matrix_rejects_protected_paths_without_headers -- --exact`
+- `cargo test -p kamn-core --test ci_strategy_docs doc_enforces_service_api_request_path_authz_docs_parity_matches_source_taxonomy -- --exact`
+- `cargo test -p kamn-core --test ci_strategy_docs doc_enforces_service_api_request_path_authz_remediation_markers_cover_reason_codes -- --exact`
+
+Regression marker:
+
+- `Regression: #4057`
+
 ## Realtime Presence Mode Gateway and Guardrail Contracts (Issues #5279, #5281, #5283)
 
 Phase-5 realtime gateway integration requires deterministic presence-mode websocket contracts and

--- a/specs/4057/plan.md
+++ b/specs/4057/plan.md
@@ -1,0 +1,45 @@
+# Issue #4057 Plan
+
+- Issue: #4057
+- Milestone: specs/milestones/r27-13-authorization-tenant-isolation-and-audit-integrity-governance/index.md
+
+## Approach
+1. Add a compact request-path fixture matrix in `service_api_endpoint_tests.rs` covering public/protected method+path combinations.
+2. Add a unit check on `route_requires_auth` for matrix determinism.
+3. Add integration coverage that exercises protected/public routes without auth headers and asserts fail-closed reason taxonomy for protected paths.
+4. Add a docs parity block in `docs/ci/strategy.md` and synchronize equivalent markers in `docs/ops/configuration.md`.
+5. Extend `crates/kamn-core/tests/ci_strategy_docs.rs` to enforce auth reason taxonomy parity/remediation coverage against `crates/kamn-node/src/service_api_endpoint.rs` constants.
+6. Run targeted tests and set `specs/4057/spec.md` status to `Implemented`.
+
+## Affected Files
+- `specs/milestones/r27-13-authorization-tenant-isolation-and-audit-integrity-governance/index.md`
+- `specs/4057/spec.md`
+- `specs/4057/plan.md`
+- `specs/4057/tasks.md`
+- `crates/kamn-node/src/main_tests/service_api_endpoint_tests.rs`
+- `crates/kamn-core/tests/ci_strategy_docs.rs`
+- `docs/ci/strategy.md`
+- `docs/ops/configuration.md`
+
+## Risks and Mitigations
+- Risk: route matrix drifts from source auth decision logic.
+  - Mitigation: unit matrix tests directly call `route_requires_auth`.
+- Risk: docs reason taxonomy drifts from source constants.
+  - Mitigation: docs tests parse expected taxonomy constants from `service_api_endpoint.rs` and compare exact strings.
+- Risk: shell LOC expands via new governance scripts.
+  - Mitigation: Rust-test/docs-only implementation; no shell/python/workflow changes.
+
+## Interface Contract
+- Authz docs parity markers:
+  - `service_api_request_path_authz_reason_taxonomy_version=<version>`
+  - `service_api_request_path_authz_reason_codes_csv=<csv>`
+  - `service_api_request_path_authz_public_routes_csv=<csv>`
+  - `service_api_request_path_authz_protected_routes_csv=<csv>`
+  - `service_api_request_path_authz_missing_header_reason_code=<reason>`
+  - `service_api_request_path_authz_ops_doc_path=docs/ops/configuration.md`
+  - `service_api_request_path_authz_strategy_doc_path=docs/ci/strategy.md`
+  - `service_api_request_path_authz_remediation_map_version=v1`
+  - `service_api_request_path_authz_remediation.<reason_code>=<action>`
+
+## ADR
+- Not required (no dependency/protocol/schema introduction).

--- a/specs/4057/spec.md
+++ b/specs/4057/spec.md
@@ -1,0 +1,56 @@
+# Issue #4057 Spec
+
+- Title: Task: implement request-path authz matrix checks and docs parity governance
+- Status: Implemented
+- Type: task
+- Priority: P1
+- Milestone: specs/milestones/r27-13-authorization-tenant-isolation-and-audit-integrity-governance/index.md
+
+## Problem Statement
+Route-level request authorization behavior must remain deterministic across protected/public paths. Without an explicit matrix contract plus docs parity checks, route behavior and remediation guidance can drift.
+
+## Scope
+In scope:
+- Add deterministic request-path authz matrix checks for public/protected service routes.
+- Assert fail-closed missing-auth behavior on protected routes.
+- Add docs parity markers/remediation mapping for authz route governance.
+- Add Rust docs-contract tests to keep strategy/ops docs synchronized with authz reason taxonomy.
+
+Out of scope:
+- New shell/python/workflow checkers.
+- Endpoint topology redesign.
+- External IAM/policy engine integration.
+
+## Shell-Surface Estimates
+- shell_loc_delta_estimate: 0
+- rust_loc_delta_estimate: 170
+- shell_to_rust_ratio_delta_estimate: -0.0002
+- shell_surface_mitigation_issue: None
+
+## Acceptance Criteria
+- AC-1: Request-path matrix covers representative public and protected routes with deterministic auth-required decisions.
+- AC-2: Protected routes fail closed without auth headers and emit stable unauthorized reason taxonomy markers.
+- AC-3: `docs/ci/strategy.md` and `docs/ops/configuration.md` remain synchronized with authz route reason taxonomy and remediation markers.
+- AC-4: Unit, Functional, Integration, and Regression tests for matrix/parity contracts pass.
+
+## Conformance Cases
+| Case | AC | Tier | Input | Expected |
+|---|---|---|---|---|
+| C-01 | AC-1 | Unit | method/path matrix fixture | `route_requires_auth` matches expected decision for each row |
+| C-02 | AC-2 | Integration | protected routes without auth headers | `401 unauthorized` + `service_api_auth_sender_did_header_missing` |
+| C-03 | AC-2 | Functional | public routes without auth headers | routes remain reachable without auth rejection |
+| C-04 | AC-3 | Integration | docs markers + auth reason taxonomy constants | strategy/ops docs taxonomy+csv markers match source constants |
+| C-05 | AC-3 | Regression | remediation marker coverage per auth reason code | each reason code has deterministic remediation markers in strategy+ops docs |
+| C-06 | AC-4 | Verification | targeted cargo test commands | all listed commands pass |
+
+## Test Mapping
+- `cargo test -p kamn-node main_tests::service_api_endpoint_tests::unit_service_api_route_authz_matrix_matches_protected_and_public_paths -- --exact`
+- `cargo test -p kamn-node main_tests::service_api_endpoint_tests::integration_service_api_endpoint_route_authz_matrix_rejects_protected_paths_without_headers -- --exact`
+- `cargo test -p kamn-core --test ci_strategy_docs doc_contains_service_api_request_path_authz_docs_parity_markers -- --exact`
+- `cargo test -p kamn-core --test ci_strategy_docs doc_enforces_service_api_request_path_authz_docs_parity_matches_source_taxonomy -- --exact`
+- `cargo test -p kamn-core --test ci_strategy_docs doc_enforces_service_api_request_path_authz_remediation_markers_cover_reason_codes -- --exact`
+
+## Success Metrics
+- Route-level authz matrix behavior is captured in deterministic Rust tests.
+- Docs parity and remediation drift fail closed via Rust tests.
+- Shell surface does not grow (`shell_loc_delta_actual=0` target).

--- a/specs/4057/tasks.md
+++ b/specs/4057/tasks.md
@@ -1,0 +1,19 @@
+# Issue #4057 Tasks
+
+- Issue: #4057
+- Milestone: specs/milestones/r27-13-authorization-tenant-isolation-and-audit-integrity-governance/index.md
+
+## Ordered Tasks
+- [x] T1 (RED): add failing route authz matrix and docs parity/remediation contract tests (`C-01`..`C-05`).
+- [x] T2 (GREEN): implement request-path matrix checks in `kamn-node` tests and stabilize fail-closed assertions (`C-01`..`C-03`).
+- [x] T3 (GREEN): add strategy/ops docs authz route parity markers and remediation mappings (`C-04`, `C-05`).
+- [x] T4 (Regression): enforce source-taxonomy/docs parity and per-reason remediation checks in `ci_strategy_docs.rs` (`C-04`, `C-05`).
+- [x] T5 (Verify): run targeted verification commands and set spec status to `Implemented` (`C-06`).
+
+## Test Tier Mapping
+| Tier | Planned Coverage |
+|---|---|
+| Unit | route matrix decision checks (`route_requires_auth`) |
+| Functional | public-route unauthenticated reachability checks |
+| Integration | protected-route fail-closed auth checks + docs/source parity |
+| Regression | per-reason remediation marker coverage + drift assertions |

--- a/specs/milestones/r27-13-authorization-tenant-isolation-and-audit-integrity-governance/index.md
+++ b/specs/milestones/r27-13-authorization-tenant-isolation-and-audit-integrity-governance/index.md
@@ -1,0 +1,30 @@
+# R27.13 Authorization, Tenant Isolation, and Audit-Integrity Governance
+
+## Milestone Summary
+
+Closure tranche focused on deterministic authorization/isolation controls in production service paths:
+- fail-closed authorization scope governance,
+- tenant-isolation negative-matrix evidence,
+- tamper-evident audit-integrity release checks.
+
+Milestone objective: keep route-level authorization behavior deterministic and auditable without expanding shell governance surface.
+
+## Issue Hierarchy
+
+- Epic:
+  - `#4053` — Epic: R27.13 close authorization, tenant-isolation, and audit-integrity governance gaps
+- Stories:
+  - `#4054` — Story: enforce deterministic authorization scope governance across protected service paths
+  - `#4055` — Story: validate tenant-isolation evidence and audit-integrity release checks with fail-closed policy
+- Tasks (Story `#4054`):
+  - `#4056` — Task: implement authorization scope-policy checker with deterministic fail-closed taxonomy
+  - `#4057` — Task: implement request-path authz matrix checks and docs parity governance
+- Subtasks (Task `#4057`):
+  - `#4062` — Subtask: implement route-level authz matrix fixtures and deterministic checker behavior
+  - `#4063` — Subtask: add docs parity and remediation marker checks for authz route governance
+
+## Governance Markers
+
+- `service_api_request_authz_scope_policy=fail_closed`
+- `tenant_isolation_negative_matrix=required`
+- `audit_integrity_release_gate=tamper_evident`


### PR DESCRIPTION
## Summary
Implements issue #4057 with a deterministic request-path authz matrix for `kamn-node` service API routes and Rust-enforced docs parity/remediation governance. Adds source taxonomy markers, route-matrix tests, and synchronized strategy/ops marker contracts without adding shell scripts.

## Links
- Milestone: `specs/milestones/r27-13-authorization-tenant-isolation-and-audit-integrity-governance/index.md`
- Closes #4057
- Spec: `specs/4057/spec.md`
- Plan: `specs/4057/plan.md`
- Tasks: `specs/4057/tasks.md`

## Spec Verification (AC → tests)
| AC | ✅/❌ | Test(s) |
|---|---|---|
| AC-1: request-path matrix covers public/protected routes with deterministic auth-required decisions | ✅ | `cargo test -p kamn-node main_tests::service_api_endpoint_tests::unit_service_api_route_authz_matrix_matches_protected_and_public_paths -- --exact` |
| AC-2: protected routes fail closed without auth headers with stable taxonomy markers | ✅ | `cargo test -p kamn-node main_tests::service_api_endpoint_tests::integration_service_api_endpoint_route_authz_matrix_rejects_protected_paths_without_headers -- --exact` |
| AC-3: strategy/ops docs parity enforced against auth taxonomy + remediation mapping | ✅ | `cargo test -p kamn-core --test ci_strategy_docs doc_contains_service_api_request_path_authz_docs_parity_markers -- --exact`; `cargo test -p kamn-core --test ci_strategy_docs doc_enforces_service_api_request_path_authz_docs_parity_matches_source_taxonomy -- --exact`; `cargo test -p kamn-core --test ci_strategy_docs doc_enforces_service_api_request_path_authz_remediation_markers_cover_reason_codes -- --exact` |
| AC-4: unit/functional/integration/regression coverage passes | ✅ | commands above + `cargo clippy -p kamn-node -p kamn-core --tests -- -D warnings` |

## TDD Evidence
- RED:
  - `cargo test -p kamn-core --test ci_strategy_docs doc_contains_service_api_request_path_authz_docs_parity_markers -- --exact`
  - failed with: `assertion failed: DOC.contains("### Service API Request-Path Authz Matrix and Docs Parity Contract")`
- GREEN:
  - `cargo test -p kamn-node main_tests::service_api_endpoint_tests::unit_service_api_route_authz_matrix_matches_protected_and_public_paths -- --exact`
  - `cargo test -p kamn-node main_tests::service_api_endpoint_tests::integration_service_api_endpoint_route_authz_matrix_rejects_protected_paths_without_headers -- --exact`
  - `cargo test -p kamn-core --test ci_strategy_docs doc_contains_service_api_request_path_authz_docs_parity_markers -- --exact`
  - `cargo test -p kamn-core --test ci_strategy_docs doc_enforces_service_api_request_path_authz_docs_parity_matches_source_taxonomy -- --exact`
  - `cargo test -p kamn-core --test ci_strategy_docs doc_enforces_service_api_request_path_authz_remediation_markers_cover_reason_codes -- --exact`
- REGRESSION:
  - `cargo fmt --check`
  - `cargo clippy -p kamn-node -p kamn-core --tests -- -D warnings`

## Test Tiers
| Tier | ✅/❌/N/A | Tests | N/A Why |
|---|---|---|---|
| Unit | ✅ | `...unit_service_api_route_authz_matrix_matches_protected_and_public_paths` | |
| Property | N/A | | no randomized invariant surface changed |
| Contract/DbC | N/A | | no DbC macro contracts in touched modules |
| Snapshot | N/A | | no snapshot output introduced |
| Functional | ✅ | route matrix integration validates public-route unauthenticated reachability | |
| Conformance | ✅ | AC/C-case mapped commands in spec and this PR | |
| Integration | ✅ | docs/source parity + protected-route fail-closed integration tests | |
| Fuzz | N/A | | no parser/untrusted-input algorithm changes |
| Mutation | N/A | | not a critical-path mutation gate change; existing critical paths unchanged |
| Regression | ✅ | docs parity + remediation drift checks and fail-closed reason-code assertions | |
| Performance | N/A | | no performance-sensitive runtime path or benchmark target changed |

## Mutation
- N/A for this issue scope (no critical-path algorithm mutation surface changed).

## Risks / Rollback
- Risk: docs marker drift if taxonomy changes without docs updates.
- Mitigation: `ci_strategy_docs` now fails closed on taxonomy/marker/remediation mismatch.
- Rollback: revert commit `6d948e36` to restore prior behavior.

## Docs / ADR
- Updated: `docs/ci/strategy.md`, `docs/ops/configuration.md`
- Added: `specs/milestones/r27-13-authorization-tenant-isolation-and-audit-integrity-governance/index.md`, `specs/4057/{spec.md,plan.md,tasks.md}`
- ADR: not required.

## Shell-Surface DoD Markers
- `shell_loc_delta_actual: 0`
- `rust_loc_delta_actual: 310`
- `shell_to_rust_ratio_delta_actual: -0.0000`
- `shell_surface_ratio_target_status: improved`
