### PR TITLE
fix(core): disable legacy baseline compat in non-debug builds

### DIFF
--- a/crates/kamn-core/src/signer_backend.rs
+++ b/crates/kamn-core/src/signer_backend.rs
@@ -102,14 +102,32 @@ fn signer_key_id_private_key_env_name(key_id: &str) -> String {
     format!("{SIGNER_PRIVATE_KEY_ENV_PREFIX}{normalized}")
 }
 
-fn signer_legacy_baseline_v1_compat_enabled() -> bool {
-    match env::var(SIGNER_LEGACY_BASELINE_V1_COMPAT_ENV) {
-        Ok(value) => matches!(
+fn signer_legacy_baseline_v1_compat_enabled_for_mode_with_env_value(
+    debug_assertions: bool,
+    env_value: Option<&str>,
+) -> bool {
+    if !debug_assertions {
+        return false;
+    }
+    match env_value {
+        Some(value) => matches!(
             value.trim().to_ascii_lowercase().as_str(),
             "1" | "true" | "yes" | "on"
         ),
-        Err(_) => false,
+        None => false,
     }
+}
+
+fn signer_legacy_baseline_v1_compat_enabled_for_mode(debug_assertions: bool) -> bool {
+    let env_value = env::var(SIGNER_LEGACY_BASELINE_V1_COMPAT_ENV).ok();
+    signer_legacy_baseline_v1_compat_enabled_for_mode_with_env_value(
+        debug_assertions,
+        env_value.as_deref(),
+    )
+}
+
+fn signer_legacy_baseline_v1_compat_enabled() -> bool {
+    signer_legacy_baseline_v1_compat_enabled_for_mode(cfg!(debug_assertions))
 }
 
 fn resolve_signer_private_key_hex(key_id: &str) -> Result<String, SignerBackendError> {
@@ -940,11 +958,30 @@ impl std::error::Error for SignerBackendError {}
 #[cfg(test)]
 mod tests {
     use super::{
-        deterministic_secure_provider_client_sign, CanonicalSecureKeyReference,
-        SecureSignerBackend, SecureSignerProvider, SignerBackend, SignerBackendError,
-        SignerBackendRouter, SignerKeyRole, SignerProviderHandshakeMatrix,
+        deterministic_secure_provider_client_sign,
+        signer_legacy_baseline_v1_compat_enabled_for_mode_with_env_value,
+        CanonicalSecureKeyReference, SecureSignerBackend, SecureSignerProvider, SignerBackend,
+        SignerBackendError, SignerBackendRouter, SignerKeyRole, SignerProviderHandshakeMatrix,
         SignerProviderHandshakeStatus, SigningRequest,
     };
+
+    #[test]
+    fn regression_legacy_baseline_compat_helper_fails_closed_for_non_debug_policy() {
+        // Regression: #5911
+        assert!(
+            !signer_legacy_baseline_v1_compat_enabled_for_mode_with_env_value(false, Some("1")),
+            "non-debug policy branch must not permit legacy baseline compatibility even with truthy env"
+        );
+    }
+
+    #[test]
+    fn regression_legacy_baseline_compat_helper_accepts_truthy_env_for_debug_policy() {
+        // Regression: #5911
+        assert!(
+            signer_legacy_baseline_v1_compat_enabled_for_mode_with_env_value(true, Some("1")),
+            "debug policy branch should preserve explicit legacy baseline compatibility opt-in"
+        );
+    }
 
     #[test]
     fn signing_request_rejects_invalid_fields() {

--- a/crates/kamn-core/src/transaction.rs
+++ b/crates/kamn-core/src/transaction.rs
@@ -106,14 +106,32 @@ fn signing_key_error_signature_for_fields(
     )
 }
 
-fn signer_legacy_baseline_v1_compat_enabled() -> bool {
-    match env::var(SIGNER_LEGACY_BASELINE_V1_COMPAT_ENV) {
-        Ok(value) => matches!(
+fn signer_legacy_baseline_v1_compat_enabled_for_mode_with_env_value(
+    debug_assertions: bool,
+    env_value: Option<&str>,
+) -> bool {
+    if !debug_assertions {
+        return false;
+    }
+    match env_value {
+        Some(value) => matches!(
             value.trim().to_ascii_lowercase().as_str(),
             "1" | "true" | "yes" | "on"
         ),
-        Err(_) => false,
+        None => false,
     }
+}
+
+fn signer_legacy_baseline_v1_compat_enabled_for_mode(debug_assertions: bool) -> bool {
+    let env_value = env::var(SIGNER_LEGACY_BASELINE_V1_COMPAT_ENV).ok();
+    signer_legacy_baseline_v1_compat_enabled_for_mode_with_env_value(
+        debug_assertions,
+        env_value.as_deref(),
+    )
+}
+
+fn signer_legacy_baseline_v1_compat_enabled() -> bool {
+    signer_legacy_baseline_v1_compat_enabled_for_mode(cfg!(debug_assertions))
 }
 
 fn resolve_transaction_signer_private_key_hex() -> Option<String> {
@@ -411,8 +429,10 @@ impl std::error::Error for TransactionGuardError {}
 #[cfg(test)]
 mod tests {
     use super::{
-        BaselineTransaction, TransactionGuardError, TransactionGuards, GENESIS_STATE_HASH,
-        SIGNER_PRIVATE_KEY_ENV,
+        signer_legacy_baseline_v1_compat_enabled,
+        signer_legacy_baseline_v1_compat_enabled_for_mode_with_env_value, BaselineTransaction,
+        TransactionGuardError, TransactionGuards, GENESIS_STATE_HASH,
+        SIGNER_LEGACY_BASELINE_V1_COMPAT_ENV, SIGNER_PRIVATE_KEY_ENV,
     };
     use std::sync::{Mutex, OnceLock};
 
@@ -458,6 +478,35 @@ mod tests {
 
     fn signed_tx(id: &str, sender: &str, nonce: u64, state_hash: &str) -> BaselineTransaction {
         BaselineTransaction::signed(id, sender, nonce, &format!("payload-{id}"), state_hash)
+    }
+
+    #[test]
+    fn regression_legacy_baseline_compat_helper_fails_closed_for_non_debug_policy() {
+        // Regression: #5911
+        assert!(
+            !signer_legacy_baseline_v1_compat_enabled_for_mode_with_env_value(false, Some("1")),
+            "non-debug policy branch must not permit legacy baseline compatibility even with truthy env"
+        );
+    }
+
+    #[test]
+    fn regression_legacy_baseline_compat_helper_accepts_truthy_env_for_debug_policy() {
+        // Regression: #5911
+        assert!(
+            signer_legacy_baseline_v1_compat_enabled_for_mode_with_env_value(true, Some("1")),
+            "debug policy branch should preserve explicit legacy baseline compatibility opt-in"
+        );
+    }
+
+    #[test]
+    fn regression_legacy_baseline_compat_wrapper_defaults_false_without_env() {
+        // Regression: #5911
+        let _lock = lock_signer_env();
+        let _compat_guard = EnvVarGuard::set(SIGNER_LEGACY_BASELINE_V1_COMPAT_ENV, None);
+        assert!(
+            !signer_legacy_baseline_v1_compat_enabled(),
+            "wrapper should default to fail-closed when compatibility env is unset"
+        );
     }
 
     #[test]

--- a/specs/5911/plan.md
+++ b/specs/5911/plan.md
@@ -1,0 +1,24 @@
+# Plan: Issue #5911 - Disable Legacy Baseline-v1 Signature Compatibility in Production Builds
+
+## Approach
+1. Harden `signer_legacy_baseline_v1_compat_enabled` in both `signer_backend.rs` and `transaction.rs` to return `false` outside debug assertions.
+2. Keep existing env parsing for debug/test branch to preserve compatibility fixtures.
+3. Add targeted helper tests to lock branch behavior semantics where practical.
+4. Run signer backend and transaction guard test slices plus fmt/clippy/mutation checks.
+
+## Affected Modules
+- `crates/kamn-core/src/signer_backend.rs`
+- `crates/kamn-core/src/transaction.rs`
+
+## Risks / Mitigations
+- Risk: Existing compatibility tests rely on env behavior.
+  - Mitigation: preserve env behavior in debug/test branch and keep regression suite coverage.
+- Risk: policy drift between signer and transaction helpers.
+  - Mitigation: apply same hardening pattern in both modules and verify with targeted tests.
+
+## Interfaces / Contracts
+- No wire/API changes.
+- Runtime policy contract tightens: legacy baseline-v1 compatibility is never available in non-debug builds.
+
+## ADR
+- Not required (no dependency/protocol/architecture boundary change).

--- a/specs/5911/spec.md
+++ b/specs/5911/spec.md
@@ -1,0 +1,47 @@
+# Spec: Issue #5911 - Disable Legacy Baseline-v1 Signature Compatibility in Production Builds
+
+- Issue: #5911
+- Status: Reviewed
+- Type: task
+- Priority: P1
+- Milestone: `specs/milestones/r52-e2e-live-runtime-integration-hardening/index.md`
+- Last Updated: 2026-02-24
+
+## Problem Statement
+Legacy deterministic baseline-v1 signature compatibility can currently be enabled with `KAMN_SIGNER_ALLOW_LEGACY_BASELINE_V1`. In non-debug production builds this creates an environment-controlled non-cryptographic signature acceptance path.
+
+## Scope
+In scope:
+- Make legacy baseline-v1 compatibility helper fail closed in non-debug builds.
+- Keep legacy compatibility behavior available only in debug/test workflows.
+- Add regression tests for helper semantics and verify signing/transaction paths stay green.
+
+Out of scope:
+- Removing baseline-v1 fixture generation APIs.
+- Refactoring signature-profile fixtures or docs beyond required behavior clarifications.
+
+## Acceptance Criteria
+### AC-1 Production compatibility path is disabled
+Given a non-debug build,
+When `KAMN_SIGNER_ALLOW_LEGACY_BASELINE_V1` is set,
+Then legacy baseline-v1 compatibility remains disabled.
+
+### AC-2 Debug/test compatibility remains explicit and deterministic
+Given a debug/test build,
+When `KAMN_SIGNER_ALLOW_LEGACY_BASELINE_V1` is set to a truthy value,
+Then legacy baseline-v1 compatibility remains available for compatibility contracts.
+
+### AC-3 Existing verification paths remain stable
+Given current signer backend and transaction verification tests,
+When compatibility helper is hardened,
+Then no regression occurs in cryptographic verification behavior.
+
+## Conformance Cases
+- C-01 (AC-1, Unit): helper returns `false` in non-debug policy branch.
+- C-02 (AC-2, Unit): helper remains env-gated for debug/test branch.
+- C-03 (AC-3, Regression): signer backend compatibility tests and transaction guard compatibility tests remain green.
+
+## Success Metrics / Observable Signals
+- Legacy baseline-v1 acceptance cannot be env-enabled in production/release binaries.
+- Debug/test compatibility fixtures continue to execute under explicit env control.
+- No regression in signer backend / transaction contract lanes.

--- a/specs/5911/tasks.md
+++ b/specs/5911/tasks.md
@@ -1,0 +1,7 @@
+# Tasks: Issue #5911 - Disable Legacy Baseline-v1 Signature Compatibility in Production Builds
+
+1. T1 (RED): add failing helper-policy tests for non-debug fail-closed compatibility semantics.
+2. T2 (GREEN): harden compatibility helper policy in signer backend and transaction modules.
+3. T3 (REFACTOR): ensure shared policy semantics stay deterministic across both modules.
+4. T4 (VERIFY): run fmt, clippy, signer backend + transaction tests.
+5. T5 (REGRESSION): run mutation slice for touched compatibility helpers.


### PR DESCRIPTION
## Summary
- Hardened legacy baseline-v1 compatibility so it is fail-closed in non-debug builds in both signer and transaction paths.
- Added explicit helper decomposition to make debug/non-debug compatibility policy testable without global env races.
- Added regression tests for non-debug fail-closed policy, debug truthy opt-in, and transaction wrapper fail-closed default.

## Linked Issues
- Closes #5911
- Milestone: `specs/milestones/r52-e2e-live-runtime-integration-hardening/index.md`
- Spec: `specs/5911/spec.md`
- Plan: `specs/5911/plan.md`

## Validation
- [x] Relevant local checks passed.
- [x] CI fast-gate checks expected to pass.

## CI Impact Declaration
- [x] No CI scope impact.
- [ ] CI scope impact present (explain below).

## Shell-Surface Impact Declaration
- [x] No shell-surface impact.
- [ ] Shell-surface impact present (explain below).

## Spec Verification (AC -> tests)
| AC | ✅/❌ | Test(s) |
|---|---|---|
| AC-1 Production compatibility path is disabled | ✅ | `cargo test -p kamn-core regression_legacy_baseline_compat_ -- --nocapture` (`signer_backend::tests::regression_legacy_baseline_compat_helper_fails_closed_for_non_debug_policy`, `transaction::tests::regression_legacy_baseline_compat_helper_fails_closed_for_non_debug_policy`, `transaction::tests::regression_legacy_baseline_compat_wrapper_defaults_false_without_env`) |
| AC-2 Debug/test compatibility remains explicit and deterministic | ✅ | `cargo test -p kamn-core regression_legacy_baseline_compat_ -- --nocapture`; `cargo test -p kamn-core --test signer_backend -- --skip performance_signer_emulator_contract_lane_stays_within_budget --nocapture`; `cargo test -p kamn-core --test transaction_guards -- --nocapture` |
| AC-3 Existing verification paths remain stable | ✅ | `cargo test -p kamn-core --test signer_backend -- --skip performance_signer_emulator_contract_lane_stays_within_budget --nocapture`; `cargo test -p kamn-core --test transaction_guards -- --nocapture` |

## TDD Evidence
- RED:
  - `cargo test -p kamn-core regression_legacy_baseline_compat_helper_fails_closed_for_non_debug_policy -- --nocapture`
  - Before hardening, both helper tests failed because truthy compatibility env still enabled compatibility in non-debug policy branch.
- GREEN:
  - `cargo test -p kamn-core regression_legacy_baseline_compat_ -- --nocapture`
  - `cargo test -p kamn-core --test signer_backend -- --skip performance_signer_emulator_contract_lane_stays_within_budget --nocapture`
  - `cargo test -p kamn-core --test transaction_guards -- --nocapture`
- REGRESSION:
  - Added `Regression: #5911` tests for non-debug fail-closed, debug explicit opt-in, and wrapper fail-closed default.

## Test Tiers
| Tier | ✅/❌/N/A | Tests | N/A Why |
|---|---|---|---|
| Unit | ✅ | `cargo test -p kamn-core regression_legacy_baseline_compat_ -- --nocapture` | |
| Property | N/A | | No new property invariants introduced. |
| Contract/DbC | N/A | | No contract macro/interface change. |
| Snapshot | N/A | | No stable snapshot output changed. |
| Functional | ✅ | `cargo test -p kamn-core --test signer_backend -- --skip performance_signer_emulator_contract_lane_stays_within_budget --nocapture` | |
| Conformance | ✅ | `cargo test -p kamn-core regression_legacy_baseline_compat_ -- --nocapture` | |
| Integration | ✅ | `cargo test -p kamn-core --test signer_backend -- --skip performance_signer_emulator_contract_lane_stays_within_budget --nocapture`; `cargo test -p kamn-core --test transaction_guards -- --nocapture` | |
| Fuzz | N/A | | No parser/untrusted-input delta in scope. |
| Mutation | ✅ | `cargo mutants --in-diff /tmp/issue5911.diff -p kamn-core -- baseline -- --test-threads=1` | |
| Regression | ✅ | `regression_legacy_baseline_compat_*` tests in `signer_backend.rs` and `transaction.rs` | |
| Performance | N/A | | Policy guard logic only; no hotspot/perf contract changes. |

## Mutation
- `14 mutants tested in 3m: 14 caught`

## Risks/Rollback
- Risk: low; behavior only tightens non-debug compatibility path.
- Rollback: revert commit `c07dd4a1`.

## Docs/ADR
- Added/updated spec artifacts:
  - `specs/5911/spec.md`
  - `specs/5911/plan.md`
  - `specs/5911/tasks.md`
- ADR: not required (no dependency/protocol/architecture boundary change).
