### PR TITLE
fix(kamn-mcp-server): publish per-tool MCP input schemas (#6113)

### DIFF
--- a/crates/kamn-mcp-server/src/tools.rs
+++ b/crates/kamn-mcp-server/src/tools.rs
@@ -11,7 +11,17 @@ pub struct ToolDescriptor {
     pub output_schema: &'static str,
 }
 
-const GENERIC_INPUT_SCHEMA_JSON: &str = r#"{"type":"object","additionalProperties":true}"#;
+const EMPTY_INPUT_SCHEMA_JSON: &str =
+    r#"{"type":"object","additionalProperties":false,"properties":{}}"#;
+const PAYLOAD_INPUT_SCHEMA_JSON: &str = r#"{"type":"object","additionalProperties":false,"required":["payload"],"properties":{"payload":{"type":"string","minLength":1}}}"#;
+const CHANNEL_ID_INPUT_SCHEMA_JSON: &str = r#"{"type":"object","additionalProperties":false,"required":["channel_id"],"properties":{"channel_id":{"type":"string","minLength":1}}}"#;
+const MESSAGE_ID_INPUT_SCHEMA_JSON: &str = r#"{"type":"object","additionalProperties":false,"required":["message_id"],"properties":{"message_id":{"type":"string","minLength":1}}}"#;
+const TASK_ID_INPUT_SCHEMA_JSON: &str = r#"{"type":"object","additionalProperties":false,"required":["task_id"],"properties":{"task_id":{"type":"string","minLength":1}}}"#;
+const DID_INPUT_SCHEMA_JSON: &str = r#"{"type":"object","additionalProperties":false,"required":["did"],"properties":{"did":{"type":"string","minLength":1}}}"#;
+const CONTENT_ID_INPUT_SCHEMA_JSON: &str = r#"{"type":"object","additionalProperties":false,"required":["content_id"],"properties":{"content_id":{"type":"string","minLength":1}}}"#;
+const BRIDGE_ID_INPUT_SCHEMA_JSON: &str = r#"{"type":"object","additionalProperties":false,"required":["bridge_id"],"properties":{"bridge_id":{"type":"string","minLength":1}}}"#;
+const ESCROW_ID_INPUT_SCHEMA_JSON: &str = r#"{"type":"object","additionalProperties":false,"required":["escrow_id"],"properties":{"escrow_id":{"type":"string","minLength":1}}}"#;
+const VERIFY_PROOF_INPUT_SCHEMA_JSON: &str = r#"{"type":"object","additionalProperties":false,"required":["message_id","tx_hash","block_height","finality"],"properties":{"message_id":{"type":"string","minLength":1},"tx_hash":{"type":"string","minLength":1},"block_height":{"oneOf":[{"type":"integer","minimum":0},{"type":"string","pattern":"^[0-9]+$"}]},"finality":{"type":"string","minLength":1}}}"#;
 const GENERIC_OUTPUT_SCHEMA_JSON: &str = r#"{"type":"object","additionalProperties":true}"#;
 
 /// Required PRD phase-2 MCP tool names.
@@ -77,8 +87,29 @@ fn tool_descriptor_for_name(name: &'static str) -> ToolDescriptor {
     ToolDescriptor {
         name,
         description,
-        input_schema: GENERIC_INPUT_SCHEMA_JSON,
+        input_schema: tool_input_schema_for_name(name),
         output_schema: GENERIC_OUTPUT_SCHEMA_JSON,
+    }
+}
+
+fn tool_input_schema_for_name(name: &'static str) -> &'static str {
+    match name {
+        "register" | "health" => EMPTY_INPUT_SCHEMA_JSON,
+        "send_message"
+        | "create_channel"
+        | "register_content"
+        | "submit_bridge_message"
+        | "create_task"
+        | "fund_escrow" => PAYLOAD_INPUT_SCHEMA_JSON,
+        "list_messages" => CHANNEL_ID_INPUT_SCHEMA_JSON,
+        "query_message" => MESSAGE_ID_INPUT_SCHEMA_JSON,
+        "query_task" | "accept_task" | "complete_task" => TASK_ID_INPUT_SCHEMA_JSON,
+        "query_agent_profile" => DID_INPUT_SCHEMA_JSON,
+        "expire_content" | "tombstone_content" | "query_content" => CONTENT_ID_INPUT_SCHEMA_JSON,
+        "forward_bridge_message" | "query_bridge_message" => BRIDGE_ID_INPUT_SCHEMA_JSON,
+        "release_escrow" => ESCROW_ID_INPUT_SCHEMA_JSON,
+        "verify_proof" => VERIFY_PROOF_INPUT_SCHEMA_JSON,
+        _ => EMPTY_INPUT_SCHEMA_JSON,
     }
 }
 
@@ -86,10 +117,21 @@ fn tool_descriptor_for_name(name: &'static str) -> ToolDescriptor {
 mod tests {
     use super::{build_tool_registry, MCP_TOOL_NAMES};
 
+    const LEGACY_GENERIC_INPUT_SCHEMA_JSON: &str =
+        r#"{"type":"object","additionalProperties":true}"#;
+
     #[test]
     fn unit_mcp_tool_registry_count_matches_constant_inventory() {
         let registry = build_tool_registry();
         assert_eq!(registry.len(), MCP_TOOL_NAMES.len());
         assert_eq!(registry.len(), 21);
+    }
+
+    #[test]
+    fn unit_mcp_tool_registry_input_schemas_are_not_legacy_generic_payloads() {
+        let registry = build_tool_registry();
+        assert!(registry
+            .iter()
+            .all(|tool| { tool.input_schema != LEGACY_GENERIC_INPUT_SCHEMA_JSON }));
     }
 }

--- a/crates/kamn-mcp-server/tests/stdio_protocol_contract.rs
+++ b/crates/kamn-mcp-server/tests/stdio_protocol_contract.rs
@@ -1,5 +1,6 @@
 use kamn_agent_lib::AgentLibError;
 use kamn_mcp_server::{process_stdio_input, McpToolBackend};
+use serde_json::Value;
 
 #[derive(Debug, Default)]
 struct ProtocolBackend;
@@ -251,6 +252,46 @@ fn spec_c02_mcp_tools_list_framed_tool_inventory_contract() {
     assert!(
         body.contains(r#""name":"query_bridge_message""#),
         "tools/list should include query_bridge_message tool: {body}",
+    );
+
+    let response_json: Value =
+        serde_json::from_str(body.as_str()).expect("tools/list response should parse as JSON");
+    let tools = response_json
+        .get("result")
+        .and_then(|value| value.get("tools"))
+        .and_then(Value::as_array)
+        .expect("tools/list response should expose result.tools array");
+
+    let query_task = tools
+        .iter()
+        .find(|tool| tool.get("name").and_then(Value::as_str) == Some("query_task"))
+        .expect("tools/list should expose query_task descriptor");
+    let query_task_required = query_task
+        .get("inputSchema")
+        .and_then(|value| value.get("required"))
+        .and_then(Value::as_array)
+        .expect("query_task input schema should expose required array");
+    assert_eq!(query_task_required.len(), 1);
+    assert_eq!(
+        query_task_required.first().and_then(Value::as_str),
+        Some("task_id")
+    );
+
+    let verify_proof = tools
+        .iter()
+        .find(|tool| tool.get("name").and_then(Value::as_str) == Some("verify_proof"))
+        .expect("tools/list should expose verify_proof descriptor");
+    let verify_required = verify_proof
+        .get("inputSchema")
+        .and_then(|value| value.get("required"))
+        .and_then(Value::as_array)
+        .expect("verify_proof input schema should expose required array");
+    assert_eq!(verify_required.len(), 4);
+    assert!(
+        verify_required
+            .iter()
+            .any(|field| field.as_str() == Some("block_height")),
+        "verify_proof input schema should require block_height",
     );
 }
 

--- a/crates/kamn-mcp-server/tests/tool_inventory_contract.rs
+++ b/crates/kamn-mcp-server/tests/tool_inventory_contract.rs
@@ -1,4 +1,5 @@
 use kamn_mcp_server::tools::{build_tool_registry, MCP_TOOL_NAMES};
+use serde_json::Value;
 
 #[test]
 fn spec_c03_mcp_tool_registry_contains_required_21_tools() {
@@ -41,15 +42,106 @@ fn spec_c03_mcp_tool_registry_contains_required_21_tools() {
 #[test]
 fn spec_c04_mcp_tool_registry_has_deterministic_schema_descriptors() {
     let registry = build_tool_registry();
-    for tool in registry {
+    let expected_required: [(&str, &[&str]); 21] = [
+        ("register", &[]),
+        ("send_message", &["payload"]),
+        ("create_channel", &["payload"]),
+        ("list_messages", &["channel_id"]),
+        ("query_message", &["message_id"]),
+        ("query_task", &["task_id"]),
+        ("query_agent_profile", &["did"]),
+        ("register_content", &["payload"]),
+        ("expire_content", &["content_id"]),
+        ("tombstone_content", &["content_id"]),
+        ("query_content", &["content_id"]),
+        ("submit_bridge_message", &["payload"]),
+        ("forward_bridge_message", &["bridge_id"]),
+        ("query_bridge_message", &["bridge_id"]),
+        ("create_task", &["payload"]),
+        ("accept_task", &["task_id"]),
+        ("complete_task", &["task_id"]),
+        ("fund_escrow", &["payload"]),
+        ("release_escrow", &["escrow_id"]),
+        (
+            "verify_proof",
+            &["message_id", "tx_hash", "block_height", "finality"],
+        ),
+        ("health", &[]),
+    ];
+
+    for (tool_name, required_fields) in expected_required {
+        let tool = registry
+            .iter()
+            .find(|tool| tool.name == tool_name)
+            .expect("tool descriptor should exist");
         assert!(!tool.description.trim().is_empty());
+
+        let input_schema: Value =
+            serde_json::from_str(tool.input_schema).expect("input schema should parse");
         assert_eq!(
-            tool.input_schema,
-            r#"{"type":"object","additionalProperties":true}"#
+            input_schema.get("type"),
+            Some(&Value::String("object".to_owned()))
         );
         assert_eq!(
-            tool.output_schema,
-            r#"{"type":"object","additionalProperties":true}"#
+            input_schema.get("additionalProperties"),
+            Some(&Value::Bool(false))
+        );
+
+        let required = input_schema
+            .get("required")
+            .and_then(Value::as_array)
+            .map(|values| {
+                values
+                    .iter()
+                    .filter_map(Value::as_str)
+                    .map(ToOwned::to_owned)
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        let expected = required_fields
+            .iter()
+            .map(|value| (*value).to_owned())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            required, expected,
+            "required fields should match contract for tool {tool_name}",
+        );
+
+        let properties = input_schema
+            .get("properties")
+            .and_then(Value::as_object)
+            .expect("input schema should include properties object");
+        for field in required_fields {
+            assert!(
+                properties.contains_key(*field),
+                "tool {tool_name} input schema should expose required field property {field}",
+            );
+        }
+
+        if tool_name == "verify_proof" {
+            let block_height = properties
+                .get("block_height")
+                .expect("verify_proof schema should include block_height");
+            assert!(
+                block_height.get("oneOf").is_some(),
+                "verify_proof block_height should allow deterministic numeric parsing modes",
+            );
+        }
+
+        assert_ne!(
+            tool.input_schema, r#"{"type":"object","additionalProperties":true}"#,
+            "tool {tool_name} should not use the legacy generic input schema",
+        );
+
+        let output_schema: Value =
+            serde_json::from_str(tool.output_schema).expect("output schema should parse");
+        assert_eq!(
+            output_schema.get("type"),
+            Some(&Value::String("object".to_owned()))
+        );
+        assert_eq!(
+            output_schema.get("additionalProperties"),
+            Some(&Value::Bool(true))
         );
     }
 }

--- a/specs/6113/plan.md
+++ b/specs/6113/plan.md
@@ -1,0 +1,22 @@
+# Plan: Issue #6113
+
+## Approach
+1. Replace the static generic input schema assignment in `tools.rs` with a deterministic tool-to-schema mapping.
+2. Keep output schema deterministic and stable.
+3. Add/adjust contract tests in `tool_inventory_contract.rs` to assert required-field parity and guard against generic schema regression.
+4. Validate via focused MCP tests.
+
+## Affected Modules
+- `crates/kamn-mcp-server/src/tools.rs`
+- `crates/kamn-mcp-server/tests/tool_inventory_contract.rs`
+- (optional) `crates/kamn-mcp-server/tests/stdio_protocol_contract.rs` assertions for tools/list payload visibility
+
+## Risks
+- Risk: schema field mismatch with dispatcher-required arguments.
+  - Mitigation: table-driven test aligns expected required fields per tool with current dispatch contract.
+- Risk: accidental non-deterministic schema serialization.
+  - Mitigation: use fixed static JSON literals.
+
+## Interfaces/Contracts
+- Preserved: `ToolDescriptor` and `build_tool_registry()` public surface.
+- Changed behavior: `input_schema` content becomes tool-specific.

--- a/specs/6113/spec.md
+++ b/specs/6113/spec.md
@@ -1,0 +1,35 @@
+# Spec: Issue #6113 - MCP per-tool input schemas
+
+Status: Reviewed
+Issue: #6113
+Milestone: r68-r59-swarm-remediation-and-full-gap-closure
+
+## Problem Statement
+`crates/kamn-mcp-server/src/tools.rs` currently publishes the same generic input schema (`{"type":"object","additionalProperties":true}`) for all 21 MCP tools. This prevents clients from discovering required parameters and weakens contract safety.
+
+## Scope
+In scope:
+- Replace generic MCP input schemas with per-tool deterministic JSON schemas.
+- Keep tool names/descriptions stable.
+- Add conformance/regression tests proving schema specificity and argument parity.
+
+Out of scope:
+- Changing MCP tool names.
+- Changing backend dispatch semantics.
+- Redesigning output schema envelope format.
+
+## Acceptance Criteria
+- AC-1: Every MCP tool descriptor exposes a tool-specific input schema that identifies required arguments for that tool.
+- AC-2: `tools/list` returns deterministic per-tool input schema payloads (not the same generic schema for all tools).
+- AC-3: Contract/regression tests fail if schemas regress back to fully generic descriptors.
+
+## Conformance Cases
+- C-01 (AC-1): `register` and `health` have no required fields and reject unknown fields via `additionalProperties:false`.
+- C-02 (AC-1): Single-argument tools expose the expected required field (`payload`, `channel_id`, `message_id`, `task_id`, `did`, `content_id`, `bridge_id`, `escrow_id`).
+- C-03 (AC-1): `verify_proof` requires `message_id`, `tx_hash`, `block_height`, and `finality`, with `block_height` typed as integer.
+- C-04 (AC-2): `tools/list` response contains per-tool schemas for known tools (example: `query_task` includes `task_id`).
+- C-05 (AC-3): No tool in the registry uses the legacy generic input schema value.
+
+## Success Metrics
+- `cargo test -p kamn-mcp-server --test tool_inventory_contract`
+- `cargo test -p kamn-mcp-server --test stdio_protocol_contract spec_c02_mcp_tools_list_framed_tool_inventory_contract -- --exact`

--- a/specs/6113/tasks.md
+++ b/specs/6113/tasks.md
@@ -1,0 +1,6 @@
+# Tasks: Issue #6113
+
+- T1 (Red): Add contract tests that assert per-tool required fields and fail on generic schemas.
+- T2 (Green): Implement deterministic per-tool `input_schema` mapping in `tools.rs`.
+- T3 (Regression): Run focused MCP registry/protocol tests.
+- T4 (Verify): Map AC/Cases to passing tests in PR summary.


### PR DESCRIPTION
## Summary
Replace MCP tool registry input schemas with deterministic per-tool JSON schemas so clients can discover required arguments instead of receiving a generic schema for every tool.

## Links
- Milestone: r68-r59-swarm-remediation-and-full-gap-closure
- Closes #6113
- Spec: specs/6113/spec.md
- Plan: specs/6113/plan.md

## Spec Verification (AC -> tests)
| AC | ✅/❌ | Test(s) |
|---|---|---|
| AC-1: per-tool required arguments are explicit | ✅ | `cargo test -p kamn-mcp-server --test tool_inventory_contract` (`spec_c04_mcp_tool_registry_has_deterministic_schema_descriptors`) |
| AC-2: tools/list returns deterministic per-tool schemas | ✅ | `cargo test -p kamn-mcp-server --test stdio_protocol_contract spec_c02_mcp_tools_list_framed_tool_inventory_contract -- --exact` |
| AC-3: no regression to legacy generic schema | ✅ | `cargo test -p kamn-mcp-server --test tool_inventory_contract` (`spec_c04` + unit `unit_mcp_tool_registry_input_schemas_are_not_legacy_generic_payloads`) |

## TDD Evidence
- RED: New schema assertions in `tool_inventory_contract` and `stdio_protocol_contract` fail against the pre-fix generic registry behavior from R59 finding I-02.
- GREEN:
  - `cargo test -p kamn-mcp-server --test tool_inventory_contract`
  - `cargo test -p kamn-mcp-server --test stdio_protocol_contract spec_c02_mcp_tools_list_framed_tool_inventory_contract -- --exact`
- REGRESSION: `spec_c04` now enforces required-field parity and rejects legacy generic input schema values.

## Test Tiers
| Tier | ✅/❌/N/A | Tests | N/A Why |
|---|---|---|---|
| Unit | ✅ | `unit_mcp_tool_registry_count_matches_constant_inventory`, `unit_mcp_tool_registry_input_schemas_are_not_legacy_generic_payloads` | |
| Property | N/A | | no randomized invariants in this scope |
| Contract/DbC | N/A | | no contracts crate annotations in this crate |
| Snapshot | N/A | | no snapshot outputs used |
| Functional | ✅ | `stdio_protocol_contract::spec_c02_mcp_tools_list_framed_tool_inventory_contract` | |
| Conformance | ✅ | `tool_inventory_contract::spec_c04_mcp_tool_registry_has_deterministic_schema_descriptors` | |
| Integration | ✅ | `stdio_protocol_contract::spec_c02_mcp_tools_list_framed_tool_inventory_contract` | |
| Fuzz | N/A | | no parser/fuzzer lane changes in this issue |
| Mutation | N/A | | out of scoped fast-remediation lane |
| Regression | ✅ | legacy generic schema guard assertions in `spec_c04` and unit guard | |
| Performance | N/A | | no runtime/perf-sensitive path changed |

## Mutation
- Not run for this scoped remediation (`N/A` in tier matrix above).

## Risks/Rollback
- Risk: callers relying on permissive undocumented arguments may fail client-side schema validation.
- Rollback: revert commit `fix(kamn-mcp-server): publish per-tool MCP input schemas (#6113)`.

## Docs/ADR
- Added spec lifecycle artifacts:
  - `specs/6113/spec.md`
  - `specs/6113/plan.md`
  - `specs/6113/tasks.md`
