### PR TITLE
[6576] Harden agent DID key-binding comparison

### DIFF
--- a/crates/kamn-core/src/did.rs
+++ b/crates/kamn-core/src/did.rs
@@ -1014,6 +1014,17 @@ mod tests {
     }
 
     #[test]
+    fn regression_agent_did_key_binding_verification_accepts_parsed_bound_did() {
+        let rendered = AgentDid::with_public_key_hex_binding("agent-5", TEST_PUBLIC_KEY_HEX)
+            .expect("bound did should render")
+            .to_string();
+        let parsed = AgentDid::parse(rendered.as_str()).expect("rendered bound did should parse");
+        parsed
+            .ensure_public_key_hex_binding(TEST_PUBLIC_KEY_HEX)
+            .expect("parsed bound did should preserve key-binding verification");
+    }
+
+    #[test]
     fn regression_agent_did_key_binding_verification_rejects_malformed_public_key_hex() {
         let did = AgentDid::with_public_key_hex_binding("agent-4", TEST_PUBLIC_KEY_HEX)
             .expect("bound did should render");

--- a/specs/6576-harden-agent-did-key-binding-compare.md
+++ b/specs/6576-harden-agent-did-key-binding-compare.md
@@ -25,11 +25,11 @@ Replace direct equality in `AgentDid::ensure_public_key_hex_binding()` with the 
 - Regression to direct equality instead of constant-time helper
 
 ## Acceptance criteria
-- [ ] `AgentDid::ensure_public_key_hex_binding()` uses `crate::constant_time_eq::constant_time_eq_bytes(...)` for fingerprint comparison
-- [ ] Matching bound DID and public key still return `Ok(())`
-- [ ] Mismatched public key still returns `AgentDidKeyBindingError::KeyBindingMismatch` with unchanged `expected` and `actual` values
-- [ ] Malformed public key hex still returns `AgentDidKeyBindingError::InvalidPublicKeyHex`
-- [ ] A regression test fails if the implementation reverts to direct equality
+- [x] `AgentDid::ensure_public_key_hex_binding()` uses `crate::constant_time_eq::constant_time_eq_bytes(...)` for fingerprint comparison
+- [x] Matching bound DID and public key still return `Ok(())`
+- [x] Mismatched public key still returns `AgentDidKeyBindingError::KeyBindingMismatch` with unchanged `expected` and `actual` values
+- [x] Malformed public key hex still returns `AgentDidKeyBindingError::InvalidPublicKeyHex`
+- [x] A regression test fails if the implementation reverts to direct equality
 
 ## Files to touch
 - `crates/kamn-core/src/did.rs`
@@ -46,3 +46,14 @@ Replace direct equality in `AgentDid::ensure_public_key_hex_binding()` with the 
 - Assert mismatched public key returns `KeyBindingMismatch` and preserves `expected`/`actual`
 - Assert malformed public key hex returns `InvalidPublicKeyHex`
 - Run targeted `kamn-core` DID tests and strict clippy for the touched crate
+
+## Integration verification
+- Existing public boundary preserved: `AgentDid::parse(...)` -> `AgentDid::ensure_public_key_hex_binding(...)`
+- Added parsed-bound-DID round-trip coverage to prove the hardened comparison is exercised through the public type boundary
+
+## Verification actuals
+- `cargo test -p kamn-core did::tests -- --nocapture`
+- `cargo clippy -p kamn-core --tests -- -D warnings`
+
+## Deviations
+- None


### PR DESCRIPTION
Closes #6576

## Summary
- replace direct DID key-binding fingerprint equality with the existing internal constant-time helper
- add regression coverage for malformed public key hex, mismatch payload preservation, and source-contract protection against reverting to direct equality
- add parsed-bound-DID round-trip verification to exercise the hardened comparison through the public boundary

## Spec
- specs/6576-harden-agent-did-key-binding-compare.md

## Test evidence
- cargo test -p kamn-core did::tests -- --nocapture
- cargo clippy -p kamn-core --tests -- -D warnings

## Why
- `AgentDid::ensure_public_key_hex_binding()` is an authentication-adjacent comparison over derived key-binding material and should not rely on plain string equality

## CI impact
- none
