### PR TITLE
[6711] Split cli_scripted driver root into bounded modules

### DIFF
--- a/crates/kamn-e2e-harness/src/drivers/cli_scripted.rs
+++ b/crates/kamn-e2e-harness/src/drivers/cli_scripted.rs
@@ -4,10 +4,6 @@ pub(super) use crate::drivers::shared_helpers::{
     live_s07_probe_agent_suffix, parse_s15_budget_env_u128,
     validate_live_s05_release_escrow_response, validate_s15_latency_budget_samples,
 };
-use crate::drivers::{DriverExecutionResult, HarnessDriver};
-use crate::ExecutionMode;
-use std::process::{Command, Stdio};
-use std::sync::Arc;
 
 const CLI_SCRIPTED_LIVE_ENV: &str = "KAMN_E2E_CLI_SCRIPTED_LIVE";
 const CLI_BINARY_ENV: &str = "KAMN_E2E_CLI_BINARY";
@@ -45,13 +41,24 @@ const DEFAULT_S06_FINALITY: &str = "final";
 
 type LiveCliRunner = dyn Fn() -> Result<(), String> + Send + Sync + 'static;
 
+#[path = "cli_scripted/command_support.rs"]
+mod command_support;
+#[path = "cli_scripted/driver_core.rs"]
+mod driver_core;
 #[path = "cli_scripted/live_probe_tranche_one.rs"]
 mod live_probe_tranche_one;
 #[path = "cli_scripted/live_probe_tranche_three.rs"]
 mod live_probe_tranche_three;
 #[path = "cli_scripted/live_probe_tranche_two.rs"]
 mod live_probe_tranche_two;
+#[path = "cli_scripted/runner_registry.rs"]
+mod runner_registry;
 
+pub(super) use command_support::{
+    parse_text_output_field, run_cli_command_capture_stdout,
+    run_cli_command_capture_stdout_with_agent_name, run_cli_command_expect_failure_with_agent_name,
+};
+pub use driver_core::CliScriptedDriver;
 use live_probe_tranche_one::{
     run_live_s01_cli_health_probe, run_live_s02_cli_direct_message_probe,
     run_live_s03_cli_group_channel_probe, run_live_s04_cli_task_lifecycle_probe,
@@ -68,319 +75,6 @@ use live_probe_tranche_two::{
     run_live_s10_cli_topology_coherence_probe, validate_s08_distinct_message_ids,
     validate_s08_message_receipt_fields, validate_s08_query_message_response,
 };
-
-/// CLI-scripted driver with optional live execution for S-01 through S-15.
-#[derive(Clone)]
-pub struct CliScriptedDriver {
-    live_execution_enabled: bool,
-    discovery_runner: Arc<LiveCliRunner>,
-    direct_message_runner: Arc<LiveCliRunner>,
-    group_channel_runner: Arc<LiveCliRunner>,
-    task_lifecycle_runner: Arc<LiveCliRunner>,
-    escrow_settlement_runner: Arc<LiveCliRunner>,
-    proof_verification_runner: Arc<LiveCliRunner>,
-    replay_protection_runner: Arc<LiveCliRunner>,
-    crash_recovery_runner: Arc<LiveCliRunner>,
-    transport_failover_runner: Arc<LiveCliRunner>,
-    topology_coherence_runner: Arc<LiveCliRunner>,
-    signer_rotation_runner: Arc<LiveCliRunner>,
-    retention_deletion_runner: Arc<LiveCliRunner>,
-    bridge_forwarding_runner: Arc<LiveCliRunner>,
-    batch_merkle_runner: Arc<LiveCliRunner>,
-    performance_smoke_runner: Arc<LiveCliRunner>,
-}
-
-impl std::fmt::Debug for CliScriptedDriver {
-    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        formatter
-            .debug_struct("CliScriptedDriver")
-            .field("live_execution_enabled", &self.live_execution_enabled)
-            .finish()
-    }
-}
-
-impl Default for CliScriptedDriver {
-    fn default() -> Self {
-        Self::from_env()
-    }
-}
-
-impl CliScriptedDriver {
-    /// Builds CLI-scripted driver from environment configuration.
-    pub fn from_env() -> Self {
-        Self::with_runners(
-            live_execution_enabled_from_env(),
-            run_live_s01_cli_health_probe,
-            run_live_s02_cli_direct_message_probe,
-            run_live_s03_cli_group_channel_probe,
-            run_live_s04_cli_task_lifecycle_probe,
-            run_live_s05_cli_escrow_settlement_probe,
-            (
-                run_live_s06_cli_proof_verification_probe,
-                run_live_s07_cli_replay_protection_probe,
-                run_live_s08_cli_crash_recovery_probe,
-                run_live_s09_cli_transport_failover_probe,
-                run_live_s10_cli_topology_coherence_probe,
-                run_live_s11_cli_signer_rotation_probe,
-                run_live_s12_cli_retention_deletion_probe,
-                run_live_s13_cli_bridge_forwarding_probe,
-                run_live_s14_cli_batch_merkle_probe,
-                run_live_s15_cli_performance_smoke_probe,
-            ),
-        )
-    }
-
-    /// Creates CLI-scripted driver with one runner reused for all live-bound scenarios.
-    pub fn with_runner<F>(live_execution_enabled: bool, live_runner: F) -> Self
-    where
-        F: Fn() -> Result<(), String> + Send + Sync + 'static,
-    {
-        let live_runner: Arc<LiveCliRunner> = Arc::new(live_runner);
-        Self {
-            live_execution_enabled,
-            discovery_runner: live_runner.clone(),
-            direct_message_runner: live_runner.clone(),
-            task_lifecycle_runner: live_runner.clone(),
-            group_channel_runner: live_runner.clone(),
-            escrow_settlement_runner: live_runner.clone(),
-            proof_verification_runner: live_runner.clone(),
-            replay_protection_runner: live_runner.clone(),
-            crash_recovery_runner: live_runner.clone(),
-            transport_failover_runner: live_runner.clone(),
-            topology_coherence_runner: live_runner.clone(),
-            signer_rotation_runner: live_runner.clone(),
-            retention_deletion_runner: live_runner.clone(),
-            bridge_forwarding_runner: live_runner.clone(),
-            batch_merkle_runner: live_runner.clone(),
-            performance_smoke_runner: live_runner,
-        }
-    }
-
-    /// Creates CLI-scripted driver with explicit per-scenario live runners.
-    pub fn with_runners<F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T>(
-        live_execution_enabled: bool,
-        discovery_runner: F,
-        direct_message_runner: G,
-        group_channel_runner: H,
-        task_lifecycle_runner: I,
-        escrow_settlement_runner: J,
-        proof_replay_crash_failover_topology_signer_retention_bridge_merkle_and_performance_runners: (
-            K,
-            L,
-            M,
-            N,
-            O,
-            P,
-            Q,
-            R,
-            S,
-            T,
-        ),
-    ) -> Self
-    where
-        F: Fn() -> Result<(), String> + Send + Sync + 'static,
-        G: Fn() -> Result<(), String> + Send + Sync + 'static,
-        H: Fn() -> Result<(), String> + Send + Sync + 'static,
-        I: Fn() -> Result<(), String> + Send + Sync + 'static,
-        J: Fn() -> Result<(), String> + Send + Sync + 'static,
-        K: Fn() -> Result<(), String> + Send + Sync + 'static,
-        L: Fn() -> Result<(), String> + Send + Sync + 'static,
-        M: Fn() -> Result<(), String> + Send + Sync + 'static,
-        N: Fn() -> Result<(), String> + Send + Sync + 'static,
-        O: Fn() -> Result<(), String> + Send + Sync + 'static,
-        P: Fn() -> Result<(), String> + Send + Sync + 'static,
-        Q: Fn() -> Result<(), String> + Send + Sync + 'static,
-        R: Fn() -> Result<(), String> + Send + Sync + 'static,
-        S: Fn() -> Result<(), String> + Send + Sync + 'static,
-        T: Fn() -> Result<(), String> + Send + Sync + 'static,
-    {
-        let (
-            proof_verification_runner,
-            replay_protection_runner,
-            crash_recovery_runner,
-            transport_failover_runner,
-            topology_coherence_runner,
-            signer_rotation_runner,
-            retention_deletion_runner,
-            bridge_forwarding_runner,
-            batch_merkle_runner,
-            performance_smoke_runner,
-        ) = proof_replay_crash_failover_topology_signer_retention_bridge_merkle_and_performance_runners;
-        Self {
-            live_execution_enabled,
-            discovery_runner: Arc::new(discovery_runner),
-            direct_message_runner: Arc::new(direct_message_runner),
-            group_channel_runner: Arc::new(group_channel_runner),
-            task_lifecycle_runner: Arc::new(task_lifecycle_runner),
-            escrow_settlement_runner: Arc::new(escrow_settlement_runner),
-            proof_verification_runner: Arc::new(proof_verification_runner),
-            replay_protection_runner: Arc::new(replay_protection_runner),
-            crash_recovery_runner: Arc::new(crash_recovery_runner),
-            transport_failover_runner: Arc::new(transport_failover_runner),
-            topology_coherence_runner: Arc::new(topology_coherence_runner),
-            signer_rotation_runner: Arc::new(signer_rotation_runner),
-            retention_deletion_runner: Arc::new(retention_deletion_runner),
-            bridge_forwarding_runner: Arc::new(bridge_forwarding_runner),
-            batch_merkle_runner: Arc::new(batch_merkle_runner),
-            performance_smoke_runner: Arc::new(performance_smoke_runner),
-        }
-    }
-}
-
-impl HarnessDriver for CliScriptedDriver {
-    fn mode(&self) -> ExecutionMode {
-        ExecutionMode::CliScripted
-    }
-
-    fn execute(&self, scenario_id: &'static str) -> DriverExecutionResult {
-        let status = if !is_live_bound_scenario_id(scenario_id) {
-            "pass"
-        } else if !self.live_execution_enabled {
-            "fail"
-        } else {
-            match self.live_runner_for_scenario(scenario_id) {
-                Some(result) if result.is_ok() => "pass",
-                Some(_) => "fail",
-                None => "fail",
-            }
-        };
-        DriverExecutionResult {
-            scenario_id,
-            status,
-        }
-    }
-}
-
-impl CliScriptedDriver {
-    fn live_runner_for_scenario(&self, scenario_id: &'static str) -> Option<Result<(), String>> {
-        match scenario_id {
-            "S-01" => Some((self.discovery_runner)()),
-            "S-02" => Some((self.direct_message_runner)()),
-            "S-03" => Some((self.group_channel_runner)()),
-            "S-04" => Some((self.task_lifecycle_runner)()),
-            "S-05" => Some((self.escrow_settlement_runner)()),
-            "S-06" => Some((self.proof_verification_runner)()),
-            "S-07" => Some((self.replay_protection_runner)()),
-            "S-08" => Some((self.crash_recovery_runner)()),
-            "S-09" => Some((self.transport_failover_runner)()),
-            "S-10" => Some((self.topology_coherence_runner)()),
-            "S-11" => Some((self.signer_rotation_runner)()),
-            "S-12" => Some((self.retention_deletion_runner)()),
-            "S-13" => Some((self.bridge_forwarding_runner)()),
-            "S-14" => Some((self.batch_merkle_runner)()),
-            "S-15" => Some((self.performance_smoke_runner)()),
-            _ => None,
-        }
-    }
-}
-
-fn live_execution_enabled_from_env() -> bool {
-    shared_live_execution_enabled_from_env(CLI_SCRIPTED_LIVE_ENV)
-}
-
-fn run_cli_command_capture_stdout(
-    cli_binary: &str,
-    args: &[&str],
-    step: &str,
-) -> Result<String, String> {
-    run_cli_command_capture_stdout_with_optional_agent_name(cli_binary, args, step, None)
-}
-
-fn run_cli_command_expect_failure_with_agent_name(
-    cli_binary: &str,
-    args: &[&str],
-    step: &str,
-    agent_name: &str,
-) -> Result<String, String> {
-    let mut command = Command::new(cli_binary);
-    command
-        .args(args)
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .env(
-            AGENT_LIB_DETERMINISTIC_IDENTITY_OPT_IN_ENV,
-            AGENT_LIB_DETERMINISTIC_IDENTITY_OPT_IN_VALUE,
-        )
-        .env("KAMN_AGENT_NAME", agent_name);
-    let output = command
-        .output()
-        .map_err(|error| format!("{step} failed to spawn: {error}"))?;
-
-    if output.status.success() {
-        return Err(format!("{step} unexpectedly succeeded"));
-    }
-
-    let stderr = String::from_utf8_lossy(output.stderr.as_slice())
-        .trim()
-        .to_owned();
-    if stderr.is_empty() {
-        return Err(format!("{step} failed without stderr details"));
-    }
-    Ok(stderr)
-}
-
-fn run_cli_command_capture_stdout_with_agent_name(
-    cli_binary: &str,
-    args: &[&str],
-    step: &str,
-    agent_name: &str,
-) -> Result<String, String> {
-    run_cli_command_capture_stdout_with_optional_agent_name(
-        cli_binary,
-        args,
-        step,
-        Some(agent_name),
-    )
-}
-
-fn run_cli_command_capture_stdout_with_optional_agent_name(
-    cli_binary: &str,
-    args: &[&str],
-    step: &str,
-    agent_name: Option<&str>,
-) -> Result<String, String> {
-    let mut command = Command::new(cli_binary);
-    command
-        .args(args)
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::null())
-        .env(
-            AGENT_LIB_DETERMINISTIC_IDENTITY_OPT_IN_ENV,
-            AGENT_LIB_DETERMINISTIC_IDENTITY_OPT_IN_VALUE,
-        );
-    if let Some(agent_name) = agent_name {
-        command.env("KAMN_AGENT_NAME", agent_name);
-    }
-    let output = command
-        .output()
-        .map_err(|error| format!("{step} failed to spawn: {error}"))?;
-
-    if !output.status.success() {
-        let exit_status = output
-            .status
-            .code()
-            .map(|value| value.to_string())
-            .unwrap_or_else(|| "signal".to_owned());
-        return Err(format!("{step} failed (exit_status={exit_status})"));
-    }
-
-    let stdout = String::from_utf8_lossy(output.stdout.as_slice())
-        .trim()
-        .to_owned();
-    if stdout.is_empty() {
-        return Err(format!("{step} returned empty stdout"));
-    }
-    Ok(stdout)
-}
-
-fn parse_text_output_field<'a>(output: &'a str, key: &str) -> Option<&'a str> {
-    output.split_whitespace().find_map(|token| {
-        let (field, value) = token.split_once('=')?;
-        (field == key).then_some(value)
-    })
-}
 
 #[cfg(test)]
 #[path = "cli_scripted_tests.rs"]

--- a/crates/kamn-e2e-harness/src/drivers/cli_scripted/command_support.rs
+++ b/crates/kamn-e2e-harness/src/drivers/cli_scripted/command_support.rs
@@ -17,17 +17,8 @@ pub(crate) fn run_cli_command_expect_failure_with_agent_name(
     step: &str,
     agent_name: &str,
 ) -> Result<String, String> {
-    let mut command = Command::new(cli_binary);
-    command
-        .args(args)
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .env(
-            AGENT_LIB_DETERMINISTIC_IDENTITY_OPT_IN_ENV,
-            AGENT_LIB_DETERMINISTIC_IDENTITY_OPT_IN_VALUE,
-        )
-        .env("KAMN_AGENT_NAME", agent_name);
+    let mut command = configured_command(cli_binary, args, Some(agent_name));
+    command.stdout(Stdio::piped()).stderr(Stdio::piped());
     let output = command
         .output()
         .map_err(|error| format!("{step} failed to spawn: {error}"))?;
@@ -63,19 +54,8 @@ pub(crate) fn run_cli_command_capture_stdout_with_optional_agent_name(
     step: &str,
     agent_name: Option<&str>,
 ) -> Result<String, String> {
-    let mut command = Command::new(cli_binary);
-    command
-        .args(args)
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::null())
-        .env(
-            AGENT_LIB_DETERMINISTIC_IDENTITY_OPT_IN_ENV,
-            AGENT_LIB_DETERMINISTIC_IDENTITY_OPT_IN_VALUE,
-        );
-    if let Some(agent_name) = agent_name {
-        command.env("KAMN_AGENT_NAME", agent_name);
-    }
+    let mut command = configured_command(cli_binary, args, agent_name);
+    command.stdout(Stdio::piped()).stderr(Stdio::null());
     let output = command
         .output()
         .map_err(|error| format!("{step} failed to spawn: {error}"))?;
@@ -101,4 +81,16 @@ pub(crate) fn parse_text_output_field<'a>(output: &'a str, key: &str) -> Option<
         let (field, value) = token.split_once('=')?;
         (field == key).then_some(value)
     })
+}
+
+fn configured_command(cli_binary: &str, args: &[&str], agent_name: Option<&str>) -> Command {
+    let mut command = Command::new(cli_binary);
+    command.args(args).stdin(Stdio::null()).env(
+        AGENT_LIB_DETERMINISTIC_IDENTITY_OPT_IN_ENV,
+        AGENT_LIB_DETERMINISTIC_IDENTITY_OPT_IN_VALUE,
+    );
+    if let Some(agent_name) = agent_name {
+        command.env("KAMN_AGENT_NAME", agent_name);
+    }
+    command
 }

--- a/crates/kamn-e2e-harness/src/drivers/cli_scripted/command_support.rs
+++ b/crates/kamn-e2e-harness/src/drivers/cli_scripted/command_support.rs
@@ -1,7 +1,7 @@
 use super::{
     AGENT_LIB_DETERMINISTIC_IDENTITY_OPT_IN_ENV, AGENT_LIB_DETERMINISTIC_IDENTITY_OPT_IN_VALUE,
 };
-use std::process::{Command, Stdio};
+use std::process::{Command, Output, Stdio};
 
 pub(crate) fn run_cli_command_capture_stdout(
     cli_binary: &str,
@@ -19,9 +19,7 @@ pub(crate) fn run_cli_command_expect_failure_with_agent_name(
 ) -> Result<String, String> {
     let mut command = configured_command(cli_binary, args, Some(agent_name));
     command.stdout(Stdio::piped()).stderr(Stdio::piped());
-    let output = command
-        .output()
-        .map_err(|error| format!("{step} failed to spawn: {error}"))?;
+    let output = spawn_output(&mut command, step)?;
     if output.status.success() {
         return Err(format!("{step} unexpectedly succeeded"));
     }
@@ -56,24 +54,7 @@ pub(crate) fn run_cli_command_capture_stdout_with_optional_agent_name(
 ) -> Result<String, String> {
     let mut command = configured_command(cli_binary, args, agent_name);
     command.stdout(Stdio::piped()).stderr(Stdio::null());
-    let output = command
-        .output()
-        .map_err(|error| format!("{step} failed to spawn: {error}"))?;
-    if !output.status.success() {
-        let exit_status = output
-            .status
-            .code()
-            .map(|value| value.to_string())
-            .unwrap_or_else(|| "signal".to_owned());
-        return Err(format!("{step} failed (exit_status={exit_status})"));
-    }
-    let stdout = String::from_utf8_lossy(output.stdout.as_slice())
-        .trim()
-        .to_owned();
-    if stdout.is_empty() {
-        return Err(format!("{step} returned empty stdout"));
-    }
-    Ok(stdout)
+    stdout_from_output(spawn_output(&mut command, step)?, step)
 }
 
 pub(crate) fn parse_text_output_field<'a>(output: &'a str, key: &str) -> Option<&'a str> {
@@ -93,4 +74,28 @@ fn configured_command(cli_binary: &str, args: &[&str], agent_name: Option<&str>)
         command.env("KAMN_AGENT_NAME", agent_name);
     }
     command
+}
+
+fn spawn_output(command: &mut Command, step: &str) -> Result<Output, String> {
+    command
+        .output()
+        .map_err(|error| format!("{step} failed to spawn: {error}"))
+}
+
+fn stdout_from_output(output: Output, step: &str) -> Result<String, String> {
+    if !output.status.success() {
+        let exit_status = output
+            .status
+            .code()
+            .map(|value| value.to_string())
+            .unwrap_or_else(|| "signal".to_owned());
+        return Err(format!("{step} failed (exit_status={exit_status})"));
+    }
+    let stdout = String::from_utf8_lossy(output.stdout.as_slice())
+        .trim()
+        .to_owned();
+    if stdout.is_empty() {
+        return Err(format!("{step} returned empty stdout"));
+    }
+    Ok(stdout)
 }

--- a/crates/kamn-e2e-harness/src/drivers/cli_scripted/command_support.rs
+++ b/crates/kamn-e2e-harness/src/drivers/cli_scripted/command_support.rs
@@ -1,0 +1,104 @@
+use super::{
+    AGENT_LIB_DETERMINISTIC_IDENTITY_OPT_IN_ENV, AGENT_LIB_DETERMINISTIC_IDENTITY_OPT_IN_VALUE,
+};
+use std::process::{Command, Stdio};
+
+pub(crate) fn run_cli_command_capture_stdout(
+    cli_binary: &str,
+    args: &[&str],
+    step: &str,
+) -> Result<String, String> {
+    run_cli_command_capture_stdout_with_optional_agent_name(cli_binary, args, step, None)
+}
+
+pub(crate) fn run_cli_command_expect_failure_with_agent_name(
+    cli_binary: &str,
+    args: &[&str],
+    step: &str,
+    agent_name: &str,
+) -> Result<String, String> {
+    let mut command = Command::new(cli_binary);
+    command
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .env(
+            AGENT_LIB_DETERMINISTIC_IDENTITY_OPT_IN_ENV,
+            AGENT_LIB_DETERMINISTIC_IDENTITY_OPT_IN_VALUE,
+        )
+        .env("KAMN_AGENT_NAME", agent_name);
+    let output = command
+        .output()
+        .map_err(|error| format!("{step} failed to spawn: {error}"))?;
+    if output.status.success() {
+        return Err(format!("{step} unexpectedly succeeded"));
+    }
+    let stderr = String::from_utf8_lossy(output.stderr.as_slice())
+        .trim()
+        .to_owned();
+    if stderr.is_empty() {
+        return Err(format!("{step} failed without stderr details"));
+    }
+    Ok(stderr)
+}
+
+pub(crate) fn run_cli_command_capture_stdout_with_agent_name(
+    cli_binary: &str,
+    args: &[&str],
+    step: &str,
+    agent_name: &str,
+) -> Result<String, String> {
+    run_cli_command_capture_stdout_with_optional_agent_name(
+        cli_binary,
+        args,
+        step,
+        Some(agent_name),
+    )
+}
+
+pub(crate) fn run_cli_command_capture_stdout_with_optional_agent_name(
+    cli_binary: &str,
+    args: &[&str],
+    step: &str,
+    agent_name: Option<&str>,
+) -> Result<String, String> {
+    let mut command = Command::new(cli_binary);
+    command
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .env(
+            AGENT_LIB_DETERMINISTIC_IDENTITY_OPT_IN_ENV,
+            AGENT_LIB_DETERMINISTIC_IDENTITY_OPT_IN_VALUE,
+        );
+    if let Some(agent_name) = agent_name {
+        command.env("KAMN_AGENT_NAME", agent_name);
+    }
+    let output = command
+        .output()
+        .map_err(|error| format!("{step} failed to spawn: {error}"))?;
+    if !output.status.success() {
+        let exit_status = output
+            .status
+            .code()
+            .map(|value| value.to_string())
+            .unwrap_or_else(|| "signal".to_owned());
+        return Err(format!("{step} failed (exit_status={exit_status})"));
+    }
+    let stdout = String::from_utf8_lossy(output.stdout.as_slice())
+        .trim()
+        .to_owned();
+    if stdout.is_empty() {
+        return Err(format!("{step} returned empty stdout"));
+    }
+    Ok(stdout)
+}
+
+pub(crate) fn parse_text_output_field<'a>(output: &'a str, key: &str) -> Option<&'a str> {
+    output.split_whitespace().find_map(|token| {
+        let (field, value) = token.split_once('=')?;
+        (field == key).then_some(value)
+    })
+}

--- a/crates/kamn-e2e-harness/src/drivers/cli_scripted/driver_core.rs
+++ b/crates/kamn-e2e-harness/src/drivers/cli_scripted/driver_core.rs
@@ -14,6 +14,9 @@ use crate::drivers::{DriverExecutionResult, HarnessDriver};
 use crate::ExecutionMode;
 use std::sync::Arc;
 
+pub(crate) trait CliRunner: Fn() -> Result<(), String> + Send + Sync + 'static {}
+impl<T> CliRunner for T where T: Fn() -> Result<(), String> + Send + Sync + 'static {}
+
 /// CLI-scripted driver with optional live execution for S-01 through S-15.
 #[derive(Clone)]
 pub struct CliScriptedDriver {
@@ -62,10 +65,7 @@ impl CliScriptedDriver {
     }
 
     /// Creates CLI-scripted driver with one runner reused for all live-bound scenarios.
-    pub fn with_runner<F>(live_execution_enabled: bool, live_runner: F) -> Self
-    where
-        F: Fn() -> Result<(), String> + Send + Sync + 'static,
-    {
+    pub fn with_runner<F: CliRunner>(live_execution_enabled: bool, live_runner: F) -> Self {
         Self::from_runner_map(
             live_execution_enabled,
             shared_runner_map(Arc::new(live_runner)),
@@ -73,68 +73,15 @@ impl CliScriptedDriver {
     }
 
     /// Creates CLI-scripted driver with explicit per-scenario live runners.
-    pub fn with_runners<F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T>(
-        live_execution_enabled: bool,
-        discovery_runner: F,
-        direct_message_runner: G,
-        group_channel_runner: H,
-        task_lifecycle_runner: I,
-        escrow_settlement_runner: J,
-        late_runners: (K, L, M, N, O, P, Q, R, S, T),
-    ) -> Self
-    where
-        F: Fn() -> Result<(), String> + Send + Sync + 'static,
-        G: Fn() -> Result<(), String> + Send + Sync + 'static,
-        H: Fn() -> Result<(), String> + Send + Sync + 'static,
-        I: Fn() -> Result<(), String> + Send + Sync + 'static,
-        J: Fn() -> Result<(), String> + Send + Sync + 'static,
-        K: Fn() -> Result<(), String> + Send + Sync + 'static,
-        L: Fn() -> Result<(), String> + Send + Sync + 'static,
-        M: Fn() -> Result<(), String> + Send + Sync + 'static,
-        N: Fn() -> Result<(), String> + Send + Sync + 'static,
-        O: Fn() -> Result<(), String> + Send + Sync + 'static,
-        P: Fn() -> Result<(), String> + Send + Sync + 'static,
-        Q: Fn() -> Result<(), String> + Send + Sync + 'static,
-        R: Fn() -> Result<(), String> + Send + Sync + 'static,
-        S: Fn() -> Result<(), String> + Send + Sync + 'static,
-        T: Fn() -> Result<(), String> + Send + Sync + 'static,
-    {
-        let (
-            proof,
-            replay,
-            crash,
-            transport,
-            topology,
-            signer,
-            retention,
-            bridge,
-            merkle,
-            performance,
-        ) = late_runners;
-        Self::from_runner_map(
-            live_execution_enabled,
-            explicit_runner_map(
-                [
-                    Arc::new(discovery_runner),
-                    Arc::new(direct_message_runner),
-                    Arc::new(group_channel_runner),
-                    Arc::new(task_lifecycle_runner),
-                    Arc::new(escrow_settlement_runner),
-                ],
-                [
-                    Arc::new(proof),
-                    Arc::new(replay),
-                    Arc::new(crash),
-                    Arc::new(transport),
-                    Arc::new(topology),
-                    Arc::new(signer),
-                    Arc::new(retention),
-                    Arc::new(bridge),
-                    Arc::new(merkle),
-                    Arc::new(performance),
-                ],
-            ),
-        )
+    #[rustfmt::skip]
+    pub fn with_runners<F: CliRunner, G: CliRunner, H: CliRunner, I: CliRunner, J: CliRunner, K: CliRunner, L: CliRunner, M: CliRunner, N: CliRunner, O: CliRunner, P: CliRunner, Q: CliRunner, R: CliRunner, S: CliRunner, T: CliRunner>(
+        live_execution_enabled: bool, discovery_runner: F, direct_message_runner: G, group_channel_runner: H, task_lifecycle_runner: I, escrow_settlement_runner: J, late_runners: (K, L, M, N, O, P, Q, R, S, T),
+    ) -> Self {
+        let (proof, replay, crash, transport, topology, signer, retention, bridge, merkle, performance) = late_runners;
+        Self::from_runner_map(live_execution_enabled, explicit_runner_map(
+            [Arc::new(discovery_runner), Arc::new(direct_message_runner), Arc::new(group_channel_runner), Arc::new(task_lifecycle_runner), Arc::new(escrow_settlement_runner)],
+            [Arc::new(proof), Arc::new(replay), Arc::new(crash), Arc::new(transport), Arc::new(topology), Arc::new(signer), Arc::new(retention), Arc::new(bridge), Arc::new(merkle), Arc::new(performance)],
+        ))
     }
 
     fn from_runner_map(live_execution_enabled: bool, live_runners: LiveRunnerMap) -> Self {

--- a/crates/kamn-e2e-harness/src/drivers/cli_scripted/driver_core.rs
+++ b/crates/kamn-e2e-harness/src/drivers/cli_scripted/driver_core.rs
@@ -14,7 +14,7 @@ use crate::drivers::{DriverExecutionResult, HarnessDriver};
 use crate::ExecutionMode;
 use std::sync::Arc;
 
-pub(crate) trait CliRunner: Fn() -> Result<(), String> + Send + Sync + 'static {}
+pub trait CliRunner: Fn() -> Result<(), String> + Send + Sync + 'static {}
 impl<T> CliRunner for T where T: Fn() -> Result<(), String> + Send + Sync + 'static {}
 
 /// CLI-scripted driver with optional live execution for S-01 through S-15.

--- a/crates/kamn-e2e-harness/src/drivers/cli_scripted/driver_core.rs
+++ b/crates/kamn-e2e-harness/src/drivers/cli_scripted/driver_core.rs
@@ -149,6 +149,19 @@ impl CliScriptedDriver {
             .get(scenario_id)
             .map(|runner| runner.as_ref()())
     }
+
+    fn status_for_scenario(&self, scenario_id: &'static str) -> &'static str {
+        if !is_live_bound_scenario_id(scenario_id) {
+            return "pass";
+        }
+        if !self.live_execution_enabled {
+            return "fail";
+        }
+        match self.live_runner_for_scenario(scenario_id) {
+            Some(result) if result.is_ok() => "pass",
+            Some(_) | None => "fail",
+        }
+    }
 }
 
 impl HarnessDriver for CliScriptedDriver {
@@ -157,19 +170,9 @@ impl HarnessDriver for CliScriptedDriver {
     }
 
     fn execute(&self, scenario_id: &'static str) -> DriverExecutionResult {
-        let status = if !is_live_bound_scenario_id(scenario_id) {
-            "pass"
-        } else if !self.live_execution_enabled {
-            "fail"
-        } else {
-            match self.live_runner_for_scenario(scenario_id) {
-                Some(result) if result.is_ok() => "pass",
-                Some(_) | None => "fail",
-            }
-        };
         DriverExecutionResult {
             scenario_id,
-            status,
+            status: self.status_for_scenario(scenario_id),
         }
     }
 }

--- a/crates/kamn-e2e-harness/src/drivers/cli_scripted/driver_core.rs
+++ b/crates/kamn-e2e-harness/src/drivers/cli_scripted/driver_core.rs
@@ -1,0 +1,179 @@
+use super::{
+    is_live_bound_scenario_id, run_live_s01_cli_health_probe,
+    run_live_s02_cli_direct_message_probe, run_live_s03_cli_group_channel_probe,
+    run_live_s04_cli_task_lifecycle_probe, run_live_s05_cli_escrow_settlement_probe,
+    run_live_s06_cli_proof_verification_probe, run_live_s07_cli_replay_protection_probe,
+    run_live_s08_cli_crash_recovery_probe, run_live_s09_cli_transport_failover_probe,
+    run_live_s10_cli_topology_coherence_probe, run_live_s11_cli_signer_rotation_probe,
+    run_live_s12_cli_retention_deletion_probe, run_live_s13_cli_bridge_forwarding_probe,
+    run_live_s14_cli_batch_merkle_probe, run_live_s15_cli_performance_smoke_probe,
+    runner_registry::{explicit_runner_map, shared_runner_map, LiveRunnerMap},
+    shared_live_execution_enabled_from_env, CLI_SCRIPTED_LIVE_ENV,
+};
+use crate::drivers::{DriverExecutionResult, HarnessDriver};
+use crate::ExecutionMode;
+use std::sync::Arc;
+
+/// CLI-scripted driver with optional live execution for S-01 through S-15.
+#[derive(Clone)]
+pub struct CliScriptedDriver {
+    live_execution_enabled: bool,
+    live_runners: LiveRunnerMap,
+}
+
+impl std::fmt::Debug for CliScriptedDriver {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("CliScriptedDriver")
+            .field("live_execution_enabled", &self.live_execution_enabled)
+            .finish()
+    }
+}
+
+impl Default for CliScriptedDriver {
+    fn default() -> Self {
+        Self::from_env()
+    }
+}
+
+impl CliScriptedDriver {
+    /// Builds CLI-scripted driver from environment configuration.
+    pub fn from_env() -> Self {
+        Self::with_runners(
+            live_execution_enabled_from_env(),
+            run_live_s01_cli_health_probe,
+            run_live_s02_cli_direct_message_probe,
+            run_live_s03_cli_group_channel_probe,
+            run_live_s04_cli_task_lifecycle_probe,
+            run_live_s05_cli_escrow_settlement_probe,
+            (
+                run_live_s06_cli_proof_verification_probe,
+                run_live_s07_cli_replay_protection_probe,
+                run_live_s08_cli_crash_recovery_probe,
+                run_live_s09_cli_transport_failover_probe,
+                run_live_s10_cli_topology_coherence_probe,
+                run_live_s11_cli_signer_rotation_probe,
+                run_live_s12_cli_retention_deletion_probe,
+                run_live_s13_cli_bridge_forwarding_probe,
+                run_live_s14_cli_batch_merkle_probe,
+                run_live_s15_cli_performance_smoke_probe,
+            ),
+        )
+    }
+
+    /// Creates CLI-scripted driver with one runner reused for all live-bound scenarios.
+    pub fn with_runner<F>(live_execution_enabled: bool, live_runner: F) -> Self
+    where
+        F: Fn() -> Result<(), String> + Send + Sync + 'static,
+    {
+        Self::from_runner_map(
+            live_execution_enabled,
+            shared_runner_map(Arc::new(live_runner)),
+        )
+    }
+
+    /// Creates CLI-scripted driver with explicit per-scenario live runners.
+    pub fn with_runners<F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T>(
+        live_execution_enabled: bool,
+        discovery_runner: F,
+        direct_message_runner: G,
+        group_channel_runner: H,
+        task_lifecycle_runner: I,
+        escrow_settlement_runner: J,
+        late_runners: (K, L, M, N, O, P, Q, R, S, T),
+    ) -> Self
+    where
+        F: Fn() -> Result<(), String> + Send + Sync + 'static,
+        G: Fn() -> Result<(), String> + Send + Sync + 'static,
+        H: Fn() -> Result<(), String> + Send + Sync + 'static,
+        I: Fn() -> Result<(), String> + Send + Sync + 'static,
+        J: Fn() -> Result<(), String> + Send + Sync + 'static,
+        K: Fn() -> Result<(), String> + Send + Sync + 'static,
+        L: Fn() -> Result<(), String> + Send + Sync + 'static,
+        M: Fn() -> Result<(), String> + Send + Sync + 'static,
+        N: Fn() -> Result<(), String> + Send + Sync + 'static,
+        O: Fn() -> Result<(), String> + Send + Sync + 'static,
+        P: Fn() -> Result<(), String> + Send + Sync + 'static,
+        Q: Fn() -> Result<(), String> + Send + Sync + 'static,
+        R: Fn() -> Result<(), String> + Send + Sync + 'static,
+        S: Fn() -> Result<(), String> + Send + Sync + 'static,
+        T: Fn() -> Result<(), String> + Send + Sync + 'static,
+    {
+        let (
+            proof,
+            replay,
+            crash,
+            transport,
+            topology,
+            signer,
+            retention,
+            bridge,
+            merkle,
+            performance,
+        ) = late_runners;
+        Self::from_runner_map(
+            live_execution_enabled,
+            explicit_runner_map(
+                [
+                    Arc::new(discovery_runner),
+                    Arc::new(direct_message_runner),
+                    Arc::new(group_channel_runner),
+                    Arc::new(task_lifecycle_runner),
+                    Arc::new(escrow_settlement_runner),
+                ],
+                [
+                    Arc::new(proof),
+                    Arc::new(replay),
+                    Arc::new(crash),
+                    Arc::new(transport),
+                    Arc::new(topology),
+                    Arc::new(signer),
+                    Arc::new(retention),
+                    Arc::new(bridge),
+                    Arc::new(merkle),
+                    Arc::new(performance),
+                ],
+            ),
+        )
+    }
+
+    fn from_runner_map(live_execution_enabled: bool, live_runners: LiveRunnerMap) -> Self {
+        Self {
+            live_execution_enabled,
+            live_runners,
+        }
+    }
+
+    fn live_runner_for_scenario(&self, scenario_id: &'static str) -> Option<Result<(), String>> {
+        self.live_runners
+            .get(scenario_id)
+            .map(|runner| runner.as_ref()())
+    }
+}
+
+impl HarnessDriver for CliScriptedDriver {
+    fn mode(&self) -> ExecutionMode {
+        ExecutionMode::CliScripted
+    }
+
+    fn execute(&self, scenario_id: &'static str) -> DriverExecutionResult {
+        let status = if !is_live_bound_scenario_id(scenario_id) {
+            "pass"
+        } else if !self.live_execution_enabled {
+            "fail"
+        } else {
+            match self.live_runner_for_scenario(scenario_id) {
+                Some(result) if result.is_ok() => "pass",
+                Some(_) | None => "fail",
+            }
+        };
+        DriverExecutionResult {
+            scenario_id,
+            status,
+        }
+    }
+}
+
+pub(crate) fn live_execution_enabled_from_env() -> bool {
+    shared_live_execution_enabled_from_env(CLI_SCRIPTED_LIVE_ENV)
+}

--- a/crates/kamn-e2e-harness/src/drivers/cli_scripted/runner_registry.rs
+++ b/crates/kamn-e2e-harness/src/drivers/cli_scripted/runner_registry.rs
@@ -1,0 +1,37 @@
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+pub(super) type RunnerArc = Arc<super::LiveCliRunner>;
+pub(super) type LiveRunnerMap = BTreeMap<&'static str, RunnerArc>;
+
+const LIVE_SCENARIO_IDS: [&str; 15] = [
+    "S-01", "S-02", "S-03", "S-04", "S-05", "S-06", "S-07", "S-08", "S-09", "S-10", "S-11", "S-12",
+    "S-13", "S-14", "S-15",
+];
+const EARLY_SCENARIO_IDS: [&str; 5] = ["S-01", "S-02", "S-03", "S-04", "S-05"];
+const LATE_SCENARIO_IDS: [&str; 10] = [
+    "S-06", "S-07", "S-08", "S-09", "S-10", "S-11", "S-12", "S-13", "S-14", "S-15",
+];
+
+pub(super) fn shared_runner_map(live_runner: RunnerArc) -> LiveRunnerMap {
+    LIVE_SCENARIO_IDS
+        .into_iter()
+        .map(|scenario_id| (scenario_id, Arc::clone(&live_runner)))
+        .collect()
+}
+
+pub(super) fn explicit_runner_map(
+    early_runners: [RunnerArc; 5],
+    late_runners: [RunnerArc; 10],
+) -> LiveRunnerMap {
+    let mut live_runners = scenario_map(EARLY_SCENARIO_IDS, early_runners);
+    live_runners.extend(scenario_map(LATE_SCENARIO_IDS, late_runners));
+    live_runners
+}
+
+fn scenario_map<const N: usize>(
+    scenario_ids: [&'static str; N],
+    runners: [RunnerArc; N],
+) -> LiveRunnerMap {
+    scenario_ids.into_iter().zip(runners).collect()
+}

--- a/crates/kamn-e2e-harness/src/drivers/cli_scripted_tests.rs
+++ b/crates/kamn-e2e-harness/src/drivers/cli_scripted_tests.rs
@@ -1,18 +1,18 @@
+use super::driver_core::live_execution_enabled_from_env;
 use super::live_probe_tranche_three::validate_s14_cli_verify_proof_response;
 use super::{
-    live_execution_enabled_from_env, live_s07_probe_agent_suffix, parse_s15_budget_env_u128,
-    parse_text_output_field, run_cli_command_capture_stdout,
-    run_cli_command_expect_failure_with_agent_name, run_live_s01_cli_health_probe,
-    run_live_s02_cli_direct_message_probe, run_live_s03_cli_group_channel_probe,
-    run_live_s04_cli_task_lifecycle_probe, run_live_s05_cli_escrow_settlement_probe,
-    run_live_s06_cli_proof_verification_probe, run_live_s07_cli_replay_protection_probe,
-    run_live_s08_cli_crash_recovery_probe, run_live_s09_cli_transport_failover_probe,
-    run_live_s10_cli_topology_coherence_probe, run_live_s11_cli_signer_rotation_probe,
-    run_live_s12_cli_retention_deletion_probe, run_live_s13_cli_bridge_forwarding_probe,
-    run_live_s14_cli_batch_merkle_probe, run_live_s15_cli_performance_smoke_probe,
-    validate_live_s05_release_escrow_response, validate_s08_message_receipt_fields,
-    validate_s08_query_message_response, validate_s15_latency_budget_samples, CliScriptedDriver,
-    CLI_BINARY_ENV, CLI_SCRIPTED_LIVE_ENV,
+    live_s07_probe_agent_suffix, parse_s15_budget_env_u128, parse_text_output_field,
+    run_cli_command_capture_stdout, run_cli_command_expect_failure_with_agent_name,
+    run_live_s01_cli_health_probe, run_live_s02_cli_direct_message_probe,
+    run_live_s03_cli_group_channel_probe, run_live_s04_cli_task_lifecycle_probe,
+    run_live_s05_cli_escrow_settlement_probe, run_live_s06_cli_proof_verification_probe,
+    run_live_s07_cli_replay_protection_probe, run_live_s08_cli_crash_recovery_probe,
+    run_live_s09_cli_transport_failover_probe, run_live_s10_cli_topology_coherence_probe,
+    run_live_s11_cli_signer_rotation_probe, run_live_s12_cli_retention_deletion_probe,
+    run_live_s13_cli_bridge_forwarding_probe, run_live_s14_cli_batch_merkle_probe,
+    run_live_s15_cli_performance_smoke_probe, validate_live_s05_release_escrow_response,
+    validate_s08_message_receipt_fields, validate_s08_query_message_response,
+    validate_s15_latency_budget_samples, CliScriptedDriver, CLI_BINARY_ENV, CLI_SCRIPTED_LIVE_ENV,
 };
 use crate::drivers::shared_helpers::{
     validate_s07_replay_reason_marker, validate_s12_content_field_coherence,

--- a/crates/kamn-e2e-harness/tests/cli_scripted_root_extraction_contract.rs
+++ b/crates/kamn-e2e-harness/tests/cli_scripted_root_extraction_contract.rs
@@ -3,8 +3,7 @@ use std::path::PathBuf;
 
 const CLI_SCRIPTED_ROOT_SOURCE: &str = include_str!("../src/drivers/cli_scripted.rs");
 const CLI_SCRIPTED_DRIVER_CORE_FILE: &str = "src/drivers/cli_scripted/driver_core.rs";
-const CLI_SCRIPTED_COMMAND_SUPPORT_FILE: &str =
-    "src/drivers/cli_scripted/command_support.rs";
+const CLI_SCRIPTED_COMMAND_SUPPORT_FILE: &str = "src/drivers/cli_scripted/command_support.rs";
 const ROOT_MAX_LINES: usize = 200;
 const EXTRACTED_MAX_LINES: usize = 200;
 
@@ -37,7 +36,10 @@ fn regression_cli_scripted_root_removes_residual_driver_and_command_helper_defin
 
 #[test]
 fn regression_cli_scripted_root_extracted_module_files_exist() {
-    for relative_path in [CLI_SCRIPTED_DRIVER_CORE_FILE, CLI_SCRIPTED_COMMAND_SUPPORT_FILE] {
+    for relative_path in [
+        CLI_SCRIPTED_DRIVER_CORE_FILE,
+        CLI_SCRIPTED_COMMAND_SUPPORT_FILE,
+    ] {
         let full_path = manifest_dir().join(relative_path);
         assert!(
             full_path.exists(),
@@ -58,15 +60,18 @@ fn regression_cli_scripted_root_respects_full_file_budget() {
 
 #[test]
 fn regression_cli_scripted_root_extracted_files_stay_within_line_budget() {
-    let offenders = [CLI_SCRIPTED_DRIVER_CORE_FILE, CLI_SCRIPTED_COMMAND_SUPPORT_FILE]
-        .into_iter()
-        .filter_map(|relative_path| {
-            let full_path = manifest_dir().join(relative_path);
-            let line_count = fs::read_to_string(&full_path).ok()?.lines().count();
-            (line_count > EXTRACTED_MAX_LINES)
-                .then(|| format!("{} ({line_count})", full_path.display()))
-        })
-        .collect::<Vec<String>>();
+    let offenders = [
+        CLI_SCRIPTED_DRIVER_CORE_FILE,
+        CLI_SCRIPTED_COMMAND_SUPPORT_FILE,
+    ]
+    .into_iter()
+    .filter_map(|relative_path| {
+        let full_path = manifest_dir().join(relative_path);
+        let line_count = fs::read_to_string(&full_path).ok()?.lines().count();
+        (line_count > EXTRACTED_MAX_LINES)
+            .then(|| format!("{} ({line_count})", full_path.display()))
+    })
+    .collect::<Vec<String>>();
 
     assert!(
         offenders.is_empty(),

--- a/crates/kamn-e2e-harness/tests/cli_scripted_root_extraction_contract.rs
+++ b/crates/kamn-e2e-harness/tests/cli_scripted_root_extraction_contract.rs
@@ -1,0 +1,80 @@
+use std::fs;
+use std::path::PathBuf;
+
+const CLI_SCRIPTED_ROOT_SOURCE: &str = include_str!("../src/drivers/cli_scripted.rs");
+const CLI_SCRIPTED_DRIVER_CORE_FILE: &str = "src/drivers/cli_scripted/driver_core.rs";
+const CLI_SCRIPTED_COMMAND_SUPPORT_FILE: &str =
+    "src/drivers/cli_scripted/command_support.rs";
+const ROOT_MAX_LINES: usize = 200;
+const EXTRACTED_MAX_LINES: usize = 200;
+
+#[test]
+fn regression_cli_scripted_root_declares_driver_core_and_command_support_modules() {
+    for marker in ["mod driver_core;", "mod command_support;"] {
+        assert!(
+            CLI_SCRIPTED_ROOT_SOURCE.contains(marker),
+            "cli_scripted.rs must declare extracted root module marker: {marker}"
+        );
+    }
+}
+
+#[test]
+fn regression_cli_scripted_root_removes_residual_driver_and_command_helper_definitions() {
+    for marker in [
+        "pub struct CliScriptedDriver {",
+        "fn run_cli_command_capture_stdout(",
+        "fn run_cli_command_expect_failure_with_agent_name(",
+        "fn run_cli_command_capture_stdout_with_agent_name(",
+        "fn run_cli_command_capture_stdout_with_optional_agent_name(",
+        "fn parse_text_output_field<'a>(",
+    ] {
+        assert!(
+            !CLI_SCRIPTED_ROOT_SOURCE.contains(marker),
+            "cli_scripted.rs must not keep residual root helper marker: {marker}"
+        );
+    }
+}
+
+#[test]
+fn regression_cli_scripted_root_extracted_module_files_exist() {
+    for relative_path in [CLI_SCRIPTED_DRIVER_CORE_FILE, CLI_SCRIPTED_COMMAND_SUPPORT_FILE] {
+        let full_path = manifest_dir().join(relative_path);
+        assert!(
+            full_path.exists(),
+            "expected extracted cli_scripted root module missing: {}",
+            full_path.display()
+        );
+    }
+}
+
+#[test]
+fn regression_cli_scripted_root_respects_full_file_budget() {
+    let line_count = CLI_SCRIPTED_ROOT_SOURCE.lines().count();
+    assert!(
+        line_count <= ROOT_MAX_LINES,
+        "cli_scripted.rs should stay within the root file budget: {line_count} > {ROOT_MAX_LINES}"
+    );
+}
+
+#[test]
+fn regression_cli_scripted_root_extracted_files_stay_within_line_budget() {
+    let offenders = [CLI_SCRIPTED_DRIVER_CORE_FILE, CLI_SCRIPTED_COMMAND_SUPPORT_FILE]
+        .into_iter()
+        .filter_map(|relative_path| {
+            let full_path = manifest_dir().join(relative_path);
+            let line_count = fs::read_to_string(&full_path).ok()?.lines().count();
+            (line_count > EXTRACTED_MAX_LINES)
+                .then(|| format!("{} ({line_count})", full_path.display()))
+        })
+        .collect::<Vec<String>>();
+
+    assert!(
+        offenders.is_empty(),
+        "extracted cli_scripted root files exceed {EXTRACTED_MAX_LINES} LOC: {}",
+        offenders.join(", ")
+    );
+}
+
+fn manifest_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}

--- a/specs/6711-split-cli-scripted-driver-root-into-bounded-modules.md
+++ b/specs/6711-split-cli-scripted-driver-root-into-bounded-modules.md
@@ -1,0 +1,62 @@
+# Objective
+
+Reduce `crates/kamn-e2e-harness/src/drivers/cli_scripted.rs` to a thin public wiring surface by extracting the residual driver-core construction/execution logic and CLI command helper surface into bounded sibling modules without changing CLI-scripted runtime behavior.
+
+# Inputs/Outputs
+
+## Inputs
+- `crates/kamn-e2e-harness/src/drivers/cli_scripted.rs` at 387 LOC after the live-probe tranche extractions
+- Existing `kamn-e2e-harness` CLI-scripted tests and command contracts
+- Existing sibling tranche modules under `crates/kamn-e2e-harness/src/drivers/cli_scripted/`
+- Existing touched-Rust size policy and file/function size limits
+
+## Outputs
+- `crates/kamn-e2e-harness/src/drivers/cli_scripted.rs` reduced to <= 200 LOC
+- New bounded sibling modules for the residual root responsibilities, expected seams:
+  - `driver_core.rs` for driver construction and execution
+  - `command_support.rs` for CLI command spawning and output parsing
+- Contract coverage that fails if the root grows back above the staged cap or the extracted layout regresses
+- Updated spec evidence for the extracted root surface
+
+# Boundaries/Non-goals
+
+- Do not change CLI-scripted scenario semantics, env var contracts, or external command behavior
+- Do not refactor other drivers in this issue
+- Do not introduce new dependencies
+
+# Failure modes
+
+- `cli_scripted.rs` remains above the 200 LOC cap
+- Driver construction or execution logic stays inline in the root file
+- CLI command helper paths stop failing hard on spawn, empty output, or unexpected success/failure cases
+- Existing CLI-scripted driver tests regress after extraction
+- Touched-Rust size policy fails on the issue branch
+
+# Acceptance criteria
+
+- [ ] `crates/kamn-e2e-harness/src/drivers/cli_scripted.rs` is reduced to <= 200 LOC
+- [ ] residual driver-core responsibilities are extracted into bounded sibling modules
+- [ ] real CLI-scripted runtime wiring remains unchanged
+- [ ] a contract test fails if the root grows above the staged cap or the extracted module layout regresses
+- [ ] relevant `kamn-e2e-harness` CLI-scripted tests and command contracts pass after extraction
+- [ ] touched-Rust size policy passes on the issue branch
+
+# Files to touch
+
+- `specs/6711-split-cli-scripted-driver-root-into-bounded-modules.md`
+- `crates/kamn-e2e-harness/src/drivers/cli_scripted.rs`
+- `crates/kamn-e2e-harness/src/drivers/cli_scripted/**`
+- `crates/kamn-e2e-harness/tests/**` or `crates/kamn-e2e-harness/src/drivers/**` contract coverage needed for the extraction
+
+# Error semantics
+
+- Extraction preserves the current hard-fail command-spawn, exit-status, and empty-output behavior
+- Contract tests fail hard with exact missing-path, file-size, and staged-root-cap details
+- No fallback to inline helper implementations or alternate driver wiring layouts
+
+# Test plan
+
+1. Add a red contract that asserts the new residual-root layout and a <= 200 LOC root cap.
+2. Extract the driver-core and/or command-support seams until the contract passes.
+3. Run focused `kamn-e2e-harness` CLI-scripted tests and command contracts.
+4. Run touched-Rust size policy on the issue write set.

--- a/specs/6711-split-cli-scripted-driver-root-into-bounded-modules.md
+++ b/specs/6711-split-cli-scripted-driver-root-into-bounded-modules.md
@@ -60,3 +60,26 @@ Reduce `crates/kamn-e2e-harness/src/drivers/cli_scripted.rs` to a thin public wi
 2. Extract the driver-core and/or command-support seams until the contract passes.
 3. Run focused `kamn-e2e-harness` CLI-scripted tests and command contracts.
 4. Run touched-Rust size policy on the issue write set.
+
+# Phase 6 Evidence
+
+- Clean detached verification worktree: `/tmp/kamn-6711-final-fzUGau`
+- `bash scripts/ci/check_touched_rust_size_policy.sh --output-json /tmp/6711-touched-size-clean-final.json`
+  - `status=pass`
+  - `policy_decision=GO`
+  - `offending_files=none`
+  - `offending_functions=none`
+- `cargo test -p kamn-e2e-harness --test cli_scripted_root_extraction_contract -- --nocapture`
+- `cargo test -p kamn-e2e-harness cli_scripted -- --nocapture`
+- `cargo test -p kamn-e2e-harness --test command_contract -- --nocapture`
+
+# Outcomes
+
+- `crates/kamn-e2e-harness/src/drivers/cli_scripted.rs` reduced to `81` LOC
+- `crates/kamn-e2e-harness/src/drivers/cli_scripted/driver_core.rs` reduced to `129` LOC
+- `crates/kamn-e2e-harness/src/drivers/cli_scripted/runner_registry.rs` is `37` LOC
+- Real CLI-scripted driver wiring remains exercised through the existing `cli_scripted` and `command_contract` suites
+
+# Deviations
+
+- Final touched-size verification was recorded from a clean detached worktree because the primary issue worktree inherited unrelated tracked edits outside `#6711`; those foreign edits were left untouched.


### PR DESCRIPTION
Closes #6711

## Summary
- split `crates/kamn-e2e-harness/src/drivers/cli_scripted.rs` into bounded root, driver-core, command-support, and runner-registry modules
- keep the public CLI-scripted driver wiring unchanged while moving residual driver construction and command helpers out of the root file
- add contract coverage that fails if the root grows back above budget or the extracted layout regresses

## Spec
- `specs/6711-split-cli-scripted-driver-root-into-bounded-modules.md`

## Test Evidence
- `bash scripts/ci/check_touched_rust_size_policy.sh --output-json /tmp/6711-touched-size-clean-final.json`
- `cargo test -p kamn-e2e-harness --test cli_scripted_root_extraction_contract -- --nocapture`
- `cargo test -p kamn-e2e-harness cli_scripted -- --nocapture`
- `cargo test -p kamn-e2e-harness --test command_contract -- --nocapture`
