### PR TITLE
fix(agent-lib): fail closed on nonce overflow

### DIFF
--- a/crates/kamn-agent-lib/src/lib.rs
+++ b/crates/kamn-agent-lib/src/lib.rs
@@ -7,7 +7,7 @@ use auth::KamnAuthHeaders;
 use client::ServiceApiHttpClient;
 use envelope::{build_and_sign_envelope, CanonicalMessageEnvelope};
 use kolme::KolmeClient;
-use nonce::NonceTracker;
+use nonce::{NonceTracker, NonceTrackerError};
 
 pub use errors::AgentLibError;
 pub use identity::AgentIdentity;
@@ -341,13 +341,18 @@ impl KamnAgentHandle {
             .nonce_tracker
             .lock()
             .map_err(|error| AgentLibError::Internal(format!("nonce lock poisoned: {error}")))?;
-        Ok(tracker.next_nonce())
+        tracker.next_nonce().map_err(|error| match error {
+            NonceTrackerError::Exhausted => AgentLibError::InvalidInput {
+                field: "nonce",
+                reason: "nonce tracker exhausted at u64::MAX".to_owned(),
+            },
+        })
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{AgentIdentity, KamnAgentHandle};
+    use super::{AgentIdentity, AgentLibError, KamnAgentHandle, NonceTracker};
 
     #[test]
     fn unit_kamn_agent_handle_exposes_identity_after_connect() {
@@ -360,5 +365,33 @@ mod tests {
         .expect("handle");
 
         assert_eq!(handle.identity().did(), identity.did());
+    }
+
+    #[test]
+    fn regression_kamn_agent_handle_rejects_nonce_overflow() {
+        // Regression: #5907
+        let identity = AgentIdentity::from_agent_name("overflow-agent").expect("identity");
+        let handle = KamnAgentHandle::with_identity(
+            "http://localhost:8080",
+            "http://localhost:3000",
+            identity,
+        )
+        .expect("handle");
+
+        {
+            let mut tracker = handle.nonce_tracker.lock().expect("nonce lock");
+            *tracker = NonceTracker::new(u64::MAX);
+        }
+
+        let error = handle
+            .build_auth_headers("state:overflow", b"{}", Some("messages:write"))
+            .expect_err("nonce overflow must fail closed");
+        assert_eq!(
+            error,
+            AgentLibError::InvalidInput {
+                field: "nonce",
+                reason: "nonce tracker exhausted at u64::MAX".to_owned(),
+            }
+        );
     }
 }

--- a/crates/kamn-agent-lib/src/nonce.rs
+++ b/crates/kamn-agent-lib/src/nonce.rs
@@ -4,6 +4,13 @@ pub struct NonceTracker {
     current: u64,
 }
 
+/// Error returned when the nonce tracker cannot advance.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NonceTrackerError {
+    /// Tracker is exhausted and cannot produce another nonce.
+    Exhausted,
+}
+
 impl NonceTracker {
     /// Builds a tracker with an initial nonce value.
     pub fn new(initial: u64) -> Self {
@@ -16,21 +23,38 @@ impl NonceTracker {
     }
 
     /// Advances and returns the next nonce value.
-    pub fn next_nonce(&mut self) -> u64 {
-        self.current = self.current.saturating_add(1);
-        self.current
+    pub fn next_nonce(&mut self) -> Result<u64, NonceTrackerError> {
+        let next = self
+            .current
+            .checked_add(1)
+            .ok_or(NonceTrackerError::Exhausted)?;
+        self.current = next;
+        Ok(self.current)
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::NonceTracker;
+    use super::{NonceTracker, NonceTrackerError};
 
     #[test]
     fn unit_nonce_tracker_advances_monotonically() {
         let mut tracker = NonceTracker::new(0);
-        assert_eq!(tracker.next_nonce(), 1);
-        assert_eq!(tracker.next_nonce(), 2);
+        assert_eq!(tracker.next_nonce(), Ok(1));
+        assert_eq!(tracker.next_nonce(), Ok(2));
         assert_eq!(tracker.current(), 2);
+    }
+
+    #[test]
+    fn regression_nonce_tracker_overflow_must_not_reuse_nonce_value() {
+        // Regression: #5907
+        let mut tracker = NonceTracker::new(u64::MAX - 1);
+        assert_eq!(tracker.next_nonce(), Ok(u64::MAX));
+        assert_ne!(
+            tracker.next_nonce(),
+            Ok(u64::MAX),
+            "overflow path must not silently emit a duplicate nonce"
+        );
+        assert_eq!(tracker.next_nonce(), Err(NonceTrackerError::Exhausted));
     }
 }

--- a/specs/5907/plan.md
+++ b/specs/5907/plan.md
@@ -1,0 +1,24 @@
+# Plan: Issue #5907 - Nonce Overflow Fail-Closed in kamn-agent-lib
+
+## Approach
+1. Introduce explicit overflow signaling from `NonceTracker` when `current == u64::MAX`.
+2. Update `AgentLib::next_nonce` to propagate this as `AgentLibError::InvalidInput` with stable reason text.
+3. Add unit tests for normal monotonic behavior and overflow behavior in `nonce.rs`.
+4. Add integration/regression tests in `kamn-agent-lib` verifying API-level fail-closed behavior when nonce is exhausted.
+
+## Affected Modules
+- `crates/kamn-agent-lib/src/nonce.rs`
+- `crates/kamn-agent-lib/src/lib.rs`
+
+## Risks / Mitigations
+- Risk: API signature changes may require many downstream updates.
+  - Mitigation: keep external `AgentLib` API unchanged; only internal nonce tracker signaling changes.
+- Risk: error drift causes unstable contracts.
+  - Mitigation: use deterministic existing `AgentLibError::InvalidInput` mapping and lock with regression tests.
+
+## Interfaces / Contracts
+- `NonceTracker` gains fail-closed overflow signaling semantics.
+- `AgentLib` request methods continue returning `Result<_, AgentLibError>`, now including nonce-overflow mapping.
+
+## ADR
+- Not required (no dependency/protocol/architecture boundary change).

--- a/specs/5907/spec.md
+++ b/specs/5907/spec.md
@@ -1,0 +1,54 @@
+# Spec: Issue #5907 - Nonce Overflow Fail-Closed in kamn-agent-lib
+
+- Issue: #5907
+- Status: Implemented
+- Type: task
+- Priority: P2
+- Milestone: `specs/milestones/r52-e2e-live-runtime-integration-hardening/index.md`
+- Last Updated: 2026-02-24
+
+## Problem Statement
+`NonceTracker::next_nonce` currently uses saturating arithmetic. At `u64::MAX`, it emits `u64::MAX` repeatedly, enabling duplicate nonce reuse instead of fail-closed behavior.
+
+## Scope
+In scope:
+- Make nonce advancement fail-closed on overflow.
+- Propagate overflow through `kamn-agent-lib` nonce allocation path.
+- Add regression tests proving overflow returns an explicit error and does not reuse nonce values.
+- Preserve existing monotonic behavior for non-overflow paths.
+
+Out of scope:
+- Durable nonce persistence.
+- Cross-process nonce leasing/synchronization.
+
+## Acceptance Criteria
+### AC-1 Overflow is rejected
+Given a nonce tracker at `u64::MAX`,
+When requesting the next nonce,
+Then the operation returns an explicit overflow error.
+
+### AC-2 No duplicate emission at overflow boundary
+Given a tracker advanced to `u64::MAX`,
+When next nonce is requested again,
+Then no duplicate nonce value is emitted.
+
+### AC-3 Existing monotonic path remains unchanged
+Given a tracker below `u64::MAX`,
+When requesting next nonce,
+Then nonce increments monotonically as before.
+
+### AC-4 Agent-lib request paths fail closed
+Given agent-lib request signing that requires nonce allocation,
+When nonce tracker is exhausted,
+Then operation fails with deterministic nonce-overflow error.
+
+## Conformance Cases
+- C-01 (AC-1, Unit): `NonceTracker` returns overflow error at `u64::MAX`.
+- C-02 (AC-2, Regression): repeated calls at overflow boundary never emit a duplicate nonce value.
+- C-03 (AC-3, Unit): monotonic increment semantics remain unchanged below overflow boundary.
+- C-04 (AC-4, Integration): `AgentLib` operations map exhausted nonce tracker to deterministic `AgentLibError`.
+
+## Success Metrics / Observable Signals
+- Overflow paths return explicit errors instead of saturating duplicates.
+- `kamn-agent-lib` nonce-using APIs fail closed when tracker is exhausted.
+- Added unit/regression tests pass and guard against future saturation regressions.

--- a/specs/5907/tasks.md
+++ b/specs/5907/tasks.md
@@ -1,0 +1,7 @@
+# Tasks: Issue #5907 - Nonce Overflow Fail-Closed in kamn-agent-lib
+
+1. T1 (RED): add failing tests for `NonceTracker` overflow and `AgentLib` overflow propagation.
+2. T2 (GREEN): implement overflow-aware nonce advancement and deterministic error mapping.
+3. T3 (REFACTOR): keep nonce API surface minimal while preserving monotonic behavior below overflow.
+4. T4 (VERIFY): run fmt, strict clippy, and targeted `kamn-agent-lib` tests.
+5. T5 (REGRESSION): ensure duplicate nonce saturation behavior cannot reappear unnoticed.


### PR DESCRIPTION
## Summary
- Fail closed on nonce exhaustion in `kamn-agent-lib` by changing `NonceTracker::next_nonce` from saturating behavior to explicit overflow signaling.
- Propagate nonce exhaustion through `KamnAgentHandle::next_nonce` as deterministic `AgentLibError::InvalidInput { field: "nonce", reason: "nonce tracker exhausted at u64::MAX" }`.
- Add/commit issue lifecycle artifacts for `#5907` (`spec.md`, `plan.md`, `tasks.md`) and mark spec status as `Implemented`.

## Links
- Milestone: `specs/milestones/r52-e2e-live-runtime-integration-hardening/index.md`
- Closes #5907
- Spec: `specs/5907/spec.md`
- Plan: `specs/5907/plan.md`
- Tasks: `specs/5907/tasks.md`

## Spec Verification (AC -> tests)
| AC | ✅/❌ | Test(s) |
|---|---|---|
| AC-1 Overflow is rejected | ✅ | `nonce::tests::regression_nonce_tracker_overflow_must_not_reuse_nonce_value` |
| AC-2 No duplicate emission at overflow boundary | ✅ | `nonce::tests::regression_nonce_tracker_overflow_must_not_reuse_nonce_value` |
| AC-3 Existing monotonic path remains unchanged | ✅ | `nonce::tests::unit_nonce_tracker_advances_monotonically` |
| AC-4 Agent-lib request paths fail closed | ✅ | `tests::regression_kamn_agent_handle_rejects_nonce_overflow` |

## TDD Evidence
- RED command:
  - `cargo test -p kamn-agent-lib -- --nocapture`
- RED excerpt:
  - `nonce::tests::regression_nonce_tracker_overflow_must_not_reuse_nonce_value ... FAILED`
  - `tests::regression_kamn_agent_handle_rejects_nonce_overflow ... FAILED`
  - `assertion left != right failed ... left: 18446744073709551615 right: 18446744073709551615`
- GREEN command:
  - `cargo test -p kamn-agent-lib -- --nocapture`
- GREEN excerpt:
  - `running 6 tests`
  - `nonce::tests::regression_nonce_tracker_overflow_must_not_reuse_nonce_value ... ok`
  - `tests::regression_kamn_agent_handle_rejects_nonce_overflow ... ok`
  - `test result: ok. 6 passed; 0 failed`
- REGRESSION summary:
  - overflow path no longer re-emits duplicate nonce at `u64::MAX`; API surface fails closed with deterministic nonce error.

## Test Tiers
| Tier | ✅/❌/N/A | Tests | N/A Why |
|---|---|---|---|
| Unit | ✅ | `nonce::tests::unit_nonce_tracker_advances_monotonically` | |
| Property | N/A | | No parser/invariant randomness surface changed in this issue. |
| Contract/DbC | N/A | | No `contracts`-annotated API surface introduced or modified. |
| Snapshot | N/A | | No stable structured output changes requiring snapshots. |
| Functional | ✅ | `tests::regression_kamn_agent_handle_rejects_nonce_overflow` | |
| Conformance | ✅ | C-01..C-04 via nonce + handle regression/unit tests listed above | |
| Integration | N/A | | No cross-crate/service integration path changed; full crate integration suite still passed via `cargo test -p kamn-agent-lib`. |
| Fuzz | N/A | | No untrusted parser/framing path touched. |
| Mutation | ✅ | `cargo mutants --in-diff /tmp/issue5907.diff -p kamn-agent-lib` | |
| Regression | ✅ | `nonce::tests::regression_nonce_tracker_overflow_must_not_reuse_nonce_value`; `tests::regression_kamn_agent_handle_rejects_nonce_overflow` | |
| Performance | N/A | | No hotspot/perf-sensitive algorithm changes; single checked add + error map only. |

## Mutation
- `cargo mutants --in-diff /tmp/issue5907.diff -p kamn-agent-lib`
- Result: `4 mutants tested in 17s: 4 caught` (0 escaped)

## Risks/Rollback
- Risk: None beyond expected nonce-overflow hard-fail semantics at exhaustion boundary.
- Rollback: revert commit `48fe90a9` if boundary behavior needs temporary restoration.

## Docs/ADR
- Updated specs/docs:
  - `specs/5907/spec.md`
  - `specs/5907/plan.md`
  - `specs/5907/tasks.md`
- ADR: Not required (no dependency/protocol/architecture boundary change).

## Validation
- [x] Relevant local checks passed.
- [x] CI fast-gate checks expected to pass.

## CI Impact Declaration
- [x] No CI scope impact.
- [ ] CI scope impact present (explain below).

CI scope impact details (required when CI scope impact is present):
- Workflow(s) touched:
- Expected runtime delta:
- Expected runner-minute delta:
- Rollback plan if CI cost/runtime regresses:

## Shell-Surface Impact Declaration
- [x] No shell-surface impact.
- [ ] Shell-surface impact present (explain below).

Shell-surface impact details (required when shell-surface impact is present):
- shell_loc_delta_actual:
- rust_loc_delta_actual:
- shell_to_rust_ratio_delta_actual:
- shell_surface_ratio_target_status: improved|neutral|regressed_with_waiver
- shell_surface_mitigation_issue: #<issue-id>|None
- regressed_with_waiver requires shell_surface_mitigation_issue to link #<issue-id>
