### PR TITLE
[6642] Ignore generated runtime data directories in workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 /target
+data/
+crates/kamn-node/data/
 __pycache__/
 *.pyc
 *.pyo

--- a/crates/kamn-core/tests/workspace_gitignore_runtime_data_policy_contract.rs
+++ b/crates/kamn-core/tests/workspace_gitignore_runtime_data_policy_contract.rs
@@ -1,0 +1,26 @@
+use std::fs;
+use std::path::PathBuf;
+
+const REQUIRED_RUNTIME_DATA_IGNORE_MARKERS: [&str; 2] = ["data/", "crates/kamn-node/data/"];
+
+fn repo_file(relative: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join(relative)
+}
+
+#[test]
+fn workspace_gitignore_declares_runtime_data_markers() {
+    let gitignore_path = repo_file(".gitignore");
+    let gitignore = fs::read_to_string(&gitignore_path)
+        .unwrap_or_else(|error| panic!("failed to read {}: {}", gitignore_path.display(), error));
+
+    for marker in REQUIRED_RUNTIME_DATA_IGNORE_MARKERS {
+        assert!(
+            gitignore.lines().any(|line| line.trim() == marker),
+            "missing required runtime-data ignore marker `{}` in {}",
+            marker,
+            gitignore_path.display()
+        );
+    }
+}

--- a/specs/6642-ignore-generated-runtime-data-directories.md
+++ b/specs/6642-ignore-generated-runtime-data-directories.md
@@ -1,0 +1,45 @@
+# 6642 Ignore Generated Runtime Data Directories
+
+## Objective
+Declare generated runtime storage directories as ignored workspace state so local runtime data does not pollute `git status` or get treated like candidate source changes during workspace hygiene.
+
+## Inputs/Outputs
+- Inputs:
+  - `.gitignore`
+  - current runtime storage defaults under `./data/...`
+  - existing workspace gitignore contract test patterns
+- Outputs:
+  - explicit `.gitignore` markers for generated runtime data directories
+  - a deterministic contract test that fails if those markers are removed or renamed
+
+## Boundaries/Non-goals
+- Do not change runtime storage defaults or profile wiring
+- Do not ignore broader path families than the current generated runtime data directories
+- Do not modify CI, workflows, or shell tooling
+- Do not delete tracked files or tracked directories
+
+## Failure modes
+- runtime data directories remain unignored and reappear in `git status`
+- ignore markers drift or are removed without a failing contract
+- `.gitignore` broadens far enough to hide tracked source unintentionally
+
+## Acceptance criteria
+- [ ] `.gitignore` contains deterministic markers for `data/` and `crates/kamn-node/data/`
+- [ ] a contract test fails if either required ignore marker is absent
+- [ ] the contract only validates the intended runtime-data markers and does not depend on ambient workspace state
+
+## Files to touch
+- `.gitignore`
+- `crates/kamn-core/tests/workspace_gitignore_runtime_data_policy_contract.rs`
+- `specs/6642-ignore-generated-runtime-data-directories.md`
+
+## Error semantics
+- missing ignore markers are hard failures in the contract test
+- file-read failures in the contract test are hard failures
+- no fallback or auto-generation of ignore markers
+
+## Test plan
+1. Add a contract test for required runtime-data ignore markers and verify it fails before implementation
+2. Add the `.gitignore` markers
+3. Re-run the targeted contract tests and require green
+4. Confirm `git status --short` remains clean after the change

--- a/specs/6642-ignore-generated-runtime-data-directories.md
+++ b/specs/6642-ignore-generated-runtime-data-directories.md
@@ -24,9 +24,9 @@ Declare generated runtime storage directories as ignored workspace state so loca
 - `.gitignore` broadens far enough to hide tracked source unintentionally
 
 ## Acceptance criteria
-- [ ] `.gitignore` contains deterministic markers for `data/` and `crates/kamn-node/data/`
-- [ ] a contract test fails if either required ignore marker is absent
-- [ ] the contract only validates the intended runtime-data markers and does not depend on ambient workspace state
+- [x] `.gitignore` contains deterministic markers for `data/` and `crates/kamn-node/data/`
+- [x] a contract test fails if either required ignore marker is absent
+- [x] the contract only validates the intended runtime-data markers and does not depend on ambient workspace state
 
 ## Files to touch
 - `.gitignore`
@@ -43,3 +43,8 @@ Declare generated runtime storage directories as ignored workspace state so loca
 2. Add the `.gitignore` markers
 3. Re-run the targeted contract tests and require green
 4. Confirm `git status --short` remains clean after the change
+
+## Phase 6 Evidence
+- `cargo test -p kamn-core --test workspace_gitignore_runtime_data_policy_contract -- --nocapture`
+- `cargo test -p kamn-core --test workspace_gitignore_python_cache_policy_contract -- --nocapture`
+- `git status --short --branch` stayed clean aside from the intended branch context after the ignore markers were added


### PR DESCRIPTION
Closes #6642

Issue: #6642
Spec: `specs/6642-ignore-generated-runtime-data-directories.md`

What/Why
- ignore generated runtime storage under `data/` and `crates/kamn-node/data/`
- keep workspace hygiene from treating local runtime state as candidate source changes
- pin the policy with a deterministic contract test

Test evidence
- `cargo test -p kamn-core --test workspace_gitignore_runtime_data_policy_contract -- --nocapture`
- `cargo test -p kamn-core --test workspace_gitignore_python_cache_policy_contract -- --nocapture`
- `git status --short --branch`
