### PR TITLE
docs(5863): mark relay projection spec implemented

### DIFF
--- a/specs/5863/spec.md
+++ b/specs/5863/spec.md
@@ -1,7 +1,7 @@
 # Spec: Issue #5863 - Daemon Relay Drain Lifecycle Projection
 
 - Issue: #5863
-- Status: Reviewed
+- Status: Implemented
 - Type: task
 - Priority: P1
 - Milestone: `specs/milestones/r52-e2e-live-runtime-integration-hardening/index.md`


### PR DESCRIPTION
Post-merge housekeeping for #5863: set `specs/5863/spec.md` status to `Implemented` per `AGENTS.md` closure contract.
