### PR TITLE
[6463] Harden DirectMessageCryptoEngine memory hygiene and debug surface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1665,6 +1665,7 @@ dependencies = [
  "hmac",
  "sha2",
  "x25519-dalek",
+ "zeroize",
 ]
 
 [[package]]

--- a/crates/kamn-core/src/direct_message_crypto.rs
+++ b/crates/kamn-core/src/direct_message_crypto.rs
@@ -11,7 +11,7 @@ pub use kamn_crypto::direct_message_crypto::{
 
 /// Compatibility wrapper that forwards direct-message crypto operations to
 /// `kamn-crypto`.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct DirectMessageCryptoEngine(kamn_crypto::direct_message_crypto::DirectMessageCryptoEngine);
 
 impl DirectMessageCryptoEngine {

--- a/crates/kamn-crypto/Cargo.toml
+++ b/crates/kamn-crypto/Cargo.toml
@@ -13,6 +13,7 @@ hkdf = "0.12.4"
 hmac = "0.12.1"
 sha2 = "0.10.8"
 x25519-dalek = { version = "2.0.1", features = ["static_secrets"] }
+zeroize = "1.8.2"
 
 [lints]
 workspace = true

--- a/crates/kamn-crypto/src/direct_message_crypto.rs
+++ b/crates/kamn-crypto/src/direct_message_crypto.rs
@@ -618,6 +618,59 @@ mod tests {
     }
 
     #[test]
+    fn spec_c09_direct_message_engine_source_contract_enforces_non_clone_redacted_debug_and_drop_zeroize()
+    {
+        assert!(
+            !SOURCE.contains("#[derive(Debug, Clone, PartialEq, Eq)]\npub struct DirectMessageCryptoEngine"),
+            "direct-message engine must not derive Clone"
+        );
+        assert!(
+            SOURCE.contains("impl fmt::Debug for DirectMessageCryptoEngine"),
+            "direct-message engine must define custom Debug"
+        );
+        assert!(
+            SOURCE.contains("impl Drop for DirectMessageCryptoEngine"),
+            "direct-message engine must define Drop"
+        );
+        assert!(
+            SOURCE.contains("self.aead_key.zeroize();"),
+            "direct-message engine Drop must zeroize aead_key"
+        );
+        assert!(
+            SOURCE.contains("self.legacy_aead_key.zeroize();"),
+            "direct-message engine Drop must zeroize legacy_aead_key"
+        );
+    }
+
+    #[test]
+    fn spec_c10_direct_message_engine_debug_output_redacts_sensitive_key_material() {
+        with_key_agreement_seed(Some(TEST_KEY_SEED_HEX), || {
+            let engine = DirectMessageCryptoEngine::new(
+                "kamn:did:agent:alice#key-agreement-1",
+                "kamn:did:agent:bob#key-agreement-1",
+            )
+            .expect("engine init should succeed");
+            let debug_output = format!("{engine:?}");
+            assert!(
+                debug_output.contains("sender_key_ref"),
+                "debug output should preserve safe sender metadata"
+            );
+            assert!(
+                debug_output.contains("recipient_key_ref"),
+                "debug output should preserve safe recipient metadata"
+            );
+            assert!(
+                !debug_output.contains("aead_key"),
+                "debug output must not expose key field labels"
+            );
+            assert!(
+                !debug_output.contains("legacy_aead_key"),
+                "debug output must not expose legacy key field labels"
+            );
+        });
+    }
+
+    #[test]
     fn decrypt_accepts_legacy_v1_sha256_kdf_ciphertext_for_compatibility() {
         with_key_agreement_seed(Some(TEST_KEY_SEED_HEX), || {
             let sender_key_ref = "kamn:did:agent:alice#key-agreement-1";

--- a/crates/kamn-crypto/src/direct_message_crypto.rs
+++ b/crates/kamn-crypto/src/direct_message_crypto.rs
@@ -639,8 +639,14 @@ mod tests {
     #[test]
     fn spec_c09_direct_message_engine_source_contract_enforces_non_clone_redacted_debug_and_drop_zeroize()
     {
+        let struct_marker = "pub struct DirectMessageCryptoEngine";
+        let struct_index = SOURCE
+            .find(struct_marker)
+            .expect("engine struct declaration should exist");
+        let derive_window_start = struct_index.saturating_sub(160);
+        let derive_window = &SOURCE[derive_window_start..struct_index];
         assert!(
-            !SOURCE.contains("#[derive(Debug, Clone, PartialEq, Eq)]\npub struct DirectMessageCryptoEngine"),
+            !derive_window.contains("Clone"),
             "direct-message engine must not derive Clone"
         );
         assert!(

--- a/crates/kamn-crypto/src/direct_message_crypto.rs
+++ b/crates/kamn-crypto/src/direct_message_crypto.rs
@@ -5,6 +5,7 @@ use std::collections::BTreeSet;
 use std::env;
 use std::fmt;
 use x25519_dalek::{PublicKey, StaticSecret};
+use zeroize::Zeroize;
 
 /// Canonical direct-message key-agreement algorithm identifier.
 pub const DIRECT_MESSAGE_KEY_AGREEMENT_ALGORITHM: &str = "X25519";
@@ -38,13 +39,23 @@ pub struct DirectMessageCiphertext {
 }
 
 /// Direct-message crypto engine with nonce reuse protection.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(PartialEq, Eq)]
 pub struct DirectMessageCryptoEngine {
     sender_key_ref: String,
     recipient_key_ref: String,
     aead_key: [u8; 32],
     legacy_aead_key: [u8; 32],
     used_nonces: BTreeSet<u64>,
+}
+
+impl fmt::Debug for DirectMessageCryptoEngine {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DirectMessageCryptoEngine")
+            .field("sender_key_ref", &self.sender_key_ref)
+            .field("recipient_key_ref", &self.recipient_key_ref)
+            .field("used_nonce_count", &self.used_nonces.len())
+            .finish()
+    }
 }
 
 impl DirectMessageCryptoEngine {
@@ -176,6 +187,14 @@ impl DirectMessageCryptoEngine {
         }?;
         String::from_utf8(plaintext)
             .map_err(|_| DirectMessageCryptoError::InvalidCiphertextEncoding)
+    }
+}
+
+impl Drop for DirectMessageCryptoEngine {
+    fn drop(&mut self) {
+        self.aead_key.zeroize();
+        self.legacy_aead_key.zeroize();
+        self.used_nonces.clear();
     }
 }
 

--- a/specs/6463-harden-direct-message-crypto-engine-memory-hygiene.md
+++ b/specs/6463-harden-direct-message-crypto-engine-memory-hygiene.md
@@ -25,11 +25,11 @@ Harden `DirectMessageCryptoEngine` against accidental secret exposure by removin
 - Facade (`kamn-core`) still advertises clone semantics while inner engine is non-clone.
 
 ## Acceptance criteria (testable booleans)
-- [ ] AC-1: `DirectMessageCryptoEngine` in `kamn-crypto` does not implement `Clone`.
-- [ ] AC-2: `Debug` output for engine omits raw key bytes and includes only safe metadata.
-- [ ] AC-3: engine `Drop` impl zeroizes `aead_key` and `legacy_aead_key`.
-- [ ] AC-4: `cargo test -p kamn-crypto --test direct_message_crypto_integration` passes.
-- [ ] AC-5: `cargo test -p kamn-crypto` and `cargo test -p kamn-core --test issue_5921_production_message_crypto` pass.
+- [x] AC-1: `DirectMessageCryptoEngine` in `kamn-crypto` does not implement `Clone`.
+- [x] AC-2: `Debug` output for engine omits raw key bytes and includes only safe metadata.
+- [x] AC-3: engine `Drop` impl zeroizes `aead_key` and `legacy_aead_key`.
+- [x] AC-4: `cargo test -p kamn-crypto --test direct_message_crypto_integration` passes.
+- [x] AC-5: `cargo test -p kamn-crypto` and `cargo test -p kamn-core --test issue_5921_production_message_crypto` pass.
 
 ## Files to touch
 - `specs/6463-harden-direct-message-crypto-engine-memory-hygiene.md`
@@ -56,7 +56,14 @@ Harden `DirectMessageCryptoEngine` against accidental secret exposure by removin
   - `cargo test -p kamn-core --test issue_5921_production_message_crypto`
 
 ## Phase 6 integration evidence
-- Pending.
+- Wrapper integration (`kamn-core`) remains wired to `kamn-crypto` facade; clone derive removed on
+  wrapper to match hardened inner type semantics.
+- Verified commands:
+  - `cargo test -p kamn-crypto spec_c09_direct_message_engine_source_contract_enforces_non_clone_redacted_debug_and_drop_zeroize -- --nocapture`
+  - `cargo test -p kamn-crypto spec_c10_direct_message_engine_debug_output_redacts_sensitive_key_material -- --nocapture`
+  - `cargo test -p kamn-crypto --test direct_message_crypto_integration`
+  - `cargo test -p kamn-crypto`
+  - `cargo test -p kamn-core --test issue_5921_production_message_crypto`
 
 ## Deviations
 - None.

--- a/specs/6463-harden-direct-message-crypto-engine-memory-hygiene.md
+++ b/specs/6463-harden-direct-message-crypto-engine-memory-hygiene.md
@@ -1,0 +1,62 @@
+# Spec: Issue 6463 - Harden DirectMessageCryptoEngine memory hygiene and debug surface
+
+## Objective
+Harden `DirectMessageCryptoEngine` against accidental secret exposure by removing cloning, replacing derived debug output with a redacted custom formatter, and zeroizing key buffers on drop.
+
+## Inputs/Outputs
+- Inputs:
+  - `crates/kamn-crypto/src/direct_message_crypto.rs`
+  - `crates/kamn-core/src/direct_message_crypto.rs` facade
+- Outputs:
+  - `DirectMessageCryptoEngine` no longer derives/implements `Clone`.
+  - Custom `Debug` impl for engine that reports non-sensitive metadata only.
+  - `Drop` impl that zeroizes `aead_key` and `legacy_aead_key`.
+  - Updated tests/contracts validating no-clone/debug/drop zeroize markers.
+
+## Boundaries/Non-goals
+- No cryptographic algorithm changes.
+- No ciphertext format changes.
+- No legacy-v1 decrypt compatibility removal.
+
+## Failure modes
+- `Clone` still available through derive or manual impl.
+- Debug output includes key material bytes.
+- Drop path does not zeroize key buffers.
+- Facade (`kamn-core`) still advertises clone semantics while inner engine is non-clone.
+
+## Acceptance criteria (testable booleans)
+- [ ] AC-1: `DirectMessageCryptoEngine` in `kamn-crypto` does not implement `Clone`.
+- [ ] AC-2: `Debug` output for engine omits raw key bytes and includes only safe metadata.
+- [ ] AC-3: engine `Drop` impl zeroizes `aead_key` and `legacy_aead_key`.
+- [ ] AC-4: `cargo test -p kamn-crypto --test direct_message_crypto_integration` passes.
+- [ ] AC-5: `cargo test -p kamn-crypto` and `cargo test -p kamn-core --test issue_5921_production_message_crypto` pass.
+
+## Files to touch
+- `specs/6463-harden-direct-message-crypto-engine-memory-hygiene.md`
+- `crates/kamn-crypto/Cargo.toml`
+- `crates/kamn-crypto/src/direct_message_crypto.rs`
+- `crates/kamn-core/src/direct_message_crypto.rs`
+
+## Error semantics
+- Preserve existing construction/encrypt/decrypt error values and display messages.
+- Preserve existing nonce reuse and integrity-failure behavior.
+
+## Test plan
+- Red:
+  - Add/adjust direct-message contract tests asserting source/debug/drop markers and remove clone expectations.
+  - Verify red failure before implementation wiring.
+- Green:
+  - Implement non-clone engine, custom debug, and drop zeroization.
+  - Align `kamn-core` wrapper derives with non-clone inner engine.
+- Refactor:
+  - Keep debug output stable and intentionally minimal.
+- Integration:
+  - `cargo test -p kamn-crypto --test direct_message_crypto_integration`
+  - `cargo test -p kamn-crypto`
+  - `cargo test -p kamn-core --test issue_5921_production_message_crypto`
+
+## Phase 6 integration evidence
+- Pending.
+
+## Deviations
+- None.


### PR DESCRIPTION
Closes #6463

## Links
- Issue: #6463
- Spec: specs/6463-harden-direct-message-crypto-engine-memory-hygiene.md

## What changed
- Removed `Clone` from `kamn-crypto::DirectMessageCryptoEngine`.
- Added custom redacted `Debug` implementation for `DirectMessageCryptoEngine`.
- Added `Drop` zeroization for `aead_key` and `legacy_aead_key`.
- Removed `Clone` derive from `kamn-core` facade wrapper to align with hardened inner type.
- Added/updated source-contract tests for non-clone/debug/drop-zeroize behavior.

## Why
- Reduce accidental secret exposure risk and align direct-message engine behavior with memory-hygiene expectations for production crypto paths.

## Test evidence
- `cargo test -p kamn-crypto spec_c09_direct_message_engine_source_contract_enforces_non_clone_redacted_debug_and_drop_zeroize -- --nocapture`
- `cargo test -p kamn-crypto spec_c10_direct_message_engine_debug_output_redacts_sensitive_key_material -- --nocapture`
- `cargo test -p kamn-crypto --test direct_message_crypto_integration`
- `cargo test -p kamn-crypto`
- `cargo test -p kamn-core --test issue_5921_production_message_crypto`
