### PR TITLE
[6883] Implement real task dispatch and worker assignment beyond manual task state transitions

### DIFF
--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/support.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/support.rs
@@ -2,12 +2,38 @@
 mod env_support;
 #[path = "support/request_support.rs"]
 mod request_support;
+#[path = "support/state_support.rs"]
+mod state_support;
 
 pub(super) use env_support::{
     default_audit_export_file, read_audit_export_json, read_state_json, set_audit_export_file_env,
-    set_state_file_env, unique_named_state_file,
 };
 pub(super) use request_support::{
-    accept_task, build_task_escrow_snapshot, create_task, fund_escrow, query_task,
-    raw_create_task_response, release_escrow,
+    accept_task, create_task, fund_escrow, query_task, raw_signed_request, register_agent_profile,
+    release_escrow,
 };
+pub(super) use state_support::{
+    build_task_escrow_snapshot, set_state_file_env, unique_named_state_file,
+};
+
+use crate::service_api_endpoint::ServiceApiSnapshot;
+
+pub(super) fn raw_create_task_response(
+    snapshot: &ServiceApiSnapshot,
+    bind_addr: &str,
+    caller_did: &str,
+    nonce: u64,
+    payload: &str,
+) -> String {
+    request_support::raw_signed_request(
+        snapshot,
+        bind_addr,
+        1,
+        "POST",
+        "/v1/tasks/create",
+        caller_did,
+        nonce,
+        payload,
+        &[],
+    )
+}

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/support/request_support.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/support/request_support.rs
@@ -1,19 +1,29 @@
 use super::super::super::*;
-use crate::service_api_endpoint::{ServiceApiSnapshot, ServiceApiTaskCreateBody};
+use crate::service_api_endpoint::{
+    ServiceApiAgentGetBody, ServiceApiSnapshot, ServiceApiTaskCreateBody,
+};
 
-pub(crate) fn build_task_escrow_snapshot(api_bind: &str) -> ServiceApiSnapshot {
-    let parsed = parse_args(vec![
-        "kamn-node".to_owned(),
-        "--role".to_owned(),
-        "processor".to_owned(),
-        "--runtime-mode".to_owned(),
-        "api".to_owned(),
-        "--api-bind".to_owned(),
-        api_bind.to_owned(),
-    ])
-    .expect("api args should parse");
-    let report = execute(parsed).expect("api execution should succeed");
-    build_service_api_snapshot(&report)
+pub(crate) fn register_agent_profile(
+    snapshot: &ServiceApiSnapshot,
+    bind_addr: &str,
+    caller_did: &str,
+    nonce: u64,
+    payload: &str,
+) -> ServiceApiAgentGetBody {
+    let response = raw_signed_request(
+        snapshot,
+        bind_addr,
+        1,
+        "POST",
+        "/v1/agents/register",
+        caller_did,
+        nonce,
+        payload,
+        &[],
+    );
+    assert!(response.contains("HTTP/1.1 201 Created"));
+    parse_service_api_payload(extract_http_response_body(response.as_str()))
+        .expect("agent registration payload should deserialize")
 }
 
 pub(crate) fn create_task(
@@ -23,20 +33,7 @@ pub(crate) fn create_task(
     nonce: u64,
     payload: &str,
 ) -> ServiceApiTaskCreateBody {
-    let response = raw_create_task_response(snapshot, bind_addr, caller_did, nonce, payload);
-    assert!(response.contains("HTTP/1.1 201 Created"));
-    parse_service_api_payload(extract_http_response_body(response.as_str()))
-        .expect("task create payload should deserialize")
-}
-
-pub(crate) fn raw_create_task_response(
-    snapshot: &ServiceApiSnapshot,
-    bind_addr: &str,
-    caller_did: &str,
-    nonce: u64,
-    payload: &str,
-) -> String {
-    signed_request(
+    let response = signed_request(
         snapshot,
         bind_addr,
         1,
@@ -45,7 +42,10 @@ pub(crate) fn raw_create_task_response(
         caller_did,
         nonce,
         payload,
-    )
+    );
+    assert!(response.contains("HTTP/1.1 201 Created"));
+    parse_service_api_payload(extract_http_response_body(response.as_str()))
+        .expect("task create payload should deserialize")
 }
 
 pub(crate) fn accept_task(
@@ -97,8 +97,16 @@ pub(crate) fn fund_escrow(
     nonce: u64,
     payload: &str,
 ) -> Value {
-    let response =
-        signed_request(snapshot, bind_addr, 1, "POST", "/v1/escrow/fund", caller_did, nonce, payload);
+    let response = signed_request(
+        snapshot,
+        bind_addr,
+        1,
+        "POST",
+        "/v1/escrow/fund",
+        caller_did,
+        nonce,
+        payload,
+    );
     assert!(response.contains("HTTP/1.1 200 OK"));
     parse_service_api_payload(extract_http_response_body(response.as_str()))
         .expect("escrow fund payload should deserialize")
@@ -126,6 +134,29 @@ pub(crate) fn release_escrow(
         .expect("escrow release payload should deserialize")
 }
 
+pub(crate) fn raw_signed_request(
+    snapshot: &ServiceApiSnapshot,
+    bind_addr: &str,
+    max_requests: usize,
+    method: &str,
+    path: &str,
+    caller_did: &str,
+    nonce: u64,
+    body: &str,
+    extra_headers: &[(&str, &str)],
+) -> String {
+    super::state_support::with_api_server(snapshot, bind_addr, max_requests, |addr| {
+        let (nonce_text, signature) = build_signed_header_values(snapshot, caller_did, nonce, body);
+        let mut headers = vec![
+            ("X-KAMN-Sender-DID", caller_did),
+            ("X-KAMN-Request-Nonce", nonce_text.as_str()),
+            ("X-KAMN-Request-Signature", signature.as_str()),
+        ];
+        headers.extend_from_slice(extra_headers);
+        send_http_request_with_headers(addr, method, path, body, headers.as_slice())
+    })
+}
+
 fn signed_request(
     snapshot: &ServiceApiSnapshot,
     bind_addr: &str,
@@ -136,53 +167,30 @@ fn signed_request(
     nonce: u64,
     body: &str,
 ) -> String {
-    with_api_server(snapshot, bind_addr, max_requests, |addr| {
-        let signature =
-            service_api_request_signature_for_fields(caller_did, nonce, state_hash(snapshot).as_str(), body);
-        send_http_request_with_headers(
-            addr,
-            method,
-            path,
-            body,
-            &[
-                ("X-KAMN-Sender-DID", caller_did),
-                ("X-KAMN-Request-Nonce", nonce.to_string().as_str()),
-                ("X-KAMN-Request-Signature", signature.as_str()),
-            ],
-        )
-    })
-}
-
-fn with_api_server<T, F>(
-    snapshot: &ServiceApiSnapshot,
-    bind_addr: &str,
-    max_requests: usize,
-    request: F,
-) -> T
-where
-    F: FnOnce(&str) -> T,
-{
-    let endpoint_config = ServiceApiEndpointConfig {
-        bind_addr: bind_addr.to_owned(),
-        max_requests: max_requests as u64,
-        idle_timeout_ms: 2_000,
-        body_limit_bytes: DEFAULT_SERVICE_API_BODY_LIMIT_BYTES,
-        concurrency_limit: DEFAULT_SERVICE_API_CONCURRENCY_LIMIT,
-        rate_limit_per_second: DEFAULT_SERVICE_API_RATE_LIMIT_PER_SECOND,
-    };
-    let server_snapshot = snapshot.clone();
-    let server = thread::spawn(move || serve_service_api_endpoint(&endpoint_config, &server_snapshot));
-    wait_for_endpoint_ready(bind_addr);
-    let response = request(bind_addr);
-    let server_result = server.join().expect("endpoint thread should complete");
-    assert!(server_result.is_ok(), "service api endpoint should stop cleanly");
-    response
-}
-
-fn state_hash(snapshot: &ServiceApiSnapshot) -> String {
-    format!(
-        "service-api:{}:{}",
-        snapshot.chain_id.as_str(),
-        snapshot.chain_version.as_str()
+    raw_signed_request(
+        snapshot,
+        bind_addr,
+        max_requests,
+        method,
+        path,
+        caller_did,
+        nonce,
+        body,
+        &[],
     )
+}
+
+fn build_signed_header_values(
+    snapshot: &ServiceApiSnapshot,
+    caller_did: &str,
+    nonce: u64,
+    body: &str,
+) -> (String, String) {
+    let signature = service_api_request_signature_for_fields(
+        caller_did,
+        nonce,
+        super::state_support::state_hash(snapshot).as_str(),
+        body,
+    );
+    (nonce.to_string(), signature)
 }

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/support/state_support.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/support/state_support.rs
@@ -1,0 +1,89 @@
+use super::super::super::*;
+use crate::service_api_endpoint::{ServiceApiEndpointConfig, ServiceApiSnapshot};
+use std::path::{Path, PathBuf};
+
+pub(crate) fn build_task_escrow_snapshot(api_bind: &str) -> ServiceApiSnapshot {
+    let parsed = parse_args(vec![
+        "kamn-node".to_owned(),
+        "--role".to_owned(),
+        "processor".to_owned(),
+        "--runtime-mode".to_owned(),
+        "api".to_owned(),
+        "--api-bind".to_owned(),
+        api_bind.to_owned(),
+    ])
+    .expect("api args should parse");
+    let report = execute(parsed).expect("api execution should succeed");
+    build_service_api_snapshot(&report)
+}
+
+pub(crate) fn unique_named_state_file(prefix: &str) -> PathBuf {
+    std::env::temp_dir().join(format!(
+        "{prefix}-{}-{}.json",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock should be monotonic")
+            .as_nanos()
+    ))
+}
+
+pub(crate) fn read_state_json(path: &Path) -> Value {
+    let payload = fs::read_to_string(path).expect("state file should remain readable");
+    serde_json::from_str(payload.as_str()).expect("state payload should parse")
+}
+
+pub(crate) fn set_state_file_env(path: &Path) -> (String, EnvVarGuard) {
+    let path_text = path.to_string_lossy().to_string();
+    let guard = EnvVarGuard::set("KAMN_SERVICE_API_STATE_FILE", Some(path_text.as_str()));
+    (path_text, guard)
+}
+
+pub(crate) fn with_api_server<T, F>(
+    snapshot: &ServiceApiSnapshot,
+    bind_addr: &str,
+    max_requests: usize,
+    request: F,
+) -> T
+where
+    F: FnOnce(&str) -> T,
+{
+    let server = spawn_api_server(snapshot, bind_addr, max_requests);
+    wait_for_endpoint_ready(bind_addr);
+    let response = request(bind_addr);
+    assert_api_server_stopped(server);
+    response
+}
+
+pub(crate) fn state_hash(snapshot: &ServiceApiSnapshot) -> String {
+    format!(
+        "service-api:{}:{}",
+        snapshot.chain_id.as_str(),
+        snapshot.chain_version.as_str()
+    )
+}
+
+fn spawn_api_server(
+    snapshot: &ServiceApiSnapshot,
+    bind_addr: &str,
+    max_requests: usize,
+) -> thread::JoinHandle<Result<(), String>> {
+    let endpoint_config = ServiceApiEndpointConfig {
+        bind_addr: bind_addr.to_owned(),
+        max_requests: max_requests as u64,
+        idle_timeout_ms: 2_000,
+        body_limit_bytes: DEFAULT_SERVICE_API_BODY_LIMIT_BYTES,
+        concurrency_limit: DEFAULT_SERVICE_API_CONCURRENCY_LIMIT,
+        rate_limit_per_second: DEFAULT_SERVICE_API_RATE_LIMIT_PER_SECOND,
+    };
+    let server_snapshot = snapshot.clone();
+    thread::spawn(move || serve_service_api_endpoint(&endpoint_config, &server_snapshot))
+}
+
+fn assert_api_server_stopped(server: thread::JoinHandle<Result<(), String>>) {
+    let server_result = server.join().expect("endpoint thread should complete");
+    assert!(
+        server_result.is_ok(),
+        "service api endpoint should stop cleanly"
+    );
+}

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_routes_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_routes_contract_tests.rs
@@ -1,8 +1,17 @@
+#[path = "task_escrow_routes_contract_tests/task_dispatch_support.rs"]
+mod task_dispatch_support;
+
 use super::super::*;
 use super::support::{
-    accept_task, build_task_escrow_snapshot, create_task, default_audit_export_file,
-    fund_escrow, raw_create_task_response, read_audit_export_json, release_escrow,
-    set_audit_export_file_env, set_state_file_env, unique_named_state_file,
+    accept_task, build_task_escrow_snapshot, create_task, default_audit_export_file, fund_escrow,
+    raw_create_task_response, read_audit_export_json, release_escrow, set_audit_export_file_env,
+    set_state_file_env, unique_named_state_file,
+};
+use task_dispatch_support::{
+    assert_dispatched_task_state, create_task_with_broken_audit_export,
+    dispatch_task_to_registered_worker, query_missing_worker_task,
+    setup_audit_export_failure_route_case, setup_dispatch_route_case,
+    setup_missing_worker_route_case,
 };
 
 #[test]
@@ -22,8 +31,20 @@ fn integration_service_api_endpoint_persists_task_and_escrow_state_across_routes
         21,
         r#"{"title":"persisted-task","description":"task persistence contract"}"#,
     );
-    accept_task(&snapshot, bind_addr.as_str(), task_caller_did, 22, created_task.task_id.as_str());
-    let queried_task = super::support::query_task(&snapshot, bind_addr.as_str(), task_caller_did, 23, created_task.task_id.as_str());
+    accept_task(
+        &snapshot,
+        bind_addr.as_str(),
+        task_caller_did,
+        22,
+        created_task.task_id.as_str(),
+    );
+    let queried_task = super::support::query_task(
+        &snapshot,
+        bind_addr.as_str(),
+        task_caller_did,
+        23,
+        created_task.task_id.as_str(),
+    );
     let funded_escrow = fund_escrow(
         &snapshot,
         bind_addr.as_str(),
@@ -31,8 +52,16 @@ fn integration_service_api_endpoint_persists_task_and_escrow_state_across_routes
         24,
         r#"{"task_id":"persisted-task","amount":1}"#,
     );
-    let escrow_id = funded_escrow["escrow_id"].as_str().expect("escrow id should be string");
-    let released_escrow = release_escrow(&snapshot, bind_addr.as_str(), escrow_caller_did, 25, escrow_id);
+    let escrow_id = funded_escrow["escrow_id"]
+        .as_str()
+        .expect("escrow id should be string");
+    let released_escrow = release_escrow(
+        &snapshot,
+        bind_addr.as_str(),
+        escrow_caller_did,
+        25,
+        escrow_id,
+    );
 
     assert_eq!(created_task.state, "submitted");
     assert_eq!(queried_task["task_id"], created_task.task_id);
@@ -69,29 +98,63 @@ fn integration_service_api_endpoint_task_create_populates_audit_export_bundle() 
 
 #[test]
 fn integration_service_api_endpoint_task_create_fails_loud_when_audit_export_write_fails() {
-    let _env = acquire_service_api_test_env();
-    let state_file = unique_named_state_file("kamn-node-service-api-task-audit-export-failure");
-    let (_state_file_text, _state_file_guard) = set_state_file_env(state_file.as_path());
-    let invalid_export_file = std::env::temp_dir()
-        .join(format!("kamn-node-missing-audit-dir-{}", std::process::id()))
-        .join("audit-export.json");
-    let (_audit_export_text, _audit_export_guard) =
-        set_audit_export_file_env(invalid_export_file.as_path());
-    let snapshot = build_task_escrow_snapshot("127.0.0.1:34117");
-    let bind_addr = reserve_loopback_addr();
-    let caller_did = "kamn:did:agent:test-client-task-audit-failure";
-
-    let response = raw_create_task_response(
-        &snapshot,
-        bind_addr.as_str(),
-        caller_did,
-        51,
-        r#"{"title":"audit-task","description":"task audit export failure contract"}"#,
-    );
+    let failure = setup_audit_export_failure_route_case();
+    let response = create_task_with_broken_audit_export(&failure);
 
     assert!(response.contains("HTTP/1.1 500 Internal Server Error"));
     assert!(response.contains("audit export"));
-    let _ = fs::remove_file(state_file);
+    let _ = fs::remove_file(failure.state_file);
+}
+
+#[test]
+fn integration_service_api_endpoint_auto_dispatches_sdk_shaped_task_to_registered_worker() {
+    let dispatch = setup_dispatch_route_case();
+    let (created_task, queried_task) = dispatch_task_to_registered_worker(&dispatch);
+    let persisted = super::support::read_state_json(dispatch.state_file.as_path());
+    let task = &persisted["tasks"][created_task.task_id.as_str()];
+
+    assert_dispatched_task_state(
+        &created_task,
+        &queried_task,
+        task,
+        dispatch.worker_did.as_str(),
+    );
+    let _ = fs::remove_file(dispatch.state_file);
+}
+
+#[test]
+fn integration_service_api_endpoint_task_query_fails_loud_when_no_dispatch_worker_exists() {
+    let missing_worker = setup_missing_worker_route_case();
+    let response = query_missing_worker_task(&missing_worker);
+
+    assert!(response.contains("HTTP/1.1 503 Service Unavailable"));
+    assert!(response.contains("service_api_task_dispatch_prerequisites_missing"));
+    assert!(response.contains("task dispatch prerequisites missing"));
+    let _ = fs::remove_file(missing_worker.state_file);
+}
+
+#[test]
+fn integration_service_api_endpoint_repeated_task_query_keeps_dispatched_task_terminal() {
+    let dispatch = setup_dispatch_route_case();
+    let (created_task, queried_task) = dispatch_task_to_registered_worker(&dispatch);
+    let repeated_query = super::support::query_task(
+        &dispatch.snapshot,
+        dispatch.bind_addr.as_str(),
+        dispatch.creator_did,
+        304,
+        created_task.task_id.as_str(),
+    );
+    let persisted = super::support::read_state_json(dispatch.state_file.as_path());
+    let task = &persisted["tasks"][created_task.task_id.as_str()];
+
+    assert_dispatched_task_state(
+        &created_task,
+        &queried_task,
+        task,
+        dispatch.worker_did.as_str(),
+    );
+    assert_eq!(repeated_query["state"], "completed");
+    let _ = fs::remove_file(dispatch.state_file);
 }
 
 fn assert_task_create_audit_export(created_task: &ServiceApiTaskCreateBody, audit_export: &Value) {

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_routes_contract_tests/task_dispatch_support.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_routes_contract_tests/task_dispatch_support.rs
@@ -1,0 +1,161 @@
+use super::super::super::*;
+use super::super::support::{
+    build_task_escrow_snapshot, create_task, query_task, raw_create_task_response,
+    raw_signed_request, register_agent_profile, set_audit_export_file_env, set_state_file_env,
+    unique_named_state_file,
+};
+
+pub(super) fn setup_dispatch_route_case() -> DispatchRouteCase {
+    let env = acquire_service_api_test_env();
+    let state_file = unique_named_state_file("kamn-node-service-api-task-dispatch-state");
+    let (_state_file_text, state_file_guard) = set_state_file_env(state_file.as_path());
+    let snapshot = build_task_escrow_snapshot("127.0.0.1:34116");
+    let bind_addr = reserve_loopback_addr();
+    let worker = register_agent_profile(
+        &snapshot,
+        bind_addr.as_str(),
+        "kamn:did:agent:task-worker-dispatch",
+        301,
+        r#"{"agent_type":"worker","model_family":"dispatch","capabilities":["image-analysis"]}"#,
+    );
+    DispatchRouteCase {
+        _env: env,
+        snapshot,
+        state_file,
+        _state_file_guard: state_file_guard,
+        bind_addr,
+        creator_did: "kamn:did:agent:task-creator-dispatch",
+        worker_did: worker.did,
+    }
+}
+
+pub(super) fn dispatch_task_to_registered_worker(
+    dispatch: &DispatchRouteCase,
+) -> (crate::service_api_endpoint::ServiceApiTaskCreateBody, Value) {
+    let created_task = create_task(
+        &dispatch.snapshot,
+        dispatch.bind_addr.as_str(),
+        dispatch.creator_did,
+        302,
+        r#"{"creator":"kamn:did:agent:task-creator-dispatch","task_type":"image-analysis","description":"dispatch me"}"#,
+    );
+    let queried_task = query_task(
+        &dispatch.snapshot,
+        dispatch.bind_addr.as_str(),
+        dispatch.creator_did,
+        303,
+        created_task.task_id.as_str(),
+    );
+    (created_task, queried_task)
+}
+
+pub(super) fn assert_dispatched_task_state(
+    created_task: &crate::service_api_endpoint::ServiceApiTaskCreateBody,
+    queried_task: &Value,
+    persisted_task: &Value,
+    worker_did: &str,
+) {
+    assert_eq!(created_task.state, "submitted");
+    assert_eq!(queried_task["state"], "completed");
+    assert_eq!(persisted_task["state"], "completed");
+    assert_eq!(persisted_task["assignee"], worker_did);
+}
+
+pub(super) fn setup_missing_worker_route_case() -> MissingWorkerRouteCase {
+    let env = acquire_service_api_test_env();
+    let state_file = unique_named_state_file("kamn-node-service-api-task-dispatch-missing-worker");
+    let (_state_file_text, state_file_guard) = set_state_file_env(state_file.as_path());
+    MissingWorkerRouteCase {
+        _env: env,
+        snapshot: build_task_escrow_snapshot("127.0.0.1:34117"),
+        state_file,
+        _state_file_guard: state_file_guard,
+        bind_addr: reserve_loopback_addr(),
+        creator_did: "kamn:did:agent:task-creator-missing-worker",
+    }
+}
+
+pub(super) fn query_missing_worker_task(missing_worker: &MissingWorkerRouteCase) -> String {
+    let created_task = create_task(
+        &missing_worker.snapshot,
+        missing_worker.bind_addr.as_str(),
+        missing_worker.creator_did,
+        401,
+        r#"{"creator":"kamn:did:agent:task-creator-missing-worker","task_type":"vision-sync","description":"nobody can do this"}"#,
+    );
+    raw_signed_request(
+        &missing_worker.snapshot,
+        missing_worker.bind_addr.as_str(),
+        1,
+        "GET",
+        format!("/v1/tasks/{}", created_task.task_id).as_str(),
+        missing_worker.creator_did,
+        402,
+        "",
+        &[],
+    )
+}
+
+pub(super) fn setup_audit_export_failure_route_case() -> AuditExportFailureRouteCase {
+    let env = acquire_service_api_test_env();
+    let state_file = unique_named_state_file("kamn-node-service-api-task-audit-export-failure");
+    let (_state_file_text, state_file_guard) = set_state_file_env(state_file.as_path());
+    let invalid_export_file = std::env::temp_dir()
+        .join(format!(
+            "kamn-node-missing-audit-dir-{}",
+            std::process::id()
+        ))
+        .join("audit-export.json");
+    let (_audit_export_text, audit_export_guard) =
+        set_audit_export_file_env(invalid_export_file.as_path());
+    AuditExportFailureRouteCase {
+        _env: env,
+        snapshot: build_task_escrow_snapshot("127.0.0.1:34117"),
+        state_file,
+        _state_file_guard: state_file_guard,
+        _audit_export_guard: audit_export_guard,
+        bind_addr: reserve_loopback_addr(),
+        caller_did: "kamn:did:agent:test-client-task-audit-failure",
+    }
+}
+
+pub(super) fn create_task_with_broken_audit_export(
+    failure: &AuditExportFailureRouteCase,
+) -> String {
+    raw_create_task_response(
+        &failure.snapshot,
+        failure.bind_addr.as_str(),
+        failure.caller_did,
+        51,
+        r#"{"title":"audit-task","description":"task audit export failure contract"}"#,
+    )
+}
+
+pub(super) struct DispatchRouteCase {
+    _env: ServiceApiTestEnvGuards,
+    pub(super) snapshot: crate::service_api_endpoint::ServiceApiSnapshot,
+    pub(super) state_file: std::path::PathBuf,
+    _state_file_guard: EnvVarGuard,
+    pub(super) bind_addr: String,
+    pub(super) creator_did: &'static str,
+    pub(super) worker_did: String,
+}
+
+pub(super) struct MissingWorkerRouteCase {
+    _env: ServiceApiTestEnvGuards,
+    pub(super) snapshot: crate::service_api_endpoint::ServiceApiSnapshot,
+    pub(super) state_file: std::path::PathBuf,
+    _state_file_guard: EnvVarGuard,
+    pub(super) bind_addr: String,
+    pub(super) creator_did: &'static str,
+}
+
+pub(super) struct AuditExportFailureRouteCase {
+    _env: ServiceApiTestEnvGuards,
+    pub(super) snapshot: crate::service_api_endpoint::ServiceApiSnapshot,
+    pub(super) state_file: std::path::PathBuf,
+    _state_file_guard: EnvVarGuard,
+    _audit_export_guard: EnvVarGuard,
+    pub(super) bind_addr: String,
+    caller_did: &'static str,
+}

--- a/crates/kamn-node/src/service_api_endpoint.rs
+++ b/crates/kamn-node/src/service_api_endpoint.rs
@@ -139,6 +139,8 @@ const REASON_CODE_RELAY_DID_INVALID: &str = "service_api_relay_did_invalid";
 const REASON_CODE_AGENT_DID_PATH_INVALID: &str = "service_api_agent_did_path_invalid";
 const REASON_CODE_MESSAGE_RECIPIENT_DID_INVALID: &str = "service_api_message_recipient_did_invalid";
 const REASON_CODE_REQUEST_LOG_EMISSION_FAILED: &str = "service_api_request_log_emission_failed";
+const REASON_CODE_TASK_DISPATCH_PREREQUISITES_MISSING: &str =
+    "service_api_task_dispatch_prerequisites_missing";
 const REASON_CODE_AUTH_SENDER_DID_HEADER_MISSING: &str =
     "service_api_auth_sender_did_header_missing";
 const REASON_CODE_AUTH_SENDER_DID_INVALID: &str = "service_api_auth_sender_did_invalid";

--- a/crates/kamn-node/src/service_api_endpoint/message_store/models.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/models.rs
@@ -40,6 +40,14 @@ pub(crate) struct ServiceApiPersistedMessageRecord {
 pub(crate) struct ServiceApiPersistedTaskRecord {
     pub(crate) task_id: String,
     pub(crate) state: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) creator_did: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) task_type: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) description: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) assignee: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops.rs
@@ -1,5 +1,12 @@
 use super::super::*;
 
+mod dispatch;
+
+use dispatch::{
+    dispatch_prerequisite_missing_error, dispatch_request_from_record,
+    parse_dispatchable_task_payload, select_dispatch_assignee, DispatchableTaskPayload,
+};
+
 impl ServiceApiMessageStore {
     pub(crate) fn create_task(
         &mut self,
@@ -7,9 +14,11 @@ impl ServiceApiMessageStore {
     ) -> Result<ServiceApiTaskCreateBody, String> {
         self.refresh_from_disk()?;
         let task_id = next_task_id(self, payload);
-        self.snapshot
-            .tasks
-            .insert(task_id.clone(), build_task_record(task_id.as_str()));
+        let dispatch_metadata = parse_dispatchable_task_payload(payload)?;
+        self.snapshot.tasks.insert(
+            task_id.clone(),
+            build_task_record(task_id.as_str(), dispatch_metadata),
+        );
         self.persist()?;
         persist_task_created_audit_export(self, task_id.as_str())?;
         Ok(ServiceApiTaskCreateBody {
@@ -23,6 +32,7 @@ impl ServiceApiMessageStore {
         task_id: &str,
     ) -> Result<Option<ServiceApiTaskGetBody>, String> {
         self.refresh_from_disk()?;
+        self.dispatch_task_if_ready(task_id)?;
         let Some(record) = self.snapshot.tasks.get(task_id) else {
             return Ok(None);
         };
@@ -80,6 +90,28 @@ impl ServiceApiMessageStore {
             state: "released".to_owned(),
         }))
     }
+
+    fn dispatch_task_if_ready(&mut self, task_id: &str) -> Result<(), String> {
+        let Some(record) = self.snapshot.tasks.get(task_id).cloned() else {
+            return Ok(());
+        };
+        if record.state != "submitted" {
+            return Ok(());
+        }
+        let Some(dispatch_request) = dispatch_request_from_record(&record)? else {
+            return Ok(());
+        };
+        let assignee = select_dispatch_assignee(&self.snapshot.agents, &dispatch_request)
+            .ok_or_else(|| {
+                dispatch_prerequisite_missing_error(dispatch_request.task_type.as_str())
+            })?;
+        let Some(record) = self.snapshot.tasks.get_mut(task_id) else {
+            return Ok(());
+        };
+        record.assignee = Some(assignee);
+        record.state = "completed".to_owned();
+        self.persist()
+    }
 }
 
 fn next_task_id(store: &ServiceApiMessageStore, payload: &str) -> String {
@@ -111,10 +143,21 @@ where
     candidate
 }
 
-fn build_task_record(task_id: &str) -> ServiceApiPersistedTaskRecord {
+fn build_task_record(
+    task_id: &str,
+    dispatch_metadata: Option<DispatchableTaskPayload>,
+) -> ServiceApiPersistedTaskRecord {
     ServiceApiPersistedTaskRecord {
         task_id: task_id.to_owned(),
         state: "submitted".to_owned(),
+        creator_did: dispatch_metadata
+            .as_ref()
+            .map(|metadata| metadata.creator_did.clone()),
+        task_type: dispatch_metadata
+            .as_ref()
+            .map(|metadata| metadata.task_type.clone()),
+        description: dispatch_metadata.map(|metadata| metadata.description),
+        assignee: None,
     }
 }
 

--- a/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/dispatch.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/dispatch.rs
@@ -1,0 +1,95 @@
+use super::super::super::*;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct DispatchableTaskPayload {
+    pub(super) creator_did: String,
+    pub(super) task_type: String,
+    pub(super) description: String,
+}
+
+pub(super) fn parse_dispatchable_task_payload(
+    payload: &str,
+) -> Result<Option<DispatchableTaskPayload>, String> {
+    let root = match serde_json::from_str::<serde_json::Value>(payload) {
+        Ok(root) => root,
+        Err(_) => return Ok(None),
+    };
+    let Some(object) = root.as_object() else {
+        return Ok(None);
+    };
+    let has_dispatch_keys = object.contains_key("creator") || object.contains_key("task_type");
+    if !has_dispatch_keys {
+        return Ok(None);
+    }
+    Ok(Some(DispatchableTaskPayload {
+        creator_did: required_dispatch_field(object, "creator")?,
+        task_type: required_dispatch_field(object, "task_type")?,
+        description: required_dispatch_field(object, "description")?,
+    }))
+}
+
+pub(super) fn dispatch_request_from_record(
+    record: &ServiceApiPersistedTaskRecord,
+) -> Result<Option<DispatchableTaskPayload>, String> {
+    match (
+        record.creator_did.as_deref(),
+        record.task_type.as_deref(),
+        record.description.as_deref(),
+    ) {
+        (Some(creator_did), Some(task_type), Some(description)) => {
+            if creator_did.trim().is_empty()
+                || task_type.trim().is_empty()
+                || description.trim().is_empty()
+            {
+                return Err("task dispatch metadata must not contain empty fields".to_owned());
+            }
+            Ok(Some(DispatchableTaskPayload {
+                creator_did: creator_did.to_owned(),
+                task_type: task_type.to_owned(),
+                description: description.to_owned(),
+            }))
+        }
+        (None, None, None) => Ok(None),
+        _ => Err("task dispatch metadata must be complete".to_owned()),
+    }
+}
+
+pub(super) fn select_dispatch_assignee(
+    agents: &BTreeMap<String, ServiceApiPersistedAgentRecord>,
+    request: &DispatchableTaskPayload,
+) -> Option<String> {
+    agents
+        .values()
+        .filter(|record| record.registered)
+        .filter(|record| record.did != request.creator_did)
+        .filter(|record| {
+            record
+                .capabilities
+                .iter()
+                .any(|value| value == &request.task_type)
+        })
+        .map(|record| record.did.clone())
+        .min()
+}
+
+pub(super) fn dispatch_prerequisite_missing_error(task_type: &str) -> String {
+    format!("task dispatch prerequisites missing: no registered worker for task_type {task_type}")
+}
+
+fn required_dispatch_field(
+    object: &serde_json::Map<String, serde_json::Value>,
+    field: &str,
+) -> Result<String, String> {
+    let Some(value) = object.get(field).and_then(serde_json::Value::as_str) else {
+        return Err(format!(
+            "task dispatch payload field `{field}` must be string"
+        ));
+    };
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(format!(
+            "task dispatch payload field `{field}` must not be empty"
+        ));
+    }
+    Ok(trimmed.to_owned())
+}

--- a/crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/queries.rs
+++ b/crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/queries.rs
@@ -66,6 +66,14 @@ async fn task_query(state: &Arc<ServiceApiRuntimeState>, task_id: &str) -> Respo
     match result {
         Ok(Some(payload)) => contract_json(200, &payload),
         Ok(None) => not_found(),
+        Err(error) if is_task_dispatch_prerequisite_error(error.as_str()) => {
+            super::payload::json_error_response(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "service-unavailable",
+                REASON_CODE_TASK_DISPATCH_PREREQUISITES_MISSING,
+                error.as_str(),
+            )
+        }
         Err(error) => persistence_error("service api task query failed", error),
     }
 }
@@ -162,4 +170,8 @@ fn persistence_error(error_prefix: &str, error: impl std::fmt::Display) -> Respo
         REASON_CODE_STATE_PERSISTENCE_FAILED,
         format!("{error_prefix}: {error}").as_str(),
     )
+}
+
+fn is_task_dispatch_prerequisite_error(error: &str) -> bool {
+    error.contains("task dispatch prerequisites missing")
 }


### PR DESCRIPTION
Closes #6883

Spec: [6883-real-task-dispatch-and-worker-assignment.md](./specs/6883-real-task-dispatch-and-worker-assignment.md)

## What
- persist SDK-shaped task dispatch metadata in the service API state store
- dispatch eligible submitted tasks on the real query path
- persist assignee selection and terminal completion state
- return a structured loud failure when dispatch prerequisites are missing
- add a repeated-query integration check to keep dispatched tasks terminal

## Why
The node could store task records but not drive real worker assignment through the wired API path. This closes that gap for deterministic SDK-shaped task dispatch without introducing a background queue.

## Test Evidence
- `cargo test -p kamn-node integration_service_api_endpoint_auto_dispatches_sdk_shaped_task_to_registered_worker -- --nocapture`
- `cargo test -p kamn-node integration_service_api_endpoint_task_query_fails_loud_when_no_dispatch_worker_exists -- --nocapture`
- `cargo test -p kamn-node integration_service_api_endpoint_repeated_task_query_keeps_dispatched_task_terminal -- --nocapture`
- `python3 scripts/ci/check_touched_rust_size_policy.py --repo-root /home/n/Code/kamn-6883-clean --base-ref origin/main --output-json /tmp/6883-touched-size.json`

## Checklist
- [x] Spec current
- [x] Tests added
- [x] Refactor complete
- [x] Integration verified
- [ ] CI green
