### PR TITLE
fix(core): require explicit opt-in for deterministic fixture crypto

### DIFF
--- a/crates/kamn-core/src/direct_message_crypto.rs
+++ b/crates/kamn-core/src/direct_message_crypto.rs
@@ -182,9 +182,6 @@ impl fmt::Display for DirectMessageCryptoError {
 impl std::error::Error for DirectMessageCryptoError {}
 
 fn insecure_direct_message_crypto_enabled() -> bool {
-    if cfg!(debug_assertions) {
-        return true;
-    }
     match env::var(ALLOW_INSECURE_DIRECT_MESSAGE_CRYPTO_ENV) {
         Ok(value) => matches!(
             value.trim().to_ascii_lowercase().as_str(),
@@ -262,33 +259,72 @@ fn hex_decode(value: &str) -> Result<Vec<u8>, DirectMessageCryptoError> {
 #[cfg(test)]
 mod tests {
     use super::{DirectMessageCryptoEngine, DirectMessageCryptoError};
+    use std::env;
+    use std::sync::{Mutex, OnceLock};
+
+    fn with_direct_message_crypto_env<T>(value: Option<&str>, run: impl FnOnce() -> T) -> T {
+        static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        let _guard = ENV_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .expect("env lock should not be poisoned");
+        let previous = env::var(super::ALLOW_INSECURE_DIRECT_MESSAGE_CRYPTO_ENV).ok();
+        match value {
+            Some(value) => env::set_var(super::ALLOW_INSECURE_DIRECT_MESSAGE_CRYPTO_ENV, value),
+            None => env::remove_var(super::ALLOW_INSECURE_DIRECT_MESSAGE_CRYPTO_ENV),
+        }
+        let output = run();
+        match previous {
+            Some(value) => env::set_var(super::ALLOW_INSECURE_DIRECT_MESSAGE_CRYPTO_ENV, value),
+            None => env::remove_var(super::ALLOW_INSECURE_DIRECT_MESSAGE_CRYPTO_ENV),
+        }
+        output
+    }
+
+    #[test]
+    fn regression_constructor_requires_explicit_opt_in_even_in_debug() {
+        // Regression: #5909
+        with_direct_message_crypto_env(None, || {
+            assert_eq!(
+                DirectMessageCryptoEngine::new(
+                    "kamn:did:agent:alice#key-agreement-1",
+                    "kamn:did:agent:bob#key-agreement-1",
+                ),
+                Err(DirectMessageCryptoError::InsecureCryptoDisabled)
+            );
+        });
+    }
 
     #[test]
     fn constructor_rejects_invalid_key_reference() {
-        assert_eq!(
-            DirectMessageCryptoEngine::new("did:alice#keys-1", "did:bob#key-agreement-1"),
-            Err(DirectMessageCryptoError::InvalidKeyRef("sender"))
-        );
+        with_direct_message_crypto_env(Some("1"), || {
+            assert_eq!(
+                DirectMessageCryptoEngine::new("did:alice#keys-1", "did:bob#key-agreement-1"),
+                Err(DirectMessageCryptoError::InvalidKeyRef("sender"))
+            );
+        });
     }
 
     #[test]
     fn decrypt_rejects_algorithm_mismatch() {
-        let mut engine = match DirectMessageCryptoEngine::new(
-            "did:alice#key-agreement-1",
-            "did:bob#key-agreement-1",
-        ) {
-            Ok(value) => value,
-            Err(error) => panic!("engine init failed: {error}"),
-        };
-        let mut sealed = match engine.encrypt("payload", 1) {
-            Ok(value) => value,
-            Err(error) => panic!("encrypt failed: {error}"),
-        };
-        sealed.cipher_algorithm = "AES-GCM".to_owned();
+        with_direct_message_crypto_env(Some("1"), || {
+            let mut engine = match DirectMessageCryptoEngine::new(
+                "did:alice#key-agreement-1",
+                "did:bob#key-agreement-1",
+            ) {
+                Ok(value) => value,
+                Err(error) => panic!("engine init failed: {error}"),
+            };
+            let mut sealed = match engine.encrypt("payload", 1) {
+                Ok(value) => value,
+                Err(error) => panic!("encrypt failed: {error}"),
+            };
+            sealed.cipher_algorithm = "AES-GCM".to_owned();
 
-        assert_eq!(
-            engine.decrypt(&sealed),
-            Err(DirectMessageCryptoError::AlgorithmMismatch)
-        );
+            assert_eq!(
+                engine.decrypt(&sealed),
+                Err(DirectMessageCryptoError::AlgorithmMismatch)
+            );
+        });
     }
 }

--- a/crates/kamn-core/src/group_channel_crypto.rs
+++ b/crates/kamn-core/src/group_channel_crypto.rs
@@ -411,9 +411,6 @@ impl fmt::Display for GroupChannelCryptoError {
 impl std::error::Error for GroupChannelCryptoError {}
 
 fn insecure_group_message_crypto_enabled() -> bool {
-    if cfg!(debug_assertions) {
-        return true;
-    }
     match env::var(ALLOW_INSECURE_GROUP_MESSAGE_CRYPTO_ENV) {
         Ok(value) => matches!(
             value.trim().to_ascii_lowercase().as_str(),
@@ -545,57 +542,95 @@ fn hex_decode(value: &str) -> Result<Vec<u8>, GroupChannelCryptoError> {
 #[cfg(test)]
 mod tests {
     use super::{GroupChannelCryptoEngine, GroupChannelCryptoError};
+    use std::env;
+    use std::sync::{Mutex, OnceLock};
+
+    fn with_group_message_crypto_env<T>(value: Option<&str>, run: impl FnOnce() -> T) -> T {
+        static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        let _guard = ENV_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .expect("env lock should not be poisoned");
+        let previous = env::var(super::ALLOW_INSECURE_GROUP_MESSAGE_CRYPTO_ENV).ok();
+        match value {
+            Some(value) => env::set_var(super::ALLOW_INSECURE_GROUP_MESSAGE_CRYPTO_ENV, value),
+            None => env::remove_var(super::ALLOW_INSECURE_GROUP_MESSAGE_CRYPTO_ENV),
+        }
+        let output = run();
+        match previous {
+            Some(value) => env::set_var(super::ALLOW_INSECURE_GROUP_MESSAGE_CRYPTO_ENV, value),
+            None => env::remove_var(super::ALLOW_INSECURE_GROUP_MESSAGE_CRYPTO_ENV),
+        }
+        output
+    }
+
+    #[test]
+    fn regression_constructor_requires_explicit_opt_in_even_in_debug() {
+        // Regression: #5909
+        with_group_message_crypto_env(None, || {
+            assert_eq!(
+                GroupChannelCryptoEngine::new("channel:group:locked"),
+                Err(GroupChannelCryptoError::InsecureCryptoDisabled)
+            );
+        });
+    }
 
     #[test]
     fn constructor_rejects_empty_channel_id() {
-        assert_eq!(
-            GroupChannelCryptoEngine::new(""),
-            Err(GroupChannelCryptoError::EmptyChannelId)
-        );
+        with_group_message_crypto_env(Some("1"), || {
+            assert_eq!(
+                GroupChannelCryptoEngine::new(""),
+                Err(GroupChannelCryptoError::EmptyChannelId)
+            );
+        });
     }
 
     #[test]
     fn distribution_rejects_empty_recipients() {
-        let mut engine =
-            GroupChannelCryptoEngine::new("channel:group:1").expect("engine should initialize");
-        assert_eq!(
-            engine.distribute_sender_key(
-                "kamn:did:agent:alice",
-                "kamn:did:agent:alice#sender-key-1",
-                Vec::new(),
-            ),
-            Err(GroupChannelCryptoError::EmptyRecipients)
-        );
+        with_group_message_crypto_env(Some("1"), || {
+            let mut engine =
+                GroupChannelCryptoEngine::new("channel:group:1").expect("engine should initialize");
+            assert_eq!(
+                engine.distribute_sender_key(
+                    "kamn:did:agent:alice",
+                    "kamn:did:agent:alice#sender-key-1",
+                    Vec::new(),
+                ),
+                Err(GroupChannelCryptoError::EmptyRecipients)
+            );
+        });
     }
 
     #[test]
     fn rotate_marks_previous_generation_inactive() {
-        let mut engine =
-            GroupChannelCryptoEngine::new("channel:group:1").expect("engine should initialize");
-        let first = engine
-            .distribute_sender_key(
-                "kamn:did:agent:alice",
-                "kamn:did:agent:alice#sender-key-1",
-                vec!["kamn:did:agent:bob".to_owned()],
-            )
-            .expect("first distribution should succeed");
+        with_group_message_crypto_env(Some("1"), || {
+            let mut engine =
+                GroupChannelCryptoEngine::new("channel:group:1").expect("engine should initialize");
+            let first = engine
+                .distribute_sender_key(
+                    "kamn:did:agent:alice",
+                    "kamn:did:agent:alice#sender-key-1",
+                    vec!["kamn:did:agent:bob".to_owned()],
+                )
+                .expect("first distribution should succeed");
 
-        let second = engine
-            .rotate_sender_key(
-                "kamn:did:agent:alice",
-                "kamn:did:agent:alice#sender-key-2",
-                vec!["kamn:did:agent:bob".to_owned()],
-            )
-            .expect("rotation should succeed");
+            let second = engine
+                .rotate_sender_key(
+                    "kamn:did:agent:alice",
+                    "kamn:did:agent:alice#sender-key-2",
+                    vec!["kamn:did:agent:bob".to_owned()],
+                )
+                .expect("rotation should succeed");
 
-        let first_record = engine
-            .sender_key_record("kamn:did:agent:alice", first.key_generation)
-            .expect("first generation should exist");
-        let second_record = engine
-            .sender_key_record("kamn:did:agent:alice", second.key_generation)
-            .expect("second generation should exist");
+            let first_record = engine
+                .sender_key_record("kamn:did:agent:alice", first.key_generation)
+                .expect("first generation should exist");
+            let second_record = engine
+                .sender_key_record("kamn:did:agent:alice", second.key_generation)
+                .expect("second generation should exist");
 
-        assert!(!first_record.active);
-        assert!(second_record.active);
+            assert!(!first_record.active);
+            assert!(second_record.active);
+        });
     }
 }

--- a/crates/kamn-core/tests/data_layer_m0_contract.rs
+++ b/crates/kamn-core/tests/data_layer_m0_contract.rs
@@ -9,6 +9,16 @@ use kamn_core::{
     DATA_LAYER_M0_CONFORMANCE_MATRIX_STABLE_REASON_CODE,
 };
 use std::collections::BTreeMap;
+use std::sync::OnceLock;
+
+const ALLOW_INSECURE_DIRECT_MESSAGE_CRYPTO_ENV: &str = "KAMN_ALLOW_INSECURE_DIRECT_MESSAGE_CRYPTO";
+
+fn enable_direct_message_crypto_fixture_mode() {
+    static ENABLED: OnceLock<()> = OnceLock::new();
+    ENABLED.get_or_init(|| {
+        std::env::set_var(ALLOW_INSECURE_DIRECT_MESSAGE_CRYPTO_ENV, "1");
+    });
+}
 
 fn valid_envelope(message_id: &str, recipients: Vec<&str>) -> CanonicalMessageEnvelope {
     let mut body = BTreeMap::new();
@@ -55,6 +65,7 @@ fn valid_input(
     recipients: Vec<&str>,
     wrapped_keys: Vec<(&str, &str)>,
 ) -> DataLayerM0RecordInput {
+    enable_direct_message_crypto_fixture_mode();
     let envelope = valid_envelope(message_id, recipients);
     let mut crypto = DirectMessageCryptoEngine::new(
         "did:key:z6Mksender#key-agreement-1",

--- a/crates/kamn-core/tests/data_layer_phase2_crypto_blind_index_pipeline.rs
+++ b/crates/kamn-core/tests/data_layer_phase2_crypto_blind_index_pipeline.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::sync::OnceLock;
 
 use kamn_core::{
     data_layer_phase2_build_operational_artifact, CanonicalMessageEnvelope,
@@ -7,6 +8,15 @@ use kamn_core::{
     EnvelopeMetadata, EnvelopeProof, CANONICAL_ENCRYPTION_ALGORITHM,
     CANONICAL_MESSAGE_ENVELOPE_TYPE, CANONICAL_PROOF_PURPOSE,
 };
+
+const ALLOW_INSECURE_DIRECT_MESSAGE_CRYPTO_ENV: &str = "KAMN_ALLOW_INSECURE_DIRECT_MESSAGE_CRYPTO";
+
+fn enable_direct_message_crypto_fixture_mode() {
+    static ENABLED: OnceLock<()> = OnceLock::new();
+    ENABLED.get_or_init(|| {
+        std::env::set_var(ALLOW_INSECURE_DIRECT_MESSAGE_CRYPTO_ENV, "1");
+    });
+}
 
 fn valid_envelope(message_id: &str) -> CanonicalMessageEnvelope {
     let mut body = BTreeMap::new();
@@ -56,6 +66,7 @@ fn valid_request(
     message_id: &str,
     recipient_bindings: Vec<DataLayerPhase2RecipientEncryptionBinding>,
 ) -> DataLayerPhase2OperationalPipelineRequest {
+    enable_direct_message_crypto_fixture_mode();
     let mut blind_index_fields = BTreeMap::new();
     blind_index_fields.insert("channel_topic".to_owned(), "alpha".to_owned());
     blind_index_fields.insert("message_type".to_owned(), "request".to_owned());

--- a/crates/kamn-core/tests/direct_message_encryption.rs
+++ b/crates/kamn-core/tests/direct_message_encryption.rs
@@ -1,7 +1,18 @@
 use kamn_core::{DirectMessageCryptoEngine, DirectMessageCryptoError};
+use std::sync::OnceLock;
+
+const ALLOW_INSECURE_DIRECT_MESSAGE_CRYPTO_ENV: &str = "KAMN_ALLOW_INSECURE_DIRECT_MESSAGE_CRYPTO";
+
+fn enable_direct_message_crypto_fixture_mode() {
+    static ENABLED: OnceLock<()> = OnceLock::new();
+    ENABLED.get_or_init(|| {
+        std::env::set_var(ALLOW_INSECURE_DIRECT_MESSAGE_CRYPTO_ENV, "1");
+    });
+}
 
 #[test]
 fn encrypt_decrypt_round_trip_preserves_plaintext() {
+    enable_direct_message_crypto_fixture_mode();
     let mut engine = DirectMessageCryptoEngine::new(
         "kamn:did:agent:alice#key-agreement-1",
         "kamn:did:agent:bob#key-agreement-1",
@@ -18,6 +29,7 @@ fn encrypt_decrypt_round_trip_preserves_plaintext() {
 
 #[test]
 fn tampered_ciphertext_fails_integrity_check() {
+    enable_direct_message_crypto_fixture_mode();
     let mut engine = DirectMessageCryptoEngine::new(
         "kamn:did:agent:alice#key-agreement-1",
         "kamn:did:agent:bob#key-agreement-1",
@@ -36,6 +48,7 @@ fn tampered_ciphertext_fails_integrity_check() {
 
 #[test]
 fn nonce_reuse_is_rejected() {
+    enable_direct_message_crypto_fixture_mode();
     let mut engine = DirectMessageCryptoEngine::new(
         "kamn:did:agent:alice#key-agreement-1",
         "kamn:did:agent:bob#key-agreement-1",
@@ -53,6 +66,7 @@ fn nonce_reuse_is_rejected() {
 
 #[test]
 fn empty_payload_is_rejected() {
+    enable_direct_message_crypto_fixture_mode();
     let mut engine = DirectMessageCryptoEngine::new(
         "kamn:did:agent:alice#key-agreement-1",
         "kamn:did:agent:bob#key-agreement-1",
@@ -66,6 +80,7 @@ fn empty_payload_is_rejected() {
 
 #[test]
 fn tampered_auth_tag_is_rejected() {
+    enable_direct_message_crypto_fixture_mode();
     let mut engine = DirectMessageCryptoEngine::new(
         "kamn:did:agent:alice#key-agreement-1",
         "kamn:did:agent:bob#key-agreement-1",

--- a/crates/kamn-core/tests/group_sender_keys.rs
+++ b/crates/kamn-core/tests/group_sender_keys.rs
@@ -1,7 +1,18 @@
 use kamn_core::{GroupChannelCryptoEngine, GroupChannelCryptoError};
+use std::sync::OnceLock;
+
+const ALLOW_INSECURE_GROUP_MESSAGE_CRYPTO_ENV: &str = "KAMN_ALLOW_INSECURE_GROUP_MESSAGE_CRYPTO";
+
+fn enable_group_message_crypto_fixture_mode() {
+    static ENABLED: OnceLock<()> = OnceLock::new();
+    ENABLED.get_or_init(|| {
+        std::env::set_var(ALLOW_INSECURE_GROUP_MESSAGE_CRYPTO_ENV, "1");
+    });
+}
 
 #[test]
 fn sender_key_distribution_allows_authorized_group_round_trip() {
+    enable_group_message_crypto_fixture_mode();
     let mut engine =
         GroupChannelCryptoEngine::new("channel:group:alpha").expect("engine should initialize");
 
@@ -28,6 +39,7 @@ fn sender_key_distribution_allows_authorized_group_round_trip() {
 
 #[test]
 fn sender_key_rotation_advances_generation() {
+    enable_group_message_crypto_fixture_mode();
     let mut engine =
         GroupChannelCryptoEngine::new("channel:group:beta").expect("engine should initialize");
 
@@ -57,6 +69,7 @@ fn sender_key_rotation_advances_generation() {
 
 #[test]
 fn integration_multiple_senders_are_isolated() {
+    enable_group_message_crypto_fixture_mode();
     let mut engine =
         GroupChannelCryptoEngine::new("channel:group:gamma").expect("engine should initialize");
 
@@ -98,6 +111,7 @@ fn integration_multiple_senders_are_isolated() {
 
 #[test]
 fn regression_unauthorized_recipient_cannot_decrypt() {
+    enable_group_message_crypto_fixture_mode();
     let mut engine =
         GroupChannelCryptoEngine::new("channel:group:delta").expect("engine should initialize");
 
@@ -126,6 +140,7 @@ fn regression_unauthorized_recipient_cannot_decrypt() {
 
 #[test]
 fn group_sender_keys_reject_invalid_sender_did_with_structured_marker() {
+    enable_group_message_crypto_fixture_mode();
     let mut engine =
         GroupChannelCryptoEngine::new("channel:group:epsilon").expect("engine should initialize");
 

--- a/specs/5909/plan.md
+++ b/specs/5909/plan.md
@@ -1,0 +1,24 @@
+# Plan: Issue #5909 - Fail Closed Insecure Deterministic Message Crypto by Default
+
+## Approach
+1. Remove `cfg!(debug_assertions)` auto-enable branches in direct/group crypto env gate helpers.
+2. Keep env-based opt-in parser logic unchanged (`1|true|yes|on`).
+3. Add RED tests proving constructors fail closed when env is unset.
+4. Add/confirm tests for explicit opt-in success paths.
+
+## Affected Modules
+- `crates/kamn-core/src/direct_message_crypto.rs`
+- `crates/kamn-core/src/group_channel_crypto.rs`
+
+## Risks / Mitigations
+- Risk: Existing local tests relying on implicit debug enable may fail.
+  - Mitigation: update tests to set/unset env deterministically using process-level synchronization patterns already used in this crate.
+- Risk: Env-state leakage between tests.
+  - Mitigation: use scoped env guards in tests and avoid parallel mutation hazards.
+
+## Interfaces / Contracts
+- Constructor behavior contract tightens: no implicit debug enable; explicit env opt-in required.
+- Error contract remains deterministic: `InsecureCryptoDisabled` when opt-in absent.
+
+## ADR
+- Not required (no dependency/protocol/architecture boundary change).

--- a/specs/5909/spec.md
+++ b/specs/5909/spec.md
@@ -1,0 +1,49 @@
+# Spec: Issue #5909 - Fail Closed Insecure Deterministic Message Crypto by Default
+
+- Issue: #5909
+- Status: Implemented
+- Type: task
+- Priority: P1
+- Milestone: `specs/milestones/r52-e2e-live-runtime-integration-hardening/index.md`
+- Last Updated: 2026-02-24
+
+## Problem Statement
+`direct_message_crypto` and `group_channel_crypto` provide deterministic XOR-based fixture engines. In debug builds these engines are currently auto-enabled, so non-cryptographic paths remain reachable without explicit operator intent.
+
+## Scope
+In scope:
+- Remove debug auto-enable behavior for insecure deterministic direct/group crypto engines.
+- Require explicit environment opt-in for deterministic fixture crypto in all build profiles.
+- Add regression tests that fail when opt-in markers are absent and pass when markers are present.
+- Keep existing fixture behavior unchanged when explicit opt-in is set.
+
+Out of scope:
+- Replacing deterministic fixture crypto with production AEAD/key-agreement primitives.
+- Protocol or wire-format redesign.
+
+## Acceptance Criteria
+### AC-1 Constructors fail closed by default
+Given no insecure-crypto opt-in environment markers,
+When constructing deterministic direct/group crypto engines,
+Then constructors return deterministic `InsecureCryptoDisabled` errors.
+
+### AC-2 Explicit local opt-in still works
+Given insecure-crypto opt-in environment markers are explicitly set,
+When constructing deterministic direct/group crypto engines,
+Then constructors succeed and preserve existing fixture behavior.
+
+### AC-3 Debug profile no longer bypasses policy
+Given a debug/test runtime without explicit opt-in markers,
+When deterministic direct/group crypto constructors are invoked,
+Then they fail closed exactly as release profile behavior.
+
+## Conformance Cases
+- C-01 (AC-1, Unit): `DirectMessageCryptoEngine::new` rejects construction without opt-in env.
+- C-02 (AC-1, Unit): `GroupChannelCryptoEngine::new` rejects construction without opt-in env.
+- C-03 (AC-2, Unit): direct/group constructors succeed when explicit env opt-in is set.
+- C-04 (AC-3, Regression): debug/test path does not auto-enable insecure deterministic crypto.
+
+## Success Metrics / Observable Signals
+- Deterministic fixture crypto is unreachable without explicit runtime opt-in.
+- Existing fixture workflows remain available with explicit opt-in.
+- New regression tests lock fail-closed policy and prevent debug auto-enable regressions.

--- a/specs/5909/tasks.md
+++ b/specs/5909/tasks.md
@@ -1,0 +1,7 @@
+# Tasks: Issue #5909 - Fail Closed Insecure Deterministic Message Crypto by Default
+
+1. T1 (RED): add failing tests for direct/group constructor behavior when opt-in env markers are absent.
+2. T2 (GREEN): remove debug auto-enable and require explicit env opt-in in both crypto modules.
+3. T3 (REFACTOR): ensure env parsing and constructor errors remain deterministic.
+4. T4 (VERIFY): run fmt, clippy, and targeted `kamn-core` tests for changed modules.
+5. T5 (REGRESSION): verify debug/test profile cannot implicitly re-enable insecure deterministic crypto.


### PR DESCRIPTION
## Summary
- Removed implicit debug-profile enablement for deterministic direct/group fixture crypto in `kamn-core`; constructors now fail closed unless explicit env opt-in is present.
- Added regression tests proving constructors reject unset opt-in markers even in debug/test profiles.
- Updated affected `kamn-core` tests to explicitly opt into fixture crypto where deterministic non-production engines are intentionally exercised.

## Links
- Milestone: `specs/milestones/r52-e2e-live-runtime-integration-hardening/index.md`
- Closes #5909
- Spec: `specs/5909/spec.md`
- Plan: `specs/5909/plan.md`
- Tasks: `specs/5909/tasks.md`

## Spec Verification (AC -> tests)
| AC | ✅/❌ | Test(s) |
|---|---|---|
| AC-1 Constructors fail closed by default | ✅ | `direct_message_crypto::tests::regression_constructor_requires_explicit_opt_in_even_in_debug`; `group_channel_crypto::tests::regression_constructor_requires_explicit_opt_in_even_in_debug` |
| AC-2 Explicit local opt-in still works | ✅ | `direct_message_crypto::tests::decrypt_rejects_algorithm_mismatch`; `group_channel_crypto::tests::distribution_rejects_empty_recipients`; integration suites `direct_message_encryption`, `group_sender_keys`, `data_layer_m0_contract`, `data_layer_phase2_crypto_blind_index_pipeline` |
| AC-3 Debug profile no longer bypasses policy | ✅ | `direct_message_crypto::tests::regression_constructor_requires_explicit_opt_in_even_in_debug`; `group_channel_crypto::tests::regression_constructor_requires_explicit_opt_in_even_in_debug` |

## TDD Evidence
- RED command:
  - `cargo test -p kamn-core regression_constructor_requires_explicit_opt_in_even_in_debug -- --nocapture`
- RED excerpt:
  - `left: Ok(DirectMessageCryptoEngine ...) right: Err(InsecureCryptoDisabled)`
  - `left: Ok(GroupChannelCryptoEngine ...) right: Err(InsecureCryptoDisabled)`
- GREEN commands:
  - `cargo test -p kamn-core regression_constructor_requires_explicit_opt_in_even_in_debug -- --nocapture`
  - `cargo test -p kamn-core --test direct_message_encryption -- --nocapture`
  - `cargo test -p kamn-core --test group_sender_keys -- --nocapture`
  - `cargo test -p kamn-core --test data_layer_m0_contract -- --nocapture`
  - `cargo test -p kamn-core --test data_layer_phase2_crypto_blind_index_pipeline -- --nocapture`
- GREEN excerpt:
  - `2 passed; 0 failed` for constructor regression tests
  - `5 passed; 0 failed` (`direct_message_encryption`)
  - `5 passed; 0 failed` (`group_sender_keys`)
  - `7 passed; 0 failed` (`data_layer_m0_contract`)
  - `3 passed; 0 failed` (`data_layer_phase2_crypto_blind_index_pipeline`)
- REGRESSION summary:
  - deterministic fixture crypto constructors now fail closed by default across debug/release; explicit opt-in remains required and verified.

## Test Tiers
| Tier | ✅/❌/N/A | Tests | N/A Why |
|---|---|---|---|
| Unit | ✅ | direct/group constructor and behavior tests in `src/*_crypto.rs` | |
| Property | N/A | | No randomized invariant/parsing surface changed. |
| Contract/DbC | N/A | | No contracts-annotated API introduced/modified. |
| Snapshot | N/A | | No snapshot-managed output contract changed. |
| Functional | ✅ | `direct_message_encryption`; `group_sender_keys` | |
| Conformance | ✅ | C-01..C-04 mapped to explicit regression/unit tests listed above | |
| Integration | ✅ | `data_layer_m0_contract`; `data_layer_phase2_crypto_blind_index_pipeline` | |
| Fuzz | N/A | | No untrusted parser/framing algorithm changes. |
| Mutation | ✅ | `cargo mutants --in-diff /tmp/issue5909.diff -p kamn-core -- --lib crypto` | |
| Regression | ✅ | constructor fail-closed regression tests in direct/group crypto modules | |
| Performance | N/A | | No hotspot/perf-path algorithm change beyond policy gating. |

## Mutation
- Command: `cargo mutants --in-diff /tmp/issue5909.diff -p kamn-core -- --lib crypto`
- Result: `4 mutants tested in 61s: 4 caught` (0 escaped)

## Risks/Rollback
- Risk: local fixtures that previously relied on implicit debug enable now require explicit env opt-in.
- Rollback: revert commit `f79aa1d3` if temporary restoration of implicit debug behavior is required.

## Docs/ADR
- Updated specs/docs:
  - `specs/5909/spec.md`
  - `specs/5909/plan.md`
  - `specs/5909/tasks.md`
- ADR: not required (no new dependency/protocol boundary).

## Validation
- [x] Relevant local checks passed.
- [x] CI fast-gate checks expected to pass.

## CI Impact Declaration
- [x] No CI scope impact.
- [ ] CI scope impact present (explain below).

CI scope impact details (required when CI scope impact is present):
- Workflow(s) touched:
- Expected runtime delta:
- Expected runner-minute delta:
- Rollback plan if CI cost/runtime regresses:

## Shell-Surface Impact Declaration
- [x] No shell-surface impact.
- [ ] Shell-surface impact present (explain below).

Shell-surface impact details (required when shell-surface impact is present):
- shell_loc_delta_actual:
- rust_loc_delta_actual:
- shell_to_rust_ratio_delta_actual:
- shell_surface_ratio_target_status: improved|neutral|regressed_with_waiver
- shell_surface_mitigation_issue: #<issue-id>|None
- regressed_with_waiver requires shell_surface_mitigation_issue to link #<issue-id>
