### PR TITLE
docs(r52): finalize milestone closure metadata for #5837

### DIFF
--- a/specs/milestones/r52-e2e-live-runtime-integration-hardening/index.md
+++ b/specs/milestones/r52-e2e-live-runtime-integration-hardening/index.md
@@ -2,8 +2,8 @@
 
 - Milestone: `R52 E2E Live Runtime Integration Hardening`
 - Epic: #5611
-- Completed issue(s): #5610, #5613, #5615, #5617, #5692, #5693, #5696, #5698, #5700, #5702, #5708, #5711, #5714, #5717, #5720, #5723, #5726, #5729, #5732, #5735, #5738, #5741, #5744, #5747, #5750, #5753, #5756, #5759, #5762, #5765, #5768, #5771, #5772, #5774, #5776, #5778, #5781, #5783, #5785, #5787, #5789, #5791, #5793, #5795, #5797, #5802, #5804, #5808, #5810, #5812, #5814, #5815, #5818, #5820, #5822, #5824, #5826, #5828, #5830, #5833, #5835
-- Active issue(s): #5837
+- Completed issue(s): #5610, #5613, #5615, #5617, #5692, #5693, #5696, #5698, #5700, #5702, #5708, #5711, #5714, #5717, #5720, #5723, #5726, #5729, #5732, #5735, #5738, #5741, #5744, #5747, #5750, #5753, #5756, #5759, #5762, #5765, #5768, #5771, #5772, #5774, #5776, #5778, #5781, #5783, #5785, #5787, #5789, #5791, #5793, #5795, #5797, #5802, #5804, #5808, #5810, #5812, #5814, #5815, #5818, #5820, #5822, #5824, #5826, #5828, #5830, #5833, #5835, #5837
+- Active issue(s): None
 - Scope: harden external runtime execution readiness behavior with deterministic diagnostics while preserving phase-6 output contract stability, green-main quality gates, and branch-hygiene post-publication reconciliation evidence.
 
 ## Delivery Slices
@@ -70,4 +70,4 @@
 61. Activate opt-in live `S-12` retention/deletion scenario across sdk-direct, cli-scripted, and mcp-agent drivers with deterministic register/expire/tombstone/query lifecycle validation, cross-surface CLI/MCP/API contract activation, and compensating archived-spec cleanup to preserve the `specs/` cap guardrail. (Completed via #5830)
 62. Activate opt-in live `S-13` bridge-forwarding scenario across sdk-direct, cli-scripted, and mcp-agent drivers with deterministic submit/forward/query continuity validation, cross-surface CLI/MCP/API contract activation, and in-diff mutation cleanliness coverage. (Completed via #5833)
 63. Activate opt-in live `S-14` batch-merkle scenario across sdk-direct, cli-scripted, and mcp-agent drivers with deterministic batched send/query/proof continuity validation while reusing existing operation surfaces. (Completed via #5835)
-64. Activate opt-in live `S-15` performance-smoke scenario across sdk-direct, cli-scripted, and mcp-agent drivers with deterministic bounded-latency continuity validation and fail-closed threshold contracts. (In progress via #5837)
+64. Activate opt-in live `S-15` performance-smoke scenario across sdk-direct, cli-scripted, and mcp-agent drivers with deterministic bounded-latency continuity validation and fail-closed threshold contracts. (Completed via #5837)


### PR DESCRIPTION
## Summary
Finalizes stale R52 milestone metadata after `#5837` merge.

## Changes
- Move `#5837` from active to completed issue list.
- Set `Active issue(s)` to `None`.
- Mark delivery slice 64 (`S-15`) as `Completed via #5837`.

## Verification
- `cargo test -p kamn-e2e-harness --test docs_contract_release_group -- --nocapture`
