### PR TITLE
[6668] Fix service api axum ingress request-validation status ordering

### DIFF
--- a/scripts/runtime/test_validate_service_api_axum_ingress_live_contract_lane.sh
+++ b/scripts/runtime/test_validate_service_api_axum_ingress_live_contract_lane.sh
@@ -25,6 +25,14 @@ if [ ! -f "$RUNBOOK_DOC" ]; then
   echo "expected service api axum ingress runbook doc to exist" >&2
   exit 1
 fi
+if ! grep -Fq '"X-KAMN-Signer-Public-Key": auth_public_key_hex' "$VALIDATION_SCRIPT"; then
+  echo "expected service api axum ingress validation script auth helper to propagate signer public key header" >&2
+  exit 1
+fi
+if ! grep -Fq 'f"X-KAMN-Signer-Public-Key: {auth_public_key_hex}\\r\\n"' "$VALIDATION_SCRIPT"; then
+  echo "expected service api axum ingress validation script websocket probe to propagate signer public key header" >&2
+  exit 1
+fi
 
 lane_report="$TMP_DIR/service-api-axum-ingress-contract-lane-report.json"
 policy_report="$TMP_DIR/service-api-axum-ingress-policy-report.json"

--- a/scripts/runtime/test_validate_service_api_axum_ingress_live_contract_lane.sh
+++ b/scripts/runtime/test_validate_service_api_axum_ingress_live_contract_lane.sh
@@ -25,12 +25,24 @@ if [ ! -f "$RUNBOOK_DOC" ]; then
   echo "expected service api axum ingress runbook doc to exist" >&2
   exit 1
 fi
-if ! grep -Fq '"X-KAMN-Signer-Public-Key": auth_public_key_hex' "$VALIDATION_SCRIPT"; then
-  echo "expected service api axum ingress validation script auth helper to propagate signer public key header" >&2
+if ! grep -Fq '"X-KAMN-Signer-Public-Key": signer["public_key_hex"]' "$VALIDATION_SCRIPT"; then
+  echo "expected service api axum ingress validation script auth helper to propagate signer-derived public key header" >&2
   exit 1
 fi
-if ! grep -Fq 'f"X-KAMN-Signer-Public-Key: {auth_public_key_hex}\\r\\n"' "$VALIDATION_SCRIPT"; then
-  echo "expected service api axum ingress validation script websocket probe to propagate signer public key header" >&2
+if ! grep -Fq 'f"X-KAMN-Signer-Public-Key: {websocket_signer['"'"'public_key_hex'"'"']}\r\n"' "$VALIDATION_SCRIPT"; then
+  echo "expected service api axum ingress validation script websocket probe to propagate signer-derived public key header" >&2
+  exit 1
+fi
+if ! grep -Fq 'auth_sender_did="kamn:did:agent:pkh-${auth_public_key_hex}"' "$VALIDATION_SCRIPT"; then
+  echo "expected service api axum ingress validation script to use self-certifying sender did binding" >&2
+  exit 1
+fi
+if ! grep -Fq 'request_validation_signer = signer_context(1)' "$VALIDATION_SCRIPT"; then
+  echo "expected service api axum ingress validation script to isolate request-validation sender context" >&2
+  exit 1
+fi
+if ! grep -Fq 'websocket_signer = signer_context(2)' "$VALIDATION_SCRIPT"; then
+  echo "expected service api axum ingress validation script to isolate websocket sender context" >&2
   exit 1
 fi
 

--- a/scripts/runtime/validate_service_api_axum_ingress_live.sh
+++ b/scripts/runtime/validate_service_api_axum_ingress_live.sh
@@ -315,19 +315,19 @@ if [ "$wait_for_ready" -ne 1 ]; then
   exit 1
 fi
 
-auth_sender_did="kamn:did:agent:axum-ingress-validator"
+auth_sender_did="kamn:did:agent:pkh-${auth_public_key_hex}"
 auth_state_hash="service-api:kamn-devnet:v0.1.0"
 
 probe_report="$TMP_DIR/service-api-axum-ingress-probes.json"
 python3 \
-  - "$api_addr" "$probe_report" "$auth_sender_did" "$auth_state_hash" "$auth_private_key_hex" <<'PY'
+  - "$api_addr" "$probe_report" "$auth_sender_did" "$auth_state_hash" "$auth_private_key_hex" "$auth_public_key_hex" <<'PY'
 import concurrent.futures
 import hashlib
 import http.client
 import json
 import socket
 import sys
-from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.asymmetric.utils import decode_dss_signature
 
@@ -336,6 +336,7 @@ probe_report = sys.argv[2]
 sender_did = sys.argv[3]
 state_hash = sys.argv[4]
 private_key_hex = sys.argv[5]
+auth_public_key_hex = sys.argv[6]
 host, port_text = api_addr.rsplit(":", 1)
 port = int(port_text)
 secp256k1_order = int(
@@ -348,7 +349,27 @@ except ValueError as exc:
     raise SystemExit("service api axum ingress probe private key hex is invalid") from exc
 if private_scalar <= 0 or private_scalar >= secp256k1_order:
     raise SystemExit("service api axum ingress probe private key scalar is invalid")
-signing_key = ec.derive_private_key(private_scalar, ec.SECP256K1())
+
+
+def signer_context(offset: int) -> dict[str, object]:
+    derived_scalar = (private_scalar + offset) % secp256k1_order
+    if derived_scalar == 0:
+        derived_scalar = 1
+    signing_key = ec.derive_private_key(derived_scalar, ec.SECP256K1())
+    public_key_hex = signing_key.public_key().public_bytes(
+        encoding=serialization.Encoding.X962,
+        format=serialization.PublicFormat.CompressedPoint,
+    ).hex()
+    return {
+        "private_scalar": derived_scalar,
+        "signing_key": signing_key,
+        "public_key_hex": public_key_hex,
+        "sender_did": f"kamn:did:agent:pkh-{public_key_hex}",
+    }
+
+
+request_validation_signer = signer_context(1)
+websocket_signer = signer_context(2)
 
 
 def signing_payload(nonce: int, payload: str, sender: str) -> str:
@@ -363,16 +384,22 @@ def signing_payload(nonce: int, payload: str, sender: str) -> str:
     )
 
 
-def signature(nonce: int, payload: str, sender: str | None = None) -> str:
-    sender_value = sender_did if sender is None else sender
+def signature(
+    nonce: int,
+    payload: str,
+    signer: dict[str, object],
+    sender: str | None = None,
+) -> str:
+    sender_value = signer["sender_did"] if sender is None else sender
     message = signing_payload(nonce, payload, sender_value).encode("utf-8")
-    der_signature = signing_key.sign(message, ec.ECDSA(hashes.SHA256()))
+    der_signature = signer["signing_key"].sign(message, ec.ECDSA(hashes.SHA256()))
     r_value, s_value = decode_dss_signature(der_signature)
     if s_value > secp256k1_order // 2:
         s_value = secp256k1_order - s_value
     message_hash = int.from_bytes(hashlib.sha256(message).digest(), byteorder="big")
     nonce_scalar = (
-        (message_hash + (r_value * private_scalar)) * pow(s_value, -1, secp256k1_order)
+        (message_hash + (r_value * signer["private_scalar"]))
+        * pow(s_value, -1, secp256k1_order)
     ) % secp256k1_order
     if nonce_scalar == 0:
         raise SystemExit("service api axum ingress probe nonce scalar resolved to zero")
@@ -469,13 +496,19 @@ def run_keep_alive_probe() -> None:
 
 
 def auth_headers(
-    nonce: int, *, scope: str, body: str = "", sender: str | None = None
+    nonce: int,
+    *,
+    scope: str,
+    signer: dict[str, object],
+    body: str = "",
+    sender: str | None = None,
 ) -> dict[str, str]:
-    sender_value = sender_did if sender is None else sender
+    sender_value = signer["sender_did"] if sender is None else sender
     return {
         "X-KAMN-Sender-DID": sender_value,
         "X-KAMN-Request-Nonce": str(nonce),
-        "X-KAMN-Request-Signature": signature(nonce, body, sender_value),
+        "X-KAMN-Request-Signature": signature(nonce, body, signer, sender_value),
+        "X-KAMN-Signer-Public-Key": signer["public_key_hex"],
         "X-KAMN-Authz-Scope": scope,
     }
 
@@ -495,12 +528,17 @@ def parse_error_envelope(payload: str, status: int, expected_status: int) -> dic
 
 
 def run_request_validation_probe() -> None:
-    request_validation_sender = "kamn:did:agent:axum-ingress-validator-request-validation"
+    request_validation_sender = request_validation_signer["sender_did"]
     websocket_status, websocket_body = request(
         "GET",
         "/v1/events/ws",
         "",
-        auth_headers(530, sender=request_validation_sender, scope="events:read"),
+        auth_headers(
+            530,
+            sender=request_validation_sender,
+            scope="events:read",
+            signer=request_validation_signer,
+        ),
     )
     websocket_payload = parse_error_envelope(websocket_body, websocket_status, 400)
     if websocket_payload.get("error") != "bad-request":
@@ -516,7 +554,12 @@ def run_request_validation_probe() -> None:
         "DELETE",
         "/v1/messages/send",
         "",
-        auth_headers(531, sender=request_validation_sender, scope="protected:unknown"),
+        auth_headers(
+            531,
+            sender=request_validation_sender,
+            scope="protected:unknown",
+            signer=request_validation_signer,
+        ),
     )
     method_payload = parse_error_envelope(method_body, method_status, 405)
     if method_payload.get("error") != "method-not-allowed":
@@ -530,7 +573,12 @@ def run_request_validation_probe() -> None:
         "GET",
         "/v1/nope",
         "",
-        auth_headers(532, sender=request_validation_sender, scope="protected:unknown"),
+        auth_headers(
+            532,
+            sender=request_validation_sender,
+            scope="protected:unknown",
+            signer=request_validation_signer,
+        ),
     )
     route_payload = parse_error_envelope(route_body, route_status, 404)
     if route_payload.get("error") != "not-found":
@@ -551,11 +599,12 @@ def run_websocket_probe() -> None:
                 f"Host: {api_addr}\r\n"
                 "Connection: Upgrade\r\n"
                 "Upgrade: websocket\r\n"
-                "Sec-WebSocket-Key: test-axum-key\r\n"
+                "Sec-WebSocket-Key: test-live-key\r\n"
                 f"Sec-WebSocket-Version: {version}\r\n"
-                f"X-KAMN-Sender-DID: {sender_did}\r\n"
+                f"X-KAMN-Sender-DID: {websocket_signer['sender_did']}\r\n"
                 f"X-KAMN-Request-Nonce: {nonce}\r\n"
-                f"X-KAMN-Request-Signature: {signature(nonce, '')}\r\n"
+                f"X-KAMN-Request-Signature: {signature(nonce, '', websocket_signer)}\r\n"
+                f"X-KAMN-Signer-Public-Key: {websocket_signer['public_key_hex']}\r\n"
                 "X-KAMN-Authz-Scope: events:read\r\n"
                 "Content-Length: 0\r\n\r\n"
             )
@@ -593,7 +642,8 @@ def run_concurrency_probe() -> None:
     def post_message(index: int) -> None:
         payload = json.dumps({"message": f"concurrency-{index}"}, separators=(",", ":"))
         nonce = 600 + index
-        sender = f"kamn:did:agent:axum-ingress-validator-concurrency-{index}"
+        signer = signer_context(100 + index)
+        sender = signer["sender_did"]
         status, body = request(
             "POST",
             "/v1/messages/send",
@@ -602,7 +652,8 @@ def run_concurrency_probe() -> None:
                 "content-type": "application/json",
                 "X-KAMN-Sender-DID": sender,
                 "X-KAMN-Request-Nonce": str(nonce),
-                "X-KAMN-Request-Signature": signature(nonce, payload, sender),
+                "X-KAMN-Request-Signature": signature(nonce, payload, signer, sender),
+                "X-KAMN-Signer-Public-Key": signer["public_key_hex"],
                 "X-KAMN-Authz-Scope": "messages:write",
             },
         )
@@ -708,6 +759,7 @@ oversized_status="$(curl -sS -o "$oversized_response_file" -w '%{http_code}' \
   -H "X-KAMN-Sender-DID: ${auth_sender_did}" \
   -H "X-KAMN-Request-Nonce: ${oversized_nonce}" \
   -H "X-KAMN-Request-Signature: ${oversized_signature}" \
+  -H "X-KAMN-Signer-Public-Key: ${auth_public_key_hex}" \
   -H "X-KAMN-Authz-Scope: messages:write" \
   --data-binary "@${oversized_body_file}")"
 if [ "$oversized_status" != "400" ]; then

--- a/scripts/runtime/validate_service_api_axum_ingress_live.sh
+++ b/scripts/runtime/validate_service_api_axum_ingress_live.sh
@@ -320,7 +320,7 @@ auth_state_hash="service-api:kamn-devnet:v0.1.0"
 
 probe_report="$TMP_DIR/service-api-axum-ingress-probes.json"
 python3 \
-  - "$api_addr" "$probe_report" "$auth_sender_did" "$auth_state_hash" "$auth_private_key_hex" "$auth_public_key_hex" <<'PY'
+  - "$api_addr" "$probe_report" "$auth_state_hash" "$auth_private_key_hex" <<'PY'
 import concurrent.futures
 import hashlib
 import http.client
@@ -333,10 +333,8 @@ from cryptography.hazmat.primitives.asymmetric.utils import decode_dss_signature
 
 api_addr = sys.argv[1]
 probe_report = sys.argv[2]
-sender_did = sys.argv[3]
-state_hash = sys.argv[4]
-private_key_hex = sys.argv[5]
-auth_public_key_hex = sys.argv[6]
+state_hash = sys.argv[3]
+private_key_hex = sys.argv[4]
 host, port_text = api_addr.rsplit(":", 1)
 port = int(port_text)
 secp256k1_order = int(

--- a/specs/6668-fix-axum-ingress-request-validation-ordering.md
+++ b/specs/6668-fix-axum-ingress-request-validation-ordering.md
@@ -1,5 +1,7 @@
 # Issue 6668: Fix Service API Axum Ingress Request-Validation Status Ordering
 
+- Status: Implemented
+
 ## Objective
 
 Restore the documented request-validation ordering in the live axum-ingress validator path so malformed websocket upgrade requests, invalid methods, and unknown routes are classified by request-shape/route validation before auth failures, producing the expected `400`, `405`, and `404` envelopes in the real runtime lane.
@@ -34,11 +36,11 @@ Restore the documented request-validation ordering in the live axum-ingress vali
 
 ## Acceptance Criteria
 
-- [ ] AC-1: The live websocket upgrade validation probe returns `400 Bad Request` with `service_api_ws_upgrade_header_missing` in the real validator path.
-- [ ] AC-2: The live invalid-method probe returns `405 Method Not Allowed` with `service_api_method_not_allowed` in the real validator path.
-- [ ] AC-3: The live unknown-route probe returns `404 Not Found` with `service_api_route_not_found` in the real validator path.
-- [ ] AC-4: `bash scripts/runtime/test_check_service_api_axum_ingress_live_policy.sh` passes locally.
-- [ ] AC-5: Any touched docs/contracts remain aligned on the restored request-validation ordering semantics.
+- [x] AC-1: The live websocket upgrade validation probe returns `400 Bad Request` with `service_api_ws_upgrade_header_missing` in the real validator path.
+- [x] AC-2: The live invalid-method probe returns `405 Method Not Allowed` with `service_api_method_not_allowed` in the real validator path.
+- [x] AC-3: The live unknown-route probe returns `404 Not Found` with `service_api_route_not_found` in the real validator path.
+- [x] AC-4: `bash scripts/runtime/test_check_service_api_axum_ingress_live_policy.sh` passes locally.
+- [x] AC-5: Any touched docs/contracts remain aligned on the restored request-validation ordering semantics.
 
 ## Files To Touch
 
@@ -63,3 +65,33 @@ Restore the documented request-validation ordering in the live axum-ingress vali
 3. Implement the minimal runtime fix to restore request-validation ordering.
 4. Re-run the targeted runtime policy lane and any touched Rust/docs contracts.
 5. Record live-lane integration evidence in this spec.
+
+## Refactor Evidence
+
+- The live validator now isolates request-validation, websocket, and concurrency probe families behind separate signer contexts instead of reusing one sender until anti-spam throttles the lane.
+- Stale embedded Python runner inputs were removed so the signer-context flow is self-contained.
+- The touched runtime shell files remain legacy oversized files outside the repo’s ideal size target; this issue kept the fix localized instead of attempting a risky decomposition of the full validator surface.
+
+## Phase 6 integration evidence
+
+- Executed:
+  - `bash scripts/runtime/validate_service_api_axum_ingress_live.sh --output-json /tmp/6668-axum-ingress-live.json`
+  - `bash scripts/runtime/test_validate_service_api_axum_ingress_live_contract_lane.sh`
+  - `bash scripts/runtime/test_check_service_api_axum_ingress_live_policy.sh`
+- Results:
+  - The live validator returned `status=pass` and `final_decision=GO`.
+  - Request-validation probes now classify through the documented envelopes:
+    - websocket upgrade missing header -> `400` / `service_api_ws_upgrade_header_missing`
+    - invalid method -> `405` / `service_api_method_not_allowed`
+    - unknown route -> `404` / `service_api_route_not_found`
+  - The axum-ingress contract lane passed end to end.
+  - The policy checker wrapper passed end to end.
+  - Both runtime scripts are already exercised by the broader harness through `scripts/ci/test_ci_tools.sh` and referenced from release/runbook docs, so the fix is wired into real entrypoints rather than a mock-only path.
+
+## Deviations
+
+- The underlying regression was not middleware ordering after all. The live validator itself had drifted behind the production auth contract by:
+  - omitting `X-KAMN-Signer-Public-Key`
+  - using legacy non-self-certifying sender DIDs
+  - reusing one sender long enough to trigger anti-spam before the websocket success probe
+- Restoring the live probe/auth inputs fixed the request-validation status ordering without changing production auth or route middleware behavior.

--- a/specs/6668-fix-axum-ingress-request-validation-ordering.md
+++ b/specs/6668-fix-axum-ingress-request-validation-ordering.md
@@ -1,0 +1,65 @@
+# Issue 6668: Fix Service API Axum Ingress Request-Validation Status Ordering
+
+## Objective
+
+Restore the documented request-validation ordering in the live axum-ingress validator path so malformed websocket upgrade requests, invalid methods, and unknown routes are classified by request-shape/route validation before auth failures, producing the expected `400`, `405`, and `404` envelopes in the real runtime lane.
+
+## Inputs/Outputs
+
+### Inputs
+- `scripts/runtime/validate_service_api_axum_ingress_live.sh`
+- `scripts/runtime/test_check_service_api_axum_ingress_live_policy.sh`
+- `crates/kamn-node/src/service_api_endpoint.rs`
+- `crates/kamn-node/src/service_api_endpoint/*`
+- Existing service API docs and runtime policy contracts
+
+### Outputs
+- Live validator path returns the expected request-validation statuses and reason codes again
+- Regression coverage that fails closed if auth preempts request-validation classification in this lane
+- Updated spec evidence documenting the restored ordering semantics
+
+## Boundaries/Non-goals
+
+- Do not redesign the full service API auth model
+- Do not weaken auth enforcement for valid protected routes
+- Do not rewrite unrelated runtime-suite lanes
+- Keep the fix limited to request-validation ordering and the contracts/docs that describe it
+
+## Failure Modes
+
+- Websocket upgrade probe still returns `401` instead of the documented `400`
+- Invalid-method or unknown-route probes are classified through auth instead of method/route handling
+- JSON error envelopes lose the documented reason codes or message markers
+- Runtime docs/contracts claim one ordering while the live lane executes another
+
+## Acceptance Criteria
+
+- [ ] AC-1: The live websocket upgrade validation probe returns `400 Bad Request` with `service_api_ws_upgrade_header_missing` in the real validator path.
+- [ ] AC-2: The live invalid-method probe returns `405 Method Not Allowed` with `service_api_method_not_allowed` in the real validator path.
+- [ ] AC-3: The live unknown-route probe returns `404 Not Found` with `service_api_route_not_found` in the real validator path.
+- [ ] AC-4: `bash scripts/runtime/test_check_service_api_axum_ingress_live_policy.sh` passes locally.
+- [ ] AC-5: Any touched docs/contracts remain aligned on the restored request-validation ordering semantics.
+
+## Files To Touch
+
+- `specs/6668-fix-axum-ingress-request-validation-ordering.md`
+- `scripts/runtime/validate_service_api_axum_ingress_live.sh`
+- `scripts/runtime/test_check_service_api_axum_ingress_live_policy.sh`
+- `crates/kamn-node/src/service_api_endpoint.rs`
+- `crates/kamn-node/src/service_api_endpoint/auth.rs`
+- `crates/kamn-node/src/service_api_endpoint/middleware_impl.rs`
+- additional service API runtime/doc contract files only if required by the restored behavior
+
+## Error Semantics
+
+- Request-validation classification must fail closed with the documented status code and reason code for malformed websocket upgrade, invalid method, and unknown route probes
+- Auth failures must still surface as unauthorized for routes that reach auth after passing request-shape/route classification
+- No silent fallback from request-validation taxonomy to auth taxonomy in the targeted live lane
+
+## Test Plan
+
+1. Reproduce the current failure in `bash scripts/runtime/test_check_service_api_axum_ingress_live_policy.sh`.
+2. Add failing regression coverage for the observed request-validation ordering mismatch.
+3. Implement the minimal runtime fix to restore request-validation ordering.
+4. Re-run the targeted runtime policy lane and any touched Rust/docs contracts.
+5. Record live-lane integration evidence in this spec.


### PR DESCRIPTION
Closes #6668

## Summary
- restore the axum-ingress live validator to the current production auth contract by propagating signer public keys and self-certifying sender DIDs through its authenticated probes
- isolate request-validation, websocket, and concurrency probe families behind separate signer contexts so the websocket success probe no longer trips sender anti-spam after the request-validation probes
- keep the fix on the live validator/contract surface rather than changing production middleware ordering

## Spec
- [6668-fix-axum-ingress-request-validation-ordering.md](./specs/6668-fix-axum-ingress-request-validation-ordering.md)

## Test Evidence
- `bash scripts/runtime/validate_service_api_axum_ingress_live.sh --output-json /tmp/6668-axum-ingress-live.json`
- `bash scripts/runtime/test_validate_service_api_axum_ingress_live_contract_lane.sh`
- `bash scripts/runtime/test_check_service_api_axum_ingress_live_policy.sh`
- `bash scripts/ci/check_spec_phase6_evidence_policy.sh --output-json /tmp/6668-spec-phase6-policy.json`

## Shell-Surface Impact Declaration
- [ ] No shell-surface impact.
- [x] Shell-surface impact present (explain below).

shell_loc_delta_actual: 70
rust_loc_delta_actual: 0
shell_to_rust_ratio_delta_actual: 0.0
shell_surface_ratio_target_status: regressed_with_waiver
shell_surface_mitigation_issue: #6668
