### PR TITLE
docs(5868): mark live e2e fail-closed spec implemented

### DIFF
--- a/specs/5868/spec.md
+++ b/specs/5868/spec.md
@@ -1,7 +1,7 @@
 # Spec: Issue #5868 - Live E2E Fail-Closed CI Execution
 
 - Issue: #5868
-- Status: Reviewed
+- Status: Implemented
 - Type: task
 - Priority: P1
 - Milestone: `specs/milestones/r52-e2e-live-runtime-integration-hardening/index.md`


### PR DESCRIPTION
## Summary
Marks `specs/5868/spec.md` status as `Implemented` after PR #5873 merged.

## Links
- Issue: #5868
- Follow-up to PR: #5873
- Spec: `specs/5868/spec.md`

## Validation
- Docs-only status update; no runtime behavior change.
