### PR TITLE
[6739] Stabilize phase6 deferred runtime marker projection

### DIFF
--- a/crates/kamn-node/src/main_tests/daemon_tests/runtime_contract_tests/selector_bundle_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/daemon_tests/runtime_contract_tests/selector_bundle_contract_tests.rs
@@ -111,23 +111,26 @@ fn assert_selector_bundle_rejects_row_count_mismatch(canonical_rows: &[String]) 
 
 fn capture_deferred_phase6_json_and_complete_log() -> (String, String) {
     let _guards = runtime_json_log_guards();
-    let (rendered, captured_logs) = capture_daemon_json_and_logs(&[
-        "--daemon-max-ticks",
-        "5",
-        "--daemon-tick-interval-ms",
-        "25",
-        "--daemon-shutdown-signal-tick",
-        "3",
-        "--daemon-shutdown-drain-ticks",
-        "2",
-        "--daemon-shutdown-timeout-ticks",
-        "4",
-        "--output",
-        "json",
-    ]);
+    let (rendered, captured_logs, execution_id) = capture_daemon_json_with_chain(
+        "phase6-deferred-contract",
+        &[
+            "--daemon-max-ticks",
+            "5",
+            "--daemon-tick-interval-ms",
+            "25",
+            "--daemon-shutdown-signal-tick",
+            "3",
+            "--daemon-shutdown-drain-ticks",
+            "2",
+            "--daemon-shutdown-timeout-ticks",
+            "4",
+            "--output",
+            "json",
+        ],
+    );
     let complete_line = find_daemon_complete_log_for_execution(
         &captured_logs,
-        "node-runtime:daemon:kamn-devnet:processor",
+        execution_id.as_str(),
     );
     (rendered, complete_line.to_owned())
 }

--- a/crates/kamn-node/src/main_tests/daemon_tests/runtime_contract_tests/selector_bundle_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/daemon_tests/runtime_contract_tests/selector_bundle_contract_tests.rs
@@ -29,6 +29,29 @@ fn functional_runtime_daemon_projects_phase6_deferred_runtime_markers_when_shutd
     );
 }
 
+#[test]
+fn regression_runtime_daemon_deferred_phase6_log_selection_uses_execution_id() {
+    let target_execution_id = "node-runtime:daemon:phase6-deferred-contract:processor";
+    let captured_logs = vec![
+        format!(
+            "{{\"event\":\"node.runtime.daemon.execute.complete\",\"execution_id\":\"node-runtime:daemon:foreign:processor\",\"phase6_reason_code\":\"m10_phase6_scheduler_cycle_applied\"}}"
+        ),
+        format!(
+            "{{\"event\":\"node.runtime.daemon.execute.complete\",\"execution_id\":\"{target_execution_id}\",\"phase6_reason_code\":\"m10_phase6_scheduler_cycle_deferred\"}}"
+        ),
+    ];
+    let selected = find_daemon_complete_log_for_execution(
+        &captured_logs,
+        target_execution_id,
+    );
+    assert_json_log_field(selected, "execution_id", target_execution_id);
+    assert_json_log_field(
+        selected,
+        "phase6_reason_code",
+        "m10_phase6_scheduler_cycle_deferred",
+    );
+}
+
 fn assert_selector_bundle_accepts_canonical_rows(canonical_rows: &[String]) {
     let canonical_fingerprint =
         crate::live_postgres_multi_host_execution_bundle_selector_rows_fingerprint_for_test();
@@ -102,9 +125,9 @@ fn capture_deferred_phase6_json_and_complete_log() -> (String, String) {
         "--output",
         "json",
     ]);
-    let complete_line = find_first_daemon_log(
+    let complete_line = find_daemon_complete_log_for_execution(
         &captured_logs,
-        "\"event\":\"node.runtime.daemon.execute.complete\"",
+        "node-runtime:daemon:kamn-devnet:processor",
     );
     (rendered, complete_line.to_owned())
 }

--- a/crates/kamn-node/src/main_tests/daemon_tests/runtime_contract_tests/support.rs
+++ b/crates/kamn-node/src/main_tests/daemon_tests/runtime_contract_tests/support.rs
@@ -62,14 +62,6 @@ fn capture_daemon_json_with_chain(
     (rendered, captured_logs, execution_id)
 }
 
-fn capture_daemon_json_and_logs(extra_args: &[&str]) -> (String, Vec<String>) {
-    let parsed = parse_daemon(extra_args);
-    let (report_result, captured_logs) = capture_test_logs(|| execute(parsed));
-    let report = report_result.expect("daemon execution should succeed");
-    let rendered = render_bootstrap_report(&report, OutputMode::json());
-    (rendered, captured_logs)
-}
-
 fn capture_daemon_renderings_and_logs(extra_args: &[&str]) -> (String, String, Vec<String>) {
     let parsed = parse_daemon(extra_args);
     let (report_result, captured_logs) = capture_test_logs(|| execute(parsed));
@@ -96,6 +88,17 @@ fn find_first_daemon_log<'a>(captured_logs: &'a [String], event: &str) -> &'a st
         .find(|line| line.contains(event))
         .map(|line| line.as_str())
         .expect("daemon execution should emit structured log marker")
+}
+
+fn find_daemon_complete_log_for_execution<'a>(
+    captured_logs: &'a [String],
+    execution_id: &str,
+) -> &'a str {
+    find_daemon_log(
+        captured_logs,
+        "\"event\":\"node.runtime.daemon.execute.complete\"",
+        execution_id,
+    )
 }
 
 fn assert_json_log_field(log_line: &str, field: &str, expected: &str) {

--- a/specs/6739-stabilize-phase6-deferred-runtime-markers.md
+++ b/specs/6739-stabilize-phase6-deferred-runtime-markers.md
@@ -54,3 +54,9 @@ Stabilize the `kamn-node` daemon Phase 6 deferred-runtime marker projection so `
 4. Re-run the isolated failing test
 5. Re-run `cargo test -p kamn-node daemon_tests -- --nocapture`
 6. Re-run touched-Rust size policy on the issue branch
+
+# Root cause and outcome
+
+- Root cause: the deferred Phase 6 projection test selected the first `node.runtime.daemon.execute.complete` log line in the captured buffer and reused the default `kamn-devnet` execution identity. In the full suite, other daemon tests emit completion lines with the same event and default execution identity, so the test could bind to the wrong completion record.
+- Fix: the test now runs under a dedicated chain id (`phase6-deferred-contract`) and resolves the completion log through an execution-id-aware helper instead of first-match selection.
+- Result: the regression selector test passes, the deferred Phase 6 test passes in isolation, and the full `daemon_tests` target is green on the clean final branch.

--- a/specs/6739-stabilize-phase6-deferred-runtime-markers.md
+++ b/specs/6739-stabilize-phase6-deferred-runtime-markers.md
@@ -1,0 +1,56 @@
+# Objective
+
+Stabilize the `kamn-node` daemon Phase 6 deferred-runtime marker projection so `functional_runtime_daemon_projects_phase6_deferred_runtime_markers_when_shutdown_signals_are_present` passes both in isolation and inside the full `daemon_tests` suite.
+
+# Inputs/Outputs
+
+- Inputs:
+  - Current `main` at `280bd32e26e0490a5801fc3be8c7f96b718602a4`
+  - Repro where the target test passes in isolation but fails in the full `daemon_tests` run
+  - Existing selector-bundle/runtime contract helpers under `crates/kamn-node/src/main_tests/daemon_tests/runtime_contract_tests/`
+- Outputs:
+  - Stable Phase 6 deferred marker assertions with deterministic capture order
+  - A regression test or helper contract documenting the suite interaction that was fixed
+  - Full `cargo test -p kamn-node daemon_tests -- --nocapture` green on the issue branch
+
+# Boundaries/Non-goals
+
+- Touch only the daemon runtime contract test surface and any narrowly scoped shared support required for deterministic capture
+- Do not weaken or delete the failing test
+- Do not refactor unrelated daemon runtime code or production behavior
+- Do not fold `#6738` observability import regression work into this issue
+
+# Failure modes
+
+- Shared log capture or JSON rendering helpers leak state between tests in the full suite
+- The test selects the wrong completion log line when multiple daemon runs emit similar markers
+- Assertions depend on non-deterministic ordering in captured logs
+- The test uses helper state that is valid in isolation but unstable under suite concurrency/order
+
+# Acceptance criteria
+
+- [ ] `cargo test -p kamn-node daemon_tests -- --nocapture` passes on the issue branch
+- [ ] `functional_runtime_daemon_projects_phase6_deferred_runtime_markers_when_shutdown_signals_are_present` passes in isolation and in the full suite
+- [ ] The root cause is documented in this spec with the exact suite interaction that was fixed
+- [ ] A regression helper/test guards the stabilized log-selection or capture behavior
+
+# Files to touch
+
+- `specs/6739-stabilize-phase6-deferred-runtime-markers.md`
+- `crates/kamn-node/src/main_tests/daemon_tests/runtime_contract_tests/selector_bundle_contract_tests.rs`
+- optional narrow helper/support files under `crates/kamn-node/src/main_tests/daemon_tests/runtime_contract_tests/`
+
+# Error semantics
+
+- Failing assertions remain hard failures with explicit missing-marker or wrong-log-line context
+- No silent retries or swallowed capture errors
+- If deterministic capture cannot be established, the test must fail with the precise missing selection reason
+
+# Test plan
+
+1. Reproduce the failure in the full `daemon_tests` suite and the pass in isolation
+2. Add a red regression around the log-line selection/capture behavior if current helpers are ambiguous
+3. Apply the minimum deterministic capture fix
+4. Re-run the isolated failing test
+5. Re-run `cargo test -p kamn-node daemon_tests -- --nocapture`
+6. Re-run touched-Rust size policy on the issue branch


### PR DESCRIPTION
Closes #6739

Issue: #6739
Spec: `specs/6739-stabilize-phase6-deferred-runtime-markers.md`

What changed:
- added an execution-id-aware regression around deferred Phase 6 completion-log selection
- switched the deferred Phase 6 marker test to a dedicated chain identity and execution-id-based completion-log lookup
- recorded the suite-only root cause and final outcome in the spec

Why:
- the previous test selected the first matching completion event and reused the default `kamn-devnet` execution identity
- in the full `daemon_tests` suite, that allowed the test to bind to the wrong completion log line from another daemon run

Test evidence:
- `cargo test -p kamn-node regression_runtime_daemon_deferred_phase6_log_selection_uses_execution_id -- --nocapture`
- `cargo test -p kamn-node functional_runtime_daemon_projects_phase6_deferred_runtime_markers_when_shutdown_signals_are_present -- --nocapture`
- `cargo test -p kamn-node daemon_tests -- --nocapture`
