### PR TITLE
[6461] Refresh test_file_size_policy baseline after signer core extraction

### DIFF
--- a/fixtures/ci/test_file_size_policy_baseline.env
+++ b/fixtures/ci/test_file_size_policy_baseline.env
@@ -1,7 +1,7 @@
 schema_version=kamn.ci.test-file-size-policy-baseline.v1
 captured_at=2026-03-05
 # Counts cover crates/**/tests/*.rs excluding any /tests/support/ paths.
-test_file_total=428
+test_file_total=429
 soft_warn_count=34
 severe_count=2
 hard_fail_count=0

--- a/fixtures/ci/test_file_size_policy_baseline.env
+++ b/fixtures/ci/test_file_size_policy_baseline.env
@@ -1,6 +1,7 @@
 schema_version=kamn.ci.test-file-size-policy-baseline.v1
 captured_at=2026-03-05
 # Counts cover crates/**/tests/*.rs excluding any /tests/support/ paths.
+# Refresh baseline whenever new test files are added or removed.
 test_file_total=429
 soft_warn_count=34
 severe_count=2

--- a/specs/6461-refresh-test-file-size-baseline-after-signer-core-extraction.md
+++ b/specs/6461-refresh-test-file-size-baseline-after-signer-core-extraction.md
@@ -22,10 +22,10 @@ Refresh `test_file_size_policy` baseline inventory counts after signer core-case
 - Fix regresses signer backend test target.
 
 ## Acceptance criteria (testable booleans)
-- [ ] AC-1: local run reproduces drift assertion (`left: 429`, `right: 428`).
-- [ ] AC-2: baseline fixture is updated to current inventory counts.
-- [ ] AC-3: `cargo test -p kamn-core --test test_file_size_policy` passes.
-- [ ] AC-4: `cargo test -p kamn-core --test signer_backend` passes.
+- [x] AC-1: local run reproduces drift assertion (`left: 429`, `right: 428`).
+- [x] AC-2: baseline fixture is updated to current inventory counts.
+- [x] AC-3: `cargo test -p kamn-core --test test_file_size_policy` passes.
+- [x] AC-4: `cargo test -p kamn-core --test signer_backend` passes.
 
 ## Files to touch
 - `specs/6461-refresh-test-file-size-baseline-after-signer-core-extraction.md`
@@ -47,7 +47,14 @@ Refresh `test_file_size_policy` baseline inventory counts after signer core-case
   - `cargo test -p kamn-core --test signer_backend`
 
 ## Phase 6 integration evidence
-- Pending.
+- Red reproduction:
+  - `cargo test -p kamn-core --test test_file_size_policy`
+  - failure: `spec_c04_oversized_test_counts_are_within_budget` with `test file inventory drift` (`left: 429`, `right: 428`)
+- Post-fix verification:
+  - `cargo test -p kamn-core --test test_file_size_policy`
+  - result: `4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out`
+  - `cargo test -p kamn-core --test signer_backend`
+  - result: `30 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out`
 
 ## Deviations
 - None.

--- a/specs/6461-refresh-test-file-size-baseline-after-signer-core-extraction.md
+++ b/specs/6461-refresh-test-file-size-baseline-after-signer-core-extraction.md
@@ -1,0 +1,53 @@
+# Spec: Issue 6461 - Refresh test file size baseline after signer core extraction
+
+## Objective
+Refresh `test_file_size_policy` baseline inventory counts after signer core-case extraction so policy assertions match the current intended test inventory.
+
+## Inputs/Outputs
+- Inputs:
+  - Existing policy test `crates/kamn-core/tests/test_file_size_policy.rs`.
+  - Existing baseline fixture `fixtures/ci/test_file_size_policy_baseline.env`.
+- Outputs:
+  - Updated baseline fixture values consistent with current repository test inventory.
+  - Passing `cargo test -p kamn-core --test test_file_size_policy`.
+
+## Boundaries/Non-goals
+- No policy threshold changes.
+- No policy assertion removals.
+- No production code or workflow changes.
+
+## Failure modes
+- Baseline values still drift from computed inventory values.
+- Policy test passes by weakening checks instead of refreshing baseline data.
+- Fix regresses signer backend test target.
+
+## Acceptance criteria (testable booleans)
+- [ ] AC-1: local run reproduces drift assertion (`left: 429`, `right: 428`).
+- [ ] AC-2: baseline fixture is updated to current inventory counts.
+- [ ] AC-3: `cargo test -p kamn-core --test test_file_size_policy` passes.
+- [ ] AC-4: `cargo test -p kamn-core --test signer_backend` passes.
+
+## Files to touch
+- `specs/6461-refresh-test-file-size-baseline-after-signer-core-extraction.md`
+- `fixtures/ci/test_file_size_policy_baseline.env`
+
+## Error semantics
+- Preserve fail-loud assertion behavior in `test_file_size_policy.rs`.
+- Preserve baseline/threshold schema validation behavior.
+
+## Test plan
+- Red:
+  - Run `cargo test -p kamn-core --test test_file_size_policy` and confirm drift failure.
+- Green:
+  - Update baseline fixture counts to current computed values.
+- Refactor:
+  - Keep baseline fixture readability and explanatory comments consistent.
+- Integration:
+  - `cargo test -p kamn-core --test test_file_size_policy`
+  - `cargo test -p kamn-core --test signer_backend`
+
+## Phase 6 integration evidence
+- Pending.
+
+## Deviations
+- None.


### PR DESCRIPTION
Closes #6461

## Links
- Issue: #6461
- Spec: specs/6461-refresh-test-file-size-baseline-after-signer-core-extraction.md

## What
- refreshed `fixtures/ci/test_file_size_policy_baseline.env` inventory baseline after #6460
  - `test_file_total`: `428 -> 429`
- kept soft/severe/hard counts unchanged (`34/2/0`)
- added a brief maintenance comment indicating baseline refresh is required when test files are added/removed
- recorded red/green evidence in spec

## Why
- `ci-fast-gate` failed for #6460 on `test_file_size_policy` with inventory drift (`left: 429`, `right: 428`)
- this keeps policy enforcement intact while aligning baseline truth data

## Test Evidence
- red reproduction: `cargo test -p kamn-core --test test_file_size_policy` failed at `spec_c04_oversized_test_counts_are_within_budget` (`429 vs 428`)
- green verification: `cargo test -p kamn-core --test test_file_size_policy` (pass: `4 passed, 0 failed`)
- guard verification: `cargo test -p kamn-core --test signer_backend` (pass: `30 passed, 0 failed, 1 ignored`)
