### PR TITLE
[6845] Enforce actions runtime ceilings and cancel-in-progress policy

### DIFF
--- a/.github/workflows/branch-cleanup.yml
+++ b/.github/workflows/branch-cleanup.yml
@@ -17,6 +17,7 @@ permissions:
 jobs:
   cleanup:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Prune merged stale branches safely
         uses: actions/github-script@v7

--- a/.github/workflows/ci-deep-validate.yml
+++ b/.github/workflows/ci-deep-validate.yml
@@ -16,7 +16,7 @@ jobs:
   deep-validate:
     name: Deep Validate (Nightly/Manual)
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    timeout-minutes: 60
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci-fast-gate.yml
+++ b/.github/workflows/ci-fast-gate.yml
@@ -189,6 +189,10 @@ jobs:
             --exception-file fixtures/ci/touched_shell_strict_mode_exceptions.txt \
             --output-json ci-touched-shell-strict-mode-report.json
 
+      - name: Enforce workflow runtime ceiling policy
+        if: steps.scope.outputs.run_ci_tool_checks == 'true'
+        run: bash scripts/ci/test_workflow_runtime_ceiling_policy.sh
+
       - name: Upload touched shell strict-mode telemetry
         if: always() && hashFiles('ci-touched-shell-strict-mode-report.json') != ''
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci-fast-gate.yml
+++ b/.github/workflows/ci-fast-gate.yml
@@ -747,7 +747,7 @@ jobs:
     name: Workspace Pre-Merge Gate (PR)
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    timeout-minutes: 60
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci-supply-chain-advisory.yml
+++ b/.github/workflows/ci-supply-chain-advisory.yml
@@ -9,12 +9,17 @@ on:
     - cron: "23 6 * * 1"
   workflow_dispatch:
 
+concurrency:
+  group: ci-supply-chain-advisory-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
 jobs:
   supply-chain-advisory:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
 
     steps:
       - name: Checkout

--- a/.github/workflows/e2e-live.yml
+++ b/.github/workflows/e2e-live.yml
@@ -10,6 +10,10 @@ on:
     - cron: '0 6 * * 1'
   workflow_dispatch:
 
+concurrency:
+  group: e2e-live-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/docs/ci/strategy.md
+++ b/docs/ci/strategy.md
@@ -8,11 +8,15 @@ Detailed policy and script-surface budget rules live in `docs/ci/ci-cost-and-lan
 ## Lane Split
 - `ci-fast-gate` (PR required): minimal critical path for merge decisions.
 - `ci-deep-validate` (nightly/manual): heavier suites outside PR hot path.
+- `workflow_runtime_ceiling_minutes=60`
+- `workflow_pr_concurrency_cancel_in_progress=true`
+- Every workflow job must declare explicit `timeout-minutes`.
+- Every workflow with a `pull_request` trigger must define top-level `concurrency` with `cancel-in-progress: true`.
 
 ## Stage-1 Budget Targets
 - Fast gate runtime: <= 8 minutes p50, <= 12 minutes p95.
 - PR runner consumption: <= 25 total runner-minutes.
-- Nightly deep validate: <= 120 minutes.
+- Nightly deep validate: <= 60 minutes.
 
 Versioned thresholds are defined in `.ci/ci-budget.env`.
 

--- a/scripts/ci/test_ci_tools.sh
+++ b/scripts/ci/test_ci_tools.sh
@@ -108,6 +108,7 @@ if [ "${KAMN_CI_TOOLS_FAST_MODE:-false}" = "true" ]; then
   bash "$ROOT_DIR/scripts/ci/test_generate_performance_smoke_report.sh"
   bash "$ROOT_DIR/scripts/ci/test_check_performance_thresholds.sh"
   bash "$ROOT_DIR/scripts/ci/test_workflow_retry_policy.sh"
+  bash "$ROOT_DIR/scripts/ci/test_workflow_runtime_ceiling_policy.sh"
   bash "$ROOT_DIR/scripts/ci/test_workflow_scope_policy.sh"
   cargo test -p kamn-core --test e2e_live_workflow_lane
   bash "$ROOT_DIR/scripts/ci/test_local_signal_secret_hygiene_ci_exclusion_policy.sh"

--- a/scripts/ci/test_workflow_runtime_ceiling_policy.sh
+++ b/scripts/ci/test_workflow_runtime_ceiling_policy.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORKFLOWS_DIR="$ROOT_DIR/.github/workflows"
+STRATEGY_DOC="$ROOT_DIR/docs/ci/strategy.md"
+MAX_TIMEOUT=60
+
+fail() {
+  echo "$1" >&2
+  exit 1
+}
+
+require_file() {
+  local path="$1"
+  [ -f "$path" ] || fail "missing required file: $path"
+}
+
+workflow_has_pr_trigger() {
+  local file="$1"
+  awk '
+    /^on:/ { in_on=1; next }
+    in_on && /^[^[:space:]]/ { in_on=0 }
+    in_on && $1 ~ /^pull_request:/ { found=1 }
+    END { exit found ? 0 : 1 }
+  ' "$file"
+}
+
+assert_pr_concurrency_policy() {
+  local file="$1"
+  awk '
+    /^concurrency:/ { seen=1; in_block=1; next }
+    in_block && /^[^[:space:]]/ { in_block=0 }
+    in_block && $1 ~ /^cancel-in-progress:/ && $2 == "true" { cancel=1 }
+    END { exit (seen && cancel) ? 0 : 1 }
+  ' "$file" || fail "workflow missing top-level PR concurrency cancellation: $file"
+}
+
+assert_timeout_policy() {
+  local file="$1"
+  awk -v limit="$MAX_TIMEOUT" '
+    BEGIN { found=0 }
+    /^[[:space:]]{4}timeout-minutes:/ {
+      found=1
+      value=$2 + 0
+      if (value > limit) {
+        printf("workflow timeout exceeds ceiling (%s > %s): %s\n", $2, limit, FILENAME) > "/dev/stderr"
+        exit 2
+      }
+    }
+    END {
+      if (!found) {
+        printf("workflow missing job timeout-minutes: %s\n", FILENAME) > "/dev/stderr"
+        exit 3
+      }
+    }
+  ' "$file" || exit $?
+}
+
+assert_strategy_doc_markers() {
+  require_file "$STRATEGY_DOC"
+  grep -Fq "workflow_runtime_ceiling_minutes=60" "$STRATEGY_DOC" || fail "missing workflow runtime ceiling marker in docs/ci/strategy.md"
+  grep -Fq "workflow_pr_concurrency_cancel_in_progress=true" "$STRATEGY_DOC" || fail "missing workflow PR concurrency cancellation marker in docs/ci/strategy.md"
+}
+
+main() {
+  require_file "$WORKFLOWS_DIR/ci-fast-gate.yml"
+  require_file "$WORKFLOWS_DIR/ci-deep-validate.yml"
+  require_file "$WORKFLOWS_DIR/ci-supply-chain-advisory.yml"
+  require_file "$WORKFLOWS_DIR/e2e-live.yml"
+  require_file "$WORKFLOWS_DIR/branch-cleanup.yml"
+
+  local file
+  while IFS= read -r file; do
+    assert_timeout_policy "$file"
+    if workflow_has_pr_trigger "$file"; then
+      assert_pr_concurrency_policy "$file"
+    fi
+  done < <(find "$WORKFLOWS_DIR" -maxdepth 1 -name '*.yml' | sort)
+
+  assert_strategy_doc_markers
+}
+
+main "$@"

--- a/scripts/ci/test_workflow_runtime_ceiling_policy.sh
+++ b/scripts/ci/test_workflow_runtime_ceiling_policy.sh
@@ -5,10 +5,16 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 WORKFLOWS_DIR="$ROOT_DIR/.github/workflows"
 STRATEGY_DOC="$ROOT_DIR/docs/ci/strategy.md"
 MAX_TIMEOUT=60
+STATUS=0
 
 fail() {
   echo "$1" >&2
   exit 1
+}
+
+record_violation() {
+  echo "$1" >&2
+  STATUS=1
 }
 
 require_file() {
@@ -33,7 +39,7 @@ assert_pr_concurrency_policy() {
     in_block && /^[^[:space:]]/ { in_block=0 }
     in_block && $1 ~ /^cancel-in-progress:/ && $2 == "true" { cancel=1 }
     END { exit (seen && cancel) ? 0 : 1 }
-  ' "$file" || fail "workflow missing top-level PR concurrency cancellation: $file"
+  ' "$file" || record_violation "workflow missing top-level PR concurrency cancellation: $file"
 }
 
 assert_timeout_policy() {
@@ -54,13 +60,13 @@ assert_timeout_policy() {
         exit 3
       }
     }
-  ' "$file" || exit $?
+  ' "$file" || STATUS=1
 }
 
 assert_strategy_doc_markers() {
   require_file "$STRATEGY_DOC"
-  grep -Fq "workflow_runtime_ceiling_minutes=60" "$STRATEGY_DOC" || fail "missing workflow runtime ceiling marker in docs/ci/strategy.md"
-  grep -Fq "workflow_pr_concurrency_cancel_in_progress=true" "$STRATEGY_DOC" || fail "missing workflow PR concurrency cancellation marker in docs/ci/strategy.md"
+  grep -Fq "workflow_runtime_ceiling_minutes=60" "$STRATEGY_DOC" || record_violation "missing workflow runtime ceiling marker in docs/ci/strategy.md"
+  grep -Fq "workflow_pr_concurrency_cancel_in_progress=true" "$STRATEGY_DOC" || record_violation "missing workflow PR concurrency cancellation marker in docs/ci/strategy.md"
 }
 
 main() {
@@ -76,9 +82,10 @@ main() {
     if workflow_has_pr_trigger "$file"; then
       assert_pr_concurrency_policy "$file"
     fi
-  done < <(find "$WORKFLOWS_DIR" -maxdepth 1 -name '*.yml' | sort)
+  done < <(find "$WORKFLOWS_DIR" -maxdepth 1 \( -name '*.yml' -o -name '*.yaml' \) | sort)
 
   assert_strategy_doc_markers
+  exit "$STATUS"
 }
 
 main "$@"

--- a/scripts/ci/test_workflow_scope_policy.sh
+++ b/scripts/ci/test_workflow_scope_policy.sh
@@ -113,6 +113,16 @@ if ! grep -Fq "Check touched shell strict mode" "$FAST_WORKFLOW"; then
   exit 1
 fi
 
+if ! grep -Fq "Enforce workflow runtime ceiling policy" "$FAST_WORKFLOW"; then
+  echo "expected workflow runtime ceiling policy step in ci-fast-gate.yml" >&2
+  exit 1
+fi
+
+if ! grep -Fq "bash scripts/ci/test_workflow_runtime_ceiling_policy.sh" "$FAST_WORKFLOW"; then
+  echo "expected workflow runtime ceiling policy step to run the policy test script in ci-fast-gate.yml" >&2
+  exit 1
+fi
+
 if ! grep -Fq "bash scripts/ci/check_touched_shell_strict_mode.sh" "$FAST_WORKFLOW"; then
   echo "expected touched shell strict-mode gate to run checker wrapper in ci-fast-gate.yml" >&2
   exit 1
@@ -125,6 +135,11 @@ fi
 
 if ! grep -Fq "ci-touched-shell-strict-mode-report.json" "$FAST_WORKFLOW"; then
   echo "expected touched shell strict-mode report artifact wiring in ci-fast-gate.yml" >&2
+  exit 1
+fi
+
+if ! grep -Fq 'bash "$ROOT_DIR/scripts/ci/test_workflow_runtime_ceiling_policy.sh"' "$ROOT_DIR/scripts/ci/test_ci_tools.sh"; then
+  echo "expected ci tools fast-mode entrypoint to run workflow runtime ceiling policy tests" >&2
   exit 1
 fi
 

--- a/specs/6845-enforce-actions-runtime-ceilings-and-cancel-in-progress-policy.md
+++ b/specs/6845-enforce-actions-runtime-ceilings-and-cancel-in-progress-policy.md
@@ -1,0 +1,63 @@
+# Objective
+Enforce a fail-closed GitHub Actions runtime policy so repository workflows cannot run for hours unnoticed. Every workflow job must declare an explicit runtime budget, no job may exceed a repository-wide ceiling of 60 minutes, and pull-request workflows that supersede earlier runs must cancel in-progress predecessors automatically.
+
+## Inputs/Outputs
+- Inputs:
+  - `.github/workflows/*.yml`
+  - `docs/ci/strategy.md`
+  - existing CI policy harnesses under `scripts/ci/` and `crates/kamn-core/tests/`
+- Outputs:
+  - a policy checker or contract lane that fails when a workflow omits `timeout-minutes`
+  - enforcement that no workflow job exceeds 60 minutes
+  - enforcement that PR-triggered workflows define top-level `concurrency` with `cancel-in-progress: true`
+  - workflow updates for existing violating files
+  - docs describing the runtime ceiling and cancellation policy
+
+## Boundaries/Non-goals
+- Do not redesign the logical contents of CI workflows.
+- Do not remove validation coverage solely to reduce runtime.
+- Do not change product runtime behavior outside GitHub Actions policy enforcement.
+- Do not introduce new third-party dependencies.
+
+## Failure modes
+- A workflow job omits `timeout-minutes`.
+- A workflow job sets `timeout-minutes` greater than 60.
+- A workflow with a `pull_request` trigger omits top-level `concurrency`.
+- A workflow with a `pull_request` trigger omits `cancel-in-progress: true` in the top-level concurrency block.
+- Policy documentation drifts from enforced workflow behavior.
+
+## Acceptance criteria
+- [ ] Every job in `.github/workflows/*.yml` declares `timeout-minutes`.
+- [ ] No workflow job declares `timeout-minutes` greater than 60.
+- [ ] Every workflow with a `pull_request` trigger defines top-level `concurrency` with `cancel-in-progress: true`.
+- [ ] Existing violating workflows are updated to comply, including `ci-fast-gate.yml`, `ci-deep-validate.yml`, `ci-supply-chain-advisory.yml`, `e2e-live.yml`, and `branch-cleanup.yml`.
+- [ ] A fail-closed CI policy test/checker exercises the workflow set and fails on missing timeouts, excessive ceilings, or missing PR concurrency cancellation.
+- [ ] `docs/ci/strategy.md` documents the workflow runtime ceiling and superseded-run cancellation rule.
+
+## Files to touch
+- `specs/6845-enforce-actions-runtime-ceilings-and-cancel-in-progress-policy.md`
+- `.github/workflows/ci-fast-gate.yml`
+- `.github/workflows/ci-deep-validate.yml`
+- `.github/workflows/ci-supply-chain-advisory.yml`
+- `.github/workflows/e2e-live.yml`
+- `.github/workflows/branch-cleanup.yml`
+- `scripts/ci/test_workflow_runtime_ceiling_policy.sh`
+- `scripts/ci/test_ci_tools.sh`
+- `docs/ci/strategy.md`
+- optionally one Rust docs/contract test if required to keep policy discoverable
+
+## Error semantics
+- Policy violations must hard-fail with file path and missing/invalid marker context.
+- The checker must not silently skip workflows or jobs.
+- Existing workflows that remain over budget after the change are not allowed; the policy is fail-closed.
+
+## Test plan
+1. Add a failing policy test that scans `.github/workflows/*.yml` and reports:
+   - missing `timeout-minutes`
+   - any timeout greater than 60
+   - missing top-level PR concurrency cancellation
+2. Run the new policy test and confirm it fails on the current workflow set.
+3. Update the violating workflows with explicit compliant budgets and concurrency markers.
+4. Re-run the policy test until green.
+5. Run existing workflow-policy regression tests impacted by the edits.
+6. Wire the new policy test into the real CI tools entrypoint so future workflow additions are checked automatically.


### PR DESCRIPTION
Closes #6845

Issue: #6845
Spec: `specs/6845-enforce-actions-runtime-ceilings-and-cancel-in-progress-policy.md`

## What
- add a fail-closed workflow runtime ceiling policy test
- require explicit job `timeout-minutes` across repo workflows
- cap workflow jobs at 60 minutes
- require top-level `concurrency.cancel-in-progress: true` for PR-triggered workflows
- wire the policy into `ci-fast-gate` and `scripts/ci/test_ci_tools.sh`
- document the policy in `docs/ci/strategy.md`

## Why
Stale GitHub Actions runs were able to stay in progress for far too long, which wasted runner capacity and left PR checks looking stuck. This change makes runtime ceilings and superseded-run cancellation explicit and enforced.

## Test evidence
- `bash scripts/ci/test_workflow_runtime_ceiling_policy.sh`
- `bash scripts/ci/test_workflow_scope_policy.sh`
- `cargo test -p kamn-core --test e2e_live_workflow_lane -- --nocapture`

## Phase checklist
- [x] Spec current
- [x] Tests added
- [x] Refactor complete
- [x] Integration verified
- [ ] CI green

shell_loc_delta_actual: 121
rust_loc_delta_actual: 0
shell_to_rust_ratio_delta_actual: 0.0
shell_surface_ratio_target_status: regressed_with_waiver
