### PR TITLE
[6882] Audit real runtime capability for message routing, task dispatch, audit emission, and live transport

### DIFF
--- a/crates/kamn-core/tests/runtime_capability_audit_docs.rs
+++ b/crates/kamn-core/tests/runtime_capability_audit_docs.rs
@@ -1,0 +1,36 @@
+use std::fs;
+use std::path::PathBuf;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .canonicalize()
+        .expect("repo root")
+}
+
+fn audit_doc() -> String {
+    fs::read_to_string(repo_root().join("docs/review/runtime-capability-audit-r57.md"))
+        .expect("runtime capability audit doc should exist")
+}
+
+#[test]
+fn runtime_capability_audit_declares_required_sections_and_statuses() {
+    let doc = audit_doc();
+    for marker in [
+        "# Runtime Capability Audit R57",
+        "## Message Routing",
+        "status:",
+        "evidence:",
+        "## Task Dispatch",
+        "## Audit Emission And Export",
+        "## Live Transport",
+        "implemented_and_wired",
+        "gated_or_partial",
+        "contract_only",
+        "missing",
+        "follow_on_issues:",
+    ] {
+        assert!(doc.contains(marker), "missing marker: {marker}");
+    }
+}

--- a/crates/kamn-core/tests/runtime_capability_audit_docs.rs
+++ b/crates/kamn-core/tests/runtime_capability_audit_docs.rs
@@ -1,6 +1,21 @@
 use std::fs;
 use std::path::PathBuf;
 
+const REQUIRED_MARKERS: &[&str] = &[
+    "# Runtime Capability Audit R57",
+    "## Message Routing",
+    "status:",
+    "evidence:",
+    "## Task Dispatch",
+    "## Audit Emission And Export",
+    "## Live Transport",
+    "implemented_and_wired",
+    "gated_or_partial",
+    "contract_only",
+    "missing",
+    "follow_on_issues:",
+];
+
 fn repo_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("..")
@@ -14,23 +29,13 @@ fn audit_doc() -> String {
         .expect("runtime capability audit doc should exist")
 }
 
-#[test]
-fn runtime_capability_audit_declares_required_sections_and_statuses() {
-    let doc = audit_doc();
-    for marker in [
-        "# Runtime Capability Audit R57",
-        "## Message Routing",
-        "status:",
-        "evidence:",
-        "## Task Dispatch",
-        "## Audit Emission And Export",
-        "## Live Transport",
-        "implemented_and_wired",
-        "gated_or_partial",
-        "contract_only",
-        "missing",
-        "follow_on_issues:",
-    ] {
+fn assert_markers_present(doc: &str) {
+    for marker in REQUIRED_MARKERS {
         assert!(doc.contains(marker), "missing marker: {marker}");
     }
+}
+
+#[test]
+fn runtime_capability_audit_declares_required_sections_and_statuses() {
+    assert_markers_present(&audit_doc());
 }

--- a/docs/review/runtime-capability-audit-r57.md
+++ b/docs/review/runtime-capability-audit-r57.md
@@ -10,10 +10,11 @@
 status: gated_or_partial
 
 evidence:
-- `crates/kamn-node/src/service_api_endpoint/middleware_impl.rs` wires message creation via `message_store.create_message(...)`
-- `crates/kamn-node/src/service_api_endpoint/middleware_impl.rs` wires requester retrieval via `message_store.get_message_for_requester(...)`
-- `crates/kamn-sdk/src/service_client_message_task_routes.rs` exposes `get_message_delivery(...)`
-- `crates/kamn-sdk/src/live/agent.rs` consumes service message delivery records
+- code: `crates/kamn-node/src/service_api_endpoint/middleware_impl.rs` wires message creation via `message_store.create_message(...)`
+- code: `crates/kamn-node/src/service_api_endpoint/middleware_impl.rs` wires requester retrieval via `message_store.get_message_for_requester(...)`
+- code: `crates/kamn-sdk/src/service_client_message_task_routes.rs` exposes `get_message_delivery(...)`
+- code: `crates/kamn-sdk/src/live/agent.rs` consumes service message delivery records
+- executable: `cargo test -p kamn-sdk --test live_transport_receive -- --nocapture`
 
 assessment:
 - The service API supports authenticated message creation, storage, and requester retrieval.
@@ -27,9 +28,10 @@ follow_on_issues:
 status: gated_or_partial
 
 evidence:
-- `crates/kamn-node/src/service_api_endpoint/middleware_impl.rs` wires task creation via `message_store.create_task(...)`
-- `crates/kamn-node/src/service_api_endpoint/middleware_impl.rs` wires manual transitions via `transition_task(task_id, "accepted")` and `transition_task(task_id, "completed")`
-- `crates/kamn-core/src/task_operations.rs` is the core task-operation surface on current main
+- code: `crates/kamn-node/src/service_api_endpoint/middleware_impl.rs` wires task creation via `message_store.create_task(...)`
+- code: `crates/kamn-node/src/service_api_endpoint/middleware_impl.rs` wires manual transitions via `transition_task(task_id, "accepted")` and `transition_task(task_id, "completed")`
+- code: `crates/kamn-core/src/task_operations.rs` is the core task-operation surface on current main
+- executable: `cargo test -p kamn-core --test task_operations -- --nocapture`
 
 assessment:
 - Task creation and manual state progression are wired.
@@ -42,10 +44,11 @@ follow_on_issues:
 status: gated_or_partial
 
 evidence:
-- `crates/kamn-core/src/data_layer_m2_gateway_access.rs` contains append-only audit-ledger construction and verification
-- `crates/kamn-core/src/upgrade_orchestration.rs` exposes `audit_view()`
-- `crates/kamn-core/src/redaction_compliance.rs` defines concrete audit-event surfaces
-- `crates/kamn-core/README.md` references `audit_exports`
+- code: `crates/kamn-core/src/data_layer_m2_gateway_access.rs` contains append-only audit-ledger construction and verification
+- code: `crates/kamn-core/src/upgrade_orchestration.rs` exposes `audit_view()`
+- code: `crates/kamn-core/src/redaction_compliance.rs` defines concrete audit-event surfaces
+- code: `crates/kamn-core/README.md` references `audit_exports`
+- executable: `cargo test -p kamn-core upgrade_orchestration::tests:: --lib -- --nocapture`
 
 assessment:
 - Concrete audit record and audit view surfaces exist.
@@ -58,11 +61,11 @@ follow_on_issues:
 status: gated_or_partial
 
 evidence:
-- `crates/kamn-core/src/p2p_transport/p2p_transport_live.rs` contains live transport runtime logic
-- `crates/kamn-core/src/p2p_transport/native_runtime.rs` contains feature-gated libp2p native runtime support
-- `crates/kamn-core/src/p2p_transport/swarm_stack.rs` contains swarm wiring
-- `crates/kamn-core/tests/p2p_libp2p_native_adapter_runtime.rs` exercises libp2p native adapter runtime under `libp2p-live-transport`
-- `crates/kamn-core/tests/p2p_live_transport_runtime.rs` covers live transport runtime behavior
+- code: `crates/kamn-core/src/p2p_transport/p2p_transport_live.rs` contains live transport runtime logic
+- code: `crates/kamn-core/src/p2p_transport/native_runtime.rs` contains feature-gated libp2p native runtime support
+- code: `crates/kamn-core/src/p2p_transport/swarm_stack.rs` contains swarm wiring
+- code: `crates/kamn-core/tests/p2p_libp2p_native_adapter_runtime.rs` exercises libp2p native adapter runtime under `libp2p-live-transport`
+- executable: `cargo test -p kamn-core --test p2p_live_transport_runtime -- --nocapture`
 
 assessment:
 - Live transport is not missing; it exists behind the `libp2p-live-transport` feature and has executable test coverage.

--- a/docs/review/runtime-capability-audit-r57.md
+++ b/docs/review/runtime-capability-audit-r57.md
@@ -1,0 +1,76 @@
+# Runtime Capability Audit R57
+
+## Status Taxonomy
+- implemented_and_wired: real entrypoint and executable behavior are present on current main
+- gated_or_partial: runtime path exists but is feature-gated, manual, or incomplete for full product claims
+- contract_only: contracts/docs exist without enough real wired runtime evidence for the claimed capability
+- missing: no meaningful implementation path was found for the claimed capability
+
+## Message Routing
+status: gated_or_partial
+
+evidence:
+- `crates/kamn-node/src/service_api_endpoint/middleware_impl.rs` wires message creation via `message_store.create_message(...)`
+- `crates/kamn-node/src/service_api_endpoint/middleware_impl.rs` wires requester retrieval via `message_store.get_message_for_requester(...)`
+- `crates/kamn-sdk/src/service_client_message_task_routes.rs` exposes `get_message_delivery(...)`
+- `crates/kamn-sdk/src/live/agent.rs` consumes service message delivery records
+
+assessment:
+- The service API supports authenticated message creation, storage, and requester retrieval.
+- The SDK can consume delivery-shaped responses from the service API.
+- The reviewed path does not show autonomous peer-to-peer delivery orchestration or background delivery routing from node to node.
+
+follow_on_issues:
+- `#6883` implement real routed agent-to-agent message delivery beyond service-api storage/retrieval
+
+## Task Dispatch
+status: gated_or_partial
+
+evidence:
+- `crates/kamn-node/src/service_api_endpoint/middleware_impl.rs` wires task creation via `message_store.create_task(...)`
+- `crates/kamn-node/src/service_api_endpoint/middleware_impl.rs` wires manual transitions via `transition_task(task_id, "accepted")` and `transition_task(task_id, "completed")`
+- `crates/kamn-core/src/task_operations.rs` is the core task-operation surface on current main
+
+assessment:
+- Task creation and manual state progression are wired.
+- The reviewed path does not show autonomous worker selection, queue-based dispatch, or scheduler-driven task assignment.
+
+follow_on_issues:
+- `#6884` implement real task dispatch and worker assignment beyond manual task state transitions
+
+## Audit Emission And Export
+status: gated_or_partial
+
+evidence:
+- `crates/kamn-core/src/data_layer_m2_gateway_access.rs` contains append-only audit-ledger construction and verification
+- `crates/kamn-core/src/upgrade_orchestration.rs` exposes `audit_view()`
+- `crates/kamn-core/src/redaction_compliance.rs` defines concrete audit-event surfaces
+- `crates/kamn-core/README.md` references `audit_exports`
+
+assessment:
+- Concrete audit record and audit view surfaces exist.
+- The reviewed path does not establish that audit export is consistently populated across major runtime flows.
+
+follow_on_issues:
+- `#6885` audit and complete runtime audit-export population across wired node flows
+
+## Live Transport
+status: gated_or_partial
+
+evidence:
+- `crates/kamn-core/src/p2p_transport/p2p_transport_live.rs` contains live transport runtime logic
+- `crates/kamn-core/src/p2p_transport/native_runtime.rs` contains feature-gated libp2p native runtime support
+- `crates/kamn-core/src/p2p_transport/swarm_stack.rs` contains swarm wiring
+- `crates/kamn-core/tests/p2p_libp2p_native_adapter_runtime.rs` exercises libp2p native adapter runtime under `libp2p-live-transport`
+- `crates/kamn-core/tests/p2p_live_transport_runtime.rs` covers live transport runtime behavior
+
+assessment:
+- Live transport is not missing; it exists behind the `libp2p-live-transport` feature and has executable test coverage.
+- It is still partial relative to stronger product claims about generalized multi-node coordination.
+
+follow_on_issues:
+- `#6879` stabilize SDK-direct live validation on main
+
+## Summary
+- The strongest overclaim is not “nothing works.”
+- The accurate statement is that several runtime surfaces are wired, but message routing, task dispatch, and audit export remain partial relative to broader coordination-network claims.

--- a/specs/6882-runtime-capability-audit.md
+++ b/specs/6882-runtime-capability-audit.md
@@ -1,0 +1,46 @@
+# 6882 Runtime Capability Audit
+
+## Objective
+Establish a spec-backed, evidence-backed audit of KAMN runtime capability for message routing, task dispatch, audit emission/export, and live transport so repository claims reflect actual current behavior on `main`.
+
+## Inputs/Outputs
+- Inputs:
+  - Current `main` source code under `crates/kamn-core`, `crates/kamn-node`, `crates/kamn-sdk`, and `crates/kamn-e2e-harness`
+  - Existing tests, runtime scripts, and workflow evidence
+- Outputs:
+  - A committed runtime capability audit document with explicit per-path status
+  - A hard-fail docs contract test that validates required audited sections and status markers
+  - Follow-on issue links for missing or partial capability where appropriate
+
+## Boundaries/Non-goals
+- Do not implement missing runtime features in this issue
+- Do not rewrite the README wholesale
+- Do not redesign architecture beyond documenting actual current path status
+
+## Failure modes
+- Audit overstates capability without executable evidence
+- Audit understates capability by ignoring wired runtime/test paths
+- Audit uses ambiguous labels instead of explicit status buckets
+- Follow-on gaps are identified but not linked to issues
+
+## Acceptance criteria
+- [ ] A runtime capability audit document exists and is committed
+- [ ] The audit covers message routing, task dispatch, audit emission/export, and live transport
+- [ ] Each area is classified as implemented_and_wired, gated_or_partial, contract_only, or missing
+- [ ] Each area includes at least one concrete evidence point (test, script, or entrypoint)
+- [ ] The audit links known missing/partial paths to issue IDs where available
+- [ ] A docs contract test validates the audit structure and required markers
+
+## Files to touch
+- `specs/6882-runtime-capability-audit.md`
+- `docs/review/runtime-capability-audit-r57.md`
+- `crates/kamn-core/tests/runtime_capability_audit_docs.rs`
+
+## Error semantics
+- Missing required audit sections or invalid status markers fail the contract test
+- Claims without evidence markers are treated as invalid audit output
+
+## Test plan
+- Red: add `runtime_capability_audit_docs` contract expecting the new audit doc and required markers; confirm failure
+- Green: write the audit doc with required sections, statuses, evidence markers, and issue links; confirm contract passes
+- Integration: verify cited commands/tests exist and are callable from current repo paths


### PR DESCRIPTION
Closes #6882

Spec: `specs/6882-runtime-capability-audit.md`

What/why:
- add a spec-backed runtime capability audit for message routing, task dispatch, audit emission/export, and live transport
- hard-fail the audit structure with a docs contract test
- bind each audited area to at least one executable evidence command
- open focused follow-on issues for the missing/partial runtime paths uncovered by the audit

Test evidence:
- cargo test -p kamn-core --test runtime_capability_audit_docs -- --nocapture
- cargo test -p kamn-sdk --test live_transport_receive -- --nocapture
- cargo test -p kamn-core --test task_operations -- --nocapture
- cargo test -p kamn-core upgrade_orchestration::tests:: --lib -- --nocapture
- cargo test -p kamn-core --test p2p_live_transport_runtime -- --nocapture
- python3 scripts/ci/check_touched_rust_size_policy.py --repo-root /home/n/Code/kamn-6882-clean --base-ref origin/main --output-json /tmp/6882-touched-size-final.json
