### PR TITLE
fix(kamn-node): restore service_api_endpoint root line-budget contract (#5947)

### DIFF
--- a/crates/kamn-node/src/service_api_endpoint.rs
+++ b/crates/kamn-node/src/service_api_endpoint.rs
@@ -861,66 +861,6 @@ fn resolve_service_api_observability(
     }
 }
 
-fn header_value<'a>(headers: &'a BTreeMap<String, String>, name: &str) -> Option<&'a str> {
-    auth::header_value(headers, name)
-}
-
-fn authorize_service_api_request(
-    state: &ServiceApiRuntimeState,
-    request: &ParsedRequest,
-    replay_guard: &mut ServiceApiReplayGuard,
-) -> Result<(), RequestAuthFailure> {
-    auth::authorize_service_api_request(state, request, replay_guard)
-}
-
-async fn enforce_sender_anti_spam(
-    state: &ServiceApiRuntimeState,
-    request: &ParsedRequest,
-) -> Result<(), ServiceApiReasonedError> {
-    auth::enforce_sender_anti_spam(state, request).await
-}
-
-fn validate_websocket_route_requirements(
-    is_websocket_route: bool,
-    headers: &BTreeMap<String, String>,
-) -> Result<(), ServiceApiReasonedError> {
-    websocket::validate_websocket_route_requirements(is_websocket_route, headers)
-}
-
-fn websocket_upgrade_response(
-    upgrade: WebSocketUpgrade,
-    event_payload: String,
-    websocket_events: &ServiceApiWebsocketEventFanout,
-) -> Response {
-    websocket::websocket_upgrade_response(upgrade, event_payload, websocket_events)
-}
-
-fn project_websocket_event_payload(
-    snapshot: &ServiceApiSnapshot,
-    headers: &BTreeMap<String, String>,
-) -> Result<String, ServiceApiReasonedError> {
-    websocket::project_websocket_event_payload(snapshot, headers)
-}
-
-fn project_websocket_error_response(
-    error: &ServiceApiReasonedError,
-) -> (StatusCode, &'static str, &'static str) {
-    websocket::project_websocket_error_response(error)
-}
-
-fn contract_response(response: ServiceApiEndpointResponse) -> Response {
-    payload::contract_response(response)
-}
-
-fn json_error_response(
-    status_code: StatusCode,
-    error: &str,
-    reason_code: &str,
-    message: &str,
-) -> Response {
-    payload::json_error_response(status_code, error, reason_code, message)
-}
-
 #[cfg(test)]
 pub(crate) fn parse_service_api_payload<T: DeserializeOwned>(payload: &str) -> Result<T, String> {
     payload::parse_service_api_payload(payload)

--- a/crates/kamn-node/src/service_api_endpoint/middleware_impl.rs
+++ b/crates/kamn-node/src/service_api_endpoint/middleware_impl.rs
@@ -109,9 +109,11 @@ pub(super) async fn service_api_auth_middleware(
 
     {
         let mut replay_guard = state.replay_guard.lock().await;
-        if let Err(error) =
-            super::authorize_service_api_request(state.as_ref(), &parsed_request, &mut replay_guard)
-        {
+        if let Err(error) = super::auth::authorize_service_api_request(
+            state.as_ref(),
+            &parsed_request,
+            &mut replay_guard,
+        ) {
             let (status_code, error_label, auth_error, outcome) = match error {
                 RequestAuthFailure::Unauthorized(reasoned_error) => (
                     StatusCode::UNAUTHORIZED,
@@ -159,7 +161,7 @@ pub(super) async fn service_api_auth_middleware(
         .await;
     }
 
-    if let Err(error) = super::enforce_sender_anti_spam(&state, &parsed_request).await {
+    if let Err(error) = super::auth::enforce_sender_anti_spam(&state, &parsed_request).await {
         let projection = service_api_lifecycle_rejection_policy(error.reason_code).unwrap_or(
             ServiceApiLifecycleRejectionPolicy {
                 rejection_class: LIFECYCLE_REJECTION_CLASS_SENDER_ADMISSION,
@@ -220,9 +222,10 @@ pub(super) async fn service_api_auth_middleware(
         }
     }
 
-    if let Err(error) =
-        super::validate_websocket_route_requirements(is_websocket_route, &parsed_request.headers)
-    {
+    if let Err(error) = super::websocket::validate_websocket_route_requirements(
+        is_websocket_route,
+        &parsed_request.headers,
+    ) {
         return service_api_middleware_error_response(
             &state,
             request_started_at,
@@ -319,7 +322,7 @@ pub(super) async fn service_api_middleware_error_response(
     request_started_at: Instant,
     error: ServiceApiMiddlewareError<'_>,
 ) -> Response {
-    let response = super::json_error_response(
+    let response = super::payload::json_error_response(
         error.status_code,
         error.error_label,
         error.reason_code,
@@ -354,12 +357,12 @@ pub(super) async fn handle_service_api_http_route(
             message_store.create_task(context.parsed_request.body.as_str())
         };
         return match create_result {
-            Ok(payload) => super::contract_response(ServiceApiEndpointResponse {
+            Ok(payload) => super::payload::contract_response(ServiceApiEndpointResponse {
                 status_code: 201,
                 content_type: "application/json",
                 body: super::serialize_service_api_json(&payload),
             }),
-            Err(error) => super::json_error_response(
+            Err(error) => super::payload::json_error_response(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "internal",
                 REASON_CODE_STATE_PERSISTENCE_FAILED,
@@ -373,12 +376,12 @@ pub(super) async fn handle_service_api_http_route(
             message_store.fund_escrow(context.parsed_request.body.as_str())
         };
         return match fund_result {
-            Ok(payload) => super::contract_response(ServiceApiEndpointResponse {
+            Ok(payload) => super::payload::contract_response(ServiceApiEndpointResponse {
                 status_code: 200,
                 content_type: "application/json",
                 body: super::serialize_service_api_json(&payload),
             }),
-            Err(error) => super::json_error_response(
+            Err(error) => super::payload::json_error_response(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "internal",
                 REASON_CODE_STATE_PERSISTENCE_FAILED,
@@ -391,7 +394,7 @@ pub(super) async fn handle_service_api_http_route(
         let channel_id = extract_channel_id_from_payload(context.parsed_request.body.as_str());
         let recipient_did =
             extract_recipient_did_from_payload(context.parsed_request.body.as_str());
-        let sender_did = super::header_value(
+        let sender_did = super::auth::header_value(
             &context.parsed_request.headers,
             REQUEST_AUTH_SENDER_DID_HEADER,
         );
@@ -423,7 +426,7 @@ pub(super) async fn handle_service_api_http_route(
                         state.relay_spool_file.as_deref(),
                         &relay_entry,
                     ) {
-                        return super::json_error_response(
+                        return super::payload::json_error_response(
                             StatusCode::INTERNAL_SERVER_ERROR,
                             "internal",
                             REASON_CODE_STATE_PERSISTENCE_FAILED,
@@ -437,13 +440,13 @@ pub(super) async fn handle_service_api_http_route(
                     recipient_did.as_deref(),
                     channel_id.as_deref(),
                 );
-                super::contract_response(ServiceApiEndpointResponse {
+                super::payload::contract_response(ServiceApiEndpointResponse {
                     status_code: 202,
                     content_type: "application/json",
                     body: super::serialize_service_api_json(&payload),
                 })
             }
-            Err(error) => super::json_error_response(
+            Err(error) => super::payload::json_error_response(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "internal",
                 REASON_CODE_STATE_PERSISTENCE_FAILED,
@@ -460,18 +463,20 @@ pub(super) async fn handle_service_api_http_route(
                 message_store.transition_task(task_id, "accepted")
             };
             return match transition_result {
-                Ok(Some(payload)) => super::contract_response(ServiceApiEndpointResponse {
-                    status_code: 200,
-                    content_type: "application/json",
-                    body: super::serialize_service_api_json(&payload),
-                }),
-                Ok(None) => super::json_error_response(
+                Ok(Some(payload)) => {
+                    super::payload::contract_response(ServiceApiEndpointResponse {
+                        status_code: 200,
+                        content_type: "application/json",
+                        body: super::serialize_service_api_json(&payload),
+                    })
+                }
+                Ok(None) => super::payload::json_error_response(
                     StatusCode::NOT_FOUND,
                     "not-found",
                     REASON_CODE_ROUTE_NOT_FOUND,
                     "not found",
                 ),
-                Err(error) => super::json_error_response(
+                Err(error) => super::payload::json_error_response(
                     StatusCode::INTERNAL_SERVER_ERROR,
                     "internal",
                     REASON_CODE_STATE_PERSISTENCE_FAILED,
@@ -487,18 +492,20 @@ pub(super) async fn handle_service_api_http_route(
                 message_store.transition_task(task_id, "completed")
             };
             return match transition_result {
-                Ok(Some(payload)) => super::contract_response(ServiceApiEndpointResponse {
-                    status_code: 200,
-                    content_type: "application/json",
-                    body: super::serialize_service_api_json(&payload),
-                }),
-                Ok(None) => super::json_error_response(
+                Ok(Some(payload)) => {
+                    super::payload::contract_response(ServiceApiEndpointResponse {
+                        status_code: 200,
+                        content_type: "application/json",
+                        body: super::serialize_service_api_json(&payload),
+                    })
+                }
+                Ok(None) => super::payload::json_error_response(
                     StatusCode::NOT_FOUND,
                     "not-found",
                     REASON_CODE_ROUTE_NOT_FOUND,
                     "not found",
                 ),
-                Err(error) => super::json_error_response(
+                Err(error) => super::payload::json_error_response(
                     StatusCode::INTERNAL_SERVER_ERROR,
                     "internal",
                     REASON_CODE_STATE_PERSISTENCE_FAILED,
@@ -514,18 +521,20 @@ pub(super) async fn handle_service_api_http_route(
                 message_store.release_escrow(escrow_id)
             };
             return match release_result {
-                Ok(Some(payload)) => super::contract_response(ServiceApiEndpointResponse {
-                    status_code: 200,
-                    content_type: "application/json",
-                    body: super::serialize_service_api_json(&payload),
-                }),
-                Ok(None) => super::json_error_response(
+                Ok(Some(payload)) => {
+                    super::payload::contract_response(ServiceApiEndpointResponse {
+                        status_code: 200,
+                        content_type: "application/json",
+                        body: super::serialize_service_api_json(&payload),
+                    })
+                }
+                Ok(None) => super::payload::json_error_response(
                     StatusCode::NOT_FOUND,
                     "not-found",
                     REASON_CODE_ROUTE_NOT_FOUND,
                     "not found",
                 ),
-                Err(error) => super::json_error_response(
+                Err(error) => super::payload::json_error_response(
                     StatusCode::INTERNAL_SERVER_ERROR,
                     "internal",
                     REASON_CODE_STATE_PERSISTENCE_FAILED,
@@ -538,7 +547,7 @@ pub(super) async fn handle_service_api_http_route(
         if let Some(message_id) =
             super::payload::message_path_id(context.parsed_request.path.as_str())
         {
-            let requester_did = super::header_value(
+            let requester_did = super::auth::header_value(
                 &context.parsed_request.headers,
                 REQUEST_AUTH_SENDER_DID_HEADER,
             );
@@ -547,18 +556,20 @@ pub(super) async fn handle_service_api_http_route(
                 message_store.get_message_for_requester(message_id, requester_did)
             };
             return match message_result {
-                Ok(Some(payload)) => super::contract_response(ServiceApiEndpointResponse {
-                    status_code: 200,
-                    content_type: "application/json",
-                    body: super::serialize_service_api_json(&payload),
-                }),
-                Ok(None) => super::json_error_response(
+                Ok(Some(payload)) => {
+                    super::payload::contract_response(ServiceApiEndpointResponse {
+                        status_code: 200,
+                        content_type: "application/json",
+                        body: super::serialize_service_api_json(&payload),
+                    })
+                }
+                Ok(None) => super::payload::json_error_response(
                     StatusCode::NOT_FOUND,
                     "not-found",
                     REASON_CODE_ROUTE_NOT_FOUND,
                     "not found",
                 ),
-                Err(error) => super::json_error_response(
+                Err(error) => super::payload::json_error_response(
                     StatusCode::INTERNAL_SERVER_ERROR,
                     "internal",
                     REASON_CODE_STATE_PERSISTENCE_FAILED,
@@ -573,7 +584,7 @@ pub(super) async fn handle_service_api_http_route(
                 let message_store = state.message_store.lock().await;
                 message_store.list_channel_messages(channel_id)
             };
-            return super::contract_response(ServiceApiEndpointResponse {
+            return super::payload::contract_response(ServiceApiEndpointResponse {
                 status_code: 200,
                 content_type: "application/json",
                 body: super::serialize_service_api_json(&payload),
@@ -585,12 +596,12 @@ pub(super) async fn handle_service_api_http_route(
                 message_store.get_task(task_id)
             };
             return match task_payload {
-                Some(payload) => super::contract_response(ServiceApiEndpointResponse {
+                Some(payload) => super::payload::contract_response(ServiceApiEndpointResponse {
                     status_code: 200,
                     content_type: "application/json",
                     body: super::serialize_service_api_json(&payload),
                 }),
-                None => super::json_error_response(
+                None => super::payload::json_error_response(
                     StatusCode::NOT_FOUND,
                     "not-found",
                     REASON_CODE_ROUTE_NOT_FOUND,
@@ -607,7 +618,7 @@ pub(super) async fn handle_service_api_http_route(
         context.parsed_request.path.as_str(),
         context.parsed_request.body.as_str(),
     );
-    super::contract_response(rendered)
+    super::payload::contract_response(rendered)
 }
 
 fn extract_channel_id_from_payload(payload: &str) -> Option<String> {
@@ -640,10 +651,16 @@ pub(super) async fn handle_service_api_websocket_route(
     upgrade: WebSocketUpgrade,
 ) -> Response {
     let _ = context.correlation_id.as_str();
-    match super::project_websocket_event_payload(&state.snapshot, &context.parsed_request.headers) {
+    match super::websocket::project_websocket_event_payload(
+        &state.snapshot,
+        &context.parsed_request.headers,
+    ) {
         Ok(event_payload) => {
-            let mut response =
-                super::websocket_upgrade_response(upgrade, event_payload, &state.websocket_events);
+            let mut response = super::websocket::websocket_upgrade_response(
+                upgrade,
+                event_payload,
+                &state.websocket_events,
+            );
             response
                 .extensions_mut()
                 .insert(ServiceApiRequestOutcome("websocket-upgrade"));
@@ -651,8 +668,8 @@ pub(super) async fn handle_service_api_websocket_route(
         }
         Err(error) => {
             let (status_code, error_label, outcome) =
-                super::project_websocket_error_response(&error);
-            let mut response = super::json_error_response(
+                super::websocket::project_websocket_error_response(&error);
+            let mut response = super::payload::json_error_response(
                 status_code,
                 error_label,
                 error.reason_code,
@@ -687,8 +704,8 @@ pub(super) fn log_service_api_event_warn(
 pub(super) fn service_api_request_correlation_id(request: &ParsedRequest) -> String {
     let method = request.method.to_ascii_lowercase();
     if let (Some(sender_did), Some(nonce)) = (
-        super::header_value(&request.headers, REQUEST_AUTH_SENDER_DID_HEADER),
-        super::header_value(&request.headers, REQUEST_AUTH_NONCE_HEADER),
+        super::auth::header_value(&request.headers, REQUEST_AUTH_SENDER_DID_HEADER),
+        super::auth::header_value(&request.headers, REQUEST_AUTH_NONCE_HEADER),
     ) {
         return format!("service-api:{method}:{}:{sender_did}:{nonce}", request.path);
     }

--- a/crates/kamn-node/src/service_api_endpoint/websocket.rs
+++ b/crates/kamn-node/src/service_api_endpoint/websocket.rs
@@ -97,26 +97,27 @@ pub(super) fn validate_websocket_route_requirements(
 pub(super) fn validate_websocket_upgrade_headers(
     headers: &BTreeMap<String, String>,
 ) -> Result<(), ServiceApiReasonedError> {
-    let upgrade = super::header_value(headers, "upgrade").ok_or_else(|| {
+    let upgrade = super::auth::header_value(headers, "upgrade").ok_or_else(|| {
         ServiceApiReasonedError::new(
             REASON_CODE_WS_UPGRADE_HEADER_MISSING,
             "missing required websocket upgrade header",
         )
     })?;
-    let connection = super::header_value(headers, "connection").ok_or_else(|| {
+    let connection = super::auth::header_value(headers, "connection").ok_or_else(|| {
         ServiceApiReasonedError::new(
             REASON_CODE_WS_CONNECTION_HEADER_MISSING,
             "missing required websocket connection header",
         )
     })?;
-    let websocket_key = super::header_value(headers, "sec-websocket-key").ok_or_else(|| {
-        ServiceApiReasonedError::new(
-            REASON_CODE_WS_KEY_HEADER_MISSING,
-            "missing required websocket key header",
-        )
-    })?;
-    let websocket_version =
-        super::header_value(headers, "sec-websocket-version").ok_or_else(|| {
+    let websocket_key =
+        super::auth::header_value(headers, "sec-websocket-key").ok_or_else(|| {
+            ServiceApiReasonedError::new(
+                REASON_CODE_WS_KEY_HEADER_MISSING,
+                "missing required websocket key header",
+            )
+        })?;
+    let websocket_version = super::auth::header_value(headers, "sec-websocket-version")
+        .ok_or_else(|| {
             ServiceApiReasonedError::new(
                 REASON_CODE_WS_VERSION_HEADER_MISSING,
                 "missing required websocket version header",
@@ -154,7 +155,7 @@ pub(super) fn project_websocket_event_payload(
     snapshot: &ServiceApiSnapshot,
     headers: &BTreeMap<String, String>,
 ) -> Result<String, ServiceApiReasonedError> {
-    let mode = super::header_value(headers, REQUEST_WS_EVENTS_MODE_HEADER)
+    let mode = super::auth::header_value(headers, REQUEST_WS_EVENTS_MODE_HEADER)
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .unwrap_or(WS_EVENTS_MODE_STATE_TRANSITION);
@@ -274,7 +275,7 @@ fn project_presence_mode_payload(
     )?
     .to_owned();
     let target_owner_did =
-        super::header_value(headers, REQUEST_WS_PRESENCE_TARGET_OWNER_DID_HEADER)
+        super::auth::header_value(headers, REQUEST_WS_PRESENCE_TARGET_OWNER_DID_HEADER)
             .map(str::trim)
             .filter(|value| !value.is_empty())
             .unwrap_or(owner_did.as_str())
@@ -285,7 +286,7 @@ fn project_presence_mode_payload(
         REASON_CODE_WS_PRESENCE_TARGET_AGENT_DID_HEADER_MISSING,
     )?
     .to_owned();
-    let gateway_node = super::header_value(headers, REQUEST_WS_PRESENCE_GATEWAY_NODE_HEADER)
+    let gateway_node = super::auth::header_value(headers, REQUEST_WS_PRESENCE_GATEWAY_NODE_HEADER)
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .unwrap_or(WS_PRESENCE_DEFAULT_GATEWAY_NODE)
@@ -350,7 +351,7 @@ fn required_presence_header<'a>(
     header_name: &str,
     reason_code: &'static str,
 ) -> Result<&'a str, ServiceApiReasonedError> {
-    super::header_value(headers, header_name)
+    super::auth::header_value(headers, header_name)
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .ok_or_else(|| {
@@ -367,7 +368,7 @@ fn parse_presence_timestamp_header(
     reason_code: &'static str,
     default_value: u64,
 ) -> Result<u64, ServiceApiReasonedError> {
-    let Some(raw_value) = super::header_value(headers, header_name) else {
+    let Some(raw_value) = super::auth::header_value(headers, header_name) else {
         return Ok(default_value);
     };
     raw_value.trim().parse::<u64>().map_err(|_| {
@@ -382,7 +383,7 @@ fn parse_presence_capabilities(
     headers: &BTreeMap<String, String>,
 ) -> Result<Vec<String>, ServiceApiReasonedError> {
     let Some(raw_capabilities) =
-        super::header_value(headers, REQUEST_WS_PRESENCE_CAPABILITIES_HEADER)
+        super::auth::header_value(headers, REQUEST_WS_PRESENCE_CAPABILITIES_HEADER)
     else {
         return Ok(vec!["ws".to_owned()]);
     };

--- a/specs/5947/plan.md
+++ b/specs/5947/plan.md
@@ -1,0 +1,32 @@
+# Plan: Issue #5947 - Task: Restore service_api_endpoint root line-budget contract by removing redundant delegates
+
+- Issue: #5947
+- Spec: `specs/5947/spec.md`
+- Status: Implemented
+- Last Updated: 2026-02-25
+
+## Approach
+1. RED evidence: run extraction contract to confirm root budget failure context (`935 > 900`) from CI signal.
+2. Remove redundant root wrappers in `service_api_endpoint.rs` that forward to `auth`, `payload`, and `websocket` submodules.
+3. Update `middleware_impl.rs` and `websocket.rs` to call submodule functions directly through `super::auth`, `super::payload`, and `super::websocket`.
+4. Verify conformance and behavior parity with targeted extraction/route/websocket tests, then run formatting and strict clippy for touched crate.
+
+## Affected Modules
+- `crates/kamn-node/src/service_api_endpoint.rs`
+- `crates/kamn-node/src/service_api_endpoint/middleware_impl.rs`
+- `crates/kamn-node/src/service_api_endpoint/websocket.rs`
+- `crates/kamn-node/tests/service_api_endpoint_module_extraction_contract.rs` (verification only)
+
+## Risks + Mitigations
+- Risk: Accidental behavior changes while replacing wrapper call paths.
+  - Mitigation: keep logic identical and only change call targets; run route/websocket regressions.
+- Risk: Future reintroduction of wrapper inflation.
+  - Mitigation: keep extraction contract gate in CI and maintain direct submodule calls.
+
+## Interfaces / Contracts
+- Primary contract source: `specs/5947/spec.md`.
+- Gate contract: `crates/kamn-node/tests/service_api_endpoint_module_extraction_contract.rs`.
+- No API/wire/protocol changes.
+
+## ADR Requirement
+- Not required (no architectural dependency/protocol decision change).

--- a/specs/5947/spec.md
+++ b/specs/5947/spec.md
@@ -1,0 +1,56 @@
+# Spec: Issue #5947 - Task: Restore service_api_endpoint root line-budget contract by removing redundant delegates
+
+- Issue: #5947
+- Status: Implemented
+- Type: task
+- Priority: P2
+- Area: backend
+- Milestone: `specs/milestones/r65-security-runtime-remediation-and-production-readiness/index.md`
+- Last Updated: 2026-02-25
+- Parent: Parent story: #5917
+
+## Problem Statement
+`crates/kamn-node/src/service_api_endpoint.rs` regressed above its extraction contract line budget (`935 > 900`) because root-level wrappers were reintroduced for functions already implemented in `auth`, `payload`, and `websocket` submodules.
+
+## Scope
+In scope:
+- Remove redundant root delegate wrappers from `service_api_endpoint.rs`.
+- Update submodule call sites to reference `auth::`, `payload::`, and `websocket::` directly.
+- Preserve runtime behavior and response/auth contracts.
+
+Out of scope:
+- New route behavior, protocol changes, or auth policy changes.
+- Additional module extraction beyond wrapper cleanup.
+
+## Risk Level
+`low`
+
+## Acceptance Criteria
+- AC-1: `service_api_endpoint.rs` root returns to the enforced extraction budget (`<= 900` lines).
+- AC-2: `service_api_endpoint_module_extraction_contract` passes after cleanup.
+- AC-3: Existing service API route/auth/websocket behavior remains unchanged.
+- AC-4: Touched `kamn-node` code compiles/tests cleanly for targeted conformance paths.
+
+## Conformance Cases
+- C-01 (Conformance, AC-1): `conformance_service_api_endpoint_root_stays_within_line_budget` passes with root line count `<= 900`.
+- C-02 (Conformance, AC-2): `cargo test -p kamn-node --test service_api_endpoint_module_extraction_contract -- --nocapture` passes.
+- C-03 (Functional, AC-3): `cargo test -p kamn-node --bin kamn-node main_tests::service_api_endpoint_tests::functional_service_api_endpoint_renders_required_route_contracts -- --exact` remains green.
+- C-04 (Regression, AC-3): `cargo test -p kamn-node --bin kamn-node main_tests::service_api_endpoint_tests::regression_service_api_endpoint_websocket_route_rejects_missing_upgrade_headers -- --exact` remains green.
+- C-05 (Verify, AC-4): `cargo fmt --check` and strict clippy for `kamn-node` pass.
+
+## Success Metrics / Observable Signals
+- Root wrappers removed and all call sites route directly to owning submodules.
+- Contract gate no longer fails on line budget.
+- Targeted route and websocket regression tests remain green.
+- Formatting and lint checks pass for touched crate.
+
+## Required Test Categories
+- Unit: N/A (no new pure helper logic introduced)
+- Functional: route contract behavior remains stable
+- Conformance: module extraction contract passes
+- Integration: existing service API route tests pass
+- Regression: websocket missing-upgrade-header rejection remains stable
+
+## Dependencies
+- #5215
+- #5917

--- a/specs/5947/tasks.md
+++ b/specs/5947/tasks.md
@@ -1,0 +1,15 @@
+# Tasks: Issue #5947 - Task: Restore service_api_endpoint root line-budget contract by removing redundant delegates
+
+- Issue: #5947
+- Spec: `specs/5947/spec.md`
+- Plan: `specs/5947/plan.md`
+- Status: Implemented
+- Last Updated: 2026-02-25
+
+## Ordered Tasks
+- T1 (RED / Conformance): confirmed CI failure context on root budget drift (`935 > 900`).
+- T2 (GREEN / Implementation): removed root delegates from `service_api_endpoint.rs` and switched call sites to direct `auth/payload/websocket` paths.
+- T3 (Refactor): reduced duplicate forwarding surface and restored module ownership boundaries.
+- T4 (Regression): ran extraction contract and targeted route/websocket tests.
+- T5 (Verify): ran `cargo fmt --check` and strict `kamn-node` clippy.
+- T6 (Process): marked lifecycle artifacts Implemented and prepared PR/issue evidence links.

--- a/specs/milestones/r65-security-runtime-remediation-and-production-readiness/index.md
+++ b/specs/milestones/r65-security-runtime-remediation-and-production-readiness/index.md
@@ -3,7 +3,7 @@
 - Milestone: `r65-security-runtime-remediation-and-production-readiness`
 - Epic: #5915
 - Stories: #5916, #5917, #5918, #5919, #5920
-- Tasks: #5921, #5922, #5923, #5924, #5925, #5926, #5927, #5928, #5929, #5930, #5931, #5932, #5933, #5934, #5935, #5936, #5937, #5938, #5939, #5940, #5941
+- Tasks: #5921, #5922, #5923, #5924, #5925, #5926, #5927, #5928, #5929, #5930, #5931, #5932, #5933, #5934, #5935, #5936, #5937, #5938, #5939, #5940, #5941, #5947
 
 ## Problem Frame
 This milestone closes production-readiness blockers across cryptography correctness, end-to-end delivery reality, transport hardening, bounded replay protection, assurance gates, and architecture/governance sustainability.
@@ -12,7 +12,7 @@ This milestone closes production-readiness blockers across cryptography correctn
 1. Security primitives and auth correctness: #5921, #5922, #5923, #5924, #5925
 2. Real runtime delivery and bounded state: #5926, #5927, #5928
 3. SDK/service transport hardening: #5929, #5930, #5931, #5932
-4. Architecture and sustainability remediation: #5933, #5934, #5935, #5936
+4. Architecture and sustainability remediation: #5933, #5934, #5935, #5936, #5947
 5. Assurance and CI gate expansion: #5937, #5938, #5939, #5940, #5941
 
 ## Artifact Index
@@ -43,6 +43,7 @@ This milestone closes production-readiness blockers across cryptography correctn
 - #5939: `specs/5939/spec.md`, `specs/5939/plan.md`, `specs/5939/tasks.md`
 - #5940: `specs/5940/spec.md`, `specs/5940/plan.md`, `specs/5940/tasks.md`
 - #5941: `specs/5941/spec.md`, `specs/5941/plan.md`, `specs/5941/tasks.md`
+- #5947: `specs/5947/spec.md`, `specs/5947/plan.md`, `specs/5947/tasks.md`
 
 ## Exit Criteria
 1. Every R65 issue has SPECIFY/PLAN/TASKS artifacts committed and linked.


### PR DESCRIPTION
## Summary
This PR removes redundant root-level delegate wrappers from `service_api_endpoint.rs` and switches call sites to direct `auth`, `payload`, and `websocket` module functions. It restores the extraction contract root line budget (`<= 900`) without changing route/auth/websocket behavior.

## Links
- Milestone: `specs/milestones/r65-security-runtime-remediation-and-production-readiness/index.md`
- Closes #5947
- Spec: `specs/5947/spec.md`
- Plan: `specs/5947/plan.md`
- Tasks: `specs/5947/tasks.md`

## Spec Verification (AC -> tests)
| AC | ✅/❌ | Test(s) |
|---|---|---|
| AC-1: `service_api_endpoint.rs` root line budget is `<= 900` | ✅ | `cargo test -p kamn-node --test service_api_endpoint_module_extraction_contract -- --nocapture` (`conformance_service_api_endpoint_root_stays_within_line_budget`) |
| AC-2: extraction contract suite passes | ✅ | `cargo test -p kamn-node --test service_api_endpoint_module_extraction_contract -- --nocapture` |
| AC-3: route/auth/websocket behavior unchanged | ✅ | `cargo test -p kamn-node --bin kamn-node main_tests::service_api_endpoint_tests::functional_service_api_endpoint_renders_required_route_contracts -- --exact`; `cargo test -p kamn-node --bin kamn-node main_tests::service_api_endpoint_tests::regression_service_api_endpoint_websocket_route_rejects_missing_upgrade_headers -- --exact` |
| AC-4: touched crate verification clean | ✅ | `cargo fmt --check`; `cargo clippy --all-targets --all-features --manifest-path crates/kamn-node/Cargo.toml -- -D warnings` |

## TDD Evidence
- RED (pre-fix evidence from failing CI gate):
  - `service_api_endpoint.rs root exceeded line budget: 935 > 900`
  - failing test: `crates/kamn-node/tests/service_api_endpoint_module_extraction_contract.rs`
- GREEN:
  - `cargo test -p kamn-node --test service_api_endpoint_module_extraction_contract -- --nocapture`
  - `cargo test -p kamn-node --bin kamn-node main_tests::service_api_endpoint_tests::functional_service_api_endpoint_renders_required_route_contracts -- --exact`
  - `cargo test -p kamn-node --bin kamn-node main_tests::service_api_endpoint_tests::regression_service_api_endpoint_websocket_route_rejects_missing_upgrade_headers -- --exact`
- REGRESSION summary:
  - Extraction contract, route contract, and websocket missing-upgrade-header regression remain green after delegate removal.

## Test Tiers
| Tier | ✅/❌/N/A | Tests | N/A Why |
|---|---|---|---|
| Unit | N/A | Existing unit coverage unchanged | Structural delegate cleanup only; no new unit-scope behavior introduced |
| Property | N/A | None | No parser/invariant algorithm changes |
| Contract/DbC | N/A | None | No new DbC surfaces introduced |
| Snapshot | N/A | None | No snapshot-managed structured output changes |
| Functional | ✅ | `main_tests::service_api_endpoint_tests::functional_service_api_endpoint_renders_required_route_contracts` | |
| Conformance | ✅ | `service_api_endpoint_module_extraction_contract` | |
| Integration | ✅ | `main_tests::service_api_endpoint_tests::regression_service_api_endpoint_websocket_route_rejects_missing_upgrade_headers` | |
| Fuzz | N/A | None | No untrusted parser/protocol implementation changes |
| Mutation | N/A | None | Scope is structural extraction parity; no critical algorithm branch changes |
| Regression | ✅ | websocket missing-upgrade-header regression above | |
| Performance | N/A | None | No runtime-path logic changes expected to impact performance |

## Mutation
- N/A for this structural extraction-contract remediation (no new critical-path algorithm branches).

## Risks / Rollback
- Risk: accidental call-path drift while removing wrappers.
- Mitigation: direct submodule calls preserve logic; route/websocket regression tests executed.
- Rollback: revert this PR commit to restore previous wrapper layout if needed.

## Docs / ADR
- Updated milestone artifact index and issue lifecycle docs:
  - `specs/milestones/r65-security-runtime-remediation-and-production-readiness/index.md`
  - `specs/5947/spec.md`
  - `specs/5947/plan.md`
  - `specs/5947/tasks.md`
- ADR: not required (no protocol/dependency decision change).
