### PR TITLE
docs(6000): mark spec lifecycle as implemented

### DIFF
--- a/specs/6000/spec.md
+++ b/specs/6000/spec.md
@@ -1,7 +1,7 @@
 # Spec: Issue #6000 - Replace content-storage FNV CIDs with SHA-256 integrity
 
 - Issue: #6000
-- Status: Reviewed
+- Status: Implemented
 - Type: story
 - Priority: P0
 - Area: security


### PR DESCRIPTION
## Summary
Update `specs/6000/spec.md` status marker from `Reviewed` to `Implemented` after merge of #6001.

## Links
- #6000
- Previous implementation PR: #6001

## Notes
No runtime behavior changes; this is lifecycle metadata consistency only.
