### PR TITLE
[6743] Stabilize phase6 applied runtime marker projection in daemon_tests

### DIFF
--- a/crates/kamn-node/src/main_tests/daemon_tests/runtime_contract_tests/phase6_projection_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/daemon_tests/runtime_contract_tests/phase6_projection_contract_tests.rs
@@ -142,17 +142,14 @@ fn assert_selector_rows_fingerprint(complete_line: &str) {
 
 fn capture_phase6_renderings_and_complete_log() -> (String, String, String) {
     let _guards = runtime_json_log_guards();
-    let (rendered_json, rendered_text, captured_logs) = capture_daemon_renderings_and_logs(&[
-        "--daemon-max-ticks",
-        "5",
-        "--daemon-tick-interval-ms",
-        "25",
-        "--output",
-        "json",
-    ]);
-    let complete_line = find_first_daemon_log(
-        &captured_logs,
-        "\"event\":\"node.runtime.daemon.execute.complete\"",
+    let (rendered_json, captured_logs, execution_id) = capture_daemon_json_with_chain(
+        "phase6-applied-contract",
+        &["--daemon-max-ticks", "5", "--daemon-tick-interval-ms", "25"],
     );
+    let rendered_text = capture_daemon_text_with_chain(
+        "phase6-applied-contract",
+        &["--daemon-max-ticks", "5", "--daemon-tick-interval-ms", "25"],
+    );
+    let complete_line = find_applied_phase6_complete_log(&captured_logs, execution_id.as_str());
     (rendered_json, rendered_text, complete_line.to_owned())
 }

--- a/crates/kamn-node/src/main_tests/daemon_tests/runtime_contract_tests/phase6_projection_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/daemon_tests/runtime_contract_tests/phase6_projection_contract_tests.rs
@@ -18,10 +18,7 @@ fn regression_runtime_daemon_applied_phase6_log_selection_uses_execution_id() {
             "{{\"event\":\"node.runtime.daemon.execute.complete\",\"execution_id\":\"{target_execution_id}\",\"phase6_reason_code\":\"m10_phase6_scheduler_cycle_applied\"}}"
         ),
     ];
-    let selected = find_applied_phase6_complete_log(
-        &captured_logs,
-        target_execution_id,
-    );
+    let selected = find_applied_phase6_complete_log(&captured_logs, target_execution_id);
     assert_json_log_field(selected, "execution_id", target_execution_id);
     assert_json_log_field(
         selected,

--- a/crates/kamn-node/src/main_tests/daemon_tests/runtime_contract_tests/phase6_projection_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/daemon_tests/runtime_contract_tests/phase6_projection_contract_tests.rs
@@ -9,6 +9,27 @@ fn functional_runtime_daemon_projects_phase6_applied_runtime_markers_in_report_o
     assert_phase6_selector_rows(&complete_line);
 }
 
+#[test]
+fn regression_runtime_daemon_applied_phase6_log_selection_uses_execution_id() {
+    let target_execution_id = "node-runtime:daemon:phase6-applied-contract:processor";
+    let captured_logs = vec![
+        "{\"event\":\"node.runtime.daemon.execute.complete\",\"execution_id\":\"node-runtime:daemon:foreign:processor\",\"phase6_reason_code\":\"m10_phase6_scheduler_cycle_deferred\"}".to_owned(),
+        format!(
+            "{{\"event\":\"node.runtime.daemon.execute.complete\",\"execution_id\":\"{target_execution_id}\",\"phase6_reason_code\":\"m10_phase6_scheduler_cycle_applied\"}}"
+        ),
+    ];
+    let selected = find_applied_phase6_complete_log(
+        &captured_logs,
+        target_execution_id,
+    );
+    assert_json_log_field(selected, "execution_id", target_execution_id);
+    assert_json_log_field(
+        selected,
+        "phase6_reason_code",
+        "m10_phase6_scheduler_cycle_applied",
+    );
+}
+
 fn expected_selector_rows_fingerprint() -> String {
     crate::live_postgres_multi_host_execution_bundle_selector_rows_fingerprint_for_test()
 }

--- a/crates/kamn-node/src/main_tests/daemon_tests/runtime_contract_tests/support.rs
+++ b/crates/kamn-node/src/main_tests/daemon_tests/runtime_contract_tests/support.rs
@@ -62,6 +62,12 @@ fn capture_daemon_json_with_chain(
     (rendered, captured_logs, execution_id)
 }
 
+fn capture_daemon_text_with_chain(chain_id: &str, extra_args: &[&str]) -> String {
+    let parsed = parse_daemon_with_chain(chain_id, extra_args);
+    let report = execute(parsed).expect("daemon execution should succeed");
+    render_bootstrap_report(&report, OutputMode::text())
+}
+
 fn capture_daemon_renderings_and_logs(extra_args: &[&str]) -> (String, String, Vec<String>) {
     let parsed = parse_daemon(extra_args);
     let (report_result, captured_logs) = capture_test_logs(|| execute(parsed));
@@ -99,6 +105,19 @@ fn find_daemon_complete_log_for_execution<'a>(
         "\"event\":\"node.runtime.daemon.execute.complete\"",
         execution_id,
     )
+}
+
+fn find_applied_phase6_complete_log<'a>(
+    captured_logs: &'a [String],
+    execution_id: &str,
+) -> &'a str {
+    let complete_line = find_daemon_complete_log_for_execution(captured_logs, execution_id);
+    assert_json_log_field(
+        complete_line,
+        "phase6_reason_code",
+        "m10_phase6_scheduler_cycle_applied",
+    );
+    complete_line
 }
 
 fn assert_json_log_field(log_line: &str, field: &str, expected: &str) {

--- a/crates/kamn-node/src/main_tests/daemon_tests/runtime_contract_tests/support.rs
+++ b/crates/kamn-node/src/main_tests/daemon_tests/runtime_contract_tests/support.rs
@@ -68,15 +68,6 @@ fn capture_daemon_text_with_chain(chain_id: &str, extra_args: &[&str]) -> String
     render_bootstrap_report(&report, OutputMode::text())
 }
 
-fn capture_daemon_renderings_and_logs(extra_args: &[&str]) -> (String, String, Vec<String>) {
-    let parsed = parse_daemon(extra_args);
-    let (report_result, captured_logs) = capture_test_logs(|| execute(parsed));
-    let report = report_result.expect("daemon execution should succeed");
-    let rendered_json = render_bootstrap_report(&report, OutputMode::json());
-    let rendered_text = render_bootstrap_report(&report, OutputMode::text());
-    (rendered_json, rendered_text, captured_logs)
-}
-
 fn find_daemon_log<'a>(captured_logs: &'a [String], event: &str, execution_id: &str) -> &'a str {
     captured_logs
         .iter()
@@ -84,14 +75,6 @@ fn find_daemon_log<'a>(captured_logs: &'a [String], event: &str, execution_id: &
             line.contains(event)
                 && extract_json_string_field(line, "execution_id").as_deref() == Some(execution_id)
         })
-        .map(|line| line.as_str())
-        .expect("daemon execution should emit structured log marker")
-}
-
-fn find_first_daemon_log<'a>(captured_logs: &'a [String], event: &str) -> &'a str {
-    captured_logs
-        .iter()
-        .find(|line| line.contains(event))
         .map(|line| line.as_str())
         .expect("daemon execution should emit structured log marker")
 }

--- a/specs/6743-stabilize-phase6-applied-runtime-markers.md
+++ b/specs/6743-stabilize-phase6-applied-runtime-markers.md
@@ -38,3 +38,13 @@ Make `functional_runtime_daemon_projects_phase6_applied_runtime_markers_in_repor
 - Fix the applied-path selector to bind deterministically
 - Run the isolated applied-path test
 - Run `cargo test -p kamn-node daemon_tests -- --nocapture`
+
+## Phase 6 evidence
+- Isolated regression: `cargo test -p kamn-node regression_runtime_daemon_applied_phase6_log_selection_uses_execution_id -- --nocapture`
+- Isolated applied-path contract: `cargo test -p kamn-node functional_runtime_daemon_projects_phase6_applied_runtime_markers_in_report_output -- --nocapture`
+- Real suite path: `cargo test -p kamn-node daemon_tests -- --nocapture`
+- Touched-Rust ratchet: `python3 scripts/ci/check_touched_rust_size_policy.py --repo-root /tmp/kamn-6742-baseline-VGAsi1 --base-ref origin/main --output-json /tmp/6743-touched-size.json`
+- Ratchet result: `policy_decision=GO`
+
+## Deviations
+- The applied-path test now captures JSON and text renders through the same dedicated chain id (`phase6-applied-contract`) so completion-log assertions bind to the intended execution consistently under full-suite ordering.

--- a/specs/6743-stabilize-phase6-applied-runtime-markers.md
+++ b/specs/6743-stabilize-phase6-applied-runtime-markers.md
@@ -1,0 +1,40 @@
+# 6743 - Stabilize phase6 applied runtime markers
+
+## Objective
+Make `functional_runtime_daemon_projects_phase6_applied_runtime_markers_in_report_output` deterministic under full `daemon_tests` execution by selecting the correct daemon completion log for the applied path instead of relying on ambiguous suite ordering.
+
+## Inputs/Outputs
+- Input: daemon runtime contract tests and log-selection helpers used by phase6 projection assertions
+- Output: deterministic applied-path selection plus regression coverage that stays green in isolation and under the full suite
+
+## Boundaries/Non-goals
+- Do not fold topology-mapping extraction work into this issue
+- Do not redesign daemon runtime semantics
+- Do not weaken existing phase6 projection assertions
+
+## Failure modes
+- The applied-path test still passes in isolation but fails under full `daemon_tests`
+- Selection logic binds to a foreign completion log with the wrong execution id or phase6 reason code
+- Regression coverage does not prove the suite-wide ordering is now deterministic
+
+## Acceptance criteria
+- [ ] `cargo test -p kamn-node daemon_tests -- --nocapture` passes on the blocker branch
+- [ ] `functional_runtime_daemon_projects_phase6_applied_runtime_markers_in_report_output` passes both in isolation and under the full suite
+- [ ] Applied-path assertions bind to the intended daemon completion log deterministically
+- [ ] Regression coverage proves the selector ignores foreign completion logs that would otherwise satisfy looser matching
+
+## Files to touch
+- `specs/6743-stabilize-phase6-applied-runtime-markers.md`
+- `crates/kamn-node/src/main_tests/daemon_tests/runtime_contract_tests/phase6_projection_contract_tests.rs`
+- `crates/kamn-node/src/main_tests/daemon_tests/runtime_contract_tests/support.rs`
+- any narrowly scoped daemon runtime test file needed for the regression
+
+## Error semantics
+- Test helpers must fail closed with explicit assertion messages when the expected execution-specific completion log is absent
+- No fallback to first-match completion logs
+
+## Test plan
+- Add a red regression covering foreign completion logs versus the target applied-path execution
+- Fix the applied-path selector to bind deterministically
+- Run the isolated applied-path test
+- Run `cargo test -p kamn-node daemon_tests -- --nocapture`


### PR DESCRIPTION
Closes #6743

Issue: https://github.com/njfio/kamn/issues/6743
Spec: `specs/6743-stabilize-phase6-applied-runtime-markers.md`

What changed:
- added an applied-path regression proving foreign completion logs are ignored
- switched the applied phase6 projection test to a dedicated execution id
- removed the ambiguous first-match completion-log helper path

Why:
- `daemon_tests` was unstable on clean `main` because the applied phase6 projection test passed in isolation but failed in the full suite due to ambiguous completion-log selection

Test evidence:
- `cargo test -p kamn-node regression_runtime_daemon_applied_phase6_log_selection_uses_execution_id -- --nocapture`
- `cargo test -p kamn-node functional_runtime_daemon_projects_phase6_applied_runtime_markers_in_report_output -- --nocapture`
- `cargo test -p kamn-node daemon_tests -- --nocapture`
- `python3 scripts/ci/check_touched_rust_size_policy.py --repo-root /tmp/kamn-6742-baseline-VGAsi1 --base-ref origin/main --output-json /tmp/6743-touched-size.json`
- touched-Rust result: `policy_decision=GO`
