### PR TITLE
[6646] Extract parse_message_lifecycle_snapshot_payload() into bounded helpers

### DIFF
--- a/crates/kamn-core/src/message_lifecycle.rs
+++ b/crates/kamn-core/src/message_lifecycle.rs
@@ -1202,10 +1202,11 @@ fn parse_message_lifecycle_snapshot_payload(
 #[cfg(test)]
 mod tests {
     use super::{
-        serialize_message_lifecycle_snapshot, FileMessageLifecycleSnapshotStore,
-        MessageLifecycleError, MessageLifecycleSnapshot, MessageLifecycleSnapshotError,
-        MessageLifecycleSnapshotStore, MessageLifecycleSnapshotStoreError, MessageLifecycleStore,
-        MessageProofAdmissionError, MessageStatus,
+        parse_message_lifecycle_snapshot_payload, serialize_message_lifecycle_snapshot,
+        FileMessageLifecycleSnapshotStore, MessageLifecycleError, MessageLifecycleSnapshot,
+        MessageLifecycleSnapshotError, MessageLifecycleSnapshotStore,
+        MessageLifecycleSnapshotStoreError, MessageLifecycleStore, MessageProofAdmissionError,
+        MessageStatus,
     };
     use crate::{ProcessorProofAdmissionEvaluator, ProcessorProofArtifact, ZkDesignError};
     use std::fs;
@@ -1502,6 +1503,77 @@ mod tests {
         assert_eq!(
             restored.ids_by_recipient("kamn:did:agent:recipient-1"),
             vec!["urn:uuid:msg-snapshot-1".to_owned()]
+        );
+    }
+
+    #[test]
+    fn unit_parse_message_lifecycle_snapshot_payload_roundtrips_valid_payload() {
+        let snapshot = MessageLifecycleSnapshot {
+            schema_version: 1,
+            records: vec![super::MessageRecordSnapshot {
+                message_id: "urn:uuid:msg-parser-1".to_owned(),
+                sender: "kamn:did:agent:sender-1".to_owned(),
+                recipients: vec![
+                    "kamn:did:agent:recipient-1".to_owned(),
+                    "kamn:did:agent:recipient-2".to_owned(),
+                ],
+                created: "2026-02-07T20:15:30.123Z".to_owned(),
+                expires: "2026-02-07T20:45:30.123Z".to_owned(),
+                status: MessageStatus::Delivered,
+                history: vec![
+                    MessageStatus::Created,
+                    MessageStatus::Signed,
+                    MessageStatus::Delivered,
+                ],
+            }],
+        };
+        let payload =
+            serialize_message_lifecycle_snapshot(&snapshot).expect("snapshot should serialize");
+
+        assert_eq!(
+            parse_message_lifecycle_snapshot_payload(&payload).expect("payload should parse"),
+            snapshot
+        );
+    }
+
+    #[test]
+    fn regression_parse_message_lifecycle_snapshot_payload_rejects_malformed_schema_line() {
+        assert_eq!(
+            parse_message_lifecycle_snapshot_payload("schema\nrecord|broken"),
+            Err(MessageLifecycleSnapshotStoreError::InvalidPayload(
+                "schema".to_owned()
+            ))
+        );
+    }
+
+    #[test]
+    fn regression_parse_message_lifecycle_snapshot_payload_rejects_malformed_record_field_count() {
+        assert_eq!(
+            parse_message_lifecycle_snapshot_payload("schema|1\nrecord|broken"),
+            Err(MessageLifecycleSnapshotStoreError::InvalidPayload(
+                "record|broken".to_owned()
+            ))
+        );
+    }
+
+    #[test]
+    fn regression_parse_message_lifecycle_snapshot_payload_rejects_invalid_status_and_history_codes(
+    ) {
+        assert_eq!(
+            parse_message_lifecycle_snapshot_payload(
+                "schema|1\nrecord|urn:uuid:msg|sender|recipient|created|expires|99|0"
+            ),
+            Err(MessageLifecycleSnapshotStoreError::InvalidPayload(
+                "record|urn:uuid:msg|sender|recipient|created|expires|99|0".to_owned()
+            ))
+        );
+        assert_eq!(
+            parse_message_lifecycle_snapshot_payload(
+                "schema|1\nrecord|urn:uuid:msg|sender|recipient|created|expires|1|0,99"
+            ),
+            Err(MessageLifecycleSnapshotStoreError::InvalidPayload(
+                "record|urn:uuid:msg|sender|recipient|created|expires|1|0,99".to_owned()
+            ))
         );
     }
 

--- a/crates/kamn-core/src/message_lifecycle.rs
+++ b/crates/kamn-core/src/message_lifecycle.rs
@@ -1075,128 +1075,111 @@ fn serialize_message_lifecycle_snapshot(
     Ok(payload)
 }
 
+struct ParsedMessageLifecycleRecordFields<'a> {
+    message_id: &'a str,
+    sender: &'a str,
+    recipients_raw: &'a str,
+    created: &'a str,
+    expires: &'a str,
+    status_raw: &'a str,
+    history_raw: &'a str,
+}
+
 fn parse_message_lifecycle_snapshot_payload(
     payload: &str,
 ) -> Result<MessageLifecycleSnapshot, MessageLifecycleSnapshotStoreError> {
     let mut lines = payload.lines().filter(|line| !line.trim().is_empty());
-    let Some(schema_line) = lines.next() else {
-        return Err(MessageLifecycleSnapshotStoreError::InvalidPayload(
-            "missing schema line".to_owned(),
-        ));
-    };
-
-    let mut schema_parts = schema_line.split('|');
-    let Some(schema_prefix) = schema_parts.next() else {
-        return Err(MessageLifecycleSnapshotStoreError::InvalidPayload(
-            schema_line.to_owned(),
-        ));
-    };
-    let Some(schema_version_raw) = schema_parts.next() else {
-        return Err(MessageLifecycleSnapshotStoreError::InvalidPayload(
-            schema_line.to_owned(),
-        ));
-    };
-    if schema_prefix != "schema" || schema_parts.next().is_some() {
-        return Err(MessageLifecycleSnapshotStoreError::InvalidPayload(
-            schema_line.to_owned(),
-        ));
-    }
-    let schema_version = schema_version_raw
-        .parse::<u16>()
-        .map_err(|_| MessageLifecycleSnapshotStoreError::InvalidPayload(schema_line.to_owned()))?;
-
-    let mut records = Vec::new();
-    for line in lines {
-        let mut parts = line.split('|');
-        let Some(prefix) = parts.next() else {
-            return Err(MessageLifecycleSnapshotStoreError::InvalidPayload(
-                line.to_owned(),
-            ));
-        };
-        if prefix != "record" {
-            return Err(MessageLifecycleSnapshotStoreError::InvalidPayload(
-                line.to_owned(),
-            ));
-        }
-        let Some(message_id) = parts.next() else {
-            return Err(MessageLifecycleSnapshotStoreError::InvalidPayload(
-                line.to_owned(),
-            ));
-        };
-        let Some(sender) = parts.next() else {
-            return Err(MessageLifecycleSnapshotStoreError::InvalidPayload(
-                line.to_owned(),
-            ));
-        };
-        let Some(recipients_raw) = parts.next() else {
-            return Err(MessageLifecycleSnapshotStoreError::InvalidPayload(
-                line.to_owned(),
-            ));
-        };
-        let Some(created) = parts.next() else {
-            return Err(MessageLifecycleSnapshotStoreError::InvalidPayload(
-                line.to_owned(),
-            ));
-        };
-        let Some(expires) = parts.next() else {
-            return Err(MessageLifecycleSnapshotStoreError::InvalidPayload(
-                line.to_owned(),
-            ));
-        };
-        let Some(status_raw) = parts.next() else {
-            return Err(MessageLifecycleSnapshotStoreError::InvalidPayload(
-                line.to_owned(),
-            ));
-        };
-        let Some(history_raw) = parts.next() else {
-            return Err(MessageLifecycleSnapshotStoreError::InvalidPayload(
-                line.to_owned(),
-            ));
-        };
-        if parts.next().is_some() {
-            return Err(MessageLifecycleSnapshotStoreError::InvalidPayload(
-                line.to_owned(),
-            ));
-        }
-
-        let recipients = if recipients_raw.is_empty() {
-            Vec::new()
-        } else {
-            recipients_raw
-                .split(',')
-                .map(|value| value.to_owned())
-                .collect::<Vec<_>>()
-        };
-        let status = parse_message_status_code(status_raw)
-            .ok_or_else(|| MessageLifecycleSnapshotStoreError::InvalidPayload(line.to_owned()))?;
-        let history = if history_raw.is_empty() {
-            Vec::new()
-        } else {
-            history_raw
-                .split(',')
-                .map(|raw| {
-                    parse_message_status_code(raw).ok_or_else(|| {
-                        MessageLifecycleSnapshotStoreError::InvalidPayload(line.to_owned())
-                    })
-                })
-                .collect::<Result<Vec<_>, _>>()?
-        };
-
-        records.push(MessageRecordSnapshot {
-            message_id: message_id.to_owned(),
-            sender: sender.to_owned(),
-            recipients,
-            created: created.to_owned(),
-            expires: expires.to_owned(),
-            status,
-            history,
-        });
-    }
-
+    let schema_line = lines
+        .next()
+        .ok_or_else(|| invalid_message_lifecycle_snapshot_payload("missing schema line"))?;
+    let schema_version = parse_message_lifecycle_snapshot_schema(schema_line)?;
+    let records = lines
+        .map(parse_message_lifecycle_snapshot_record)
+        .collect::<Result<Vec<_>, _>>()?;
     Ok(MessageLifecycleSnapshot {
         schema_version,
         records,
     })
+}
+
+fn parse_message_lifecycle_snapshot_schema(
+    schema_line: &str,
+) -> Result<u16, MessageLifecycleSnapshotStoreError> {
+    match schema_line.split('|').collect::<Vec<_>>().as_slice() {
+        ["schema", schema_version_raw] => schema_version_raw
+            .parse::<u16>()
+            .map_err(|_| invalid_message_lifecycle_snapshot_payload(schema_line)),
+        _ => Err(invalid_message_lifecycle_snapshot_payload(schema_line)),
+    }
+}
+
+fn parse_message_lifecycle_snapshot_record(
+    line: &str,
+) -> Result<MessageRecordSnapshot, MessageLifecycleSnapshotStoreError> {
+    let fields = parse_message_lifecycle_snapshot_record_fields(line)?;
+    let status = parse_message_lifecycle_snapshot_status(fields.status_raw, line)?;
+    let history = parse_message_lifecycle_snapshot_status_history(fields.history_raw, line)?;
+    Ok(MessageRecordSnapshot {
+        message_id: fields.message_id.to_owned(),
+        sender: fields.sender.to_owned(),
+        recipients: parse_message_lifecycle_snapshot_recipients(fields.recipients_raw),
+        created: fields.created.to_owned(),
+        expires: fields.expires.to_owned(),
+        status,
+        history,
+    })
+}
+
+fn parse_message_lifecycle_snapshot_record_fields(
+    line: &str,
+) -> Result<ParsedMessageLifecycleRecordFields<'_>, MessageLifecycleSnapshotStoreError> {
+    match line.split('|').collect::<Vec<_>>().as_slice() {
+        ["record", message_id, sender, recipients_raw, created, expires, status_raw, history_raw] =>
+        {
+            Ok(ParsedMessageLifecycleRecordFields {
+                message_id,
+                sender,
+                recipients_raw,
+                created,
+                expires,
+                status_raw,
+                history_raw,
+            })
+        }
+        _ => Err(invalid_message_lifecycle_snapshot_payload(line)),
+    }
+}
+
+fn parse_message_lifecycle_snapshot_recipients(raw: &str) -> Vec<String> {
+    if raw.is_empty() {
+        return Vec::new();
+    }
+    raw.split(',').map(|value| value.to_owned()).collect()
+}
+
+fn parse_message_lifecycle_snapshot_status(
+    raw: &str,
+    line: &str,
+) -> Result<MessageStatus, MessageLifecycleSnapshotStoreError> {
+    parse_message_status_code(raw).ok_or_else(|| invalid_message_lifecycle_snapshot_payload(line))
+}
+
+fn parse_message_lifecycle_snapshot_status_history(
+    raw: &str,
+    line: &str,
+) -> Result<Vec<MessageStatus>, MessageLifecycleSnapshotStoreError> {
+    if raw.is_empty() {
+        return Ok(Vec::new());
+    }
+    raw.split(',')
+        .map(|value| parse_message_lifecycle_snapshot_status(value, line))
+        .collect()
+}
+
+fn invalid_message_lifecycle_snapshot_payload(
+    value: &str,
+) -> MessageLifecycleSnapshotStoreError {
+    MessageLifecycleSnapshotStoreError::InvalidPayload(value.to_owned())
 }
 
 #[cfg(test)]

--- a/crates/kamn-core/src/message_lifecycle.rs
+++ b/crates/kamn-core/src/message_lifecycle.rs
@@ -1134,8 +1134,7 @@ fn parse_message_lifecycle_snapshot_record_fields(
     line: &str,
 ) -> Result<ParsedMessageLifecycleRecordFields<'_>, MessageLifecycleSnapshotStoreError> {
     match line.split('|').collect::<Vec<_>>().as_slice() {
-        ["record", message_id, sender, recipients_raw, created, expires, status_raw, history_raw] =>
-        {
+        ["record", message_id, sender, recipients_raw, created, expires, status_raw, history_raw] => {
             Ok(ParsedMessageLifecycleRecordFields {
                 message_id,
                 sender,
@@ -1176,9 +1175,7 @@ fn parse_message_lifecycle_snapshot_status_history(
         .collect()
 }
 
-fn invalid_message_lifecycle_snapshot_payload(
-    value: &str,
-) -> MessageLifecycleSnapshotStoreError {
+fn invalid_message_lifecycle_snapshot_payload(value: &str) -> MessageLifecycleSnapshotStoreError {
     MessageLifecycleSnapshotStoreError::InvalidPayload(value.to_owned())
 }
 

--- a/crates/kamn-core/tests/message_lifecycle_parser_extraction_contract.rs
+++ b/crates/kamn-core/tests/message_lifecycle_parser_extraction_contract.rs
@@ -1,0 +1,60 @@
+use std::fs;
+
+const SOURCE_FILE: &str = "src/message_lifecycle.rs";
+const TARGET_FUNCTION: &str = "fn parse_message_lifecycle_snapshot_payload(";
+const TARGET_HELPERS: &[&str] = &[
+    "fn parse_message_lifecycle_snapshot_schema(",
+    "fn parse_message_lifecycle_snapshot_record(",
+    "fn parse_message_lifecycle_snapshot_status_history(",
+];
+const MAX_COORDINATOR_LINES: usize = 25;
+
+fn read_source_file(path: &str) -> String {
+    fs::read_to_string(format!("{}/{}", env!("CARGO_MANIFEST_DIR"), path))
+        .unwrap_or_else(|error| panic!("failed to read {path}: {error}"))
+}
+
+fn function_line_count(source: &str, header: &str) -> usize {
+    let start = source
+        .find(header)
+        .unwrap_or_else(|| panic!("missing function header: {header}"));
+    let body = &source[start..];
+    let open = body
+        .find('{')
+        .unwrap_or_else(|| panic!("missing opening brace for {header}"));
+    let mut depth = 0_i32;
+    for (offset, ch) in body[open..].char_indices() {
+        match ch {
+            '{' => depth += 1,
+            '}' => {
+                depth -= 1;
+                if depth == 0 {
+                    return body[..open + offset + 1].lines().count();
+                }
+            }
+            _ => {}
+        }
+    }
+    panic!("missing closing brace for {header}");
+}
+
+#[test]
+fn spec_c01_message_lifecycle_snapshot_parser_is_coordinator_sized() {
+    let source = read_source_file(SOURCE_FILE);
+    let line_count = function_line_count(&source, TARGET_FUNCTION);
+    assert!(
+        line_count <= MAX_COORDINATOR_LINES,
+        "expected {TARGET_FUNCTION} to stay within {MAX_COORDINATOR_LINES} lines, found {line_count}"
+    );
+}
+
+#[test]
+fn spec_c02_message_lifecycle_snapshot_parser_declares_extracted_helpers() {
+    let source = read_source_file(SOURCE_FILE);
+    for helper in TARGET_HELPERS {
+        assert!(
+            source.contains(helper),
+            "expected helper declaration missing: {helper}"
+        );
+    }
+}

--- a/specs/6646-extract-parse-message-lifecycle-snapshot-payload.md
+++ b/specs/6646-extract-parse-message-lifecycle-snapshot-payload.md
@@ -62,3 +62,9 @@ Reduce `parse_message_lifecycle_snapshot_payload()` in `crates/kamn-core/src/mes
 ## Notes / Deviations
 
 - The current function is 122 LOC on `origin/main`, not ~702 LOC as stated in the issue body, but it still violates the 25 LOC function policy and has obvious extraction seams.
+
+## Integration Evidence
+
+- `cargo test -p kamn-core --test message_lifecycle_parser_extraction_contract -- --nocapture`
+- `cargo test -p kamn-core parse_message_lifecycle_snapshot_payload -- --nocapture`
+- `cargo test -p kamn-core file_message_lifecycle_snapshot_store -- --nocapture`

--- a/specs/6646-extract-parse-message-lifecycle-snapshot-payload.md
+++ b/specs/6646-extract-parse-message-lifecycle-snapshot-payload.md
@@ -1,0 +1,64 @@
+# 6646 - Extract parse_message_lifecycle_snapshot_payload into bounded helpers
+
+## Objective
+
+Reduce `parse_message_lifecycle_snapshot_payload()` in `crates/kamn-core/src/message_lifecycle.rs` to a small coordinator that delegates schema parsing, record-field parsing, list decoding, and snapshot assembly to clearly named helpers without changing the payload format or external API behavior.
+
+## Inputs/Outputs
+
+### Inputs
+- `crates/kamn-core/src/message_lifecycle.rs`
+- Existing snapshot serialization/parsing helpers in the same module
+- Existing snapshot store regression coverage in `crates/kamn-core/src/message_lifecycle.rs` tests
+
+### Outputs
+- A small `parse_message_lifecycle_snapshot_payload()` coordinator function
+- Extracted helper functions for schema parsing, record line parsing, status/history decoding, and record construction
+- Direct regression tests for happy-path parsing and malformed payload failure cases
+- Preserved `MessageLifecycleSnapshotStoreError::InvalidPayload` error semantics for corrupt payloads
+
+## Boundaries/Non-goals
+
+- Do not change the on-disk snapshot payload format
+- Do not change public APIs or external error types
+- Do not redesign the broader message lifecycle store or journal flow
+- Do not split `message_lifecycle.rs` into new files in this issue
+
+## Failure Modes
+
+- Missing or malformed schema line stops parsing with `InvalidPayload`
+- Non-`record` line prefixes stop parsing with `InvalidPayload`
+- Record lines with missing or extra fields stop parsing with `InvalidPayload`
+- Invalid status codes in `status` or `history` stop parsing with `InvalidPayload`
+- Refactor drifts store/journal restore behavior by changing accepted payload shapes
+
+## Acceptance Criteria
+
+- [ ] `parse_message_lifecycle_snapshot_payload()` is reduced to a small coordinator function
+- [ ] Schema parsing, record parsing, and status/history decoding are extracted into clearly named helper functions
+- [ ] Helper functions preserve current `InvalidPayload` failure semantics for malformed lines
+- [ ] Direct regression tests cover a valid payload plus malformed schema, malformed record field count, and invalid status/history payloads
+- [ ] Existing snapshot store round-trip and malformed-payload tests remain green
+- [ ] No new extracted helper exceeds the repo 25 LOC function limit unless explicitly staged and justified in this spec
+
+## Files To Touch
+
+- `specs/6646-extract-parse-message-lifecycle-snapshot-payload.md`
+- `crates/kamn-core/src/message_lifecycle.rs`
+
+## Error Semantics
+
+- Malformed payloads continue to return `MessageLifecycleSnapshotStoreError::InvalidPayload`
+- Helpers fail closed and bubble invalid line contents back through the existing error type
+- No silent fallback or payload normalization is introduced
+
+## Test Plan
+
+1. Red: add direct parser tests in `message_lifecycle.rs` for valid payload round-trip, malformed schema, malformed record field count, and invalid status/history lines
+2. Green: extract helpers for schema parsing, record parsing, list decoding, and snapshot assembly until the new tests and existing malformed-payload/store tests pass
+3. Refactor: trim duplication in invalid-line error construction and keep each helper within the function budget
+4. Integration: rerun the parser-focused tests plus existing snapshot store round-trip/malformed recovery tests that exercise the real file/journal restore paths
+
+## Notes / Deviations
+
+- The current function is 122 LOC on `origin/main`, not ~702 LOC as stated in the issue body, but it still violates the 25 LOC function policy and has obvious extraction seams.


### PR DESCRIPTION
Closes #6646

Issue: #6646
Spec: [specs/6646-extract-parse-message-lifecycle-snapshot-payload.md](https://github.com/njfio/kamn/blob/6646-extract-parse-message-lifecycle-snapshot-payload/specs/6646-extract-parse-message-lifecycle-snapshot-payload.md)

## What
- reduce `parse_message_lifecycle_snapshot_payload()` to a coordinator-sized function
- extract schema, record, status, and history parsing helpers
- add direct parser regression tests and a structural extraction contract

## Why
- remove a 122-line parser hot spot that exceeded the repo function budget
- keep payload semantics stable while making failure paths and helper seams explicit

## Test Evidence
- `cargo test -p kamn-core --test message_lifecycle_parser_extraction_contract -- --nocapture`
- `cargo test -p kamn-core parse_message_lifecycle_snapshot_payload -- --nocapture`
- `cargo test -p kamn-core file_message_lifecycle_snapshot_store -- --nocapture`