### PR TITLE
[6647] Define target crate graph for kamn-core decomposition and kamn-types inversion

### DIFF
--- a/crates/kamn-core/tests/kamn_core_target_crate_graph_docs.rs
+++ b/crates/kamn-core/tests/kamn_core_target_crate_graph_docs.rs
@@ -1,0 +1,57 @@
+const TARGET_GRAPH_DOC: &str = include_str!("../../../docs/architecture/kamn-core-target-crate-graph.md");
+const ARCHITECTURE_INDEX_DOC: &str = include_str!("../../../docs/architecture/README.md");
+const KAMN_TYPES_DOC: &str = include_str!("../../../docs/architecture/kamn-types.md");
+
+#[test]
+fn target_graph_doc_declares_required_markers() {
+    for marker in [
+        "## Target Crate Graph (Issue #6647)",
+        "kamn_core_target_crate_graph_version=kamn.arch.kamn-core-target-crate-graph.v1",
+        "kamn_core_target_crate_graph_status=planned",
+        "kamn_core_target_foundational_crates_csv=kamn-types,kamn-crypto,kamn-runtime-guards,kamn-snapshot-journal,kamn-bridges,kamn-data-layer,kamn-kolme,kamn-live-probe-matrix",
+        "kamn_core_target_domain_crates_csv=kamn-governance,kamn-escrow,kamn-compliance",
+        "kamn_core_target_forbidden_edges_csv=kamn-types->kamn-core,domain-crates->kamn-core-through-shims",
+        "kamn_core_target_bridge_rule_csv=kamn-core-reexports-temporary,extracted-crates-must-not-depend-on-kamn-core",
+        "kamn_core_target_migration_order_csv=types-inversion,governance,escrow,compliance",
+        "kamn_core_target_module_map_source=docs/architecture/kamn-core-module-map.md",
+    ] {
+        assert!(
+            TARGET_GRAPH_DOC.contains(marker),
+            "missing target crate graph marker: {marker}"
+        );
+    }
+}
+
+#[test]
+fn target_graph_doc_maps_candidate_module_groups() {
+    for marker in [
+        "`did`, `agent_key_hierarchy`, `key_lifecycle`, `key_recovery`",
+        "`governance_workflow`, `operator_actions`, `operator_dashboard_api`, `operator_dashboard_ui`",
+        "`task_operations`, `task_lifecycle`, `task_payment`, `task_artifacts`, `escrow`, `service_marketplace`, `token`",
+        "`content_storage`, `content_retrieval`, `content_lifecycle`, `content_replication`, `data_classification`, `redaction_compliance`, `audit_exports`",
+    ] {
+        assert!(
+            TARGET_GRAPH_DOC.contains(marker),
+            "missing candidate module mapping marker: {marker}"
+        );
+    }
+}
+
+#[test]
+fn architecture_index_links_target_graph_doc() {
+    assert!(ARCHITECTURE_INDEX_DOC.contains("docs/architecture/kamn-core-target-crate-graph.md"));
+}
+
+#[test]
+fn kamn_types_doc_declares_inversion_target() {
+    for marker in [
+        "kamn_types_current_dependency_status=temporary-kamn-core-reexport",
+        "kamn_types_target_dependency_policy=no-kamn-core",
+        "kamn_types_inversion_first_wave_csv=AgentDid,KamnDid,DidDocument,DidService,DidVerificationMethod",
+    ] {
+        assert!(
+            KAMN_TYPES_DOC.contains(marker),
+            "missing kamn-types inversion marker: {marker}"
+        );
+    }
+}

--- a/crates/kamn-types/tests/identity_boundary_contract.rs
+++ b/crates/kamn-types/tests/identity_boundary_contract.rs
@@ -12,6 +12,8 @@ fn docs_contain_identity_boundary_and_migration_markers() {
     assert!(README.contains("kamn_types_migration_import=use kamn_types::did::AgentDid"));
     assert!(ARCH_DOC.contains("kamn_types_identity_boundary=did-helpers"));
     assert!(ARCH_DOC.contains("kamn_types_import_ownership=explicit"));
+    assert!(ARCH_DOC.contains("kamn_types_current_dependency_status=temporary-kamn-core-reexport"));
+    assert!(ARCH_DOC.contains("kamn_types_target_dependency_policy=no-kamn-core"));
     assert!(DID_FORMAT_DOC.contains("did_format_current_canonical=kamn:did:{role}:{id}"));
     assert!(DID_FORMAT_DOC.contains("did_format_divergent_shape=did:kamn:{role}:{id}"));
     assert!(DID_FORMAT_DOC.contains("did_format_target_standard=kamn:did:{role}:{id}"));

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -11,6 +11,7 @@ diagram references.
 
 - `docs/architecture/kamn-core-module-map.md`
 - `docs/architecture/kamn-core-module-map.md#decomposition-tranche-roadmap-issue-6275`
+- `docs/architecture/kamn-core-target-crate-graph.md`
 - `docs/architecture/kamn-node-module-map.md`
 
 ## Crate Architecture Notes

--- a/docs/architecture/kamn-core-module-map.md
+++ b/docs/architecture/kamn-core-module-map.md
@@ -170,6 +170,10 @@ contributors can locate runtime/domain ownership responsibilities quickly.
 
 ## Decomposition Tranche Roadmap (Issue #6275)
 
+Dependency directions, temporary bridge rules, and the `kamn-types` inversion
+plan for these tranches are defined in
+`docs/architecture/kamn-core-target-crate-graph.md`.
+
 kamn_core_decomposition_map_version=kamn.arch.kamn-core-decomposition-map.v1
 kamn_core_decomposition_reason_taxonomy_version=kamn.arch.kamn-core-decomposition-reason-taxonomy.v1
 kamn_core_decomposition_reason_codes_csv=module_group_boundary_missing,tranche_ordering_missing,target_destination_missing,hotspot_prioritization_missing,architecture_index_link_missing

--- a/docs/architecture/kamn-core-target-crate-graph.md
+++ b/docs/architecture/kamn-core-target-crate-graph.md
@@ -1,0 +1,189 @@
+# KAMN Core Target Crate Graph
+
+## Target Crate Graph (Issue #6647)
+
+kamn_core_target_crate_graph_version=kamn.arch.kamn-core-target-crate-graph.v1
+kamn_core_target_crate_graph_status=planned
+kamn_core_target_foundational_crates_csv=kamn-types,kamn-crypto,kamn-runtime-guards,kamn-snapshot-journal,kamn-bridges,kamn-data-layer,kamn-kolme,kamn-live-probe-matrix
+kamn_core_target_domain_crates_csv=kamn-governance,kamn-escrow,kamn-compliance
+kamn_core_target_forbidden_edges_csv=kamn-types->kamn-core,domain-crates->kamn-core-through-shims
+kamn_core_target_bridge_rule_csv=kamn-core-reexports-temporary,extracted-crates-must-not-depend-on-kamn-core
+kamn_core_target_migration_order_csv=types-inversion,governance,escrow,compliance
+kamn_core_target_module_map_source=docs/architecture/kamn-core-module-map.md
+
+This document defines the target layering that should exist after the next
+`kamn-core` decomposition waves. It complements the existing tranche roadmap in
+`docs/architecture/kamn-core-module-map.md` by specifying allowed dependency
+flow, temporary compatibility rules, and the smallest viable `kamn-types`
+inversion path.
+
+## Current Graph Summary
+
+- `kamn-core` depends on focused leaf crates that already represent extracted
+  capabilities: `kamn-bridges`, `kamn-crypto`, `kamn-data-layer`,
+  `kamn-kolme`, `kamn-live-probe-matrix`, `kamn-runtime-guards`, and
+  `kamn-snapshot-journal`.
+- `kamn-sdk` depends on both `kamn-core` and `kamn-types`.
+- `kamn-types` currently depends directly on `kamn-core` because it re-exports
+  DID types and parse errors from `kamn-core::did`.
+- That means `kamn-types` is currently a facade over `kamn-core`, not a
+  foundational crate.
+
+## Target Layers
+
+### Foundational Layer
+
+These crates may be depended on by `kamn-core`, SDKs, agents, and future domain
+crates, but they must not depend on `kamn-core`.
+
+- `kamn-types`
+- `kamn-crypto`
+- `kamn-runtime-guards`
+- `kamn-snapshot-journal`
+- `kamn-bridges`
+- `kamn-data-layer`
+- `kamn-kolme`
+- `kamn-live-probe-matrix`
+
+### Domain Layer
+
+These crates should absorb cohesive business domains that are currently still
+owned by `kamn-core`.
+
+- `kamn-governance`
+- `kamn-escrow`
+- `kamn-compliance`
+
+### Orchestration Layer
+
+- `kamn-core` remains the runtime orchestration and composition crate.
+- `kamn-node`, `kamn-sdk`, `kamn-agent-lib`, and `kamn-cli` remain consumers of
+  the layered workspace graph rather than owners of domain logic.
+
+## Allowed Dependency Directions
+
+- Foundational crates may depend only on std/workspace primitives and other
+  foundational crates when there is a clear value-type or helper relationship.
+- Domain crates may depend on foundational crates.
+- `kamn-core` may depend on foundational crates and domain crates.
+- Application crates (`kamn-node`, `kamn-sdk`, `kamn-agent-lib`, `kamn-cli`)
+  may depend on `kamn-core` plus foundational crates when they need stable leaf
+  types directly.
+- Domain crates must not depend back on `kamn-core` through compatibility shims.
+- `kamn-types` must not depend on `kamn-core` in the target state.
+
+## Temporary Bridge Rules
+
+- `kamn-core` may re-export APIs from extracted crates temporarily to preserve
+  compatibility while callers migrate.
+- Extracted crates must not re-import those APIs through `kamn-core`.
+- New shared value types should be introduced in `kamn-types` first, not added
+  to `kamn-core` and mirrored later.
+- Shim retirement should happen only after downstream imports are moved to the
+  extracted crate paths.
+
+## kamn-types Inversion Plan
+
+### Current Coupling
+
+`kamn-types` currently depends on `kamn-core` because it forwards and uses the
+DID value surface from `kamn-core::did`.
+
+Current directly coupled surface:
+- `AgentDid`
+- `KamnDid`
+- `AgentDidError`
+- `KamnDidError`
+- `AgentDidKeyBindingError`
+- `AgentDidMetadata`
+- `DidDocument`
+- `DidService`
+- `DidVerificationMethod`
+
+### First Inversion Wave
+
+Move the DID value types and parse errors out of `kamn-core::did` into
+`kamn-types`, keeping runtime registry logic in `kamn-core`.
+
+First-wave owned surface in `kamn-types`:
+- `AgentDid`, `KamnDid`
+- `DidDocument`, `DidService`, `DidVerificationMethod`
+- `AgentDidError`, `KamnDidError`, `AgentDidKeyBindingError`
+- `AgentDidMetadata`
+- Canonical parse helpers now exposed from `kamn_types::did`
+
+What stays in `kamn-core` initially:
+- `did_registry`
+- runtime handshake and orchestration flows
+- higher-level identity workflows that compose runtime state and persistence
+
+## Candidate Module Mapping
+
+### Target: kamn-types
+
+- First wave modules/value surface:
+  - `did`, `agent_key_hierarchy`, `key_lifecycle`, `key_recovery`
+- Scope note:
+  - only the reusable value-type and parse boundary moves first; registry and
+    orchestration logic stay in `kamn-core` until later follow-up issues.
+
+### Target: kamn-governance
+
+- Candidate modules:
+  - `governance_workflow`, `operator_actions`, `operator_dashboard_api`, `operator_dashboard_ui`
+- Scope note:
+  - these modules already form a policy and operator control-plane boundary and
+    should stop accreting inside `kamn-core`.
+
+### Target: kamn-escrow
+
+- Candidate modules:
+  - `task_operations`, `task_lifecycle`, `task_payment`, `task_artifacts`, `escrow`, `service_marketplace`, `token`
+- Scope note:
+  - task DAG progression and settlement state belong in one economic domain
+    slice instead of remaining distributed through the core orchestration crate.
+
+### Target: kamn-compliance
+
+- Candidate modules:
+  - `content_storage`, `content_retrieval`, `content_lifecycle`, `content_replication`, `data_classification`, `redaction_compliance`, `audit_exports`
+- Scope note:
+  - content policy, retention, replication, and evidence export should become a
+    dedicated compliance/content policy crate.
+
+### Retained In kamn-core During These Waves
+
+- Runtime orchestration and state composition:
+  - `runtime`, `bootstrap`, `config`, `migrations`, `state`, `durable_guard_store`
+- Messaging and channel control plane:
+  - `message_envelope`, `message_lifecycle`, `channel_models`, `channel_policies`, `instruction_verify`
+- Transport/runtime integration:
+  - `p2p_transport`, `kolme_runtime_commit`, `runtime_*`
+
+## Migration Order
+
+1. `types-inversion`
+- move the first-wave DID/value surface into `kamn-types`
+- invert `kamn-core` to depend on `kamn-types`
+- keep `kamn-core` re-exports as temporary compatibility shims
+
+2. `governance`
+- extract the governance/operator control plane into `kamn-governance`
+- keep orchestration entrypoints in `kamn-core`
+
+3. `escrow`
+- extract task/escrow/economic modules into `kamn-escrow`
+- preserve runtime composition from `kamn-core`
+
+4. `compliance`
+- extract content/compliance/audit policy modules into `kamn-compliance`
+- keep remaining runtime composition and cross-domain orchestration in `kamn-core`
+
+## Graph Check Plan
+
+Follow-up extraction issues should add or extend graph-check contracts that
+assert:
+- `kamn-types` has no `kamn-core` dependency
+- new domain crates do not depend back on `kamn-core`
+- `kamn-core` is allowed to depend on extracted crates during the migration
+  window

--- a/docs/architecture/kamn-core-target-crate-graph.md
+++ b/docs/architecture/kamn-core-target-crate-graph.md
@@ -29,6 +29,21 @@ inversion path.
 - That means `kamn-types` is currently a facade over `kamn-core`, not a
   foundational crate.
 
+### Concrete Coupling Points
+
+- Manifest edge:
+  - `crates/kamn-types/Cargo.toml` declares `kamn-core` in `[dependencies]`.
+- Re-export and parse coupling:
+  - `crates/kamn-types/src/lib.rs` re-exports `AgentDid`, `KamnDid`,
+    `DidDocument`, `DidService`, `DidVerificationMethod`,
+    `AgentDidKeyBindingError`, `AgentDidError`, and `KamnDidError` from
+    `kamn-core`.
+  - the same file constructs `SharedDidParseError` from `AgentDidError` and
+    `KamnDidError` and calls `AgentDid::parse(...)` / `KamnDid::parse(...)`
+    directly.
+- Source ownership today:
+  - the concrete DID value types still live in `crates/kamn-core/src/did.rs`.
+
 ## Target Layers
 
 ### Foundational Layer

--- a/docs/architecture/kamn-types.md
+++ b/docs/architecture/kamn-types.md
@@ -7,6 +7,9 @@ Defines the architecture contract for `kamn-types` in the KAMN workspace and doc
 - `kamn_types_identity_boundary=did-helpers`
 - `kamn_types_primary_module=kamn_types::did`
 - `kamn_types_import_ownership=explicit`
+- `kamn_types_current_dependency_status=temporary-kamn-core-reexport`
+- `kamn_types_target_dependency_policy=no-kamn-core`
+- `kamn_types_inversion_first_wave_csv=AgentDid,KamnDid,DidDocument,DidService,DidVerificationMethod`
 
 ## Responsibilities
 - Own the canonical DID helper boundary (`kamn_types::did`).
@@ -15,9 +18,15 @@ Defines the architecture contract for `kamn-types` in the KAMN workspace and doc
 
 ## Boundaries
 - Owns crate-local behavior and contracts for `kamn-types`.
-- Depends on `kamn-core` through explicit Rust interfaces only.
+- Current state: depends on `kamn-core` through explicit Rust interfaces only.
+- Target state: owns the DID value surface directly and does not depend on `kamn-core`.
 - Exposes stable DID surfaces expected by higher-level crates/workflows.
 - Non-DID runtime behavior stays outside this crate.
+
+## Inversion Plan
+- First wave moves reusable DID value types, parse errors, and canonical parse helpers from `kamn-core::did` into `kamn-types`.
+- `kamn-core` becomes a consumer of `kamn-types` and preserves temporary re-export shims during migration.
+- Runtime registry/orchestration flows remain in `kamn-core` until follow-up extraction issues land.
 
 ## Operational Notes
 - Primary validation path: `cargo test -p kamn-types`.

--- a/specs/6647-define-kamn-core-target-crate-graph.md
+++ b/specs/6647-define-kamn-core-target-crate-graph.md
@@ -61,3 +61,24 @@ Define the target crate graph that should exist after `kamn-core` decomposition,
 - Run `cargo test -p kamn-types --test identity_boundary_contract -- --nocapture`
 - Run `cargo test -p kamn-core --test kamn_core_decomposition_map_docs -- --nocapture`
 - Verify the architecture index links the new target graph document
+
+## Findings
+
+- `cargo metadata` shows the current direct workspace edge `kamn-types -> kamn-core`.
+- `crates/kamn-types/src/lib.rs` is the concrete inversion hotspot: it re-exports
+  DID types/errors from `kamn-core`, stores `AgentDidError` and `KamnDidError`
+  inside `SharedDidParseError`, and calls `AgentDid::parse(...)` /
+  `KamnDid::parse(...)` directly.
+- Existing decomposition planning already lives in `docs/architecture/kamn-core-module-map.md`,
+  but it did not define the target dependency directions or bridge rules before
+  this issue.
+
+## Integration Evidence
+
+- `cargo test -p kamn-core --test kamn_core_target_crate_graph_docs -- --nocapture`
+- `cargo test -p kamn-types --test identity_boundary_contract -- --nocapture`
+- `cargo test -p kamn-core --test kamn_core_decomposition_map_docs -- --nocapture`
+
+## Deviations
+
+- None. The issue stayed architecture-definition only.

--- a/specs/6647-define-kamn-core-target-crate-graph.md
+++ b/specs/6647-define-kamn-core-target-crate-graph.md
@@ -1,0 +1,63 @@
+# 6647 Define KAMN Core Target Crate Graph
+
+## Objective
+
+Define the target crate graph that should exist after `kamn-core` decomposition, including explicit allowed dependency directions, a concrete inversion plan for `kamn-types`, and candidate module-to-crate mapping for the first domain extraction waves.
+
+## Inputs/Outputs
+
+- Inputs:
+  - Current workspace crate graph from `cargo metadata`
+  - Existing `docs/architecture/kamn-core-module-map.md`
+  - Existing `docs/architecture/kamn-types.md`
+  - Current `kamn-types` dependency on `kamn-core`
+- Outputs:
+  - New architecture document describing the target crate graph and migration rules
+  - Updated architecture index and `kamn-types` boundary doc reflecting the inversion plan
+  - Contract tests pinning the new architecture markers and index links
+
+## Boundaries/Non-goals
+
+- Do not move code between crates in this issue
+- Do not rename crates or remove compatibility shims in this issue
+- Do not change runtime behavior or public APIs in this issue
+- Do not redefine the existing decomposition tranche map except where it is referenced by the new target graph
+
+## Failure Modes
+
+- The architecture document omits allowed dependency directions, so follow-up extraction issues can reintroduce coupling
+- The document does not explain how `kamn-types` becomes foundational, leaving the inversion unresolved
+- Candidate module groupings are too vague to guide extraction issues
+- The architecture index and crate docs drift from the new target graph contract
+- No test pins the architecture markers, allowing silent design drift
+
+## Acceptance Criteria
+
+- [ ] A new architecture document defines the post-`kamn-core` target crate graph
+- [ ] The document names proposed domain slices, including governance, escrow/task settlement, and compliance/content policy
+- [ ] Allowed dependency directions and temporary bridge rules are explicit
+- [ ] The target state makes `kamn-types` foundational with no dependency on `kamn-core`
+- [ ] Candidate modules from current `kamn-core` are mapped into future crates or retained-core domains
+- [ ] Migration order is documented
+- [ ] At least one contract test pins the new graph markers and architecture index link
+
+## Files To Touch
+
+- `specs/6647-define-kamn-core-target-crate-graph.md`
+- `docs/architecture/kamn-core-target-crate-graph.md`
+- `docs/architecture/README.md`
+- `docs/architecture/kamn-types.md`
+- `crates/kamn-core/tests/kamn_core_target_crate_graph_docs.rs`
+
+## Error Semantics
+
+- Missing architecture markers or index links must fail deterministically in contract tests
+- The architecture document must fail closed on layering by stating forbidden dependency directions explicitly
+- Temporary bridge rules must be explicit so follow-up extraction work cannot assume silent compatibility behavior
+
+## Test Plan
+
+- Run `cargo test -p kamn-core --test kamn_core_target_crate_graph_docs -- --nocapture`
+- Run `cargo test -p kamn-types --test identity_boundary_contract -- --nocapture`
+- Run `cargo test -p kamn-core --test kamn_core_decomposition_map_docs -- --nocapture`
+- Verify the architecture index links the new target graph document


### PR DESCRIPTION
Closes #6647

Issue: https://github.com/njfio/kamn/issues/6647
Spec: https://github.com/njfio/kamn/blob/6647-define-kamn-core-target-crate-graph/specs/6647-define-kamn-core-target-crate-graph.md

## What
- add `docs/architecture/kamn-core-target-crate-graph.md` as the target layering contract for post-`kamn-core` decomposition
- update `docs/architecture/README.md` and `docs/architecture/kamn-core-module-map.md` so contributors reach the new graph from existing architecture entrypoints
- update `docs/architecture/kamn-types.md` with the explicit inversion target for removing the `kamn-types -> kamn-core` dependency
- add doc contracts that pin the new graph markers and the `kamn-types` inversion markers

## Why
- the repo already had a decomposition tranche map, but it did not define allowed dependency directions, temporary bridge rules, or the concrete `kamn-types` inversion path
- extraction issues need one stable architecture contract before code moves start

## Test Evidence
- `cargo test -p kamn-core --test kamn_core_target_crate_graph_docs -- --nocapture`
- `cargo test -p kamn-types --test identity_boundary_contract -- --nocapture`
- `cargo test -p kamn-core --test kamn_core_decomposition_map_docs -- --nocapture`
