### PR TITLE
[6651] Increase test density in utility crates Wave 1

### DIFF
--- a/crates/kamn-snapshot-journal/tests/snapshot_journal_roundtrip_contract.rs
+++ b/crates/kamn-snapshot-journal/tests/snapshot_journal_roundtrip_contract.rs
@@ -2,7 +2,7 @@ use std::fs;
 use std::path::PathBuf;
 
 const REQUIRED_TEST_MARKERS: [&str; 4] = [
-    "fn integration_append_and_parse_round_trip_empty_payload()",
+    "fn integration_append_and_parse_round_trip_whitespace_payload()",
     "fn integration_append_and_parse_round_trip_unicode_payload()",
     "fn integration_append_and_parse_round_trip_multiline_json_payload()",
     "fn integration_checked_parse_and_decode_restore_payload_exactly()",

--- a/crates/kamn-snapshot-journal/tests/snapshot_journal_roundtrip_contract.rs
+++ b/crates/kamn-snapshot-journal/tests/snapshot_journal_roundtrip_contract.rs
@@ -1,0 +1,27 @@
+use std::fs;
+use std::path::PathBuf;
+
+const REQUIRED_TEST_MARKERS: [&str; 4] = [
+    "fn integration_append_and_parse_round_trip_empty_payload()",
+    "fn integration_append_and_parse_round_trip_unicode_payload()",
+    "fn integration_append_and_parse_round_trip_multiline_json_payload()",
+    "fn integration_checked_parse_and_decode_restore_payload_exactly()",
+];
+
+fn repo_file(path: &str) -> String {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+    fs::read_to_string(root.join(path))
+        .unwrap_or_else(|error| panic!("failed to read {path}: {error}"))
+}
+
+#[test]
+fn spec_c01_snapshot_journal_roundtrip_target_exists_with_required_markers() {
+    let source =
+        repo_file("crates/kamn-snapshot-journal/tests/snapshot_journal_roundtrip_integration.rs");
+    for marker in REQUIRED_TEST_MARKERS {
+        assert!(
+            source.contains(marker),
+            "snapshot-journal roundtrip target should contain marker: {marker}"
+        );
+    }
+}

--- a/crates/kamn-snapshot-journal/tests/snapshot_journal_roundtrip_integration.rs
+++ b/crates/kamn-snapshot-journal/tests/snapshot_journal_roundtrip_integration.rs
@@ -1,0 +1,55 @@
+use kamn_snapshot_journal::{
+    append_snapshot_journal_record, decode_snapshot_journal_hex, parse_snapshot_journal_record,
+    parse_snapshot_journal_record_checked,
+};
+use std::fs;
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn temp_journal_path() -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock must be monotonic enough for tmp naming")
+        .as_nanos();
+    std::env::temp_dir().join(format!("kamn-snapshot-journal-roundtrip-{nanos}.journal"))
+}
+
+fn append_and_restore(payload: &str) -> String {
+    let journal_path = temp_journal_path();
+    append_snapshot_journal_record(&journal_path, payload).expect("append record");
+    let journal = fs::read_to_string(&journal_path).expect("read journal");
+    let line = journal.lines().next().expect("journal line");
+    let payload_hex = parse_snapshot_journal_record_checked(line).expect("parse checked line");
+    let decoded = decode_snapshot_journal_hex(&payload_hex).expect("decode payload hex");
+    let restored = String::from_utf8(decoded).expect("utf8 payload");
+    let _ = fs::remove_file(&journal_path);
+    restored
+}
+
+#[test]
+fn integration_append_and_parse_round_trip_whitespace_payload() {
+    assert_eq!(append_and_restore(" \n\t "), " \n\t ");
+}
+
+#[test]
+fn integration_append_and_parse_round_trip_unicode_payload() {
+    let payload = "{\"message\":\"hello \\u{2603}\"}";
+    assert_eq!(append_and_restore(payload), payload);
+}
+
+#[test]
+fn integration_append_and_parse_round_trip_multiline_json_payload() {
+    let payload = "{\n  \"state\": \"ok\",\n  \"count\": 2\n}";
+    assert_eq!(append_and_restore(payload), payload);
+}
+
+#[test]
+fn integration_checked_parse_and_decode_restore_payload_exactly() {
+    let line = r#"{"schema_version":"kamn.snapshot-journal.entry.v1","payload_hex":"7b226b6579223a2276616c75655c6e6c696e65227d"}"#;
+    let payload_hex =
+        parse_snapshot_journal_record_checked(line).expect("json record should parse");
+    assert_eq!(parse_snapshot_journal_record(line), Some(payload_hex.clone()));
+    let decoded = decode_snapshot_journal_hex(&payload_hex).expect("decode payload hex");
+    let restored = String::from_utf8(decoded).expect("utf8 payload");
+    assert_eq!(restored, "{\"key\":\"value\\nline\"}");
+}

--- a/crates/kamn-types/tests/did_boundary_regressions.rs
+++ b/crates/kamn-types/tests/did_boundary_regressions.rs
@@ -1,0 +1,70 @@
+use kamn_types::did;
+use kamn_types::{
+    parse_agent_did_canonical, parse_kamn_did_canonical, AgentDid, AgentDidKeyBindingError,
+    AgentDidError, KamnDidError, SharedDidParseError,
+};
+
+const PUBLIC_KEY_HEX: &str = "025f6ceceac37540cf6ef5f09d4f62c05f0b8f57fe6d8ae32a8f13f4a2eb6e940d";
+const PUBLIC_KEY_HEX_ALT: &str =
+    "02dbf4fcb77ef6a9f2d0f5f0d7c7faaf02f53b724f4cfe6fe1d95ff5a6d4bf8132";
+
+#[test]
+fn integration_plain_agent_did_reports_missing_key_binding() {
+    let did = AgentDid::parse("kamn:did:agent:plain-boundary").expect("plain agent did should parse");
+    assert_eq!(
+        did.ensure_public_key_hex_binding(PUBLIC_KEY_HEX),
+        Err(AgentDidKeyBindingError::MissingKeyBinding)
+    );
+}
+
+#[test]
+fn integration_bound_agent_did_rejects_mismatched_public_key_with_typed_error() {
+    let did = did::AgentDid::with_public_key_hex_binding("typed-boundary", PUBLIC_KEY_HEX)
+        .expect("bound did should render");
+
+    let error = did
+        .ensure_public_key_hex_binding(PUBLIC_KEY_HEX_ALT)
+        .expect_err("mismatched public key should fail");
+
+    let AgentDidKeyBindingError::KeyBindingMismatch { expected, actual } = error else {
+        panic!("expected key binding mismatch error");
+    };
+    assert_eq!(expected.len(), 32);
+    assert_eq!(actual.len(), 32);
+}
+
+#[test]
+fn integration_parse_helpers_preserve_displayable_typed_errors() {
+    let empty = parse_agent_did_canonical(" ").expect_err("empty input should fail");
+    assert_eq!(empty, SharedDidParseError::EmptyInput);
+    assert_eq!(empty.to_string(), "did input must not be empty");
+
+    let agent = parse_agent_did_canonical("did:example:agent").expect_err("invalid agent did");
+    assert_eq!(
+        agent,
+        SharedDidParseError::Agent(AgentDidError::InvalidPrefix("did:example:agent".to_owned()))
+    );
+    assert!(agent.to_string().contains("agent did parse failed"));
+
+    let kamn = parse_kamn_did_canonical("did:example:operator").expect_err("invalid kamn did");
+    assert_eq!(
+        kamn,
+        SharedDidParseError::Kamn(KamnDidError::InvalidPrefix(
+            "did:example:operator".to_owned()
+        ))
+    );
+    assert!(kamn.to_string().contains("kamn did parse failed"));
+}
+
+#[test]
+fn integration_bound_agent_did_round_trips_after_parse() {
+    let rendered = AgentDid::with_public_key_hex_binding("roundtrip-boundary", PUBLIC_KEY_HEX)
+        .expect("bound did should render")
+        .to_string();
+
+    let parsed = AgentDid::parse(rendered.as_str()).expect("rendered bound did should parse");
+    assert_eq!(parsed.as_str(), rendered);
+    parsed
+        .ensure_public_key_hex_binding(PUBLIC_KEY_HEX)
+        .expect("parsed bound did should preserve key binding");
+}

--- a/crates/kamn-types/tests/did_boundary_regressions_contract.rs
+++ b/crates/kamn-types/tests/did_boundary_regressions_contract.rs
@@ -1,0 +1,26 @@
+use std::fs;
+use std::path::PathBuf;
+
+const REQUIRED_TEST_MARKERS: [&str; 4] = [
+    "fn integration_plain_agent_did_reports_missing_key_binding()",
+    "fn integration_bound_agent_did_rejects_mismatched_public_key_with_typed_error()",
+    "fn integration_parse_helpers_preserve_displayable_typed_errors()",
+    "fn integration_bound_agent_did_round_trips_after_parse()",
+];
+
+fn repo_file(path: &str) -> String {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+    fs::read_to_string(root.join(path))
+        .unwrap_or_else(|error| panic!("failed to read {path}: {error}"))
+}
+
+#[test]
+fn spec_c01_did_boundary_regression_target_exists_with_required_markers() {
+    let source = repo_file("crates/kamn-types/tests/did_boundary_regressions.rs");
+    for marker in REQUIRED_TEST_MARKERS {
+        assert!(
+            source.contains(marker),
+            "kamn-types did boundary regression target should contain marker: {marker}"
+        );
+    }
+}

--- a/specs/6651-increase-test-density-in-utility-crates-wave-1.md
+++ b/specs/6651-increase-test-density-in-utility-crates-wave-1.md
@@ -1,0 +1,68 @@
+# 6651 Increase Test Density In Utility Crates Wave 1
+
+## Objective
+
+Increase direct public-surface regression coverage in the first Wave 1 utility crates by adding high-signal tests for `kamn-types` DID boundary behaviors and `kamn-snapshot-journal` serialization round-trips, while explicitly recording why `kamn-bridges` is deferred from this wave.
+
+## Inputs/Outputs
+
+- Inputs:
+  - Public DID boundary helpers and reexports in `crates/kamn-types/src/lib.rs`
+  - Snapshot-journal append/parse/decode helpers in `crates/kamn-snapshot-journal/src/lib.rs`
+  - Existing integration/contract tests in both crates
+  - Issue inventory suggesting `kamn-types`, `kamn-snapshot-journal`, and `kamn-bridges`
+- Outputs:
+  - New public-surface regression tests in `kamn-types`
+  - New append/parse round-trip tests in `kamn-snapshot-journal`
+  - Explicit before/after test inventory evidence for the selected crates
+  - Spec rationale recording why `kamn-bridges` is deferred from Wave 1
+
+## Boundaries/Non-goals
+
+- Do not redesign coverage policy across the repo
+- Do not add mutation/fuzz coverage in this issue
+- Do not add low-value tests that only restate implementation details without public contract value
+- Do not expand this wave to `kamn-bridges` unless the existing direct coverage proves materially weaker than the source audit indicates
+
+## Failure Modes
+
+- Wave 1 selection is arbitrary and not justified by public-surface/test inventory evidence
+- `kamn-types` still lacks direct tests for reexported DID boundary behaviors that downstream crates rely on
+- `kamn-snapshot-journal` still lacks append/parse round-trip coverage for payload classes that matter at the public API boundary
+- New tests duplicate existing `kamn-core` coverage instead of validating the utility-crate contract surface
+- The final evidence does not state the before/after test counts for the selected crates
+
+## Acceptance Criteria
+
+- [x] Wave 1 selects 2 crates with explicit rationale
+- [x] Missing public-surface tests are added for the selected crates
+- [x] Serialization round-trip coverage is added where relevant
+- [x] Regression tests cover known weak or previously untested paths
+- [x] The selected crates have explicit before/after test inventory evidence
+
+## Files To Touch
+
+- `specs/6651-increase-test-density-in-utility-crates-wave-1.md`
+- `crates/kamn-types/tests/did_boundary_regressions.rs`
+- `crates/kamn-snapshot-journal/tests/snapshot_journal_roundtrip_integration.rs`
+
+## Error Semantics
+
+- `kamn-types` tests must assert typed DID boundary failures rather than string-only failures
+- `kamn-snapshot-journal` tests must preserve fail-closed behavior for invalid parse/decode cases while proving successful round-trips where expected
+- Test evidence should distinguish public utility-crate coverage from broader `kamn-core` transitive coverage
+
+## Test Plan
+
+- Run `cargo test -p kamn-types --test did_boundary_regressions -- --nocapture`
+- Run `cargo test -p kamn-snapshot-journal --test snapshot_journal_roundtrip_integration -- --nocapture`
+- Run `cargo test -p kamn-types -- --nocapture`
+- Run `cargo test -p kamn-snapshot-journal -- --nocapture`
+
+## Notes / Deviations
+
+- Wave 1 intentionally selects `kamn-types` and `kamn-snapshot-journal`.
+- `kamn-bridges` is deferred because it already has direct unit + integration coverage across normalization and settlement decision branches in both source and crate tests; that crate remains a follow-up candidate, but not the highest-leverage first wave after current repo inspection.
+- Before Wave 1, inventory is:
+  - `kamn-types`: 19 tests across 4 integration targets plus 5 unit tests in `src/lib.rs`
+  - `kamn-snapshot-journal`: 14 tests across 3 integration targets plus 4 unit tests in `src/lib.rs`

--- a/specs/6651-increase-test-density-in-utility-crates-wave-1.md
+++ b/specs/6651-increase-test-density-in-utility-crates-wave-1.md
@@ -78,3 +78,25 @@ Increase direct public-surface regression coverage in the first Wave 1 utility c
   - `crates/kamn-types/tests/did_boundary_regressions_contract.rs` = 26 LOC
   - `crates/kamn-snapshot-journal/tests/snapshot_journal_roundtrip_contract.rs` = 27 LOC
 - New helper functions remain single-purpose and under the function-size target.
+
+## Integration Evidence
+
+- `cargo test -p kamn-types --test did_boundary_regressions -- --nocapture`
+  - passed
+- `cargo test -p kamn-types --test did_boundary_regressions_contract -- --nocapture`
+  - passed
+- `cargo test -p kamn-types -- --nocapture`
+  - passed
+- `cargo test -p kamn-snapshot-journal --test snapshot_journal_roundtrip_integration -- --nocapture`
+  - passed
+- `cargo test -p kamn-snapshot-journal --test snapshot_journal_roundtrip_contract -- --nocapture`
+  - passed
+- `cargo test -p kamn-snapshot-journal -- --nocapture`
+  - passed
+- After Wave 1, inventory is:
+  - `kamn-types`: 29 total tests (`24` before -> `29` after)
+  - `kamn-snapshot-journal`: 23 total tests (`18` before -> `23` after)
+
+## Deviations
+
+- No `kamn-bridges` tests were added in this wave. The issue body allowed selection of 2-3 crates, and repo inspection showed `kamn-bridges` already had broader direct normalization/settlement coverage than the first-pass issue summary implied, so the wave stayed focused on the two highest-leverage crates instead of diluting the change set.

--- a/specs/6651-increase-test-density-in-utility-crates-wave-1.md
+++ b/specs/6651-increase-test-density-in-utility-crates-wave-1.md
@@ -43,7 +43,9 @@ Increase direct public-surface regression coverage in the first Wave 1 utility c
 ## Files To Touch
 
 - `specs/6651-increase-test-density-in-utility-crates-wave-1.md`
+- `crates/kamn-types/tests/did_boundary_regressions_contract.rs`
 - `crates/kamn-types/tests/did_boundary_regressions.rs`
+- `crates/kamn-snapshot-journal/tests/snapshot_journal_roundtrip_contract.rs`
 - `crates/kamn-snapshot-journal/tests/snapshot_journal_roundtrip_integration.rs`
 
 ## Error Semantics
@@ -66,3 +68,13 @@ Increase direct public-surface regression coverage in the first Wave 1 utility c
 - Before Wave 1, inventory is:
   - `kamn-types`: 19 tests across 4 integration targets plus 5 unit tests in `src/lib.rs`
   - `kamn-snapshot-journal`: 14 tests across 3 integration targets plus 4 unit tests in `src/lib.rs`
+- The initial red sketch assumed an empty payload round-trip target for `kamn-snapshot-journal`; that was corrected during implementation because the current public API intentionally fail-closes empty `payload_hex` records. Wave 1 instead adds round-trip coverage for whitespace, unicode, multiline JSON, and exact decode restoration.
+
+## Refactor Evidence
+
+- All new test files remain below the 200 LOC file limit:
+  - `crates/kamn-types/tests/did_boundary_regressions.rs` = 70 LOC
+  - `crates/kamn-snapshot-journal/tests/snapshot_journal_roundtrip_integration.rs` = 55 LOC
+  - `crates/kamn-types/tests/did_boundary_regressions_contract.rs` = 26 LOC
+  - `crates/kamn-snapshot-journal/tests/snapshot_journal_roundtrip_contract.rs` = 27 LOC
+- New helper functions remain single-purpose and under the function-size target.


### PR DESCRIPTION
Closes #6651

Issue: https://github.com/njfio/kamn/issues/6651
Spec: [specs/6651-increase-test-density-in-utility-crates-wave-1.md](specs/6651-increase-test-density-in-utility-crates-wave-1.md)

## What / Why

- select `kamn-types` and `kamn-snapshot-journal` as the highest-leverage Wave 1 crates
- add direct public-boundary regression tests for `kamn-types` DID reexports and key-binding failure paths
- add append/parse/decode round-trip coverage for `kamn-snapshot-journal` payload classes that matter at the public API boundary
- record before/after test inventory evidence in the spec
- defer `kamn-bridges` to follow-up because current direct normalization/settlement coverage is already broader than the initial issue summary suggested

## Test Evidence

- `cargo test -p kamn-types --test did_boundary_regressions -- --nocapture`
- `cargo test -p kamn-types --test did_boundary_regressions_contract -- --nocapture`
- `cargo test -p kamn-types -- --nocapture`
- `cargo test -p kamn-snapshot-journal --test snapshot_journal_roundtrip_integration -- --nocapture`
- `cargo test -p kamn-snapshot-journal --test snapshot_journal_roundtrip_contract -- --nocapture`
- `cargo test -p kamn-snapshot-journal -- --nocapture`

## PR Checklist

- [x] Spec current
- [x] Tests added
- [x] Refactor complete
- [x] Integration verified
- [x] CI green
