### PR TITLE
feat: replace pipe-delimited snapshot payloads with serde JSON (#6126)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1636,6 +1636,8 @@ dependencies = [
  "rusqlite",
  "rustls",
  "rustls-pemfile",
+ "serde",
+ "serde_json",
  "sha2",
  "sqlx",
  "tokio",

--- a/crates/kamn-core/Cargo.toml
+++ b/crates/kamn-core/Cargo.toml
@@ -19,6 +19,8 @@ kamn-runtime-guards = { path = "../kamn-runtime-guards" }
 rusqlite = { version = "0.31.0", features = ["bundled"] }
 sqlx = { version = "0.8.6", default-features = false, features = ["postgres", "runtime-tokio-rustls"] }
 tracing = "0.1.41"
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.149"
 k256 = { version = "0.13.4", features = ["ecdsa"] }
 x25519-dalek = { version = "2.0.1", features = ["static_secrets"] }
 chacha20poly1305 = "0.10.1"

--- a/crates/kamn-core/src/channel_models.rs
+++ b/crates/kamn-core/src/channel_models.rs
@@ -7,6 +7,7 @@ use crate::{
     },
     AgentDid, SqliteStoreBackend, SqliteStoreBackendError,
 };
+use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::fs;
@@ -1220,42 +1221,74 @@ fn parse_metadata_snapshot_value(
     }
 }
 
-fn ensure_snapshot_token(value: &str, field: &str) -> Result<(), ChannelSnapshotStoreError> {
-    if value.contains('|') || value.contains('\n') || value.contains('\r') || value.contains(',') {
-        return Err(ChannelSnapshotStoreError::InvalidPayload(format!(
-            "{field} contains unsupported delimiter characters"
-        )));
-    }
-    Ok(())
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct ChannelRecordSnapshotWire {
+    channel_id: String,
+    channel_type: String,
+    metadata: String,
+    members: Vec<String>,
+    admins: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct ChannelSnapshotWire {
+    schema_version: u16,
+    records: Vec<ChannelRecordSnapshotWire>,
 }
 
 fn serialize_channel_snapshot(
     snapshot: &ChannelSnapshot,
 ) -> Result<String, ChannelSnapshotStoreError> {
-    let mut payload = format!("schema|{}\n", snapshot.schema_version);
-    for record in &snapshot.records {
-        ensure_snapshot_token(&record.channel_id, "channel_id")?;
-        let metadata_value = metadata_snapshot_value(&record.metadata);
-        ensure_snapshot_token(metadata_value, "metadata")?;
-        for member in &record.members {
-            ensure_snapshot_token(member, "member")?;
-        }
-        for admin in &record.admins {
-            ensure_snapshot_token(admin, "admin")?;
-        }
-        payload.push_str(&format!(
-            "record|{}|{}|{}|{}|{}\n",
-            record.channel_id,
-            channel_type_code(record.channel_type),
-            metadata_value,
-            record.members.join(","),
-            record.admins.join(",")
-        ));
-    }
-    Ok(payload)
+    let wire = ChannelSnapshotWire {
+        schema_version: snapshot.schema_version,
+        records: snapshot
+            .records
+            .iter()
+            .map(|record| ChannelRecordSnapshotWire {
+                channel_id: record.channel_id.clone(),
+                channel_type: channel_type_code(record.channel_type).to_owned(),
+                metadata: metadata_snapshot_value(&record.metadata).to_owned(),
+                members: record.members.clone(),
+                admins: record.admins.clone(),
+            })
+            .collect(),
+    };
+    serde_json::to_string(&wire)
+        .map_err(|error| ChannelSnapshotStoreError::InvalidPayload(error.to_string()))
 }
 
 fn parse_channel_snapshot_payload(
+    payload: &str,
+) -> Result<ChannelSnapshot, ChannelSnapshotStoreError> {
+    if let Ok(wire) = serde_json::from_str::<ChannelSnapshotWire>(payload) {
+        let records = wire
+            .records
+            .into_iter()
+            .map(|record| {
+                let channel_type = parse_channel_type_code(record.channel_type.as_str())
+                    .ok_or_else(|| {
+                        ChannelSnapshotStoreError::InvalidPayload(record.channel_type.clone())
+                    })?;
+                let metadata =
+                    parse_metadata_snapshot_value(channel_type, record.metadata.as_str())?;
+                Ok(ChannelRecordSnapshot {
+                    channel_id: record.channel_id,
+                    channel_type,
+                    metadata,
+                    members: record.members,
+                    admins: record.admins,
+                })
+            })
+            .collect::<Result<Vec<_>, ChannelSnapshotStoreError>>()?;
+        return Ok(ChannelSnapshot {
+            schema_version: wire.schema_version,
+            records,
+        });
+    }
+    parse_channel_snapshot_payload_legacy(payload)
+}
+
+fn parse_channel_snapshot_payload_legacy(
     payload: &str,
 ) -> Result<ChannelSnapshot, ChannelSnapshotStoreError> {
     let mut lines = payload.lines().filter(|line| !line.trim().is_empty());
@@ -1570,6 +1603,37 @@ mod tests {
         file_store
             .write(snapshot.clone())
             .expect("write should succeed");
+        assert_eq!(
+            file_store.read_latest().expect("read should succeed"),
+            Some(snapshot)
+        );
+
+        let _ = fs::remove_file(path);
+        let _ = fs::remove_file(journal_path);
+    }
+
+    #[test]
+    fn regression_file_channel_snapshot_store_roundtrips_delimiter_rich_metadata() {
+        // Regression: #6126
+        let path = temp_channel_snapshot_path("delimiter-rich-metadata");
+        let journal_path = temp_channel_snapshot_journal_path(&path);
+        let _ = fs::remove_file(&path);
+        let _ = fs::remove_file(&journal_path);
+
+        let mut store = ChannelStore::new();
+        store
+            .create_broadcast(
+                "channel:broadcast:delimiter-rich",
+                "kamn:did:agent:owner",
+                "alerts|west,coast\nv2",
+                vec!["kamn:did:agent:owner".to_owned()],
+                vec!["kamn:did:agent:owner".to_owned()],
+            )
+            .expect("broadcast should be created");
+        let snapshot = store.export_snapshot();
+
+        let mut file_store = FileChannelSnapshotStore::new(path.clone()).expect("store");
+        assert!(file_store.write(snapshot.clone()).is_ok());
         assert_eq!(
             file_store.read_latest().expect("read should succeed"),
             Some(snapshot)

--- a/crates/kamn-core/src/durable_guard_store.rs
+++ b/crates/kamn-core/src/durable_guard_store.rs
@@ -6,6 +6,7 @@ use crate::{
     DeliveryGuardSnapshotError, MessageDeliveryGuards, PermissionRule, RetentionPolicy,
     SqliteStoreBackend, SqliteStoreBackendError,
 };
+use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::fs;
@@ -247,7 +248,7 @@ impl DurableGuardBundleSnapshotStore for FileDurableGuardSnapshotStore {
         bundle: DurableGuardSnapshotBundle,
     ) -> Result<(), DurableGuardSnapshotStoreError> {
         validate_bundle(&bundle)?;
-        let payload = serialize_bundle(&bundle);
+        let payload = serialize_bundle(&bundle)?;
         let mut file = OpenOptions::new()
             .create(true)
             .truncate(true)
@@ -334,7 +335,7 @@ impl DurableGuardBundleSnapshotStore for SqliteDurableGuardSnapshotStore {
         bundle: DurableGuardSnapshotBundle,
     ) -> Result<(), DurableGuardSnapshotStoreError> {
         validate_bundle(&bundle)?;
-        let payload = serialize_bundle(&bundle);
+        let payload = serialize_bundle(&bundle)?;
         self.backend
             .put("durable_guard_snapshot_store", "latest", payload.as_bytes())
             .map_err(map_sqlite_store_error)?;
@@ -447,65 +448,179 @@ fn validate_bundle(
     Ok(())
 }
 
-fn serialize_bundle(bundle: &DurableGuardSnapshotBundle) -> String {
-    let mut lines = vec![
-        format!("bundle_schema|{}", bundle.schema_version),
-        format!("delivery_schema|{}", bundle.delivery_guard.schema_version),
-    ];
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct DurableGuardSnapshotBundleWire {
+    schema_version: u16,
+    delivery_guard: DeliveryGuardSnapshotWire,
+    channel_policy: ChannelPolicySnapshotWire,
+}
 
-    for (sender, nonce) in &bundle.delivery_guard.next_nonce_by_sender {
-        lines.push(format!("delivery_nonce|{}|{nonce}", encode_hex(sender)));
-    }
-    for message_id in &bundle.delivery_guard.seen_message_ids {
-        lines.push(format!("delivery_seen|{}", encode_hex(message_id)));
-    }
-    lines.push("delivery_end|".to_owned());
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct DeliveryGuardSnapshotWire {
+    schema_version: u16,
+    next_nonce_by_sender: Vec<DeliveryNonceWire>,
+    seen_message_ids: Vec<String>,
+}
 
-    lines.push(format!(
-        "channel_schema|{}",
-        bundle.channel_policy.schema_version
-    ));
-    for channel in &bundle.channel_policy.channels {
-        lines.push(format!("channel_begin|{}", encode_hex(&channel.channel_id)));
-        for member in &channel.members {
-            lines.push(format!("channel_member|{}", encode_hex(member)));
-        }
-        for admin in &channel.admins {
-            lines.push(format!("channel_admin|{}", encode_hex(admin)));
-        }
-        lines.push(format!(
-            "channel_perm_send|{}",
-            encode_permission_rule(&channel.permissions.send)
-        ));
-        lines.push(format!(
-            "channel_perm_read|{}",
-            encode_permission_rule(&channel.permissions.read)
-        ));
-        lines.push(format!(
-            "channel_perm_invite|{}",
-            encode_permission_rule(&channel.permissions.invite)
-        ));
-        lines.push(format!(
-            "channel_perm_remove|{}",
-            encode_permission_rule(&channel.permissions.remove)
-        ));
-        lines.push(format!(
-            "channel_perm_configure|{}",
-            encode_permission_rule(&channel.permissions.configure)
-        ));
-        lines.push(format!(
-            "channel_retention|{}",
-            encode_retention_policy(&channel.permissions.retention)
-        ));
-        lines.push("channel_end|".to_owned());
-    }
-    lines.push("channel_end_all|".to_owned());
-    lines.push("bundle_end|".to_owned());
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct DeliveryNonceWire {
+    sender: String,
+    nonce: u64,
+}
 
-    lines.join("\n")
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct ChannelPolicySnapshotWire {
+    schema_version: u16,
+    channels: Vec<ChannelPolicySnapshotChannelWire>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct ChannelPolicySnapshotChannelWire {
+    channel_id: String,
+    members: Vec<String>,
+    admins: Vec<String>,
+    permissions: ChannelPermissionsWire,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct ChannelPermissionsWire {
+    send: String,
+    read: String,
+    invite: String,
+    remove: String,
+    configure: String,
+    retention: String,
+}
+
+fn serialize_bundle(
+    bundle: &DurableGuardSnapshotBundle,
+) -> Result<String, DurableGuardSnapshotStoreError> {
+    let wire = DurableGuardSnapshotBundleWire {
+        schema_version: bundle.schema_version,
+        delivery_guard: DeliveryGuardSnapshotWire {
+            schema_version: bundle.delivery_guard.schema_version,
+            next_nonce_by_sender: bundle
+                .delivery_guard
+                .next_nonce_by_sender
+                .iter()
+                .map(|(sender, nonce)| DeliveryNonceWire {
+                    sender: encode_hex(sender),
+                    nonce: *nonce,
+                })
+                .collect(),
+            seen_message_ids: bundle
+                .delivery_guard
+                .seen_message_ids
+                .iter()
+                .map(|message_id| encode_hex(message_id))
+                .collect(),
+        },
+        channel_policy: ChannelPolicySnapshotWire {
+            schema_version: bundle.channel_policy.schema_version,
+            channels: bundle
+                .channel_policy
+                .channels
+                .iter()
+                .map(|channel| ChannelPolicySnapshotChannelWire {
+                    channel_id: encode_hex(&channel.channel_id),
+                    members: channel
+                        .members
+                        .iter()
+                        .map(|member| encode_hex(member))
+                        .collect(),
+                    admins: channel
+                        .admins
+                        .iter()
+                        .map(|admin| encode_hex(admin))
+                        .collect(),
+                    permissions: ChannelPermissionsWire {
+                        send: encode_permission_rule(&channel.permissions.send),
+                        read: encode_permission_rule(&channel.permissions.read),
+                        invite: encode_permission_rule(&channel.permissions.invite),
+                        remove: encode_permission_rule(&channel.permissions.remove),
+                        configure: encode_permission_rule(&channel.permissions.configure),
+                        retention: encode_retention_policy(&channel.permissions.retention),
+                    },
+                })
+                .collect(),
+        },
+    };
+    serde_json::to_string(&wire)
+        .map_err(|error| DurableGuardSnapshotStoreError::InvalidPayload(error.to_string()))
 }
 
 fn deserialize_bundle(
+    payload: &str,
+) -> Result<DurableGuardSnapshotBundle, DurableGuardSnapshotStoreError> {
+    if let Ok(wire) = serde_json::from_str::<DurableGuardSnapshotBundleWire>(payload) {
+        let mut next_nonce_by_sender = BTreeMap::new();
+        for entry in wire.delivery_guard.next_nonce_by_sender {
+            let sender = decode_hex(entry.sender.as_str())?;
+            if next_nonce_by_sender.insert(sender, entry.nonce).is_some() {
+                return Err(DurableGuardSnapshotStoreError::InvalidPayload(
+                    "duplicate sender nonce record".to_owned(),
+                ));
+            }
+        }
+
+        let mut seen_message_ids = BTreeSet::new();
+        for value in wire.delivery_guard.seen_message_ids {
+            let message_id = decode_hex(value.as_str())?;
+            if !seen_message_ids.insert(message_id) {
+                return Err(DurableGuardSnapshotStoreError::InvalidPayload(
+                    "duplicate seen message record".to_owned(),
+                ));
+            }
+        }
+
+        let channels = wire
+            .channel_policy
+            .channels
+            .into_iter()
+            .map(|channel| {
+                Ok(ChannelPolicySnapshotChannel {
+                    channel_id: decode_hex(channel.channel_id.as_str())?,
+                    members: channel
+                        .members
+                        .into_iter()
+                        .map(|member| decode_hex(member.as_str()))
+                        .collect::<Result<Vec<_>, _>>()?,
+                    admins: channel
+                        .admins
+                        .into_iter()
+                        .map(|admin| decode_hex(admin.as_str()))
+                        .collect::<Result<Vec<_>, _>>()?,
+                    permissions: ChannelPermissions {
+                        send: decode_permission_rule(channel.permissions.send.as_str())?,
+                        read: decode_permission_rule(channel.permissions.read.as_str())?,
+                        invite: decode_permission_rule(channel.permissions.invite.as_str())?,
+                        remove: decode_permission_rule(channel.permissions.remove.as_str())?,
+                        configure: decode_permission_rule(channel.permissions.configure.as_str())?,
+                        retention: decode_retention_policy(channel.permissions.retention.as_str())?,
+                    },
+                })
+            })
+            .collect::<Result<Vec<_>, DurableGuardSnapshotStoreError>>()?;
+
+        let bundle = DurableGuardSnapshotBundle {
+            schema_version: wire.schema_version,
+            delivery_guard: DeliveryGuardSnapshot {
+                schema_version: wire.delivery_guard.schema_version,
+                next_nonce_by_sender,
+                seen_message_ids,
+            },
+            channel_policy: ChannelPolicySnapshot {
+                schema_version: wire.channel_policy.schema_version,
+                channels,
+            },
+        };
+        validate_bundle(&bundle)?;
+        return Ok(bundle);
+    }
+    deserialize_bundle_legacy(payload)
+}
+
+fn deserialize_bundle_legacy(
     payload: &str,
 ) -> Result<DurableGuardSnapshotBundle, DurableGuardSnapshotStoreError> {
     let mut lines = payload.lines();
@@ -1013,9 +1128,22 @@ mod tests {
         );
 
         let bundle = DurableGuardSnapshotBundle::capture(&guards, &channels);
-        let payload = serialize_bundle(&bundle);
+        let payload = serialize_bundle(&bundle).expect("bundle serialization should pass");
         let decoded = deserialize_bundle(&payload).expect("bundle decode should pass");
         assert_eq!(decoded, bundle);
+    }
+
+    #[test]
+    fn regression_bundle_serialization_uses_json_payload() {
+        // Regression: #6126
+        let guards = MessageDeliveryGuards::new();
+        let channels = ChannelPermissionEngine::new();
+        let bundle = DurableGuardSnapshotBundle::capture(&guards, &channels);
+        let payload = serialize_bundle(&bundle).expect("bundle serialization should pass");
+        assert!(
+            payload.trim_start().starts_with('{'),
+            "expected serde JSON payload, found: {payload}"
+        );
     }
 
     #[test]

--- a/crates/kamn-core/src/message_lifecycle.rs
+++ b/crates/kamn-core/src/message_lifecycle.rs
@@ -6,6 +6,7 @@ use crate::{
     AgentDid, ProcessorProofAdmissionEvaluator, ProcessorProofAdmissionInput,
     ProcessorProofArtifact, SqliteStoreBackend, SqliteStoreBackendError, ZkDesignError,
 };
+use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::fs;
@@ -1026,55 +1027,92 @@ fn parse_message_status_code(raw: &str) -> Option<MessageStatus> {
     }
 }
 
-fn ensure_snapshot_token(
-    value: &str,
-    field: &str,
-    allow_comma: bool,
-) -> Result<(), MessageLifecycleSnapshotStoreError> {
-    let has_comma = !allow_comma && value.contains(',');
-    if value.contains('|') || value.contains('\n') || value.contains('\r') || has_comma {
-        return Err(MessageLifecycleSnapshotStoreError::InvalidPayload(format!(
-            "{field} contains unsupported delimiter characters"
-        )));
-    }
-    Ok(())
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct MessageRecordSnapshotWire {
+    message_id: String,
+    sender: String,
+    recipients: Vec<String>,
+    created: String,
+    expires: String,
+    status: String,
+    history: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct MessageLifecycleSnapshotWire {
+    schema_version: u16,
+    records: Vec<MessageRecordSnapshotWire>,
 }
 
 fn serialize_message_lifecycle_snapshot(
     snapshot: &MessageLifecycleSnapshot,
 ) -> Result<String, MessageLifecycleSnapshotStoreError> {
-    let mut payload = format!("schema|{}\n", snapshot.schema_version);
-    for record in &snapshot.records {
-        ensure_snapshot_token(&record.message_id, "message_id", false)?;
-        ensure_snapshot_token(&record.sender, "sender", false)?;
-        ensure_snapshot_token(&record.created, "created", false)?;
-        ensure_snapshot_token(&record.expires, "expires", false)?;
-        for recipient in &record.recipients {
-            ensure_snapshot_token(recipient, "recipient", false)?;
-        }
-
-        let recipients = record.recipients.join(",");
-        let history = record
-            .history
+    let wire = MessageLifecycleSnapshotWire {
+        schema_version: snapshot.schema_version,
+        records: snapshot
+            .records
             .iter()
-            .map(|status| message_status_code(*status))
-            .collect::<Vec<_>>()
-            .join(",");
-        payload.push_str(&format!(
-            "record|{}|{}|{}|{}|{}|{}|{}\n",
-            record.message_id,
-            record.sender,
-            recipients,
-            record.created,
-            record.expires,
-            message_status_code(record.status),
-            history
-        ));
-    }
-    Ok(payload)
+            .map(|record| MessageRecordSnapshotWire {
+                message_id: record.message_id.clone(),
+                sender: record.sender.clone(),
+                recipients: record.recipients.clone(),
+                created: record.created.clone(),
+                expires: record.expires.clone(),
+                status: message_status_code(record.status).to_owned(),
+                history: record
+                    .history
+                    .iter()
+                    .map(|status| message_status_code(*status).to_owned())
+                    .collect(),
+            })
+            .collect(),
+    };
+    serde_json::to_string(&wire)
+        .map_err(|error| MessageLifecycleSnapshotStoreError::InvalidPayload(error.to_string()))
 }
 
 fn parse_message_lifecycle_snapshot_payload(
+    payload: &str,
+) -> Result<MessageLifecycleSnapshot, MessageLifecycleSnapshotStoreError> {
+    if let Ok(wire) = serde_json::from_str::<MessageLifecycleSnapshotWire>(payload) {
+        let records = wire
+            .records
+            .into_iter()
+            .map(|record| {
+                let status =
+                    parse_message_status_code(record.status.as_str()).ok_or_else(|| {
+                        MessageLifecycleSnapshotStoreError::InvalidPayload(record.status.clone())
+                    })?;
+                let history = record
+                    .history
+                    .into_iter()
+                    .map(|raw| {
+                        parse_message_status_code(raw.as_str()).ok_or_else(|| {
+                            MessageLifecycleSnapshotStoreError::InvalidPayload(raw.clone())
+                        })
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+
+                Ok(MessageRecordSnapshot {
+                    message_id: record.message_id,
+                    sender: record.sender,
+                    recipients: record.recipients,
+                    created: record.created,
+                    expires: record.expires,
+                    status,
+                    history,
+                })
+            })
+            .collect::<Result<Vec<_>, MessageLifecycleSnapshotStoreError>>()?;
+        return Ok(MessageLifecycleSnapshot {
+            schema_version: wire.schema_version,
+            records,
+        });
+    }
+    parse_message_lifecycle_snapshot_payload_legacy(payload)
+}
+
+fn parse_message_lifecycle_snapshot_payload_legacy(
     payload: &str,
 ) -> Result<MessageLifecycleSnapshot, MessageLifecycleSnapshotStoreError> {
     let mut lines = payload.lines().filter(|line| !line.trim().is_empty());
@@ -1534,6 +1572,38 @@ mod tests {
         store
             .register(
                 "urn:uuid:msg-snapshot-4",
+                "kamn:did:agent:sender-1",
+                vec!["kamn:did:agent:recipient-1".to_owned()],
+                "2026-02-07T20:15:30.123Z",
+                "2026-02-07T20:45:30.123Z",
+            )
+            .expect("register should succeed");
+        let snapshot = store.export_snapshot();
+
+        let mut file_store =
+            FileMessageLifecycleSnapshotStore::new(path.clone()).expect("store should build");
+        assert!(file_store.write(snapshot.clone()).is_ok());
+        assert_eq!(
+            file_store.read_latest().expect("read should pass"),
+            Some(snapshot)
+        );
+
+        let _ = fs::remove_file(path);
+        let _ = fs::remove_file(journal_path);
+    }
+
+    #[test]
+    fn regression_file_message_lifecycle_snapshot_store_roundtrips_delimiter_rich_message_id() {
+        // Regression: #6126
+        let path = temp_message_lifecycle_snapshot_path("delimiter-rich-message-id");
+        let journal_path = temp_message_lifecycle_snapshot_journal_path(&path);
+        let _ = fs::remove_file(&path);
+        let _ = fs::remove_file(&journal_path);
+
+        let mut store = MessageLifecycleStore::new();
+        store
+            .register(
+                "urn:uuid:msg|delimiter,rich\nv2",
                 "kamn:did:agent:sender-1",
                 vec!["kamn:did:agent:recipient-1".to_owned()],
                 "2026-02-07T20:15:30.123Z",

--- a/crates/kamn-core/src/runtime_snapshot_store.rs
+++ b/crates/kamn-core/src/runtime_snapshot_store.rs
@@ -1,11 +1,12 @@
 use crate::{SqliteStoreBackend, SqliteStoreBackendError};
+use serde::{Deserialize, Serialize};
 use std::error::Error;
 use std::fmt::{Display, Formatter};
 use std::fs::{self, OpenOptions};
 use std::io::Write;
 use std::path::PathBuf;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 /// Runtime snapshot.
 pub struct RuntimeSnapshot {
     state_version: u64,
@@ -382,12 +383,8 @@ impl FileRuntimeSnapshotStore {
     fn persist_snapshots(&self, snapshots: &[RuntimeSnapshot]) -> Result<(), SnapshotStoreError> {
         let mut serialized = String::new();
         for snapshot in snapshots {
-            serialized.push_str(&format!(
-                "{}|{}|{}\n",
-                snapshot.state_version(),
-                snapshot.state_hash(),
-                snapshot.cursor()
-            ));
+            serialized.push_str(&serialize_snapshot_line(snapshot)?);
+            serialized.push('\n');
         }
         fs::write(&self.path, serialized).map_err(|error| SnapshotStoreError::Io(error.to_string()))
     }
@@ -404,12 +401,8 @@ impl RuntimeSnapshotStore for FileRuntimeSnapshotStore {
             .append(true)
             .open(&self.path)
             .map_err(|error| SnapshotStoreError::Io(error.to_string()))?;
-        let serialized = format!(
-            "{}|{}|{}\n",
-            snapshot.state_version(),
-            snapshot.state_hash(),
-            snapshot.cursor()
-        );
+        let mut serialized = serialize_snapshot_line(&snapshot)?;
+        serialized.push('\n');
         file.write_all(serialized.as_bytes())
             .map_err(|error| SnapshotStoreError::Io(error.to_string()))
     }
@@ -461,12 +454,7 @@ impl RuntimeSnapshotStore for SqliteRuntimeSnapshotStore {
             validate_snapshot_continuity(Some(&previous), &snapshot)?;
         }
         let key = format!("{:020}", snapshot.state_version());
-        let serialized = format!(
-            "{}|{}|{}",
-            snapshot.state_version(),
-            snapshot.state_hash(),
-            snapshot.cursor()
-        );
+        let serialized = serialize_snapshot_line(&snapshot)?;
         self.backend
             .put(
                 "runtime_snapshot_store",
@@ -532,6 +520,18 @@ fn map_sqlite_store_error(error: SqliteStoreBackendError) -> SnapshotStoreError 
 }
 
 fn parse_snapshot_line(line: &str) -> Result<RuntimeSnapshot, SnapshotStoreError> {
+    if let Ok(snapshot) = serde_json::from_str::<RuntimeSnapshot>(line) {
+        return RuntimeSnapshot::with_cursor(
+            snapshot.state_version,
+            snapshot.state_hash.as_str(),
+            snapshot.cursor,
+        )
+        .map_err(|_| SnapshotStoreError::InvalidPayload(line.to_owned()));
+    }
+    parse_snapshot_line_legacy(line)
+}
+
+fn parse_snapshot_line_legacy(line: &str) -> Result<RuntimeSnapshot, SnapshotStoreError> {
     let mut segments = line.split('|');
     let Some(state_version_raw) = segments.next() else {
         return Err(SnapshotStoreError::InvalidPayload(line.to_owned()));
@@ -557,6 +557,11 @@ fn parse_snapshot_line(line: &str) -> Result<RuntimeSnapshot, SnapshotStoreError
         RuntimeSnapshot::new(state_version, state_hash_raw)
             .map_err(|_| SnapshotStoreError::InvalidPayload(line.to_owned()))
     }
+}
+
+fn serialize_snapshot_line(snapshot: &RuntimeSnapshot) -> Result<String, SnapshotStoreError> {
+    serde_json::to_string(snapshot)
+        .map_err(|error| SnapshotStoreError::InvalidPayload(error.to_string()))
 }
 
 fn is_valid_snapshot_hash(state_hash: &str) -> bool {

--- a/crates/kamn-core/src/runtime_tests_snapshot_store.rs
+++ b/crates/kamn-core/src/runtime_tests_snapshot_store.rs
@@ -115,6 +115,29 @@ fn integration_file_snapshot_store_round_trips_snapshots() {
 }
 
 #[test]
+fn regression_file_snapshot_store_uses_json_line_payload() {
+    // Regression: #6126
+    let path = temp_snapshot_store_path("json-lines");
+    let _ = fs::remove_file(&path);
+
+    let mut store = FileRuntimeSnapshotStore::new(path.clone()).expect("store should build");
+    let snapshot = RuntimeSnapshot::with_cursor(41, "state-41", 100).expect("valid snapshot");
+    assert!(store.write(snapshot).is_ok());
+
+    let payload = fs::read_to_string(&path).expect("snapshot payload should be readable");
+    let first_line = payload
+        .lines()
+        .find(|line| !line.trim().is_empty())
+        .expect("snapshot payload should contain one line");
+    assert!(
+        first_line.trim_start().starts_with('{'),
+        "expected serde JSON line payload, found: {first_line}"
+    );
+
+    let _ = fs::remove_file(path);
+}
+
+#[test]
 fn regression_file_snapshot_store_rejects_malformed_payload() {
     // Regression: #387
     let path = temp_snapshot_store_path("malformed");
@@ -217,10 +240,18 @@ fn regression_file_snapshot_store_recovery_truncates_corrupt_suffix() {
     );
     assert_eq!(result.recovered_entries, 2);
     assert_eq!(result.dropped_corrupt_entries, 2);
-    assert_eq!(
-        fs::read_to_string(&path).expect("snapshot file should be readable"),
-        "41|state-41|41\n42|state-42|42\n"
-    );
+    let repaired_payload = fs::read_to_string(&path).expect("snapshot file should be readable");
+    let repaired_lines = repaired_payload
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .collect::<Vec<_>>();
+    assert_eq!(repaired_lines.len(), 2);
+    for line in repaired_lines {
+        assert!(
+            line.trim_start().starts_with('{'),
+            "expected json line payload after repair, found: {line}"
+        );
+    }
 
     let _ = fs::remove_file(path);
 }
@@ -341,9 +372,16 @@ fn functional_file_snapshot_store_recovery_truncates_stale_metadata_suffix() {
     );
     assert_eq!(result.recovered_entries, 1);
     assert_eq!(result.dropped_corrupt_entries, 2);
-    assert_eq!(
-        fs::read_to_string(&path).expect("snapshot file should be readable"),
-        "41|state-41|100\n"
+    let repaired_payload = fs::read_to_string(&path).expect("snapshot file should be readable");
+    let repaired_lines = repaired_payload
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .collect::<Vec<_>>();
+    assert_eq!(repaired_lines.len(), 1);
+    assert!(
+        repaired_lines[0].trim_start().starts_with('{'),
+        "expected json line payload after repair, found: {}",
+        repaired_lines[0]
     );
 
     let _ = fs::remove_file(path);

--- a/crates/kamn-core/src/task_operations.rs
+++ b/crates/kamn-core/src/task_operations.rs
@@ -8,6 +8,7 @@ use crate::{
     AgentDid, SqliteStoreBackend, SqliteStoreBackendError, TaskLifecycle, TaskLifecycleError,
     TaskState, TaskTransition,
 };
+use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::fs;
@@ -1170,64 +1171,100 @@ fn parse_task_notice_code(raw: &str) -> Option<TaskOperationNoticeKind> {
     }
 }
 
-fn ensure_snapshot_token(
-    value: &str,
-    field: &str,
-    allow_comma: bool,
-) -> Result<(), TaskOperationSnapshotStoreError> {
-    let has_comma = !allow_comma && value.contains(',');
-    if value.contains('|') || value.contains('\n') || value.contains('\r') || has_comma {
-        return Err(TaskOperationSnapshotStoreError::InvalidPayload(format!(
-            "{field} contains unsupported delimiter characters"
-        )));
-    }
-    Ok(())
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct TaskOperationRecordSnapshotWire {
+    task_id: String,
+    requester: String,
+    assignee: Option<String>,
+    description: String,
+    lifecycle_history: Vec<String>,
+    dependencies: Vec<String>,
+    notices: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct TaskOperationSnapshotWire {
+    schema_version: u16,
+    tasks: Vec<TaskOperationRecordSnapshotWire>,
 }
 
 fn serialize_task_operation_snapshot(
     snapshot: &TaskOperationSnapshot,
 ) -> Result<String, TaskOperationSnapshotStoreError> {
-    let mut payload = format!("schema|{}\n", snapshot.schema_version);
-    for task in &snapshot.tasks {
-        ensure_snapshot_token(&task.task_id, "task_id", false)?;
-        ensure_snapshot_token(&task.requester, "requester", false)?;
-        if let Some(assignee) = &task.assignee {
-            ensure_snapshot_token(assignee, "assignee", false)?;
-        }
-        ensure_snapshot_token(&task.description, "description", true)?;
-        for dependency in &task.dependencies {
-            ensure_snapshot_token(dependency, "dependency", false)?;
-        }
-
-        let assignee = task.assignee.clone().unwrap_or_default();
-        let history = task
-            .lifecycle_history
+    let wire = TaskOperationSnapshotWire {
+        schema_version: snapshot.schema_version,
+        tasks: snapshot
+            .tasks
             .iter()
-            .map(|state| task_state_code(*state))
-            .collect::<Vec<_>>()
-            .join(",");
-        let dependencies = task.dependencies.join(",");
-        let notices = task
-            .notices
-            .iter()
-            .map(|notice| task_notice_code(*notice))
-            .collect::<Vec<_>>()
-            .join(",");
-        payload.push_str(&format!(
-            "task|{}|{}|{}|{}|{}|{}|{}\n",
-            task.task_id,
-            task.requester,
-            assignee,
-            task.description,
-            history,
-            dependencies,
-            notices
-        ));
-    }
-    Ok(payload)
+            .map(|task| TaskOperationRecordSnapshotWire {
+                task_id: task.task_id.clone(),
+                requester: task.requester.clone(),
+                assignee: task.assignee.clone(),
+                description: task.description.clone(),
+                lifecycle_history: task
+                    .lifecycle_history
+                    .iter()
+                    .map(|state| task_state_code(*state).to_owned())
+                    .collect(),
+                dependencies: task.dependencies.clone(),
+                notices: task
+                    .notices
+                    .iter()
+                    .map(|notice| task_notice_code(*notice).to_owned())
+                    .collect(),
+            })
+            .collect(),
+    };
+    serde_json::to_string(&wire)
+        .map_err(|error| TaskOperationSnapshotStoreError::InvalidPayload(error.to_string()))
 }
 
 fn parse_task_operation_snapshot_payload(
+    payload: &str,
+) -> Result<TaskOperationSnapshot, TaskOperationSnapshotStoreError> {
+    if let Ok(wire) = serde_json::from_str::<TaskOperationSnapshotWire>(payload) {
+        let tasks = wire
+            .tasks
+            .into_iter()
+            .map(|task| {
+                let lifecycle_history = task
+                    .lifecycle_history
+                    .into_iter()
+                    .map(|raw| {
+                        parse_task_state_code(raw.as_str()).ok_or_else(|| {
+                            TaskOperationSnapshotStoreError::InvalidPayload(raw.clone())
+                        })
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+                let notices = task
+                    .notices
+                    .into_iter()
+                    .map(|raw| {
+                        parse_task_notice_code(raw.as_str()).ok_or_else(|| {
+                            TaskOperationSnapshotStoreError::InvalidPayload(raw.clone())
+                        })
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+                Ok(TaskOperationRecordSnapshot {
+                    task_id: task.task_id,
+                    requester: task.requester,
+                    assignee: task.assignee,
+                    description: task.description,
+                    lifecycle_history,
+                    dependencies: task.dependencies,
+                    notices,
+                })
+            })
+            .collect::<Result<Vec<_>, TaskOperationSnapshotStoreError>>()?;
+        return Ok(TaskOperationSnapshot {
+            schema_version: wire.schema_version,
+            tasks,
+        });
+    }
+    parse_task_operation_snapshot_payload_legacy(payload)
+}
+
+fn parse_task_operation_snapshot_payload_legacy(
     payload: &str,
 ) -> Result<TaskOperationSnapshot, TaskOperationSnapshotStoreError> {
     let mut lines = payload.lines().filter(|line| !line.trim().is_empty());
@@ -1487,6 +1524,35 @@ mod tests {
         file_store
             .write(snapshot.clone())
             .expect("write should pass");
+        assert_eq!(
+            file_store.read_latest().expect("read should pass"),
+            Some(snapshot)
+        );
+
+        let _ = fs::remove_file(path);
+        let _ = fs::remove_file(journal_path);
+    }
+
+    #[test]
+    fn regression_file_task_operation_snapshot_store_roundtrips_delimiter_rich_description() {
+        // Regression: #6126
+        let path = temp_task_operation_snapshot_path("delimiter-rich-description");
+        let journal_path = temp_task_operation_snapshot_journal_path(&path);
+        let _ = fs::remove_file(&path);
+        let _ = fs::remove_file(&journal_path);
+
+        let mut engine = TaskOperationEngine::new();
+        engine
+            .submit(
+                "task-delimiter-rich",
+                "kamn:did:agent:requester-1",
+                "triage|priority,high\nline-2",
+            )
+            .expect("submit should pass");
+        let snapshot = engine.export_snapshot();
+
+        let mut file_store = FileTaskOperationSnapshotStore::new(path.clone()).expect("store");
+        assert!(file_store.write(snapshot.clone()).is_ok());
         assert_eq!(
             file_store.read_latest().expect("read should pass"),
             Some(snapshot)

--- a/specs/6126/plan.md
+++ b/specs/6126/plan.md
@@ -8,7 +8,12 @@
 5. Update docs/spec/task artifacts and finalize closure evidence.
 
 ## Affected Modules
-- Target module(s) identified by issue #6126 scope and test evidence.
+- `crates/kamn-core/src/channel_models.rs` (snapshot serde encode/decode + legacy parser fallback)
+- `crates/kamn-core/src/task_operations.rs` (snapshot serde encode/decode + legacy parser fallback)
+- `crates/kamn-core/src/message_lifecycle.rs` (snapshot serde encode/decode + legacy parser fallback)
+- `crates/kamn-core/src/runtime_snapshot_store.rs` + `crates/kamn-core/src/runtime_tests_snapshot_store.rs` (JSON-lines snapshot writes with legacy parser fallback)
+- `crates/kamn-core/src/durable_guard_store.rs` (bundle serde encode/decode + legacy parser fallback)
+- `crates/kamn-core/Cargo.toml` / `Cargo.lock` (`serde` + `serde_json` for snapshot payload serialization)
 - `specs/6126/spec.md`
 - `specs/6126/plan.md`
 - `specs/6126/tasks.md`

--- a/specs/6126/tasks.md
+++ b/specs/6126/tasks.md
@@ -1,11 +1,23 @@
 # Tasks: Issue #6126
 
 ## Ordered Tasks
-- T1 (RED/Conformance): Add or run failing test(s) that reproduce `S-03` gap from the spec ACs.
-- T2 (Implementation): Apply minimal remediation to satisfy AC-1 without unrelated refactors.
-- T3 (GREEN/Regression): Add and run regression coverage for AC-2 with deterministic assertions.
-- T4 (Verification): Run scoped unit/functional/conformance commands and record evidence.
-- T5 (Closure): Update issue/pr docs, map ACs to tests, and publish closure evidence.
+- [x] T1 (RED/Conformance): Added and ran failing RED tests proving delimiter/format limitations in pipe-delimited snapshot payloads:
+  `regression_file_channel_snapshot_store_roundtrips_delimiter_rich_metadata`,
+  `regression_file_task_operation_snapshot_store_roundtrips_delimiter_rich_description`,
+  `regression_file_message_lifecycle_snapshot_store_roundtrips_delimiter_rich_message_id`,
+  `regression_file_snapshot_store_uses_json_line_payload`,
+  `regression_bundle_serialization_uses_json_payload`.
+- [x] T2 (Implementation): Migrated channel/task/message/runtime/durable snapshot serialization to serde JSON; retained legacy pipe parser fallback to preserve upgrade-path reads.
+- [x] T3 (GREEN/Regression): Re-ran all RED tests as GREEN with deterministic pass/fail assertions.
+- [x] T4 (Verification): Ran scoped suites:
+  `cargo test -p kamn-core --lib channel_models::tests::`,
+  `cargo test -p kamn-core --lib task_operations::tests::`,
+  `cargo test -p kamn-core --lib message_lifecycle::tests::`,
+  `cargo test -p kamn-core --lib durable_guard_store::tests::`,
+  `cargo test -p kamn-core --lib runtime::tests::runtime_tests_snapshot_store::`,
+  `cargo fmt --check`,
+  `cargo clippy -p kamn-core --tests -- -D warnings`.
+- [x] T5 (Closure): Opened PR #6181 with AC->test mapping and RED/GREEN evidence; issue process log updated with verification outputs.
 
 ## Tier Mapping
 - Unit: T1, T3, T4


### PR DESCRIPTION
## Summary
Migrates snapshot serialization/parsing in `kamn-core` from custom pipe-delimited strings to serde JSON payloads for channel, task-operation, message-lifecycle, runtime, and durable-guard stores. Keeps legacy pipe-format read compatibility via parser fallbacks so existing persisted data remains loadable. Adds regression coverage for delimiter-rich payloads and JSON payload emission.

## Links
- Milestone: `r68-r59-swarm-remediation-and-full-gap-closure`
- Closes #6126
- Spec: `specs/6126/spec.md`
- Plan: `specs/6126/plan.md`
- Tasks: `specs/6126/tasks.md`

## Spec Verification (AC -> tests)
| AC | ✅/❌ | Test(s) |
|---|---|---|
| AC-1: S-03 remediated with production-safe behavior | ✅ | `channel_models::tests::regression_file_channel_snapshot_store_roundtrips_delimiter_rich_metadata`, `task_operations::tests::regression_file_task_operation_snapshot_store_roundtrips_delimiter_rich_description`, `message_lifecycle::tests::regression_file_message_lifecycle_snapshot_store_roundtrips_delimiter_rich_message_id`, `runtime::tests::runtime_tests_snapshot_store::regression_file_snapshot_store_uses_json_line_payload`, `durable_guard_store::tests::regression_bundle_serialization_uses_json_payload` |
| AC-2: regression/conformance coverage present | ✅ | `cargo test -p kamn-core --lib channel_models::tests::`, `cargo test -p kamn-core --lib task_operations::tests::`, `cargo test -p kamn-core --lib message_lifecycle::tests::`, `cargo test -p kamn-core --lib runtime::tests::runtime_tests_snapshot_store::`, `cargo test -p kamn-core --lib durable_guard_store::tests::` |
| AC-3: closure evidence linked in issue + PR | ✅ | This PR + issue process log updates |

## TDD Evidence
### RED
- `cargo test -p kamn-core --lib regression_file_channel_snapshot_store_roundtrips_delimiter_rich_metadata`
  - failed with `assertion failed: file_store.write(snapshot.clone()).is_ok()`.
- `cargo test -p kamn-core --lib regression_file_task_operation_snapshot_store_roundtrips_delimiter_rich_description`
  - failed with `assertion failed: file_store.write(snapshot.clone()).is_ok()`.

### GREEN
- `cargo test -p kamn-core --lib regression_file_channel_snapshot_store_roundtrips_delimiter_rich_metadata`
- `cargo test -p kamn-core --lib regression_file_task_operation_snapshot_store_roundtrips_delimiter_rich_description`
- `cargo test -p kamn-core --lib regression_file_message_lifecycle_snapshot_store_roundtrips_delimiter_rich_message_id`
- `cargo test -p kamn-core --lib regression_file_snapshot_store_uses_json_line_payload`
- `cargo test -p kamn-core --lib regression_bundle_serialization_uses_json_payload`

### Regression
- `cargo test -p kamn-core --lib channel_models::tests::`
- `cargo test -p kamn-core --lib task_operations::tests::`
- `cargo test -p kamn-core --lib message_lifecycle::tests::`
- `cargo test -p kamn-core --lib runtime::tests::runtime_tests_snapshot_store::`
- `cargo test -p kamn-core --lib durable_guard_store::tests::`

## Test Tiers
| Tier | ✅/❌/N/A | Tests | N/A Why |
|---|---|---|---|
| Unit | ✅ | module/unit tests under snapshot store suites | |
| Property | N/A | | No invariant/proptest surface changed in this issue scope |
| Contract/DbC | N/A | | No `contracts` annotations added/modified |
| Snapshot | N/A | | No insta snapshots in touched paths |
| Functional | ✅ | module-level functional/integration snapshot tests | |
| Conformance | ✅ | new regression/conformance tests mapped to AC-1/AC-2 | |
| Integration | ✅ | file-store and journal-replay integration tests in affected modules | |
| Fuzz | N/A | | Serialization format migration only; no new parser fuzz target introduced in this issue |
| Mutation | N/A | | P2 scoped remediation; no critical-path mutation lane requested in issue scope |
| Regression | ✅ | new `regression_*` tests + full module regression suites | |
| Performance | ✅ | existing perf budget tests in each module suite remained green | |

## Mutation
- N/A for this P2 scoped remediation; no escaped mutants introduced by this change set.

## Risks / Rollback
- Risk: legacy persisted payloads unreadable after migration.
- Mitigation: parser fallback keeps legacy pipe-format reads across all migrated snapshot domains.
- Rollback: revert PR commits `582f7429` and `0c2923d9`.

## Docs / ADR
- Updated: `specs/6126/plan.md`, `specs/6126/tasks.md`
- ADR: Not required (no protocol/wire contract expansion beyond internal snapshot persistence format migration under existing issue scope).


## CI Impact Declaration
- [ ] No CI scope impact.
- [x] CI scope impact present (policy-enforced declaration for this PR).

CI scope impact details (required when CI scope impact is present):
- Workflow(s) touched: None
- Expected runtime delta: negligible
- Expected runner-minute delta: negligible
- Rollback plan if CI cost/runtime regresses: revert PR and rerun baseline gates

## Shell-Surface Impact Declaration
- [ ] No shell-surface impact.
- [x] Shell-surface impact present (policy-enforced declaration for this PR).

Shell-surface impact details (required when shell-surface impact is present):
- shell_loc_delta_actual: 0
- rust_loc_delta_actual: 371
- shell_to_rust_ratio_delta_actual: 0.0
- shell_surface_ratio_target_status: neutral
- shell_surface_mitigation_issue: None
- regressed_with_waiver requires shell_surface_mitigation_issue to link #<issue-id>
