### PR TITLE
[6638] Add runtime wiring transport-profile integration coverage

### DIFF
--- a/crates/kamn-core/tests/runtime_wiring_transport_profile_contract.rs
+++ b/crates/kamn-core/tests/runtime_wiring_transport_profile_contract.rs
@@ -1,0 +1,34 @@
+use std::fs;
+
+fn read_repo_file(path: &str) -> String {
+    let root = env!("CARGO_MANIFEST_DIR");
+    let full_path = format!("{root}/{path}");
+    fs::read_to_string(&full_path).unwrap_or_else(|error| {
+        panic!("failed to read {path}: {error}");
+    })
+}
+
+#[test]
+fn runtime_wiring_transport_profile_contract_requires_dedicated_integration_surface() {
+    let integration = read_repo_file("tests/runtime_wiring_transport_profile_integration.rs");
+    assert!(
+        integration.contains("fn integration_default_runtime_wiring_uses_in_memory_transport_markers()"),
+        "integration surface must cover default in-memory runtime wiring markers"
+    );
+    assert!(
+        integration.contains("fn integration_live_transport_profile_emits_provider_and_compile_mode_markers()"),
+        "integration surface must cover live transport profile markers"
+    );
+    assert!(
+        integration.contains("fn integration_gossip_disabled_runtime_wiring_uses_disabled_marker_only()"),
+        "integration surface must cover gossip-disabled runtime wiring markers"
+    );
+    assert!(
+        integration.contains("fn integration_role_specific_runtime_wiring_components_stay_stable()"),
+        "integration surface must cover role-specific runtime wiring components"
+    );
+    assert!(
+        integration.contains("fn integration_feature_gate_name_and_compile_mode_marker_align()"),
+        "integration surface must cover feature gate and compile mode alignment"
+    );
+}

--- a/crates/kamn-core/tests/runtime_wiring_transport_profile_integration.rs
+++ b/crates/kamn-core/tests/runtime_wiring_transport_profile_integration.rs
@@ -15,15 +15,43 @@ fn config_for(role: NodeRole, gossip_enabled: bool) -> NodeConfig {
     }
 }
 
+fn assert_contains_all(components: &[&'static str], expected: &[&'static str]) {
+    for marker in expected {
+        assert!(
+            components.contains(marker),
+            "missing component marker: {marker}"
+        );
+    }
+}
+
+fn assert_contains_none(components: &[&'static str], forbidden: &[&'static str]) {
+    for marker in forbidden {
+        assert!(
+            !components.contains(marker),
+            "unexpected component marker present: {marker}"
+        );
+    }
+}
+
 #[test]
 fn integration_default_runtime_wiring_uses_in_memory_transport_markers() {
     let wiring = build_runtime_wiring(&config_for(NodeRole::Processor, true));
     let components = wiring.all_components();
 
-    assert!(components.contains(&"p2p-transport-profile:in-memory-deterministic"));
-    assert!(components.contains(&"p2p-in-memory-transport-fallback"));
-    assert!(!components.contains(&"p2p-transport-profile:libp2p-live"));
-    assert!(!components.contains(&"p2p-live-libp2p-provider"));
+    assert_contains_all(
+        components.as_slice(),
+        &[
+            "p2p-transport-profile:in-memory-deterministic",
+            "p2p-in-memory-transport-fallback",
+        ],
+    );
+    assert_contains_none(
+        components.as_slice(),
+        &[
+            "p2p-transport-profile:libp2p-live",
+            "p2p-live-libp2p-provider",
+        ],
+    );
 }
 
 #[test]
@@ -34,10 +62,15 @@ fn integration_live_transport_profile_emits_provider_and_compile_mode_markers() 
     );
     let components = wiring.all_components();
 
-    assert!(components.contains(&"p2p-transport-profile:libp2p-live"));
-    assert!(components.contains(&"p2p-live-libp2p-provider"));
-    assert!(components.contains(&resolve_libp2p_compile_mode().marker_component()));
-    assert!(!components.contains(&"p2p-in-memory-transport-fallback"));
+    assert_contains_all(
+        components.as_slice(),
+        &[
+            "p2p-transport-profile:libp2p-live",
+            "p2p-live-libp2p-provider",
+            resolve_libp2p_compile_mode().marker_component(),
+        ],
+    );
+    assert_contains_none(components.as_slice(), &["p2p-in-memory-transport-fallback"]);
 }
 
 #[test]
@@ -48,15 +81,23 @@ fn integration_gossip_disabled_runtime_wiring_uses_disabled_marker_only() {
         RuntimeTransportProfile::Libp2pLive,
     );
 
-    for components in [default_wiring.all_components(), live_wiring.all_components()] {
-        assert!(components.contains(&"gossip-transport-disabled"));
-        assert!(!components.contains(&"p2p-discovery"));
-        assert!(!components.contains(&"p2p-gossip-transport"));
-        assert!(!components.contains(&"p2p-libp2p-swarm-stack"));
-        assert!(!components.contains(&"p2p-transport-profile:in-memory-deterministic"));
-        assert!(!components.contains(&"p2p-transport-profile:libp2p-live"));
-        assert!(!components.contains(&"p2p-live-libp2p-provider"));
-        assert!(!components.contains(&"p2p-in-memory-transport-fallback"));
+    for components in [
+        default_wiring.all_components(),
+        live_wiring.all_components(),
+    ] {
+        assert_contains_all(components.as_slice(), &["gossip-transport-disabled"]);
+        assert_contains_none(
+            components.as_slice(),
+            &[
+                "p2p-discovery",
+                "p2p-gossip-transport",
+                "p2p-libp2p-swarm-stack",
+                "p2p-transport-profile:in-memory-deterministic",
+                "p2p-transport-profile:libp2p-live",
+                "p2p-live-libp2p-provider",
+                "p2p-in-memory-transport-fallback",
+            ],
+        );
     }
 }
 
@@ -68,7 +109,12 @@ fn integration_role_specific_runtime_wiring_components_stay_stable() {
 
     assert_eq!(
         processor.role_components,
-        vec!["mempool", "executor", "block-producer", "consensus-validator"]
+        vec![
+            "mempool",
+            "executor",
+            "block-producer",
+            "consensus-validator"
+        ]
     );
     assert_eq!(
         listener.role_components,
@@ -87,7 +133,10 @@ fn integration_feature_gate_name_and_compile_mode_marker_align() {
     let compile_mode = resolve_libp2p_compile_mode();
     if cfg!(feature = "libp2p-live-transport") {
         assert_eq!(compile_mode, Libp2pCompileMode::NativeLibp2p);
-        assert_eq!(compile_mode.marker_component(), "p2p-live-libp2p-provider:native");
+        assert_eq!(
+            compile_mode.marker_component(),
+            "p2p-live-libp2p-provider:native"
+        );
     } else {
         assert_eq!(compile_mode, Libp2pCompileMode::ContractOnly);
         assert_eq!(

--- a/crates/kamn-core/tests/runtime_wiring_transport_profile_integration.rs
+++ b/crates/kamn-core/tests/runtime_wiring_transport_profile_integration.rs
@@ -1,0 +1,98 @@
+use kamn_core::{
+    build_runtime_wiring, build_runtime_wiring_with_transport_profile, libp2p_feature_gate_name,
+    resolve_libp2p_compile_mode, Libp2pCompileMode, NodeConfig, NodeRole, RuntimeTransportProfile,
+    SyncMode,
+};
+
+fn config_for(role: NodeRole, gossip_enabled: bool) -> NodeConfig {
+    NodeConfig {
+        chain_id: "kamn-devnet".to_owned(),
+        chain_version: "v0.1.0".to_owned(),
+        role,
+        storage_dir: "/tmp/kamn".to_owned(),
+        enable_gossip: gossip_enabled,
+        sync_mode: SyncMode::Fast,
+    }
+}
+
+#[test]
+fn integration_default_runtime_wiring_uses_in_memory_transport_markers() {
+    let wiring = build_runtime_wiring(&config_for(NodeRole::Processor, true));
+    let components = wiring.all_components();
+
+    assert!(components.contains(&"p2p-transport-profile:in-memory-deterministic"));
+    assert!(components.contains(&"p2p-in-memory-transport-fallback"));
+    assert!(!components.contains(&"p2p-transport-profile:libp2p-live"));
+    assert!(!components.contains(&"p2p-live-libp2p-provider"));
+}
+
+#[test]
+fn integration_live_transport_profile_emits_provider_and_compile_mode_markers() {
+    let wiring = build_runtime_wiring_with_transport_profile(
+        &config_for(NodeRole::Processor, true),
+        RuntimeTransportProfile::Libp2pLive,
+    );
+    let components = wiring.all_components();
+
+    assert!(components.contains(&"p2p-transport-profile:libp2p-live"));
+    assert!(components.contains(&"p2p-live-libp2p-provider"));
+    assert!(components.contains(&resolve_libp2p_compile_mode().marker_component()));
+    assert!(!components.contains(&"p2p-in-memory-transport-fallback"));
+}
+
+#[test]
+fn integration_gossip_disabled_runtime_wiring_uses_disabled_marker_only() {
+    let default_wiring = build_runtime_wiring(&config_for(NodeRole::Processor, false));
+    let live_wiring = build_runtime_wiring_with_transport_profile(
+        &config_for(NodeRole::Processor, false),
+        RuntimeTransportProfile::Libp2pLive,
+    );
+
+    for components in [default_wiring.all_components(), live_wiring.all_components()] {
+        assert!(components.contains(&"gossip-transport-disabled"));
+        assert!(!components.contains(&"p2p-discovery"));
+        assert!(!components.contains(&"p2p-gossip-transport"));
+        assert!(!components.contains(&"p2p-libp2p-swarm-stack"));
+        assert!(!components.contains(&"p2p-transport-profile:in-memory-deterministic"));
+        assert!(!components.contains(&"p2p-transport-profile:libp2p-live"));
+        assert!(!components.contains(&"p2p-live-libp2p-provider"));
+        assert!(!components.contains(&"p2p-in-memory-transport-fallback"));
+    }
+}
+
+#[test]
+fn integration_role_specific_runtime_wiring_components_stay_stable() {
+    let processor = build_runtime_wiring(&config_for(NodeRole::Processor, true));
+    let listener = build_runtime_wiring(&config_for(NodeRole::Listener, true));
+    let approver = build_runtime_wiring(&config_for(NodeRole::Approver, true));
+
+    assert_eq!(
+        processor.role_components,
+        vec!["mempool", "executor", "block-producer", "consensus-validator"]
+    );
+    assert_eq!(
+        listener.role_components,
+        vec!["external-listener", "event-normalizer"]
+    );
+    assert_eq!(
+        approver.role_components,
+        vec!["quorum-approver", "outbound-authorizer"]
+    );
+}
+
+#[test]
+fn integration_feature_gate_name_and_compile_mode_marker_align() {
+    assert_eq!(libp2p_feature_gate_name(), "libp2p-live-transport");
+
+    let compile_mode = resolve_libp2p_compile_mode();
+    if cfg!(feature = "libp2p-live-transport") {
+        assert_eq!(compile_mode, Libp2pCompileMode::NativeLibp2p);
+        assert_eq!(compile_mode.marker_component(), "p2p-live-libp2p-provider:native");
+    } else {
+        assert_eq!(compile_mode, Libp2pCompileMode::ContractOnly);
+        assert_eq!(
+            compile_mode.marker_component(),
+            "p2p-live-libp2p-provider:contract-only"
+        );
+    }
+}

--- a/fixtures/ci/test_file_size_policy_baseline.env
+++ b/fixtures/ci/test_file_size_policy_baseline.env
@@ -1,8 +1,8 @@
 schema_version=kamn.ci.test-file-size-policy-baseline.v1
-captured_at=2026-03-08
+captured_at=2026-03-09
 # Counts cover crates/**/tests/*.rs excluding any /tests/support/ paths.
 # Refresh baseline whenever new test files are added or removed.
-test_file_total=489
+test_file_total=491
 soft_warn_count=36
 severe_count=2
 hard_fail_count=0

--- a/specs/6638-add-runtime-wiring-transport-profile-coverage.md
+++ b/specs/6638-add-runtime-wiring-transport-profile-coverage.md
@@ -38,24 +38,24 @@ transport tests.
 - workspace `test_file_size_policy` inventory drifts after adding new test targets
 
 ## Acceptance criteria (testable booleans)
-- [ ] `runtime_wiring_transport_profile_contract` fails when the dedicated integration surface or
+- [x] `runtime_wiring_transport_profile_contract` fails when the dedicated integration surface or
       its required marker cases disappear
-- [ ] integration coverage asserts default `build_runtime_wiring(...)` returns in-memory transport
+- [x] integration coverage asserts default `build_runtime_wiring(...)` returns in-memory transport
       profile markers and excludes live-provider markers
-- [ ] integration coverage asserts
+- [x] integration coverage asserts
       `build_runtime_wiring_with_transport_profile(..., RuntimeTransportProfile::Libp2pLive)`
       emits live transport, provider, and compile-mode markers through the public API
-- [ ] integration coverage asserts gossip-disabled wiring emits deterministic disabled-gossip marker
+- [x] integration coverage asserts gossip-disabled wiring emits deterministic disabled-gossip marker
       and excludes transport markers
-- [ ] integration coverage asserts processor/listener/approver configs return their expected
+- [x] integration coverage asserts processor/listener/approver configs return their expected
       public role components
-- [ ] integration coverage asserts `libp2p_feature_gate_name()` and
+- [x] integration coverage asserts `libp2p_feature_gate_name()` and
       `resolve_libp2p_compile_mode().marker_component()` stay aligned with the active feature state
-- [ ] `cargo test -p kamn-core --test runtime_wiring_transport_profile_contract -- --nocapture`
+- [x] `cargo test -p kamn-core --test runtime_wiring_transport_profile_contract -- --nocapture`
       passes
-- [ ] `cargo test -p kamn-core --test runtime_wiring_transport_profile_integration -- --nocapture`
+- [x] `cargo test -p kamn-core --test runtime_wiring_transport_profile_integration -- --nocapture`
       passes
-- [ ] `cargo test -p kamn-core --test test_file_size_policy -- --nocapture` passes
+- [x] `cargo test -p kamn-core --test test_file_size_policy -- --nocapture` passes
 
 ## Files to touch
 - `specs/6638-add-runtime-wiring-transport-profile-coverage.md`
@@ -79,7 +79,11 @@ transport tests.
    inventory counts.
 
 ## Deviations
-- None.
+- The workspace `test_file_size_policy` inventory changed from `489` to `491`, so
+  `fixtures/ci/test_file_size_policy_baseline.env` was refreshed during integration.
 
 ## Phase 6 Evidence
-- Pending.
+- `cargo test -p kamn-core --test runtime_wiring_transport_profile_contract -- --nocapture`
+- `cargo test -p kamn-core --test runtime_wiring_transport_profile_integration -- --nocapture`
+- `cargo test -p kamn-core --test test_file_size_policy -- --nocapture`
+- `cargo clippy -p kamn-core --tests -- -D warnings`

--- a/specs/6638-add-runtime-wiring-transport-profile-coverage.md
+++ b/specs/6638-add-runtime-wiring-transport-profile-coverage.md
@@ -1,0 +1,85 @@
+# 6638-add-runtime-wiring-transport-profile-coverage
+
+## Objective
+Add dedicated crate-level contract and integration coverage for the public runtime wiring and
+transport-profile API in `runtime_peer_coordination.rs` so marker selection, disabled-gossip
+behavior, role-specific wiring, and compile-mode alignment stay pinned outside broader live
+transport tests.
+
+## Inputs/Outputs
+- Inputs:
+  - public `RuntimeWiring::all_components()`
+  - public `RuntimeTransportProfile`
+  - public `Libp2pCompileMode`
+  - public `libp2p_feature_gate_name()`
+  - public `resolve_libp2p_compile_mode()`
+  - public `build_runtime_wiring_with_transport_profile(...)`
+  - public `build_runtime_wiring(...)`
+- Outputs:
+  - dedicated integration test surface at
+    `crates/kamn-core/tests/runtime_wiring_transport_profile_integration.rs`
+  - dedicated contract test at
+    `crates/kamn-core/tests/runtime_wiring_transport_profile_contract.rs`
+  - refreshed `test_file_size_policy` baseline if test inventory count changes
+
+## Boundaries/Non-goals
+- No production behavior changes in `crates/kamn-core/src/runtime_peer_coordination.rs`
+- No authenticated peer frame, proposal planner, or runtime-network-fault coverage in this issue
+- No CI or workflow changes
+- No visibility expansion for internal helpers just to support tests
+
+## Failure modes
+- dedicated runtime-wiring integration surface missing entirely
+- default runtime wiring stops emitting deterministic in-memory transport markers
+- live libp2p transport wiring stops emitting transport profile, provider, or compile-mode markers
+- disabled gossip stops fail-closing to deterministic `gossip-transport-disabled` marker behavior
+- role-specific wiring stops returning deterministic processor/listener/approver components
+- feature gate name or compile-mode marker alignment drifts
+- workspace `test_file_size_policy` inventory drifts after adding new test targets
+
+## Acceptance criteria (testable booleans)
+- [ ] `runtime_wiring_transport_profile_contract` fails when the dedicated integration surface or
+      its required marker cases disappear
+- [ ] integration coverage asserts default `build_runtime_wiring(...)` returns in-memory transport
+      profile markers and excludes live-provider markers
+- [ ] integration coverage asserts
+      `build_runtime_wiring_with_transport_profile(..., RuntimeTransportProfile::Libp2pLive)`
+      emits live transport, provider, and compile-mode markers through the public API
+- [ ] integration coverage asserts gossip-disabled wiring emits deterministic disabled-gossip marker
+      and excludes transport markers
+- [ ] integration coverage asserts processor/listener/approver configs return their expected
+      public role components
+- [ ] integration coverage asserts `libp2p_feature_gate_name()` and
+      `resolve_libp2p_compile_mode().marker_component()` stay aligned with the active feature state
+- [ ] `cargo test -p kamn-core --test runtime_wiring_transport_profile_contract -- --nocapture`
+      passes
+- [ ] `cargo test -p kamn-core --test runtime_wiring_transport_profile_integration -- --nocapture`
+      passes
+- [ ] `cargo test -p kamn-core --test test_file_size_policy -- --nocapture` passes
+
+## Files to touch
+- `specs/6638-add-runtime-wiring-transport-profile-coverage.md`
+- `crates/kamn-core/tests/runtime_wiring_transport_profile_contract.rs`
+- `crates/kamn-core/tests/runtime_wiring_transport_profile_integration.rs`
+- `fixtures/ci/test_file_size_policy_baseline.env` if inventory count changes
+
+## Error semantics
+- Tests assert the existing public behavior only
+- No new production error types or translation layers are introduced
+- Feature-gate and wiring marker assertions must use the existing public API surface
+
+## Test plan
+1. Add a contract test that references
+   `runtime_wiring_transport_profile_integration.rs` before that file exists so RED is a real
+   missing-surface failure.
+2. Add dedicated integration coverage for default in-memory wiring, live libp2p wiring,
+   gossip-disabled wiring, role-specific components, and compile-mode marker alignment.
+3. Run targeted contract and integration tests.
+4. Run `test_file_size_policy` and refresh its baseline only if the new test targets change
+   inventory counts.
+
+## Deviations
+- None.
+
+## Phase 6 Evidence
+- Pending.


### PR DESCRIPTION
Closes #6638

## What changed
- added dedicated contract coverage in `crates/kamn-core/tests/runtime_wiring_transport_profile_contract.rs`
- added dedicated integration coverage in `crates/kamn-core/tests/runtime_wiring_transport_profile_integration.rs`
- refreshed `fixtures/ci/test_file_size_policy_baseline.env` for the new test inventory count

## Why
Recent `6630/6632/6634/6636` issues added dedicated public-API coverage for other `runtime_peer_coordination.rs` surfaces, but runtime wiring and transport-profile helpers still lacked the same isolated contract/integration boundary.

## Spec
- `specs/6638-add-runtime-wiring-transport-profile-coverage.md`

## Test evidence
- `cargo test -p kamn-core --test runtime_wiring_transport_profile_contract -- --nocapture`
- `cargo test -p kamn-core --test runtime_wiring_transport_profile_integration -- --nocapture`
- `cargo test -p kamn-core --test test_file_size_policy -- --nocapture`
- `cargo clippy -p kamn-core --tests -- -D warnings`
