### PR TITLE
[6757] Split performance/governance tail tranche from crates/kamn-core/tests/ci_strategy_docs.rs

### DIFF
--- a/crates/kamn-core/tests/ci_strategy_docs.rs
+++ b/crates/kamn-core/tests/ci_strategy_docs.rs
@@ -155,7 +155,6 @@ fn dependency_license_metadata_governance_reason_codes() -> Vec<&'static str> {
         .split(',')
         .collect()
 }
-
 #[path = "ci_strategy_docs/service_api_policy_support.rs"]
 mod service_api_policy_support;
 #[path = "ci_strategy_docs/service_api_request_path_authz_contract_tests.rs"]
@@ -174,6 +173,10 @@ mod fairness_deletion_support;
 mod fairness_docs_parity_contract_tests;
 #[path = "ci_strategy_docs/deletion_docs_parity_contract_tests.rs"]
 mod deletion_docs_parity_contract_tests;
+#[path = "ci_strategy_docs/performance_docs_contract_tests.rs"]
+mod performance_docs_contract_tests;
+#[path = "ci_strategy_docs/governance_gate_contract_tests.rs"]
+mod governance_gate_contract_tests;
 
 #[test]
 fn doc_contains_make_and_demo_scope_contract_rules() {
@@ -2412,132 +2415,4 @@ fn doc_contains_public_api_surface_ratchet_contract_markers() {
     assert!(DOC.contains("reason_codes=public_api_surface_fail_threshold_exceeded_unwaived"));
     assert!(DOC.contains("reason_codes=waiver_cap_exceeded"));
     assert!(DOC.contains("set `mitigation_issue=#<issue-id>` and a bounded `max_total_delta`"));
-}
-
-#[test]
-fn doc_contains_performance_baseline_provenance_contract_markers() {
-    assert!(DOC.contains("## Performance Baseline Artifact Provenance Contract"));
-    assert!(DOC.contains("fixtures/ci/performance_hot_path_fixture_matrix.json"));
-    assert!(DOC.contains("baseline_provenance.artifact_version"));
-    assert!(DOC.contains("baseline_provenance.source_commit"));
-    assert!(DOC.contains("baseline_provenance.source_run_id"));
-    assert!(DOC.contains("baseline_provenance.generated_at_utc"));
-    assert!(DOC.contains("baseline_provenance.generator"));
-    assert!(DOC.contains("drift_threshold_seed_id"));
-    assert!(DOC.contains("drift_threshold_seed.max_latency_p50_ms"));
-    assert!(DOC.contains("drift_threshold_seed.max_latency_p99_ms"));
-    assert!(DOC.contains("drift_threshold_seed.min_throughput_tps"));
-    assert!(DOC.contains("drift_threshold_seed.min_availability_pct"));
-    assert!(DOC.contains("performance_baseline_refresh_policy=manual_on_contract_change"));
-    assert!(DOC.contains(
-        "performance_baseline_refresh_contract=update fixture provenance + seed markers in the same PR as threshold-contract changes"
-    ));
-    assert!(DOC.contains("missing required baseline marker: baseline_provenance_artifact_version"));
-    assert!(DOC.contains("bash scripts/ci/test_generate_performance_smoke_report.sh"));
-    assert!(DOC.contains("bash scripts/ci/test_check_performance_thresholds.sh"));
-}
-
-#[test]
-fn doc_contains_performance_ci_smoke_docs_parity_and_remediation_markers() {
-    assert!(DOC.contains("## Performance CI Smoke Threshold Governance Contract"));
-    assert!(DOC.contains(
-        "bash scripts/ci/check_performance_thresholds.sh --lane smoke --report-json /tmp/performance-smoke-report.json --profile-file .ci/performance-targets.env --ci-tools-file scripts/ci/test_ci_tools.sh --workflow-file .github/workflows/ci-fast-gate.yml --strategy-doc docs/ci/strategy.md --max-seconds 120"
-    ));
-    assert!(DOC.contains(&format!(
-        "performance_ci_smoke_reason_taxonomy_version={PERFORMANCE_CI_SMOKE_REASON_TAXONOMY_VERSION}"
-    )));
-    assert!(DOC.contains(&format!(
-        "performance_ci_smoke_reason_codes_csv={PERFORMANCE_CI_SMOKE_REASON_CODES_CSV}"
-    )));
-    assert!(DOC.contains("performance_ci_smoke_docs_status=verified|violation"));
-    assert!(DOC.contains("performance_ci_smoke_docs_remediation_status=verified|violation"));
-    assert!(DOC.contains("performance_ci_smoke_remediation_map_version=v1"));
-    assert!(DOC.contains(
-        "cargo test -p kamn-core --test ci_strategy_docs doc_contains_performance_ci_smoke_docs_parity_and_remediation_markers -- --exact"
-    ));
-    assert!(DOC.contains(
-        "cargo test -p kamn-core --test ci_strategy_docs doc_enforces_performance_ci_smoke_docs_remediation_markers_cover_reason_codes -- --exact"
-    ));
-    assert!(DOC.contains("Regression: #4002, #4003"));
-}
-
-#[test]
-fn doc_enforces_performance_ci_smoke_docs_remediation_markers_cover_reason_codes() {
-    for reason_code in performance_ci_smoke_reason_codes() {
-        assert!(
-            DOC.contains(&format!("performance_ci_smoke_remediation.{reason_code}=")),
-            "missing performance-ci-smoke remediation marker for {reason_code}"
-        );
-    }
-}
-
-#[test]
-fn doc_contains_governance_feature_commit_ratio_gate_markers() {
-    assert!(DOC.contains("## Governance/Feature Commit-Ratio Fast Gate"));
-    assert!(DOC.contains(
-        "python3 scripts/ci/check_governance_feature_commit_ratio.py --commit-subjects-file /tmp/pr-commit-subjects.txt --window-size 50 --max-governance-ratio 0.20 --output-json /tmp/governance-feature-commit-ratio-report.json"
-    ));
-    assert!(DOC.contains("bash scripts/ci/test_check_governance_feature_commit_ratio.sh"));
-    assert!(DOC.contains("source .ci/governance-feature-commit-ratio-moratorium.env"));
-    assert!(DOC.contains(
-        "git log --no-merges --pretty=format:%s \"${GOVERNANCE_FEATURE_COMMIT_RATIO_MORATORIUM_BASE_SHA}..HEAD\""
-    ));
-    assert!(DOC.contains("ci-governance-feature-commit-ratio.json"));
-    assert!(DOC.contains(
-        "governance_feature_commit_ratio_schema_version=kamn.ci.governance-feature-commit-ratio-report.v1"
-    ));
-    assert!(DOC.contains(
-        "governance_feature_commit_ratio_reason_taxonomy_version=kamn.ci.governance-feature-commit-ratio-reason-taxonomy.v1"
-    ));
-    assert!(DOC.contains(
-        "governance_feature_commit_ratio_reason_codes_csv=governance_commit_subjects_empty,governance_commit_subject_unclassified,governance_commit_ratio_threshold_exceeded"
-    ));
-    assert!(DOC.contains("governance_feature_commit_ratio_threshold_max=0.20"));
-    assert!(DOC.contains("governance_feature_commit_ratio_feature_ratio_min=0.80"));
-    assert!(DOC.contains("governance_feature_commit_ratio_window_size=50"));
-    assert!(DOC.contains("governance_feature_commit_ratio_scope=rolling_latest_non_merge_commits"));
-    assert!(DOC.contains("governance_feature_commit_ratio_policy_source=base_branch"));
-    assert!(
-        DOC.contains("governance_feature_commit_ratio_classification_mode=changed_path_surface")
-    );
-    assert!(DOC.contains(
-        "governance_feature_commit_ratio_activation_base_sha_file=.ci/governance-feature-commit-ratio-moratorium.env"
-    ));
-    assert!(DOC.contains(
-        "governance_feature_commit_ratio_activation_base_sha=d2c2fe1b901a1d53ea419f31778e1d836f2b1323"
-    ));
-    assert!(DOC.contains(
-        "governance_feature_commit_ratio_activation_scope=post_moratorium_commits_only"
-    ));
-    assert!(DOC.contains(
-        "governance_feature_commit_ratio_activation_base_status=head_at_activation_base"
-    ));
-    assert!(DOC.contains(
-        "governance_feature_commit_ratio_preactivation_rerun_status=head_precedes_activation_base"
-    ));
-    assert!(DOC.contains("governance_feature_commit_ratio_non_merge_only=true"));
-}
-
-#[test]
-fn doc_contains_review_document_freeze_gate_markers() {
-    assert!(DOC.contains("## Review-Document Freeze Fast Gate"));
-    assert!(DOC.contains(
-        "python3 scripts/ci/check_review_document_freeze.py --changed-files-file /tmp/pr-changed-files.txt --freeze-manifest docs/review/review-document-freeze.manifest --output-json /tmp/review-document-freeze-report.json"
-    ));
-    assert!(DOC.contains("bash scripts/ci/test_check_review_document_freeze.sh"));
-    assert!(DOC.contains("git diff --name-only <base_sha>..<head_sha>"));
-    assert!(DOC.contains("ci-review-document-freeze.json"));
-    assert!(DOC.contains(
-        "review_document_freeze_schema_version=kamn.ci.review-document-freeze-gate-report.v1"
-    ));
-    assert!(DOC.contains(
-        "review_document_freeze_reason_taxonomy_version=kamn.ci.review-document-freeze-gate-reason-taxonomy.v1"
-    ));
-    assert!(DOC.contains(
-        "review_document_freeze_reason_codes_csv=review_document_freeze_changed_files_missing,review_document_freeze_manifest_missing,review_document_freeze_manifest_invalid,review_document_freeze_violation_detected"
-    ));
-    assert!(DOC.contains(
-        "review_document_freeze_manifest_path=docs/review/review-document-freeze.manifest"
-    ));
-    assert!(DOC.contains("review_document_freeze_scope=docs/review/gaps-and-issues-r*.md"));
 }

--- a/crates/kamn-core/tests/ci_strategy_docs/governance_gate_contract_tests.rs
+++ b/crates/kamn-core/tests/ci_strategy_docs/governance_gate_contract_tests.rs
@@ -1,0 +1,77 @@
+use super::fairness_deletion_support::assert_contains_all;
+use super::DOC;
+
+#[test]
+fn doc_contains_governance_feature_commit_ratio_gate_markers() {
+    assert_governance_gate_commands();
+    assert_governance_gate_schema_markers();
+    assert_governance_gate_policy_markers();
+}
+
+#[test]
+fn doc_contains_review_document_freeze_gate_markers() {
+    assert_contains_all(
+        DOC,
+        &[
+            "## Review-Document Freeze Fast Gate",
+            "python3 scripts/ci/check_review_document_freeze.py --changed-files-file /tmp/pr-changed-files.txt --freeze-manifest docs/review/review-document-freeze.manifest --output-json /tmp/review-document-freeze-report.json",
+            "bash scripts/ci/test_check_review_document_freeze.sh",
+            "git diff --name-only <base_sha>..<head_sha>",
+            "ci-review-document-freeze.json",
+            "review_document_freeze_schema_version=kamn.ci.review-document-freeze-gate-report.v1",
+            "review_document_freeze_reason_taxonomy_version=kamn.ci.review-document-freeze-gate-reason-taxonomy.v1",
+            "review_document_freeze_reason_codes_csv=review_document_freeze_changed_files_missing,review_document_freeze_manifest_missing,review_document_freeze_manifest_invalid,review_document_freeze_violation_detected",
+            "review_document_freeze_manifest_path=docs/review/review-document-freeze.manifest",
+            "review_document_freeze_scope=docs/review/gaps-and-issues-r*.md",
+        ],
+        "review document freeze",
+    );
+}
+
+fn assert_governance_gate_commands() {
+    assert_contains_all(
+        DOC,
+        &[
+            "## Governance/Feature Commit-Ratio Fast Gate",
+            "python3 scripts/ci/check_governance_feature_commit_ratio.py --commit-subjects-file /tmp/pr-commit-subjects.txt --window-size 50 --max-governance-ratio 0.20 --output-json /tmp/governance-feature-commit-ratio-report.json",
+            "bash scripts/ci/test_check_governance_feature_commit_ratio.sh",
+            "source .ci/governance-feature-commit-ratio-moratorium.env",
+            "git log --no-merges --pretty=format:%s \"${GOVERNANCE_FEATURE_COMMIT_RATIO_MORATORIUM_BASE_SHA}..HEAD\"",
+            "ci-governance-feature-commit-ratio.json",
+        ],
+        "governance feature-commit ratio command",
+    );
+}
+
+fn assert_governance_gate_schema_markers() {
+    assert_contains_all(
+        DOC,
+        &[
+            "governance_feature_commit_ratio_schema_version=kamn.ci.governance-feature-commit-ratio-report.v1",
+            "governance_feature_commit_ratio_reason_taxonomy_version=kamn.ci.governance-feature-commit-ratio-reason-taxonomy.v1",
+            "governance_feature_commit_ratio_reason_codes_csv=governance_commit_subjects_empty,governance_commit_subject_unclassified,governance_commit_ratio_threshold_exceeded",
+            "governance_feature_commit_ratio_threshold_max=0.20",
+            "governance_feature_commit_ratio_feature_ratio_min=0.80",
+            "governance_feature_commit_ratio_window_size=50",
+            "governance_feature_commit_ratio_scope=rolling_latest_non_merge_commits",
+            "governance_feature_commit_ratio_policy_source=base_branch",
+            "governance_feature_commit_ratio_classification_mode=changed_path_surface",
+        ],
+        "governance feature-commit ratio schema",
+    );
+}
+
+fn assert_governance_gate_policy_markers() {
+    assert_contains_all(
+        DOC,
+        &[
+            "governance_feature_commit_ratio_activation_base_sha_file=.ci/governance-feature-commit-ratio-moratorium.env",
+            "governance_feature_commit_ratio_activation_base_sha=d2c2fe1b901a1d53ea419f31778e1d836f2b1323",
+            "governance_feature_commit_ratio_activation_scope=post_moratorium_commits_only",
+            "governance_feature_commit_ratio_activation_base_status=head_at_activation_base",
+            "governance_feature_commit_ratio_preactivation_rerun_status=head_precedes_activation_base",
+            "governance_feature_commit_ratio_non_merge_only=true",
+        ],
+        "governance feature-commit ratio policy",
+    );
+}

--- a/crates/kamn-core/tests/ci_strategy_docs/performance_docs_contract_tests.rs
+++ b/crates/kamn-core/tests/ci_strategy_docs/performance_docs_contract_tests.rs
@@ -1,0 +1,82 @@
+use super::*;
+use super::fairness_deletion_support::assert_contains_all;
+
+#[test]
+fn doc_contains_performance_baseline_provenance_contract_markers() {
+    assert_contains_all(
+        DOC,
+        &[
+            "## Performance Baseline Artifact Provenance Contract",
+            "fixtures/ci/performance_hot_path_fixture_matrix.json",
+            "baseline_provenance.artifact_version",
+            "baseline_provenance.source_commit",
+            "baseline_provenance.source_run_id",
+            "baseline_provenance.generated_at_utc",
+            "baseline_provenance.generator",
+            "drift_threshold_seed_id",
+            "drift_threshold_seed.max_latency_p50_ms",
+            "drift_threshold_seed.max_latency_p99_ms",
+            "drift_threshold_seed.min_throughput_tps",
+            "drift_threshold_seed.min_availability_pct",
+            "performance_baseline_refresh_policy=manual_on_contract_change",
+            "performance_baseline_refresh_contract=update fixture provenance + seed markers in the same PR as threshold-contract changes",
+            "missing required baseline marker: baseline_provenance_artifact_version",
+            "bash scripts/ci/test_generate_performance_smoke_report.sh",
+            "bash scripts/ci/test_check_performance_thresholds.sh",
+        ],
+        "performance baseline",
+    );
+}
+
+#[test]
+fn doc_contains_performance_ci_smoke_docs_parity_and_remediation_markers() {
+    assert_performance_ci_smoke_doc_headers();
+    assert_performance_ci_smoke_doc_status_markers();
+    assert_performance_ci_smoke_doc_commands();
+    assert!(DOC.contains("Regression: #4002, #4003"));
+}
+
+#[test]
+fn doc_enforces_performance_ci_smoke_docs_remediation_markers_cover_reason_codes() {
+    for reason_code in performance_ci_smoke_reason_codes() {
+        assert!(
+            DOC.contains(&format!("performance_ci_smoke_remediation.{reason_code}=")),
+            "missing performance-ci-smoke remediation marker for {reason_code}"
+        );
+    }
+}
+
+fn assert_performance_ci_smoke_doc_headers() {
+    assert_contains_all(
+        DOC,
+        &[
+            "## Performance CI Smoke Threshold Governance Contract",
+            "bash scripts/ci/check_performance_thresholds.sh --lane smoke --report-json /tmp/performance-smoke-report.json --profile-file .ci/performance-targets.env --ci-tools-file scripts/ci/test_ci_tools.sh --workflow-file .github/workflows/ci-fast-gate.yml --strategy-doc docs/ci/strategy.md --max-seconds 120",
+            "performance_ci_smoke_docs_status=verified|violation",
+            "performance_ci_smoke_docs_remediation_status=verified|violation",
+            "performance_ci_smoke_remediation_map_version=v1",
+        ],
+        "performance ci smoke",
+    );
+    assert!(DOC.contains(&format!(
+        "performance_ci_smoke_reason_taxonomy_version={PERFORMANCE_CI_SMOKE_REASON_TAXONOMY_VERSION}"
+    )));
+    assert!(DOC.contains(&format!(
+        "performance_ci_smoke_reason_codes_csv={PERFORMANCE_CI_SMOKE_REASON_CODES_CSV}"
+    )));
+}
+
+fn assert_performance_ci_smoke_doc_status_markers() {
+    assert_contains_all(
+        DOC,
+        &[
+            "cargo test -p kamn-core --test ci_strategy_docs doc_contains_performance_ci_smoke_docs_parity_and_remediation_markers -- --exact",
+            "cargo test -p kamn-core --test ci_strategy_docs doc_enforces_performance_ci_smoke_docs_remediation_markers_cover_reason_codes -- --exact",
+        ],
+        "performance ci smoke command",
+    );
+}
+
+fn assert_performance_ci_smoke_doc_commands() {
+    assert!(!performance_ci_smoke_reason_codes().is_empty());
+}

--- a/crates/kamn-core/tests/ci_strategy_docs/performance_docs_contract_tests.rs
+++ b/crates/kamn-core/tests/ci_strategy_docs/performance_docs_contract_tests.rs
@@ -32,7 +32,7 @@ fn doc_contains_performance_baseline_provenance_contract_markers() {
 fn doc_contains_performance_ci_smoke_docs_parity_and_remediation_markers() {
     assert_performance_ci_smoke_doc_headers();
     assert_performance_ci_smoke_doc_status_markers();
-    assert_performance_ci_smoke_doc_commands();
+    assert_performance_ci_smoke_reason_codes_non_empty();
     assert!(DOC.contains("Regression: #4002, #4003"));
 }
 
@@ -77,6 +77,6 @@ fn assert_performance_ci_smoke_doc_status_markers() {
     );
 }
 
-fn assert_performance_ci_smoke_doc_commands() {
+fn assert_performance_ci_smoke_reason_codes_non_empty() {
     assert!(!performance_ci_smoke_reason_codes().is_empty());
 }

--- a/crates/kamn-core/tests/ci_strategy_docs_tail_performance_governance_extraction_contract.rs
+++ b/crates/kamn-core/tests/ci_strategy_docs_tail_performance_governance_extraction_contract.rs
@@ -1,0 +1,45 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const ROOT: &str = "tests/ci_strategy_docs.rs";
+const MODULE_DIR: &str = "tests/ci_strategy_docs";
+const ROOT_MAX_LINES: usize = 2420;
+const REQUIRED_MODULES: &[&str] = &[
+    "performance_docs_contract_tests.rs",
+    "governance_gate_contract_tests.rs",
+];
+const REQUIRED_MARKERS: &[&str] = &[
+    "mod performance_docs_contract_tests;",
+    "mod governance_gate_contract_tests;",
+];
+const MOVED_TEST_MARKERS: &[&str] = &[
+    "fn doc_contains_performance_baseline_provenance_contract_markers()",
+    "fn doc_contains_governance_feature_commit_ratio_gate_markers()",
+];
+
+#[test]
+fn ci_strategy_docs_tail_performance_governance_tranche_is_extracted() {
+    let root = fs::read_to_string(repo_path(ROOT)).expect("read root");
+    let lines = root.lines().count();
+    assert!(
+        lines <= ROOT_MAX_LINES,
+        "expected {ROOT} <= {ROOT_MAX_LINES} lines after tranche extraction, found {lines}"
+    );
+    for marker in REQUIRED_MARKERS {
+        assert!(root.contains(marker), "missing root module marker: {marker}");
+    }
+    for name in REQUIRED_MODULES {
+        let path = repo_path(MODULE_DIR).join(name);
+        assert!(path.exists(), "missing extracted module: {}", path.display());
+    }
+    for marker in MOVED_TEST_MARKERS {
+        assert!(
+            !root.contains(marker),
+            "moved tail test marker still present in root: {marker}"
+        );
+    }
+}
+
+fn repo_path(path: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(path)
+}

--- a/specs/6757-split-ci-strategy-docs-tail-performance-governance.md
+++ b/specs/6757-split-ci-strategy-docs-tail-performance-governance.md
@@ -1,0 +1,55 @@
+# 6757-split-ci-strategy-docs-tail-performance-governance
+
+## Objective
+Extract the tail performance/governance tranche from `crates/kamn-core/tests/ci_strategy_docs.rs` into bounded sibling modules while preserving the existing docs-contract assertions and the real `ci_strategy_docs` test entrypoint.
+
+## Inputs/Outputs
+- Inputs:
+  - `crates/kamn-core/tests/ci_strategy_docs.rs`
+  - `docs/ci/strategy.md`
+  - referenced performance/governance docs and fixtures already consumed by the current tests
+- Outputs:
+  - root `ci_strategy_docs.rs` with the tail tranche removed
+  - bounded sibling modules for performance baseline, performance CI smoke, governance feature-commit ratio, and review document freeze tests
+  - extraction contract for the tail layout
+
+## Boundaries/Non-goals
+- Do not split unrelated `ci_strategy_docs` sections in this issue
+- Do not change performance/governance marker semantics
+- Do not modify runtime or CI workflow behavior
+
+## Failure modes
+- moved tail test bodies remain inline in the root file
+- extracted files exceed the size policy
+- moved functions exceed the touched-function policy
+- module wiring breaks the `ci_strategy_docs` target
+- touched-Rust size policy remains NO-GO
+
+## Acceptance criteria
+- [ ] tail performance/governance tests are removed from root `ci_strategy_docs.rs`
+- [ ] bounded sibling files exist under `crates/kamn-core/tests/ci_strategy_docs/`
+- [ ] extraction contract fails on the old layout and passes on the new layout
+- [ ] `cargo test -p kamn-core --test ci_strategy_docs -- --nocapture` passes
+- [ ] touched-Rust size policy returns `GO`
+- [ ] spec records final evidence and deviations
+
+## Files to touch
+- `specs/6757-split-ci-strategy-docs-tail-performance-governance.md`
+- `crates/kamn-core/tests/ci_strategy_docs.rs`
+- `crates/kamn-core/tests/ci_strategy_docs/*.rs`
+- `crates/kamn-core/tests/ci_strategy_docs_tail_performance_governance_extraction_contract.rs`
+
+## Error semantics
+- extraction assertions fail loudly on missing files, missing root markers, or stale inline test bodies
+- existing docs-contract assertions remain authoritative and unchanged in meaning
+- no silent fallback module wiring
+
+## Test plan
+1. Add a red extraction contract for the tail performance/governance tranche
+2. Confirm it fails against current `main`
+3. Extract the tail functions into bounded sibling files, using small helpers as needed
+4. Run:
+   - `cargo test -p kamn-core --test ci_strategy_docs_tail_performance_governance_extraction_contract -- --nocapture`
+   - `cargo test -p kamn-core --test ci_strategy_docs -- --nocapture`
+   - `python3 scripts/ci/check_touched_rust_size_policy.py --repo-root /tmp/kamn-6748 --base-ref origin/main --output-json /tmp/6757-touched-size.json`
+5. Record evidence and open the PR

--- a/specs/6757-split-ci-strategy-docs-tail-performance-governance.md
+++ b/specs/6757-split-ci-strategy-docs-tail-performance-governance.md
@@ -53,3 +53,12 @@ Extract the tail performance/governance tranche from `crates/kamn-core/tests/ci_
    - `cargo test -p kamn-core --test ci_strategy_docs -- --nocapture`
    - `python3 scripts/ci/check_touched_rust_size_policy.py --repo-root /tmp/kamn-6748 --base-ref origin/main --output-json /tmp/6757-touched-size.json`
 5. Record evidence and open the PR
+
+## Phase 6 Evidence
+- `cargo test -p kamn-core --test ci_strategy_docs_tail_performance_governance_extraction_contract -- --nocapture`
+- `cargo test -p kamn-core --test ci_strategy_docs -- --nocapture`
+- `python3 scripts/ci/check_touched_rust_size_policy.py --repo-root /tmp/kamn-6748 --base-ref origin/main --output-json /tmp/6757-touched-size-refactor.json`
+- Result: `policy_decision=GO`
+
+## Deviations
+- None.


### PR DESCRIPTION
Closes #6757

Spec: `specs/6757-split-ci-strategy-docs-tail-performance-governance.md`

What changed:
- extracted the tail performance/governance tranche out of `crates/kamn-core/tests/ci_strategy_docs.rs`
- added bounded sibling modules for performance baseline/performance CI smoke and governance/review freeze markers
- added `ci_strategy_docs_tail_performance_governance_extraction_contract.rs`

Test evidence:
- `cargo test -p kamn-core --test ci_strategy_docs_tail_performance_governance_extraction_contract -- --nocapture`
- `cargo test -p kamn-core --test ci_strategy_docs -- --nocapture`
- `python3 scripts/ci/check_touched_rust_size_policy.py --repo-root /tmp/kamn-6748 --base-ref origin/main --output-json /tmp/6757-touched-size-refactor.json`
