### PR TITLE
[6970] Prove one current SDK TCP signed relay vertical slice on main

### DIFF
--- a/crates/kamn-sdk/tests/sdk_tcp_vertical_slice_contract.rs
+++ b/crates/kamn-sdk/tests/sdk_tcp_vertical_slice_contract.rs
@@ -1,0 +1,60 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const DOC_PATH: &str = "docs/validation/sdk-tcp-vertical-slice.md";
+const DEMO_SCRIPT_PATH: &str = "scripts/sdk/run_tcp_signed_relay_demo.sh";
+const DOC_MARKERS: &[&str] = &[
+    "# SDK TCP Vertical Slice",
+    "two identities",
+    "signed handshake",
+    "successful relay",
+    "replay or tamper rejection",
+    "bash scripts/sdk/run_tcp_signed_relay_demo.sh",
+    "What This Proves",
+    "What This Does Not Prove",
+];
+const SCRIPT_MARKERS: &[&str] = &[
+    "tcp_signed_relay_listener",
+    "tcp_signed_relay_sender",
+    "verified=true",
+    "adapter=tcp",
+    "tcp signed relay demo completed.",
+];
+
+#[test]
+fn regression_sdk_tcp_vertical_slice_doc_exists_with_required_markers() {
+    let doc = read_workspace_file(DOC_PATH);
+    for marker in DOC_MARKERS {
+        assert!(
+            doc.contains(marker),
+            "sdk tcp vertical-slice doc missing required marker: {}",
+            marker
+        );
+    }
+}
+
+#[test]
+fn regression_sdk_tcp_demo_script_retains_required_markers() {
+    let script = read_workspace_file(DEMO_SCRIPT_PATH);
+    for marker in SCRIPT_MARKERS {
+        assert!(
+            script.contains(marker),
+            "sdk tcp demo script missing required marker: {}",
+            marker
+        );
+    }
+}
+
+fn read_workspace_file(relative_path: &str) -> String {
+    let path = workspace_root().join(relative_path);
+    assert!(path.exists(), "expected path to exist: {}", path.display());
+    fs::read_to_string(&path)
+        .unwrap_or_else(|error| panic!("failed to read {}: {}", path.display(), error))
+}
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("workspace root should resolve")
+}

--- a/docs/foundation/rust-sdk-alpha.md
+++ b/docs/foundation/rust-sdk-alpha.md
@@ -80,6 +80,9 @@ Security guard behavior now fails closed across reconnect cycles:
 `Regression: #822` ensures deterministic envelope parsing rejects malformed payloads and preserves signed relay markers.
 `Regression: #823` ensures forged handshake frames and replayed nonces are rejected across reconnect.
 
+Dedicated validation runbook:
+- `docs/validation/sdk-tcp-vertical-slice.md`
+
 ## TCP Failover/Reconnect Integration Matrix (Issue #824)
 Deterministic failover matrix coverage is available as a bounded fast lane with optional scheduled deep expansion:
 

--- a/docs/validation/sdk-tcp-vertical-slice.md
+++ b/docs/validation/sdk-tcp-vertical-slice.md
@@ -1,0 +1,40 @@
+# SDK TCP Vertical Slice
+
+This runbook documents one current KAMN SDK TCP signed-relay slice on `main` that proves a real transport-backed path with two identities, signed handshake acceptance, one successful relay, and explicit replay or tamper rejection outcomes.
+
+## Scope
+- Runtime surface: `kamn-sdk` TCP relay adapter and the TCP signed-relay examples.
+- Identities: one sender DID and one listener DID.
+- Success path: signed handshake acceptance and one successful TCP relay.
+- Failure path: replay or tamper rejection through the real TCP adapter contract surface.
+
+## Preconditions
+- Clean checkout on current `main`.
+- Rust toolchain able to build `kamn-sdk` examples and tests.
+- No external services are required.
+
+## Run
+```bash
+bash scripts/sdk/run_tcp_signed_relay_demo.sh
+cargo test -p kamn-sdk --test tcp_transport_adapter replay_nonce_is_rejected_across_reconnect -- --nocapture
+cargo test -p kamn-sdk --test tcp_transport_adapter forged_handshake_frame_is_rejected -- --nocapture
+```
+
+## Expected Evidence
+- two identities participate in the relay flow
+- signed handshake acceptance is evidenced by `verified=true`
+- successful relay is evidenced by `status=ok`, `adapter=tcp`, and `tcp signed relay demo completed.`
+- replay or tamper rejection is evidenced by:
+  - `tcp handshake replay detected`
+  - `handshake.signature`
+
+## What This Proves
+- The current SDK TCP path can complete one real signed relay between two identities.
+- The listener verifies the signed handshake and envelope before accepting the message.
+- The TCP adapter fails closed on nonce replay across reconnect.
+- The TCP adapter fails closed on forged handshake signatures.
+
+## What This Does Not Prove
+- It does not prove task lifecycle, escrow settlement, bridge finality, or multi-node consensus.
+- It does not prove production deployment readiness or long-lived network resilience.
+- It does not prove wire compatibility with non-Rust SDK implementations.

--- a/specs/6970-prove-sdk-tcp-vertical-slice.md
+++ b/specs/6970-prove-sdk-tcp-vertical-slice.md
@@ -29,11 +29,11 @@ Prove one current, operator-comprehensible KAMN SDK TCP signed-relay vertical sl
 - The proof overclaims scope beyond signed handshake, relay, and explicit rejection signals.
 
 ## Acceptance criteria
-- [ ] A dedicated SDK TCP vertical-slice proof doc exists on current `main`.
-- [ ] The doc is runnable from a clean checkout with explicit commands and prerequisites.
-- [ ] The doc demonstrates two identities, signed handshake acceptance, one successful relay, and at least one replay or tamper rejection outcome.
-- [ ] At least one hard-fail regression contract ties the doc to the exact executable proof path.
-- [ ] The spec records exactly what this transport proof demonstrates and what remains out of scope.
+- [x] A dedicated SDK TCP vertical-slice proof doc exists on current `main`.
+- [x] The doc is runnable from a clean checkout with explicit commands and prerequisites.
+- [x] The doc demonstrates two identities, signed handshake acceptance, one successful relay, and at least one replay or tamper rejection outcome.
+- [x] At least one hard-fail regression contract ties the doc to the exact executable proof path.
+- [x] The spec records exactly what this transport proof demonstrates and what remains out of scope.
 
 ## Files to touch
 - `specs/6970-prove-sdk-tcp-vertical-slice.md`
@@ -57,3 +57,26 @@ Prove one current, operator-comprehensible KAMN SDK TCP signed-relay vertical sl
 
 ## Execution notes
 This issue exists to make one current transport-backed slice defensible when evaluating whether KAMN has real runtime substance. If the existing TCP relay path cannot be documented honestly with explicit failure evidence, the issue must record the exact blocker instead of inflating claims.
+
+
+## Final implementation
+- Dedicated proof doc: [docs/validation/sdk-tcp-vertical-slice.md](/home/n/Code/kamn/docs/validation/sdk-tcp-vertical-slice.md)
+- Hard-fail regression contract: [sdk_tcp_vertical_slice_contract.rs](/home/n/Code/kamn/crates/kamn-sdk/tests/sdk_tcp_vertical_slice_contract.rs)
+- Existing SDK docs now link the proof from [rust-sdk-alpha.md](/home/n/Code/kamn/docs/foundation/rust-sdk-alpha.md)
+
+## Final evidence
+- `cargo test -p kamn-sdk --test sdk_tcp_vertical_slice_contract -- --nocapture`
+- `bash scripts/sdk/test_run_tcp_signed_relay_demo.sh`
+- `cargo test -p kamn-sdk --test tcp_transport_adapter replay_nonce_is_rejected_across_reconnect -- --nocapture`
+- `cargo test -p kamn-sdk --test tcp_transport_adapter forged_handshake_frame_is_rejected -- --nocapture`
+- `python3 scripts/ci/check_touched_rust_size_policy.py --repo-root /home/n/Code/kamn --base-ref origin/main --output-json /tmp/6970-touched-size.json`
+- touched-Rust result: `policy_decision=GO`
+
+## Observed proof
+- The current SDK TCP path proves one successful signed relay between a sender DID and listener DID.
+- The listener emits `verified=true` and `status=ok` markers through the real demo script path.
+- Replay across reconnect is rejected with `tcp handshake replay detected`.
+- Forged handshake frames are rejected with `handshake.signature` classification.
+
+## Deviations
+- None. The current TCP transport surface was already sufficient; this issue formalized it as one operator-readable proof.

--- a/specs/6970-prove-sdk-tcp-vertical-slice.md
+++ b/specs/6970-prove-sdk-tcp-vertical-slice.md
@@ -1,0 +1,59 @@
+# 6970-prove-sdk-tcp-vertical-slice
+
+## Objective
+Prove one current, operator-comprehensible KAMN SDK TCP signed-relay vertical slice on `main` that exercises the real TCP relay adapter path end-to-end: two identities, signed handshake acceptance, one successful relay, one explicit replay/tamper rejection signal, and one reproducible operator command that fails closed on regressions.
+
+## Inputs/Outputs
+- Inputs:
+  - current `kamn-sdk` TCP relay adapter and handshake implementation
+  - existing TCP demo runner `scripts/sdk/run_tcp_signed_relay_demo.sh`
+  - existing transport tests under `crates/kamn-sdk/tests/`
+  - current SDK docs under `docs/foundation/rust-sdk-alpha.md`
+- Outputs:
+  - one dedicated operator-facing proof doc for the SDK TCP signed-relay slice
+  - one hard-fail regression contract tying that doc to the exact executable proof path
+  - any minimal runtime/doc/test wiring needed to make the proof honest and reproducible on current `main`
+
+## Boundaries/Non-goals
+- Do not redesign the TCP transport or handshake protocol.
+- Do not add dependencies.
+- Do not expand this into service-api, bridge, or consensus proof work.
+- Do not claim task lifecycle, escrow settlement, or production deployment readiness from this transport slice.
+- Do not add mock-only demo adapters.
+
+## Failure modes
+- The proof doc points at a script or test path that no longer reflects the real TCP adapter behavior.
+- The slice demonstrates only a happy-path relay and omits replay/tamper failure evidence.
+- The proof relies on synthetic markers not emitted by the actual demo/runtime path.
+- The regression contract can pass while the operator doc drifts from the executable path.
+- The proof overclaims scope beyond signed handshake, relay, and explicit rejection signals.
+
+## Acceptance criteria
+- [ ] A dedicated SDK TCP vertical-slice proof doc exists on current `main`.
+- [ ] The doc is runnable from a clean checkout with explicit commands and prerequisites.
+- [ ] The doc demonstrates two identities, signed handshake acceptance, one successful relay, and at least one replay or tamper rejection outcome.
+- [ ] At least one hard-fail regression contract ties the doc to the exact executable proof path.
+- [ ] The spec records exactly what this transport proof demonstrates and what remains out of scope.
+
+## Files to touch
+- `specs/6970-prove-sdk-tcp-vertical-slice.md`
+- likely one new proof doc under `docs/validation/`
+- likely one new regression contract under `crates/kamn-sdk/tests/`
+- only minimal doc/test/runtime files required to keep the proof honest
+
+## Error semantics
+- Missing doc artifacts, missing proof commands, missing replay/tamper rejection markers, or drift between the doc and executable path must fail loudly.
+- The proof must not silently fall back to mock/in-memory transport.
+- Any documented failure signal must remain explicit and operator-readable.
+
+## Test plan
+- Phase 3 red test that fails because the dedicated proof doc/contract does not yet exist.
+- One hard-fail regression contract asserting required markers in the proof doc and executable path.
+- Re-run the existing TCP signed-relay demo validation path and any directly related SDK TCP tests needed to keep the path green.
+- Final verification should include:
+  - the new proof contract
+  - the existing TCP demo script test
+  - one direct SDK TCP transport target covering successful relay and rejection behavior
+
+## Execution notes
+This issue exists to make one current transport-backed slice defensible when evaluating whether KAMN has real runtime substance. If the existing TCP relay path cannot be documented honestly with explicit failure evidence, the issue must record the exact blocker instead of inflating claims.


### PR DESCRIPTION
Closes #6970

Issue: #6970
Spec: [specs/6970-prove-sdk-tcp-vertical-slice.md](specs/6970-prove-sdk-tcp-vertical-slice.md)

What changed
- added a dedicated operator-facing SDK TCP vertical-slice runbook
- added a hard-fail regression contract that requires the runbook and exact TCP demo markers
- wired the proof doc into the existing Rust SDK alpha documentation surface

Why
- this creates one transport-backed product proof on current `main`
- it anchors the repo discussion in a real SDK relay path with both success and rejection evidence

Test evidence
- `cargo test -p kamn-sdk --test sdk_tcp_vertical_slice_contract -- --nocapture`
- `bash scripts/sdk/test_run_tcp_signed_relay_demo.sh`
- `cargo test -p kamn-sdk --test tcp_transport_adapter replay_nonce_is_rejected_across_reconnect -- --nocapture`
- `cargo test -p kamn-sdk --test tcp_transport_adapter forged_handshake_frame_is_rejected -- --nocapture`
- `python3 scripts/ci/check_touched_rust_size_policy.py --repo-root /home/n/Code/kamn --base-ref origin/main --output-json /tmp/6970-touched-size.json`
- touched-Rust: `policy_decision=GO`

PR checklist
- [x] Spec current
- [x] Tests added
- [x] Refactor complete
- [x] Integration verified
- [ ] CI green
