### PR TITLE
[6972] Publish corrected audit response anchored to current main

### DIFF
--- a/crates/kamn-core/tests/corrected_audit_response_docs.rs
+++ b/crates/kamn-core/tests/corrected_audit_response_docs.rs
@@ -27,8 +27,8 @@ fn corrected_audit_response_doc_exists_with_required_proof_anchors_and_conclusio
         "Stale Or Incorrect Claims",
         "Unproven Claims",
         "build-health blockers from the earlier audit are fixed on current main",
-        "Rust LOC under crates/: 104944",
-        "direct #[test] count under crates/: 5047",
+        "Rust LOC under crates/: 93370",
+        "direct #[test] count under crates/: 5058",
         "AGENTS size debt remains real",
     ] {
         assert!(doc.contains(marker), "missing marker: {marker}");

--- a/crates/kamn-core/tests/corrected_audit_response_docs.rs
+++ b/crates/kamn-core/tests/corrected_audit_response_docs.rs
@@ -1,0 +1,45 @@
+use std::fs;
+use std::path::PathBuf;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("crate dir")
+        .parent()
+        .expect("repo root")
+        .to_path_buf()
+}
+
+fn read_text(path: &str) -> String {
+    let full_path = repo_root().join(path);
+    fs::read_to_string(&full_path)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", full_path.display()))
+}
+
+#[test]
+fn corrected_audit_response_doc_exists_with_required_proof_anchors_and_conclusions() {
+    let doc = read_text("docs/review/corrected-audit-response-2026-03-14.md");
+
+    for marker in [
+        "docs/validation/working-vertical-slice.md",
+        "docs/validation/sdk-tcp-vertical-slice.md",
+        "Accurate Claims",
+        "Stale Or Incorrect Claims",
+        "Unproven Claims",
+        "build-health blockers from the earlier audit are fixed on current main",
+        "Rust LOC under crates/: 104944",
+        "direct #[test] count under crates/: 5047",
+        "AGENTS size debt remains real",
+    ] {
+        assert!(doc.contains(marker), "missing marker: {marker}");
+    }
+}
+
+#[test]
+fn corrected_audit_response_doc_is_linked_from_review_readme() {
+    let readme = read_text("docs/review/README.md");
+    assert!(
+        readme.contains("corrected-audit-response-2026-03-14.md"),
+        "review README must link the corrected audit response doc"
+    );
+}

--- a/crates/kamn-core/tests/corrected_audit_response_docs.rs
+++ b/crates/kamn-core/tests/corrected_audit_response_docs.rs
@@ -1,6 +1,20 @@
 use std::fs;
 use std::path::PathBuf;
 
+const DOC_PATH: &str = "docs/review/corrected-audit-response-2026-03-14.md";
+const REVIEW_README_PATH: &str = "docs/review/README.md";
+const REQUIRED_MARKERS: [&str; 9] = [
+    "docs/validation/working-vertical-slice.md",
+    "docs/validation/sdk-tcp-vertical-slice.md",
+    "Accurate Claims",
+    "Stale Or Incorrect Claims",
+    "Unproven Claims",
+    "build-health blockers from the earlier audit are fixed on current main",
+    "Rust LOC under crates/: 93370",
+    "direct #[test] count under crates/: 5058",
+    "AGENTS size debt remains real",
+];
+
 fn repo_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .parent()
@@ -18,26 +32,16 @@ fn read_text(path: &str) -> String {
 
 #[test]
 fn corrected_audit_response_doc_exists_with_required_proof_anchors_and_conclusions() {
-    let doc = read_text("docs/review/corrected-audit-response-2026-03-14.md");
+    let doc = read_text(DOC_PATH);
 
-    for marker in [
-        "docs/validation/working-vertical-slice.md",
-        "docs/validation/sdk-tcp-vertical-slice.md",
-        "Accurate Claims",
-        "Stale Or Incorrect Claims",
-        "Unproven Claims",
-        "build-health blockers from the earlier audit are fixed on current main",
-        "Rust LOC under crates/: 93370",
-        "direct #[test] count under crates/: 5058",
-        "AGENTS size debt remains real",
-    ] {
+    for marker in REQUIRED_MARKERS {
         assert!(doc.contains(marker), "missing marker: {marker}");
     }
 }
 
 #[test]
 fn corrected_audit_response_doc_is_linked_from_review_readme() {
-    let readme = read_text("docs/review/README.md");
+    let readme = read_text(REVIEW_README_PATH);
     assert!(
         readme.contains("corrected-audit-response-2026-03-14.md"),
         "review README must link the corrected audit response doc"

--- a/docs/review/README.md
+++ b/docs/review/README.md
@@ -1,5 +1,9 @@
 # Review Artifact Marker Contract
 
+## Current Review Responses
+
+- `corrected-audit-response-2026-03-14.md` anchors the recent external KAMN critique to current `main`, including `docs/validation/working-vertical-slice.md` and `docs/validation/sdk-tcp-vertical-slice.md`.
+
 R43+ `gaps-and-issues` review artifacts must carry deterministic governance-vs-feature activity markers using key/value lines.
 
 Required marker keys for `docs/review/gaps-and-issues-r<release>.md` where `<release> >= 43`:

--- a/docs/review/corrected-audit-response-2026-03-14.md
+++ b/docs/review/corrected-audit-response-2026-03-14.md
@@ -1,0 +1,71 @@
+# Corrected Audit Response (2026-03-14)
+
+## Scope
+This response evaluates one recent external KAMN audit against current `main` as of 2026-03-14. It is not a release review and it does not rewrite the historical `gaps-and-issues-r*.md` artifacts.
+
+The two current proof anchors on `main` are:
+- `docs/validation/working-vertical-slice.md`
+- `docs/validation/sdk-tcp-vertical-slice.md`
+
+Those two proofs matter because they establish that current `main` is not only type definitions and wrappers. The node path proves one real service-API vertical slice. The SDK path proves one real TCP signed-relay vertical slice.
+
+## Accurate Claims
+- `kamn-core` is still too large and too central.
+- AGENTS size debt remains real.
+- The repo still contains more architecture, policy, and documentation surface than one would want without concrete runtime proofs.
+- The strongest technical surfaces remain the cryptographic discipline, typed contracts, and fail-closed validation paths.
+- The strategic criticism is fair: KAMN needs more undeniable end-to-end runtime proof, not only more decomposition.
+
+## Stale Or Incorrect Claims
+- The earlier build-health blockers from the earlier audit are fixed on current main.
+- The earlier audit's `~23K LOC Rust` claim is stale.
+- The earlier audit's `8,536 tests` claim is stale.
+- The earlier audit's exact docs/spec counts are stale.
+
+Current reproducible telemetry from this checkout:
+- Rust LOC under crates/: 93370
+  - command: `rg --files crates -g '*.rs' | xargs wc -l | tail -n 1`
+- direct #[test] count under crates/: 5058
+  - command: `rg -n '#\[test\]' crates | wc -l`
+- docs file count: 271
+  - command: `find docs -type f | wc -l`
+- spec file count: 3429
+  - command: `find specs -type f | wc -l`
+
+Current build-health status for the specific blockers that audit called out:
+- `cargo check` passes on current `main`.
+- `cargo test --no-run` no longer fails on the former M7 parse error.
+- the two production `unwrap()` violations previously cited in M1 were fixed in `#6963`.
+
+## Unproven Claims
+- The repo does not yet prove broad production readiness.
+- The repo does not yet prove full consensus maturity, bridge finality, or live economic settlement from one operator-facing path.
+- The repo does not yet prove that every major noun in the architecture has equivalent runtime depth.
+- Claims like `no real persistence` or `only scaffolding` are too absolute for current `main`, but broad product maturity is still not proven either.
+
+## Current Proof Anchors On Main
+### Node Service-API Vertical Slice
+`docs/validation/working-vertical-slice.md` proves one current node-backed path with:
+- two identities in one coherent runtime path
+- real service-API message send plus daemon relay projection
+- persisted `data_layer_runtime_evidence`
+- one real task lifecycle transition to `completed`
+- audit export containing `service_api_task_created`
+
+### SDK TCP Signed-Relay Vertical Slice
+`docs/validation/sdk-tcp-vertical-slice.md` proves one current SDK path with:
+- one transport-backed relay between two identities
+- signed handshake acceptance through the real TCP path
+- one successful relay with `status=ok`, `adapter=tcp`, and `verified=true`
+- explicit replay rejection
+- explicit forged-handshake rejection
+
+## Bottom Line
+The strongest version of the external critique is strategic, not numerical.
+
+The critique is right that KAMN has too much protocol and process surface relative to the number of undeniable runtime proofs. It is wrong when it presents stale repo-size telemetry and it is now stale on build health.
+
+The correct current reading is:
+- KAMN is larger and more implemented than the audit claims.
+- KAMN still needs more runtime-proof depth than the repo currently demonstrates.
+- There are now at least two real proof anchors on `main`, so the repo can no longer be described honestly as only paper architecture.

--- a/specs/6972-corrected-audit-response.md
+++ b/specs/6972-corrected-audit-response.md
@@ -1,0 +1,64 @@
+# 6972-corrected-audit-response
+
+## Objective
+Publish one corrected audit response on current `main` that evaluates the recent external KAMN critique against the code as it exists today, explicitly anchored to the two proof slices now present on `main`: the node service-API vertical slice and the SDK TCP signed-relay vertical slice.
+
+## Inputs/Outputs
+- Inputs:
+  - current review critique text and the claims already discussed in issue `#6972`
+  - current proof docs under `docs/validation/`
+  - current executable contracts proving those slices
+  - current repo telemetry available from the working tree
+- Outputs:
+  - one review response doc under `docs/review/`
+  - one hard-fail docs contract tying that review doc to the current proof anchors and corrected conclusions
+  - minimal review index wiring so the response is discoverable from the existing review surface
+
+## Boundaries/Non-goals
+- Do not rewrite historical `gaps-and-issues-r*.md` review artifacts.
+- Do not claim full product readiness, production deployment, or consensus maturity.
+- Do not invent telemetry that cannot be reproduced from the current checkout.
+- Do not add dependencies.
+- Do not expand this into new runtime implementation work beyond any minimal doc/test wiring needed to keep the response honest.
+
+## Failure modes
+- The review response repeats stale or inflated numbers without correcting them.
+- The review response omits the two current proof anchors and therefore overstates hollowness.
+- The review response overcorrects and claims maturity that current `main` does not prove.
+- The docs contract can pass while the review doc drifts away from the actual proof paths or corrected conclusions.
+- The review doc is left unwired from the review index and becomes another floating artifact.
+
+## Acceptance criteria
+- [ ] A dedicated corrected audit response doc exists under `docs/review/` on current `main`.
+- [ ] The doc explicitly references both proof anchors:
+  - `docs/validation/working-vertical-slice.md`
+  - `docs/validation/sdk-tcp-vertical-slice.md`
+- [ ] The doc separates at least three classes of claims: accurate, stale/incorrect, and unproven.
+- [ ] The doc records corrected current-main telemetry where available instead of repeating stale audit numbers.
+- [ ] A hard-fail regression contract enforces the presence of the proof anchors and key corrected conclusions.
+- [ ] The finished review doc is linked from the existing `docs/review/` surface.
+
+## Files to touch
+- `specs/6972-corrected-audit-response.md`
+- one new review doc under `docs/review/`
+- one new docs contract under `crates/kamn-core/tests/` or another existing docs-contract surface
+- `docs/review/README.md` for discoverability wiring
+- only minimal files required to keep the review honest and enforced
+
+## Error semantics
+- Missing proof-anchor references, missing corrected-telemetry markers, or missing classification of claims must fail loudly in the docs contract.
+- The review response must not silently downgrade proven runtime paths into hypothetical claims.
+- The review response must not silently upgrade unproven areas into working guarantees.
+
+## Test plan
+- Phase 3 red test that fails because the corrected review doc/contract does not yet exist.
+- Add one hard-fail docs contract asserting:
+  - both proof-doc paths are referenced
+  - build-health blockers cited by the stale audit are marked fixed
+  - the stale `~23K Rust LOC` and `8,536 tests` claims are explicitly corrected
+  - AGENTS size debt remains acknowledged
+- Re-run the new docs contract and any directly related docs/index contract coverage needed to keep the review surface honest.
+- Final verification should include the new docs contract and the touched-Rust policy gate.
+
+## Execution notes
+This issue is not a marketing rebuttal. It exists to make the repo's current state defensible: what the critique gets right, what is now stale, what remains unproven, and what two concrete runtime proofs now exist on `main`.

--- a/specs/6972-corrected-audit-response.md
+++ b/specs/6972-corrected-audit-response.md
@@ -62,3 +62,25 @@ Publish one corrected audit response on current `main` that evaluates the recent
 
 ## Execution notes
 This issue is not a marketing rebuttal. It exists to make the repo's current state defensible: what the critique gets right, what is now stale, what remains unproven, and what two concrete runtime proofs now exist on `main`.
+
+## Final implementation
+- Review response: [docs/review/corrected-audit-response-2026-03-14.md](/home/n/Code/kamn/docs/review/corrected-audit-response-2026-03-14.md)
+- Hard-fail docs contract: [corrected_audit_response_docs.rs](/home/n/Code/kamn/crates/kamn-core/tests/corrected_audit_response_docs.rs)
+- Review index wiring: [README.md](/home/n/Code/kamn/docs/review/README.md)
+
+## Final evidence
+- `cargo test -p kamn-core --test corrected_audit_response_docs -- --nocapture`
+- `cargo check -q`
+- `cargo test --no-run -q`
+- `cargo clippy -q -p kamn-core --lib -- -D clippy::unwrap_used`
+- `python3 scripts/ci/check_touched_rust_size_policy.py --repo-root /home/n/Code/kamn --base-ref origin/main --output-json /tmp/6972-touched-size.json`
+- touched-Rust result: `policy_decision=GO`
+
+## Final conclusions captured by the response
+- The earlier external audit is directionally useful on strategy and size debt.
+- Its build-health section is stale on current `main` after `#6963`.
+- Its `~23K LOC Rust` and `8,536 tests` telemetry is stale against the current checkout.
+- Current `main` now has two concrete proof anchors: the node service-API vertical slice and the SDK TCP signed-relay vertical slice.
+
+## Deviations
+- None. The issue remained docs-plus-contract work only and did not require runtime changes.


### PR DESCRIPTION
Closes #6972

Issue: #6972
Spec: specs/6972-corrected-audit-response.md

What changed
- published a corrected audit response under docs/review/
- added a hard-fail docs contract that requires the review doc to reference both current proof anchors and corrected conclusions
- wired the review response into docs/review/README.md so it is discoverable from the existing review surface

Why
- make the recent external critique defensible against current main instead of stale telemetry and pre-proof assumptions
- anchor the response to the two current runtime proofs already on main

Test evidence
- cargo test -p kamn-core --test corrected_audit_response_docs -- --nocapture
- cargo check -q
- cargo test --no-run -q
- cargo clippy -q -p kamn-core --lib -- -D clippy::unwrap_used
- python3 scripts/ci/check_touched_rust_size_policy.py --repo-root /home/n/Code/kamn --base-ref origin/main --output-json /tmp/6972-touched-size.json
- touched-Rust result: policy_decision=GO
