### PR TITLE
docs(5867): mark e2e delivery spec implemented

### DIFF
--- a/specs/5867/spec.md
+++ b/specs/5867/spec.md
@@ -1,7 +1,7 @@
 # Spec: Issue #5867 - End-to-End Message Delivery Continuity
 
 - Issue: #5867
-- Status: Reviewed
+- Status: Implemented
 - Type: task
 - Priority: P1
 - Milestone: `specs/milestones/r52-e2e-live-runtime-integration-hardening/index.md`


### PR DESCRIPTION
## Summary
Marks `specs/5867/spec.md` as `Implemented` after PR #5871 merged.

## Links
- Issue: #5867
- Follow-up to PR: #5871
- Spec: `specs/5867/spec.md`

## Validation
- Docs-only status update; no runtime behavior change.
