### PR TITLE
refactor(core): retire wave2 shim export wiring and deprecate compatibility modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1710,6 +1710,7 @@ dependencies = [
  "k256",
  "kamn-core",
  "kamn-kolme",
+ "kamn-runtime-guards",
  "rustls",
  "rustls-pemfile",
  "serde",

--- a/crates/kamn-core/src/anti_spam.rs
+++ b/crates/kamn-core/src/anti_spam.rs
@@ -1,3 +1,7 @@
 //! Compatibility re-exports for anti-spam contracts extracted from `kamn-core`.
 
+#[deprecated(
+    since = "0.1.0",
+    note = "use kamn_runtime_guards::anti_spam::* directly; kamn_core::anti_spam module shim is scheduled for removal in R61"
+)]
 pub use kamn_runtime_guards::anti_spam::*;

--- a/crates/kamn-core/src/cross_chain_receipt.rs
+++ b/crates/kamn-core/src/cross_chain_receipt.rs
@@ -1,3 +1,7 @@
 //! Compatibility facade for cross-chain receipt normalization extracted to `kamn-bridges`.
 
+#[deprecated(
+    since = "0.1.0",
+    note = "use kamn_bridges::cross_chain_receipt::* directly; kamn_core::cross_chain_receipt module shim is scheduled for removal in R61"
+)]
 pub use kamn_bridges::cross_chain_receipt::*;

--- a/crates/kamn-core/src/fairness_policy.rs
+++ b/crates/kamn-core/src/fairness_policy.rs
@@ -1,43 +1,7 @@
 //! Compatibility re-exports for fairness-policy contracts extracted from `kamn-core`.
 
+#[deprecated(
+    since = "0.1.0",
+    note = "use kamn_runtime_guards::fairness_policy::* directly; kamn_core::fairness_policy module shim is scheduled for removal in R61"
+)]
 pub use kamn_runtime_guards::fairness_policy::*;
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn spec_c10_core_fairness_policy_reexport_contracts() {
-        let allow = FairnessPolicyInput {
-            scope: "tenant_interactive".to_owned(),
-            window_seconds: 30,
-            active_weighted_share: 7,
-            max_weighted_share_gap: 7,
-        };
-        assert_eq!(
-            evaluate_fairness_policy(&allow),
-            FairnessPolicyDecision::Allow
-        );
-
-        let reject = FairnessPolicyInput {
-            scope: "tenant_interactive".to_owned(),
-            window_seconds: 30,
-            active_weighted_share: 8,
-            max_weighted_share_gap: 7,
-        };
-        assert_eq!(
-            evaluate_fairness_policy(&reject),
-            FairnessPolicyDecision::Reject {
-                reason: FairnessPolicyViolationReason::WeightedShareExceedsGap,
-            }
-        );
-        assert_eq!(
-            FairnessPolicyViolationReason::WeightedShareExceedsGap.as_str(),
-            "fairness_weighted_share_exceeds_gap"
-        );
-        assert_eq!(
-            fairness_policy_reason_taxonomy_version(),
-            "kamn.runtime.fairness-policy-reason-taxonomy.v1"
-        );
-    }
-}

--- a/crates/kamn-core/src/lib.rs
+++ b/crates/kamn-core/src/lib.rs
@@ -9,7 +9,11 @@
 pub mod agent_key_hierarchy;
 /// Agent-driven upgrade proposal, review, and execution workflow contracts.
 pub mod agent_upgrade_workflow;
-/// Anti-spam admission, rate-limit, and suspension policy contracts.
+/// Deprecated compatibility shim for anti-spam contracts extracted to `kamn-runtime-guards`.
+#[deprecated(
+    since = "0.1.0",
+    note = "use kamn_runtime_guards::anti_spam::* directly; kamn_core::anti_spam module shim will be removed in R61"
+)]
 pub mod anti_spam;
 /// Audit export filters, bundles, and governance evidence contracts.
 pub mod audit_exports;
@@ -34,7 +38,11 @@ pub mod content_retrieval;
 pub mod content_storage;
 /// Cross-chain route validation, inbound normalization, and outbound quorum dispatch contracts.
 pub mod cross_chain_bridge;
-/// Cross-chain receipt proof normalization and finality mapping contracts.
+/// Deprecated compatibility shim for cross-chain receipt normalization extracted to `kamn-bridges`.
+#[deprecated(
+    since = "0.1.0",
+    note = "use kamn_bridges::cross_chain_receipt::* directly; kamn_core::cross_chain_receipt module shim will be removed in R61"
+)]
 pub mod cross_chain_receipt;
 /// Cross-store replay consistency checker and deterministic divergence taxonomy contracts.
 pub mod cross_store_replay_consistency;
@@ -100,7 +108,11 @@ pub mod discord_bridge;
 pub mod durable_guard_store;
 /// Escrow hold, release, refund, and dispute lifecycle contracts.
 pub mod escrow;
-/// Fairness/starvation policy contracts for deterministic overload-governance checks.
+/// Deprecated compatibility shim for fairness-policy contracts extracted to `kamn-runtime-guards`.
+#[deprecated(
+    since = "0.1.0",
+    note = "use kamn_runtime_guards::fairness_policy::* directly; kamn_core::fairness_policy module shim will be removed in R61"
+)]
 pub mod fairness_policy;
 /// Governance proposal, voting, and execution lifecycle contracts.
 pub mod governance_workflow;
@@ -115,9 +127,17 @@ pub mod key_lifecycle;
 /// Key compromise and recovery lifecycle contracts.
 pub mod key_recovery;
 pub mod kolme_runtime_commit;
-/// Live probe matrix contracts for mode/scenario outcome validation and deterministic aggregation.
+/// Deprecated compatibility shim for live-probe-matrix contracts extracted to `kamn-live-probe-matrix`.
+#[deprecated(
+    since = "0.1.0",
+    note = "use kamn_live_probe_matrix::* directly; kamn_core::live_probe_matrix module shim will be removed in R61"
+)]
 pub mod live_probe_matrix;
-/// Message delivery replay, nonce, and acceptance window guardrail contracts.
+/// Deprecated compatibility shim for delivery-guard contracts extracted to `kamn-runtime-guards`.
+#[deprecated(
+    since = "0.1.0",
+    note = "use kamn_runtime_guards::message_delivery_guards::* directly; kamn_core::message_delivery_guards module shim will be removed in R61"
+)]
 pub mod message_delivery_guards;
 /// Canonical message envelope schema validation and normalization contracts.
 pub mod message_envelope;
@@ -142,7 +162,11 @@ pub mod operator_dashboard_ui;
 pub mod p2p_transport;
 /// Performance target thresholds and benchmark outcome classification contracts.
 pub mod performance_targets;
-/// Per-scope quota policy evaluation and deterministic fail-closed taxonomy contracts.
+/// Deprecated compatibility shim for quota-policy contracts extracted to `kamn-runtime-guards`.
+#[deprecated(
+    since = "0.1.0",
+    note = "use kamn_runtime_guards::quota_policy::* directly; kamn_core::quota_policy module shim will be removed in R61"
+)]
 pub mod quota_policy;
 /// Redaction request approval, audit-event, and visibility compliance contracts.
 pub mod redaction_compliance;
@@ -150,7 +174,11 @@ pub mod redaction_compliance;
 pub mod reputation_signals;
 /// Reputation state persistence, restore, and export contracts.
 pub mod reputation_state;
-/// Retention policy evaluation, tombstone lifecycle, and purge guard contracts.
+/// Deprecated compatibility shim for retention-engine contracts extracted to `kamn-runtime-guards`.
+#[deprecated(
+    since = "0.1.0",
+    note = "use kamn_runtime_guards::retention_engine::* directly; kamn_core::retention_engine module shim will be removed in R61"
+)]
 pub mod retention_engine;
 /// Runtime lifecycle, queue, quorum, watchdog, and recovery contracts.
 pub mod runtime;
@@ -186,7 +214,11 @@ pub mod trust_score;
 pub mod upgrade_orchestration;
 /// Validator onboarding/offboarding, quorum-change, and rollback lifecycle contracts.
 pub mod validator_lifecycle;
-/// Runtime watchdog anomaly taxonomy and report contracts.
+/// Deprecated compatibility shim for watchdog contracts extracted to `kamn-runtime-guards`.
+#[deprecated(
+    since = "0.1.0",
+    note = "use kamn_runtime_guards::watchdog::* directly; kamn_core::watchdog module shim will be removed in R61"
+)]
 pub mod watchdog;
 /// Zero-knowledge message-proof option evaluation, witness, and consensus contracts.
 pub mod zk_message_proofs;
@@ -198,10 +230,6 @@ pub use agent_upgrade_workflow::{
     AgentDrivenUpgradeWorkflow, AgentUpgradeAuditEvent, AgentUpgradeAuditEventKind,
     AgentUpgradeProposalDraft, AgentUpgradeProposalRecord, AgentUpgradeProposalState,
     AgentUpgradeWorkflowConfig, AgentUpgradeWorkflowError,
-};
-pub use anti_spam::{
-    AntiSpamConfig, AntiSpamDecision, AntiSpamEngine, AntiSpamError, AntiSpamRejection,
-    AntiSpamTelemetry,
 };
 pub use audit_exports::{
     AuditDomain, AuditEventRecord, AuditExportBundle, AuditExportEngine, AuditExportError,
@@ -270,11 +298,6 @@ pub use cross_chain_bridge::{
     CrossChainBridgeConfig, CrossChainBridgeEngine, CrossChainBridgeError,
     CrossChainInboundRequest, CrossChainNetwork, CrossChainOutboundApproval,
     CrossChainOutboundDispatch,
-};
-pub use cross_chain_receipt::{
-    normalize_cross_chain_receipt, CrossChainReceiptFinality, CrossChainReceiptNetwork,
-    CrossChainReceiptNormalizationError, CrossChainReceiptProof, CrossChainReceiptStatus,
-    NormalizedCrossChainReceipt, ETHEREUM_FINAL_CONFIRMATION_THRESHOLD,
 };
 pub use cross_store_replay_consistency::{
     cross_store_replay_reason_codes_csv, cross_store_replay_reason_taxonomy_version,
@@ -653,11 +676,6 @@ pub use escrow::{
     EscrowLifecycle, EscrowLifecycleError, EscrowReceiptFinality, EscrowSettlementAction,
     EscrowSettlementOutcome, EscrowStatus, EscrowTransitionAction, EscrowTransitionEvidence,
 };
-pub use fairness_policy::{
-    evaluate_fairness_policy, fairness_policy_reason_codes_csv,
-    fairness_policy_reason_taxonomy_version, FairnessPolicyDecision, FairnessPolicyInput,
-    FairnessPolicyViolationReason,
-};
 pub use governance_workflow::{
     GovernanceExecutionRecord, GovernanceParameterChangeDraft, GovernanceProposalDraft,
     GovernanceProposalRecord, GovernanceProposalStatus, GovernanceVoteChoice, GovernanceVoteRecord,
@@ -676,6 +694,44 @@ pub use invariants::{
     catalog as invariant_catalog, classify_smoke_error, classify_transaction_guard_error,
     invariant_by_id, validate_catalog, InvariantCatalogError, InvariantDomain,
     InvariantFailureCode, InvariantSpec, InvariantViolation,
+};
+pub use kamn_bridges::cross_chain_receipt::{
+    normalize_cross_chain_receipt, CrossChainReceiptFinality, CrossChainReceiptNetwork,
+    CrossChainReceiptNormalizationError, CrossChainReceiptProof, CrossChainReceiptStatus,
+    NormalizedCrossChainReceipt, ETHEREUM_FINAL_CONFIRMATION_THRESHOLD,
+};
+pub use kamn_live_probe_matrix::{
+    LiveProbeMatrixEntry, LiveProbeMatrixError, LiveProbeMatrixMode, LiveProbeMatrixReport,
+    LiveProbeMatrixStatus,
+};
+pub use kamn_runtime_guards::anti_spam::{
+    AntiSpamConfig, AntiSpamDecision, AntiSpamEngine, AntiSpamError, AntiSpamRejection,
+    AntiSpamTelemetry,
+};
+pub use kamn_runtime_guards::fairness_policy::{
+    evaluate_fairness_policy, fairness_policy_reason_codes_csv,
+    fairness_policy_reason_taxonomy_version, FairnessPolicyDecision, FairnessPolicyInput,
+    FairnessPolicyViolationReason,
+};
+pub use kamn_runtime_guards::message_delivery_guards::{
+    DeliveryFailureCode, DeliveryGuardInput, DeliveryGuardSnapshot, DeliveryGuardSnapshotError,
+    DeliveryValidationResult, FailedDeliveryNotice, MessageDeliveryGuards,
+    DELIVERY_GUARD_SNAPSHOT_SCHEMA_VERSION,
+};
+pub use kamn_runtime_guards::quota_policy::{
+    evaluate_quota_policy, quota_policy_reason_codes_csv, quota_policy_reason_taxonomy_version,
+    QuotaPolicyDecision, QuotaPolicyInput, QuotaPolicyViolationReason,
+};
+pub use kamn_runtime_guards::retention_engine::{
+    evaluate_retention_policy, retention_policy_reason_codes_csv,
+    retention_policy_reason_taxonomy_version, RetentionClass, RetentionDomain,
+    RetentionEnginePolicy, RetentionEvaluation, RetentionPolicyCheckerInput,
+    RetentionPolicyDecision, RetentionPolicyEngine, RetentionPolicyError,
+    RetentionPolicyViolationReason, RetentionRecord, RetentionStatus,
+};
+pub use kamn_runtime_guards::watchdog::{
+    WatchdogAlert, WatchdogAlertKind, WatchdogConfig, WatchdogError, WatchdogNode,
+    WatchdogObservation, WatchdogSeverity, WatchdogSnapshot,
 };
 pub use key_lifecycle::{
     KeyLifecycle, KeyLifecycleAuditError, KeyLifecycleAuditRecord, KeyLifecycleError,
@@ -698,15 +754,6 @@ pub use kolme_runtime_commit::{
     KolmeRuntimeCommitSignedBroadcastEnvelope, KolmeRuntimeCommitTransportErrorKind,
     KolmeRuntimeCommitWebsocketConnector, RuntimeCommitFinalityProjection,
     RuntimeCommitLifecycleRecord, RuntimeCommitLifecycleState, RuntimeCommitPipeline,
-};
-pub use live_probe_matrix::{
-    LiveProbeMatrixEntry, LiveProbeMatrixError, LiveProbeMatrixMode, LiveProbeMatrixReport,
-    LiveProbeMatrixStatus,
-};
-pub use message_delivery_guards::{
-    DeliveryFailureCode, DeliveryGuardInput, DeliveryGuardSnapshot, DeliveryGuardSnapshotError,
-    DeliveryValidationResult, FailedDeliveryNotice, MessageDeliveryGuards,
-    DELIVERY_GUARD_SNAPSHOT_SCHEMA_VERSION,
 };
 pub use message_envelope::{
     AttachmentRef, CanonicalMessageEnvelope, EnvelopeEncryption, EnvelopeHeader, EnvelopeMetadata,
@@ -778,10 +825,6 @@ pub use performance_targets::{
     PerformanceMetric, PerformanceMetricResult, PerformanceRunError, PerformanceRunReport,
     PerformanceSample, PrdPerformanceTargets,
 };
-pub use quota_policy::{
-    evaluate_quota_policy, quota_policy_reason_codes_csv, quota_policy_reason_taxonomy_version,
-    QuotaPolicyDecision, QuotaPolicyInput, QuotaPolicyViolationReason,
-};
 pub use redaction_compliance::{
     RedactionAction, RedactionAuditEvent, RedactionAuditEventKind, RedactionComplianceEngine,
     RedactionComplianceError, RedactionRequestStatus, RedactionVisibility,
@@ -794,13 +837,6 @@ pub use reputation_state::{
     agent_state_key, AgentReputation, CapabilityVerification, DisputeRecord, Endorsement,
     ReputationError, ReputationPersistedRecord, ReputationStore, ReputationTaskOutcome,
     ScoreSnapshot, DEFAULT_TRUST_SCORE, MAX_TRUST_SCORE,
-};
-pub use retention_engine::{
-    evaluate_retention_policy, retention_policy_reason_codes_csv,
-    retention_policy_reason_taxonomy_version, RetentionClass, RetentionDomain,
-    RetentionEnginePolicy, RetentionEvaluation, RetentionPolicyCheckerInput,
-    RetentionPolicyDecision, RetentionPolicyEngine, RetentionPolicyError,
-    RetentionPolicyViolationReason, RetentionRecord, RetentionStatus,
 };
 pub use runtime::{
     build_runtime_wiring, build_runtime_wiring_with_transport_profile, libp2p_feature_gate_name,
@@ -885,10 +921,6 @@ pub use upgrade_orchestration::{
 pub use validator_lifecycle::{
     ValidatorLifecycleError, ValidatorLifecycleManager, ValidatorSetSnapshot,
     ValidatorTransitionKind, ValidatorTransitionProof, ValidatorTransitionRecord,
-};
-pub use watchdog::{
-    WatchdogAlert, WatchdogAlertKind, WatchdogConfig, WatchdogError, WatchdogNode,
-    WatchdogObservation, WatchdogSeverity, WatchdogSnapshot,
 };
 pub use zk_message_proofs::{
     build_message_witness, evaluate_zk_option, phase4_baseline_options, recommend_phase4_plan,

--- a/crates/kamn-core/src/live_probe_matrix.rs
+++ b/crates/kamn-core/src/live_probe_matrix.rs
@@ -1,3 +1,7 @@
 //! Compatibility re-exports for live-probe-matrix contracts extracted from `kamn-core`.
 
+#[deprecated(
+    since = "0.1.0",
+    note = "use kamn_live_probe_matrix::* directly; kamn_core::live_probe_matrix module shim is scheduled for removal in R61"
+)]
 pub use kamn_live_probe_matrix::*;

--- a/crates/kamn-core/src/message_delivery_guards.rs
+++ b/crates/kamn-core/src/message_delivery_guards.rs
@@ -1,3 +1,7 @@
 //! Compatibility re-exports for delivery-guard contracts extracted from `kamn-core`.
 
+#[deprecated(
+    since = "0.1.0",
+    note = "use kamn_runtime_guards::message_delivery_guards::* directly; kamn_core::message_delivery_guards module shim is scheduled for removal in R61"
+)]
 pub use kamn_runtime_guards::message_delivery_guards::*;

--- a/crates/kamn-core/src/quota_policy.rs
+++ b/crates/kamn-core/src/quota_policy.rs
@@ -1,40 +1,7 @@
 //! Compatibility re-exports for quota-policy contracts extracted from `kamn-core`.
 
+#[deprecated(
+    since = "0.1.0",
+    note = "use kamn_runtime_guards::quota_policy::* directly; kamn_core::quota_policy module shim is scheduled for removal in R61"
+)]
 pub use kamn_runtime_guards::quota_policy::*;
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn spec_c09_core_quota_policy_reexport_contracts() {
-        let allow = QuotaPolicyInput {
-            scope: "peer_sync".to_owned(),
-            window_seconds: 10,
-            limit: 4,
-            observed_count: 4,
-        };
-        assert_eq!(evaluate_quota_policy(&allow), QuotaPolicyDecision::Allow);
-
-        let reject = QuotaPolicyInput {
-            scope: "peer_sync".to_owned(),
-            window_seconds: 10,
-            limit: 4,
-            observed_count: 5,
-        };
-        assert_eq!(
-            evaluate_quota_policy(&reject),
-            QuotaPolicyDecision::Reject {
-                reason: QuotaPolicyViolationReason::QuotaLimitExceeded,
-            }
-        );
-        assert_eq!(
-            QuotaPolicyViolationReason::QuotaLimitExceeded.as_str(),
-            "quota_limit_exceeded"
-        );
-        assert_eq!(
-            quota_policy_reason_taxonomy_version(),
-            "kamn.runtime.quota-policy-reason-taxonomy.v1"
-        );
-    }
-}

--- a/crates/kamn-core/src/retention_engine.rs
+++ b/crates/kamn-core/src/retention_engine.rs
@@ -1,3 +1,7 @@
 //! Compatibility re-exports for retention-engine contracts extracted from `kamn-core`.
 
+#[deprecated(
+    since = "0.1.0",
+    note = "use kamn_runtime_guards::retention_engine::* directly; kamn_core::retention_engine module shim is scheduled for removal in R61"
+)]
 pub use kamn_runtime_guards::retention_engine::*;

--- a/crates/kamn-core/src/watchdog.rs
+++ b/crates/kamn-core/src/watchdog.rs
@@ -1,3 +1,7 @@
 //! Compatibility re-exports for watchdog contracts extracted from `kamn-core`.
 
+#[deprecated(
+    since = "0.1.0",
+    note = "use kamn_runtime_guards::watchdog::* directly; kamn_core::watchdog module shim is scheduled for removal in R61"
+)]
 pub use kamn_runtime_guards::watchdog::*;

--- a/crates/kamn-core/tests/issue_5933_runtime_guards_extraction.rs
+++ b/crates/kamn-core/tests/issue_5933_runtime_guards_extraction.rs
@@ -1,6 +1,8 @@
-use kamn_core::anti_spam::AntiSpamConfig as CoreAntiSpamConfig;
-use kamn_core::fairness_policy::FAIRNESS_POLICY_REASON_TAXONOMY_VERSION as CORE_FAIRNESS_VERSION;
-use kamn_core::quota_policy::QUOTA_POLICY_REASON_TAXONOMY_VERSION as CORE_QUOTA_VERSION;
+use kamn_core::{
+    fairness_policy_reason_taxonomy_version as core_fairness_reason_taxonomy_version,
+    quota_policy_reason_taxonomy_version as core_quota_reason_taxonomy_version,
+    AntiSpamConfig as CoreAntiSpamConfig,
+};
 use kamn_runtime_guards::anti_spam::AntiSpamConfig as GuardsAntiSpamConfig;
 use kamn_runtime_guards::fairness_policy::FAIRNESS_POLICY_REASON_TAXONOMY_VERSION as GUARDS_FAIRNESS_VERSION;
 use kamn_runtime_guards::quota_policy::QUOTA_POLICY_REASON_TAXONOMY_VERSION as GUARDS_QUOTA_VERSION;
@@ -11,6 +13,9 @@ fn spec_c01_phase1_runtime_guards_extraction_keeps_policy_parity() {
         CoreAntiSpamConfig::default(),
         GuardsAntiSpamConfig::default()
     );
-    assert_eq!(CORE_QUOTA_VERSION, GUARDS_QUOTA_VERSION);
-    assert_eq!(CORE_FAIRNESS_VERSION, GUARDS_FAIRNESS_VERSION);
+    assert_eq!(core_quota_reason_taxonomy_version(), GUARDS_QUOTA_VERSION);
+    assert_eq!(
+        core_fairness_reason_taxonomy_version(),
+        GUARDS_FAIRNESS_VERSION
+    );
 }

--- a/crates/kamn-node/Cargo.toml
+++ b/crates/kamn-node/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/main.rs"
 [dependencies]
 kamn-core = { path = "../kamn-core", features = ["libp2p-live-transport"] }
 kamn-kolme = { path = "../kamn-kolme" }
+kamn-runtime-guards = { path = "../kamn-runtime-guards" }
 axum = { version = "0.8.8", features = ["ws"] }
 futures-util = "0.3.31"
 k256 = { version = "0.13.4", features = ["ecdsa"] }

--- a/crates/kamn-node/src/service_api_endpoint.rs
+++ b/crates/kamn-node/src/service_api_endpoint.rs
@@ -30,11 +30,13 @@ use axum::{
 use kamn_core::{
     cross_store_replay_reason_codes_csv, cross_store_replay_reason_taxonomy_version,
     data_layer_m9_gateway_project_presence_event, service_auth_verify_with_public_key_hex,
-    AgentDid, AntiSpamConfig, AntiSpamDecision, AntiSpamEngine, AntiSpamRejection,
-    DataLayerM9GatewayBridgeError, DataLayerM9GatewayPresenceProjectionRequest,
+    AgentDid, DataLayerM9GatewayBridgeError, DataLayerM9GatewayPresenceProjectionRequest,
     DataLayerM9PresenceConnectRequest, DataLayerM9PresenceQuery, DataLayerM9RealtimeDeliveryError,
     DataLayerM9RealtimeDeliveryRegistry, DATA_LAYER_M9_OWNER_SCOPE_DENIED_REASON_CODE,
     DATA_LAYER_M9_PRESENCE_VISIBILITY_DENIED_REASON_CODE,
+};
+use kamn_runtime_guards::anti_spam::{
+    AntiSpamConfig, AntiSpamDecision, AntiSpamEngine, AntiSpamRejection,
 };
 #[cfg(test)]
 use serde::de::DeserializeOwned;

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -37,6 +37,7 @@ diagram references.
 - `docs/architecture/adr-kamn-sdk-service-https-transport.md`
 - `docs/architecture/adr-001-production-message-crypto-primitives.md`
 - `docs/architecture/adr-002-runtime-guards-phase1-extraction.md`
+- `docs/architecture/adr-003-kamn-core-wave2-shim-retirement.md`
 - `docs/architecture/adr-cargo-audit-ci-gate.md`
 - `docs/architecture/adr-critical-path-assurance-gates.md`
 

--- a/docs/architecture/adr-003-kamn-core-wave2-shim-retirement.md
+++ b/docs/architecture/adr-003-kamn-core-wave2-shim-retirement.md
@@ -1,0 +1,27 @@
+# ADR-003: kamn-core Wave2 Shim Retirement And Direct Extracted-Crate Wiring
+
+## Context
+
+ADR-002 extracted runtime guard contracts from `kamn-core` and retained module-level
+compatibility shims to preserve public paths. With extraction stabilized, continuing to route
+core exports through shim modules obscures ownership boundaries and slows follow-on decomposition.
+
+Issue link: `#6249`
+Spec link: `specs/6249/spec.md`
+
+## Decision
+
+For wave2 extraction completion:
+
+- Keep compatibility shim modules in `kamn-core` only as temporary deprecated surfaces.
+- Rewire `kamn-core` root exports for migrated domains to re-export directly from extracted crates
+  (`kamn-runtime-guards`, `kamn-live-probe-matrix`, `kamn-bridges`) instead of via shim modules.
+- Migrate in-repo consumers to import extracted crates directly for migrated domains.
+- Set explicit shim retirement target milestone: **R61**.
+
+## Consequences
+
+- Ownership boundaries are now explicit at `kamn-core` root export level.
+- In-repo consumers can converge on extracted crates without relying on compatibility modules.
+- Deprecated shim modules remain available short-term for downstream compatibility, but each use
+  now carries an explicit deprecation path and timeline.

--- a/docs/planning/r59-followup.md
+++ b/docs/planning/r59-followup.md
@@ -1,0 +1,22 @@
+# R59 Follow-up
+
+## Issue #6249: kamn-core Wave2 Shim Retirement
+
+### Shim Inventory And Decisions
+
+| Shim module (`kamn-core`) | Extracted owner crate | Decision (R59) | Workspace migration status | Removal target |
+|---|---|---|---|---|
+| `src/anti_spam.rs` | `kamn-runtime-guards` | Keep temporarily, hard-deprecated | `kamn-node` service-api anti-spam path now imports extracted crate directly | R61 |
+| `src/fairness_policy.rs` | `kamn-runtime-guards` | Keep temporarily, hard-deprecated | Root `kamn-core` exports now wired directly to extracted crate | R61 |
+| `src/quota_policy.rs` | `kamn-runtime-guards` | Keep temporarily, hard-deprecated | Root `kamn-core` exports now wired directly to extracted crate | R61 |
+| `src/message_delivery_guards.rs` | `kamn-runtime-guards` | Keep temporarily, hard-deprecated | Root `kamn-core` exports now wired directly to extracted crate | R61 |
+| `src/retention_engine.rs` | `kamn-runtime-guards` | Keep temporarily, hard-deprecated | Root `kamn-core` exports now wired directly to extracted crate | R61 |
+| `src/watchdog.rs` | `kamn-runtime-guards` | Keep temporarily, hard-deprecated | Root `kamn-core` exports now wired directly to extracted crate | R61 |
+| `src/live_probe_matrix.rs` | `kamn-live-probe-matrix` | Keep temporarily, hard-deprecated | Root `kamn-core` exports now wired directly to extracted crate | R61 |
+| `src/cross_chain_receipt.rs` | `kamn-bridges` | Keep temporarily, hard-deprecated | Root `kamn-core` exports now wired directly to extracted crate | R61 |
+
+### Notes
+
+- Shim modules remain only for transitional compatibility and are annotated as deprecated.
+- `kamn-core` root exports for the migrated surfaces no longer depend on shim modules; they re-export directly from extracted crates.
+- New in-repo imports should target extracted crates directly.

--- a/specs/6249/plan.md
+++ b/specs/6249/plan.md
@@ -1,0 +1,23 @@
+# Issue 6249 Plan
+
+Status: Reviewed
+
+1. Inventory compatibility shim/facade modules in `crates/kamn-core/src` and classify each as remove-now or keep-temporary.
+2. Replace shim module wrappers in `kamn-core` with direct extracted-crate re-exports in `lib.rs`.
+3. Retire shim modules from primary export wiring, mark remaining module wrappers as deprecated compatibility surfaces, and adjust tests that validated shim-module paths.
+4. Migrate `kamn-node` anti-spam imports to `kamn_runtime_guards::anti_spam` direct usage.
+5. Update docs:
+   - `docs/planning/r59-followup.md` shim inventory + keep/remove + timeline.
+   - `docs/architecture/adr-003-kamn-core-wave2-shim-retirement.md` extraction boundary decision.
+6. Verify with scoped tests for `kamn-core`, `kamn-runtime-guards`, and `kamn-node` service API paths.
+
+## Risks / Mitigations
+- Risk: removing module wrappers breaks path-based imports unexpectedly.
+  - Mitigation: migrate in-repo imports first and keep temporary root re-exports where needed.
+- Risk: compatibility contract drift between docs and code.
+  - Mitigation: include explicit shim table and ADR with removal timeline.
+
+## Interfaces / Contracts
+- `crates/kamn-core/src/lib.rs` public exports.
+- Extracted crates: `kamn-runtime-guards`, `kamn-live-probe-matrix`, `kamn-bridges`.
+- Consumer: `crates/kamn-node/src/service_api_endpoint*.rs` anti-spam path.

--- a/specs/6249/spec.md
+++ b/specs/6249/spec.md
@@ -1,0 +1,41 @@
+# Issue 6249 Spec
+
+Status: Reviewed
+Priority: P1
+Milestone: R59 Swarm Gap Closure
+Parent: #6246
+
+## Problem Statement
+`kamn-core` still contains wave-1 compatibility shim modules that only re-export symbols from extracted crates (`kamn-runtime-guards`, `kamn-live-probe-matrix`, `kamn-bridges`). This keeps extraction incomplete, increases maintenance overhead, and obscures ownership boundaries.
+
+## Scope
+In scope:
+- Inventory shim/facade modules in `kamn-core` with explicit keep/remove decisions.
+- Retire removable shim modules by replacing module-level wrappers with direct extracted-crate re-exports in `kamn-core`.
+- Migrate in-repo consumers (workspace crates) to use extracted crates directly for migrated surfaces.
+- Document compatibility surfaces that remain and define an explicit removal timeline.
+
+Out of scope:
+- External downstream repository migration outside this workspace.
+- Functional redesign of runtime-guard algorithms.
+
+## Acceptance Criteria
+- AC-1: Shim inventory is documented with keep/remove decision and rationale per shim.
+- AC-2: Workspace consumers for migrated surfaces use extracted crates directly (not `kamn-core` shim modules).
+- AC-3: Obsolete shim modules are retired from the primary export path in `kamn-core`; any temporary compatibility shims are explicitly hard-deprecated.
+- AC-4: Compatibility timeline for any kept re-export surface is explicitly documented.
+- AC-5: Unit, Functional, Integration, and Regression tests for migrated surfaces pass.
+
+## Conformance Cases
+- C-01 (AC-1, Functional): `docs/planning/r59-followup.md` includes shim inventory table with module path + decision.
+- C-02 (AC-2, Integration): `kamn-node` anti-spam service-api path imports `kamn_runtime_guards::anti_spam::*` directly.
+- C-03 (AC-3, Conformance): `kamn-core/src/lib.rs` no longer depends on shim modules for migrated exports, and remaining shim modules carry explicit deprecation markers.
+- C-04 (AC-4, Functional): ADR/follow-up docs include explicit removal target milestone/date for temporary compatibility exports.
+- C-05 (AC-5, Regression): Targeted tests for runtime guards and migrated consumer paths pass.
+
+## Test Mapping
+- Unit: guard contract tests in `kamn-runtime-guards` and `kamn-node` anti-spam helpers.
+- Functional: shim inventory/doc contract checks.
+- Integration: `kamn-node` service API anti-spam behavior remains unchanged.
+- Regression: extraction-bridge and compatibility tests in `kamn-core` updated to assert direct extracted-crate linkage.
+- Performance: N/A (module ownership and import-path migration only).

--- a/specs/6249/tasks.md
+++ b/specs/6249/tasks.md
@@ -1,0 +1,7 @@
+# Issue 6249 Tasks
+
+- T1 (Red/Baseline): Inventory `kamn-core` shim/facade modules and capture current consumer import paths.
+- T2 (Green/Core): Retire shim wrappers from primary `kamn-core` export wiring and replace with direct extracted-crate re-exports.
+- T3 (Green/Consumers): Migrate workspace consumers to direct extracted crates for migrated surfaces.
+- T4 (Green/Docs): Update follow-up doc + ADR with keep/remove decisions and compatibility timeline.
+- T5 (Regression): Run scoped `cargo test` for affected crates and paths.


### PR DESCRIPTION
## Summary
Completes wave2 of `kamn-core` extraction by retiring compatibility shim modules from the primary export path and wiring `kamn-core` root exports directly to extracted crates (`kamn-runtime-guards`, `kamn-live-probe-matrix`, `kamn-bridges`).
`kamn-node` service-api anti-spam imports are migrated to `kamn-runtime-guards` directly, while shim modules remain only as hard-deprecated transitional surfaces with an explicit R61 removal target.

## Links
- Milestone: R59 Swarm Gap Closure
- Closes #6249
- Spec: `specs/6249/spec.md`
- Plan: `specs/6249/plan.md`
- Tasks: `specs/6249/tasks.md`
- ADR: `docs/architecture/adr-003-kamn-core-wave2-shim-retirement.md`

## Spec Verification (AC -> tests)
| AC | ✅/❌ | Test(s) |
|---|---|---|
| AC-1: Shim inventory documented with decision per shim | ✅ | `docs/planning/r59-followup.md` |
| AC-2: Workspace consumer uses extracted crate directly for migrated surface | ✅ | `crates/kamn-node/src/service_api_endpoint.rs` now imports `kamn_runtime_guards::anti_spam::*`; validated by `cargo test -p kamn-node service_api_endpoint::` |
| AC-3: Primary export path no longer depends on shim modules; shims hard-deprecated | ✅ | `crates/kamn-core/src/lib.rs` direct `kamn_runtime_guards` / `kamn_live_probe_matrix` / `kamn_bridges` re-exports; shim modules carry `#[deprecated]` |
| AC-4: Compatibility timeline documented | ✅ | `docs/planning/r59-followup.md`, `docs/architecture/adr-003-kamn-core-wave2-shim-retirement.md` (target: R61) |
| AC-5: Unit/Functional/Integration/Regression tests pass | ✅ | Commands listed below |

## TDD Evidence
- RED (baseline):
  - Command: `rg -n "pub use (anti_spam|fairness_policy|quota_policy|message_delivery_guards|retention_engine|watchdog|live_probe_matrix|cross_chain_receipt)::" crates/kamn-core/src/lib.rs`
  - Baseline result before this change: `kamn-core` root export wiring referenced shim modules.
- GREEN:
  - Command: `cargo test -p kamn-core --test issue_5933_runtime_guards_extraction --test anti_spam_controls --test fairness_policy_checker_contract --test quota_policy_checker_contract --test retention_policy_checker_contract --test cross_chain_receipt_finality --test live_probe_matrix_contract`
  - Result: all listed tests passed.
- REGRESSION:
  - Command: `cargo test -p kamn-node service_api_endpoint::`
  - Result: all `service_api_endpoint` tests passed.

## Test Tiers
| Tier | ✅/❌/N/A | Tests | N/A Why |
|---|---|---|---|
| Unit | ✅ | `cargo test -p kamn-runtime-guards`; `cargo test -p kamn-core --test issue_5933_runtime_guards_extraction` | |
| Property | N/A | | No property-based harness changes in this migration |
| Contract/DbC | N/A | | No new DbC annotations introduced |
| Snapshot | N/A | | No snapshot fixture format changes |
| Functional | ✅ | `cargo test -p kamn-core --test fairness_policy_checker_contract --test quota_policy_checker_contract --test retention_policy_checker_contract` | |
| Conformance | ✅ | AC/C-case mapping validated via spec + docs + targeted tests | |
| Integration | ✅ | `cargo test -p kamn-core --test cross_chain_receipt_finality --test live_probe_matrix_contract`; `cargo test -p kamn-node service_api_endpoint::` | |
| Fuzz | N/A | | No untrusted parser/fuzz surface changed |
| Mutation | N/A | | Extraction wiring/deprecation/docs migration only |
| Regression | ✅ | `cargo test -p kamn-node service_api_endpoint::`; `cargo test -p kamn-core --test issue_5933_runtime_guards_extraction` | |
| Performance | N/A | | No hot-path algorithm change |

## Additional Verification
- `cargo fmt --check`
- `cargo clippy -p kamn-core -p kamn-node -- -D warnings`

## Risks / Rollback
- Risk: downstream users still importing deprecated module paths may need migration support.
- Rollback: revert this PR commit to restore prior shim-based root wiring.

## Docs / ADR
- Updated: `docs/planning/r59-followup.md`
- Added: `docs/architecture/adr-003-kamn-core-wave2-shim-retirement.md`
- Updated index: `docs/architecture/README.md`

## Review Note
This is a P1 issue under AGENTS contract; spec status is `Reviewed`, and this PR is flagged for human review before merge.
