### PR TITLE
[6976] Publish current proven runtime slices index on main

### DIFF
--- a/crates/kamn-node/tests/runtime_proof_index_contract.rs
+++ b/crates/kamn-node/tests/runtime_proof_index_contract.rs
@@ -17,10 +17,7 @@ const INDEX_MARKERS: &[&str] = &[
 
 #[test]
 fn runtime_proof_index_exists_with_required_markers() {
-    let doc = read_workspace_file(INDEX_DOC_PATH);
-    for marker in INDEX_MARKERS {
-        assert!(doc.contains(marker), "runtime proof index missing marker: {}", marker);
-    }
+    assert_contains_all(read_workspace_file(INDEX_DOC_PATH).as_str(), INDEX_MARKERS);
 }
 
 #[test]
@@ -30,6 +27,12 @@ fn corrected_audit_response_links_runtime_proof_index() {
         doc.contains("docs/validation/current-proven-runtime-slices.md"),
         "corrected audit response must link the runtime proof index"
     );
+}
+
+fn assert_contains_all(doc: &str, markers: &[&str]) {
+    for marker in markers {
+        assert!(doc.contains(marker), "runtime proof index missing marker: {}", marker);
+    }
 }
 
 fn read_workspace_file(relative_path: &str) -> String {

--- a/crates/kamn-node/tests/runtime_proof_index_contract.rs
+++ b/crates/kamn-node/tests/runtime_proof_index_contract.rs
@@ -1,0 +1,47 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const INDEX_DOC_PATH: &str = "docs/validation/current-proven-runtime-slices.md";
+const AUDIT_RESPONSE_PATH: &str = "docs/review/corrected-audit-response-2026-03-14.md";
+const INDEX_MARKERS: &[&str] = &[
+    "# Current Proven Runtime Slices",
+    "docs/validation/working-vertical-slice.md",
+    "docs/validation/sdk-tcp-vertical-slice.md",
+    "docs/validation/durable-cross-node-relay-slice.md",
+    "What Is Currently Proven",
+    "What Remains Unproven",
+    "service-api vertical slice",
+    "TCP signed-relay vertical slice",
+    "durable cross-node relay slice",
+];
+
+#[test]
+fn runtime_proof_index_exists_with_required_markers() {
+    let doc = read_workspace_file(INDEX_DOC_PATH);
+    for marker in INDEX_MARKERS {
+        assert!(doc.contains(marker), "runtime proof index missing marker: {}", marker);
+    }
+}
+
+#[test]
+fn corrected_audit_response_links_runtime_proof_index() {
+    let doc = read_workspace_file(AUDIT_RESPONSE_PATH);
+    assert!(
+        doc.contains("docs/validation/current-proven-runtime-slices.md"),
+        "corrected audit response must link the runtime proof index"
+    );
+}
+
+fn read_workspace_file(relative_path: &str) -> String {
+    let path = workspace_root().join(relative_path);
+    assert!(path.exists(), "expected path to exist: {}", path.display());
+    fs::read_to_string(&path)
+        .unwrap_or_else(|error| panic!("failed to read {}: {}", path.display(), error))
+}
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("workspace root should resolve")
+}

--- a/docs/review/corrected-audit-response-2026-03-14.md
+++ b/docs/review/corrected-audit-response-2026-03-14.md
@@ -4,6 +4,7 @@
 This response evaluates one recent external KAMN audit against current `main` as of 2026-03-14. It is not a release review and it does not rewrite the historical `gaps-and-issues-r*.md` artifacts.
 
 The two current proof anchors on `main` are:
+- `docs/validation/current-proven-runtime-slices.md`
 - `docs/validation/working-vertical-slice.md`
 - `docs/validation/sdk-tcp-vertical-slice.md`
 

--- a/docs/validation/current-proven-runtime-slices.md
+++ b/docs/validation/current-proven-runtime-slices.md
@@ -1,0 +1,20 @@
+# Current Proven Runtime Slices
+
+This index summarizes the runtime behavior that current `main` proves today through executable runbooks and regression contracts.
+
+## What Is Currently Proven
+- Service-api vertical slice: `docs/validation/working-vertical-slice.md`
+  - proves one service-api vertical slice with two identities, encrypted delivery evidence, one task lifecycle transition, and audit export output
+- TCP signed-relay vertical slice: `docs/validation/sdk-tcp-vertical-slice.md`
+  - proves one SDK TCP signed-relay vertical slice with signed handshake acceptance, one successful relay, and fail-closed replay or forged-handshake rejection
+- durable cross-node relay slice: `docs/validation/durable-cross-node-relay-slice.md`
+  - proves durable sender spool enqueue, fail-closed pending spool preservation, later successful relay projection, and recipient-visible delivered state across fresh boot
+
+## What Remains Unproven
+- broad production readiness
+- consensus or multi-node finality
+- bridge finality or escrow settlement
+- global fault tolerance under arbitrary partitions
+
+## How To Use This Index
+Start here when evaluating what KAMN actually demonstrates on current `main`. Then follow the linked runbooks to the exact test commands and operator evidence for each slice.

--- a/docs/validation/live-environment.md
+++ b/docs/validation/live-environment.md
@@ -4,6 +4,8 @@ This document defines the first implementation slice for Story #2975 and Task #2
 
 ## Objective
 
+For the current proven runtime slices on `main`, start with `docs/validation/current-proven-runtime-slices.md`.
+
 Provide a repeatable local live-validation environment that verifies:
 
 - multi-process deployment topology contracts, and

--- a/specs/6976-runtime-proof-index.md
+++ b/specs/6976-runtime-proof-index.md
@@ -53,3 +53,17 @@ Publish one operator-facing index on current `main` that summarizes the currentl
 
 ## Execution notes
 This issue exists to give operators and reviewers one current-main entrypoint for runtime substance. It should reduce repetitive repo-wide argument and point directly at the three proofs already established on `main`.
+
+## Final implementation
+- Validation index: [docs/validation/current-proven-runtime-slices.md](/home/n/Code/kamn/docs/validation/current-proven-runtime-slices.md)
+- Hard-fail docs contract: [runtime_proof_index_contract.rs](/home/n/Code/kamn/crates/kamn-node/tests/runtime_proof_index_contract.rs)
+- Discoverability wiring: [live-environment.md](/home/n/Code/kamn/docs/validation/live-environment.md)
+- Review-doc link: [corrected-audit-response-2026-03-14.md](/home/n/Code/kamn/docs/review/corrected-audit-response-2026-03-14.md)
+
+## Final evidence
+- `cargo test -p kamn-node --test runtime_proof_index_contract -- --nocapture`
+- `python3 scripts/ci/check_touched_rust_size_policy.py --repo-root /home/n/Code/kamn --base-ref origin/main --output-json /tmp/6976-touched-size.json`
+- touched-Rust result: `policy_decision=GO`
+
+## Deviations
+- None. The index remained docs-plus-contract work only.

--- a/specs/6976-runtime-proof-index.md
+++ b/specs/6976-runtime-proof-index.md
@@ -1,0 +1,55 @@
+# 6976-runtime-proof-index
+
+## Objective
+Publish one operator-facing index on current `main` that summarizes the currently proven KAMN runtime slices, links each proof runbook, and states the boundaries of those proofs without inflating product maturity claims.
+
+## Inputs/Outputs
+- Inputs:
+  - current validation runbooks under `docs/validation/`
+  - current corrected audit response under `docs/review/`
+  - current executable proof contracts already on `main`
+- Outputs:
+  - one validation index under `docs/validation/`
+  - one hard-fail docs contract ensuring the index keeps the three proof links and key summary markers
+  - minimal wiring from an existing validation/docs surface so the index is discoverable
+
+## Boundaries/Non-goals
+- Do not change runtime behavior.
+- Do not add dependencies.
+- Do not claim production readiness, consensus maturity, or settlement guarantees.
+- Do not duplicate full runbook content; summarize and link.
+
+## Failure modes
+- The index omits one of the three current proof slices.
+- The index restates claims more broadly than the underlying proof docs justify.
+- The docs contract can pass while the index drifts away from the current proof set.
+- The index is left floating without any discoverability wiring.
+
+## Acceptance criteria
+- [ ] A dedicated runtime-proof index exists under `docs/validation/`.
+- [ ] The index links all three current proof slices.
+- [ ] The index states what each slice proves in bounded language.
+- [ ] The index states what remains unproven overall.
+- [ ] A hard-fail docs contract enforces the three links and key summary markers.
+- [ ] The finished index is reachable from an existing validation/docs surface on current `main`.
+
+## Files to touch
+- `specs/6976-runtime-proof-index.md`
+- one new index doc under `docs/validation/`
+- one new docs contract under `crates/kamn-node/tests/` or another existing validation-contract surface
+- one existing validation/docs surface for discoverability wiring
+
+## Error semantics
+- Missing proof links, missing scope markers, or missing unproven-boundary markers must fail loudly.
+- The index must not silently expand the proof scope beyond what the linked runbooks already demonstrate.
+
+## Test plan
+- Phase 3 red test that fails because the index doc/contract does not yet exist.
+- One hard-fail docs contract asserting:
+  - the three proof-runbook links remain present
+  - the index states current proven slices
+  - the index states remaining unproven areas
+- Re-run the new docs contract and touched-Rust policy.
+
+## Execution notes
+This issue exists to give operators and reviewers one current-main entrypoint for runtime substance. It should reduce repetitive repo-wide argument and point directly at the three proofs already established on `main`.


### PR DESCRIPTION
Closes #6976

Issue: #6976
Spec: specs/6976-runtime-proof-index.md

What changed
- added a validation index for the three current proven runtime slices
- added a hard-fail docs contract for the index
- wired the index into validation and review surfaces

Why
- give operators and reviewers one current-main entrypoint for runtime substance instead of hunting through separate runbooks

Test evidence
- cargo test -p kamn-node --test runtime_proof_index_contract -- --nocapture
- python3 scripts/ci/check_touched_rust_size_policy.py --repo-root /home/n/Code/kamn --base-ref origin/main --output-json /tmp/6976-touched-size.json
- touched-Rust result: policy_decision=GO
