### PR TITLE
[6978] Prove service API restart persistence slice on main

### DIFF
--- a/crates/kamn-node/tests/restart_persistence_proof_contract.rs
+++ b/crates/kamn-node/tests/restart_persistence_proof_contract.rs
@@ -1,0 +1,39 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const DOC_PATH: &str = "docs/validation/restart-persistence-slice.md";
+const DOC_MARKERS: &[&str] = &[
+    "# Restart Persistence Slice",
+    "integration_service_api_endpoint_persists_message_state_across_restart",
+    "integration_service_api_endpoint_persists_task_and_escrow_state_across_restart",
+    "integration_service_api_endpoint_persists_channel_creation_state_across_restart",
+    "integration_service_api_endpoint_persists_agent_profile_query_state_across_restart",
+    "integration_service_api_endpoint_recipient_mailbox_and_delivery_status_contract",
+    "regression_service_api_endpoint_non_recipient_query_keeps_relayed_status_across_restart",
+    "What This Proves",
+    "What This Does Not Prove",
+    "restart persistence",
+    "not crash recovery",
+];
+
+#[test]
+fn restart_persistence_doc_exists_with_required_markers() {
+    let doc = read_workspace_file(DOC_PATH);
+    for marker in DOC_MARKERS {
+        assert!(doc.contains(marker), "restart persistence proof doc missing marker: {}", marker);
+    }
+}
+
+fn read_workspace_file(relative_path: &str) -> String {
+    let path = workspace_root().join(relative_path);
+    assert!(path.exists(), "expected path to exist: {}", path.display());
+    fs::read_to_string(&path)
+        .unwrap_or_else(|error| panic!("failed to read {}: {}", path.display(), error))
+}
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("workspace root should resolve")
+}

--- a/crates/kamn-node/tests/restart_persistence_proof_contract.rs
+++ b/crates/kamn-node/tests/restart_persistence_proof_contract.rs
@@ -18,9 +18,16 @@ const DOC_MARKERS: &[&str] = &[
 
 #[test]
 fn restart_persistence_doc_exists_with_required_markers() {
-    let doc = read_workspace_file(DOC_PATH);
-    for marker in DOC_MARKERS {
-        assert!(doc.contains(marker), "restart persistence proof doc missing marker: {}", marker);
+    assert_contains_all(read_workspace_file(DOC_PATH).as_str(), DOC_MARKERS);
+}
+
+fn assert_contains_all(doc: &str, markers: &[&str]) {
+    for marker in markers {
+        assert!(
+            doc.contains(marker),
+            "restart persistence proof doc missing marker: {}",
+            marker
+        );
     }
 }
 

--- a/docs/validation/current-proven-runtime-slices.md
+++ b/docs/validation/current-proven-runtime-slices.md
@@ -9,6 +9,8 @@ This index summarizes the runtime behavior that current `main` proves today thro
   - proves one SDK TCP signed-relay vertical slice with signed handshake acceptance, one successful relay, and fail-closed replay or forged-handshake rejection
 - durable cross-node relay slice: `docs/validation/durable-cross-node-relay-slice.md`
   - proves durable sender spool enqueue, fail-closed pending spool preservation, later successful relay projection, and recipient-visible delivered state across fresh boot
+- restart persistence slice: `docs/validation/restart-persistence-slice.md`
+  - proves restart persistence across message state, task and escrow state, directory state, and relayed or delivered status continuity
 
 ## What Remains Unproven
 - broad production readiness

--- a/docs/validation/restart-persistence-slice.md
+++ b/docs/validation/restart-persistence-slice.md
@@ -1,0 +1,54 @@
+# Restart Persistence Slice
+
+This runbook documents one current KAMN service-API slice on `main` that proves restart persistence across several persisted service-API surfaces. It is deliberately narrower than crash-recovery claims.
+
+## Scope
+- message state across restart
+- task and escrow state across restart
+- directory state across restart
+- relayed and delivered status continuity across restart or fresh boot
+
+## Proof Anchors
+This slice is grounded in current-main tests:
+- `integration_service_api_endpoint_persists_message_state_across_restart`
+- `integration_service_api_endpoint_persists_task_and_escrow_state_across_restart`
+- `integration_service_api_endpoint_persists_channel_creation_state_across_restart`
+- `integration_service_api_endpoint_persists_agent_profile_query_state_across_restart`
+- `integration_service_api_endpoint_recipient_mailbox_and_delivery_status_contract`
+- `regression_service_api_endpoint_non_recipient_query_keeps_relayed_status_across_restart`
+
+## What This Proves
+- restart persistence for message state is present on the current service-api storage path
+- restart persistence for task and escrow state is present on the current service-api storage path
+- restart persistence for directory state is present for channel creation and agent-profile query state
+- relayed and delivered status remain queryable across restart or fresh boot on the current durable state path
+- non-recipient restart reads preserve `relayed` and do not incorrectly promote delivery
+
+## What This Does Not Prove
+- not crash recovery
+- not WAL durability after abrupt kill or corruption
+- not consensus, bridge finality, or escrow settlement guarantees
+- not production deployment readiness
+
+## Operator Commands
+Run the exact restart-persistence proof targets from a clean checkout:
+
+```bash
+cargo test -p kamn-node integration_service_api_endpoint_persists_message_state_across_restart -- --exact --nocapture
+cargo test -p kamn-node integration_service_api_endpoint_persists_task_and_escrow_state_across_restart -- --exact --nocapture
+cargo test -p kamn-node integration_service_api_endpoint_persists_channel_creation_state_across_restart -- --exact --nocapture
+cargo test -p kamn-node integration_service_api_endpoint_persists_agent_profile_query_state_across_restart -- --exact --nocapture
+cargo test -p kamn-node integration_service_api_endpoint_recipient_mailbox_and_delivery_status_contract -- --exact --nocapture
+cargo test -p kamn-node regression_service_api_endpoint_non_recipient_query_keeps_relayed_status_across_restart -- --exact --nocapture
+```
+
+## Expected Evidence
+- a created message remains queryable after restart with stable persisted state
+- accepted task state and released escrow state remain present after restart
+- created channel state and queried agent profile state remain present after restart
+- a fresh reader can still observe `delivered` for recipient-visible state
+- a non-recipient restart path keeps `relayed` stable
+
+## Notes
+- This slice proves restart persistence, not stronger crash-recovery semantics.
+- The stronger durable relay and restart-status proof remains documented separately in `docs/validation/durable-cross-node-relay-slice.md`.

--- a/specs/6978-restart-persistence-proof.md
+++ b/specs/6978-restart-persistence-proof.md
@@ -54,3 +54,28 @@ Prove one current, operator-comprehensible KAMN service-API restart persistence 
 
 ## Execution notes
 This issue exists to make current restart persistence claims defensible. If current `main` cannot support a coherent restart-persistence proof, the issue must record the exact gap rather than overstating recovery maturity.
+
+## Final implementation
+- Validation runbook: [docs/validation/restart-persistence-slice.md](/home/n/Code/kamn/docs/validation/restart-persistence-slice.md)
+- Hard-fail docs contract: [restart_persistence_proof_contract.rs](/home/n/Code/kamn/crates/kamn-node/tests/restart_persistence_proof_contract.rs)
+- Runtime index wiring: [current-proven-runtime-slices.md](/home/n/Code/kamn/docs/validation/current-proven-runtime-slices.md)
+
+## Final evidence
+- `cargo test -p kamn-node --test restart_persistence_proof_contract -- --nocapture`
+- `cargo test -p kamn-node integration_service_api_endpoint_persists_message_state_across_restart -- --exact --nocapture`
+- `cargo test -p kamn-node integration_service_api_endpoint_persists_task_and_escrow_state_across_restart -- --exact --nocapture`
+- `cargo test -p kamn-node integration_service_api_endpoint_persists_channel_creation_state_across_restart -- --exact --nocapture`
+- `cargo test -p kamn-node integration_service_api_endpoint_persists_agent_profile_query_state_across_restart -- --exact --nocapture`
+- `cargo test -p kamn-node integration_service_api_endpoint_recipient_mailbox_and_delivery_status_contract -- --exact --nocapture`
+- `cargo test -p kamn-node regression_service_api_endpoint_non_recipient_query_keeps_relayed_status_across_restart -- --exact --nocapture`
+- `python3 scripts/ci/check_touched_rust_size_policy.py --repo-root /home/n/Code/kamn --base-ref origin/main --output-json /tmp/6978-touched-size.json`
+- touched-Rust result: `policy_decision=GO`
+
+## Observed proof
+- Message state remains queryable after restart on the current service-api storage path.
+- Task and escrow state remain queryable after restart on the current service-api storage path.
+- Channel and agent-profile directory state remain queryable after restart.
+- Recipient-visible `delivered` and non-recipient `relayed` state continuity both remain observable across restart or fresh boot.
+
+## Deviations
+- None. Current `main` already contained the required restart-persistence runtime coverage; this issue formalized it as one operator-readable proof.

--- a/specs/6978-restart-persistence-proof.md
+++ b/specs/6978-restart-persistence-proof.md
@@ -1,0 +1,56 @@
+# 6978-restart-persistence-proof
+
+## Objective
+Prove one current, operator-comprehensible KAMN service-API restart persistence slice on `main` that summarizes which persisted service-API state survives restart or fresh boot today, using existing executable restart contracts rather than broader crash-recovery claims.
+
+## Inputs/Outputs
+- Inputs:
+  - current restart-persistence integration tests under `crates/kamn-node/src/main_tests/service_api_endpoint_tests/`
+  - current durable relay/restart validation docs already on `main`
+  - current architecture and audit-response docs that need bounded restart language
+- Outputs:
+  - one dedicated restart-persistence validation doc under `docs/validation/`
+  - one hard-fail docs contract tying that doc to the exact restart-persistence proof anchors
+  - minimal docs wiring so the proof is discoverable from the validation surface
+
+## Boundaries/Non-goals
+- Do not claim SIGKILL/WAL crash recovery if the current proof anchors only cover restart persistence.
+- Do not redesign state persistence.
+- Do not add dependencies.
+- Do not add mock-only runtime paths.
+- Do not expand this into consensus, escrow settlement, or bridge finality claims beyond restart persistence.
+
+## Failure modes
+- The proof claims crash recovery when the underlying tests only prove restart persistence.
+- The proof omits one of the major restart-persistence surfaces already present on `main`.
+- The docs contract can pass while the validation doc drifts away from the executable restart anchors.
+- The proof overstates breadth beyond message, task/escrow, directory, and relay-status continuity.
+
+## Acceptance criteria
+- [ ] A dedicated restart-persistence proof doc exists under `docs/validation/`.
+- [ ] The proof links real current-main restart coverage for at least:
+  - message state across restart
+  - task and escrow state across restart
+  - directory state across restart
+  - relayed/delivered status continuity across restart or fresh boot
+- [ ] The proof states clearly what it proves and what remains unproven.
+- [ ] A hard-fail docs contract enforces the required proof anchors and bounded language.
+- [ ] The finished proof is wired into an existing docs/validation or related operator-facing surface.
+
+## Files to touch
+- `specs/6978-restart-persistence-proof.md`
+- one new validation doc under `docs/validation/`
+- one new docs contract under `crates/kamn-node/tests/`
+- one existing validation/docs surface for discoverability wiring
+
+## Error semantics
+- Missing restart-proof anchors or missing boundary markers must fail loudly.
+- The proof must not silently equate restart persistence with stronger crash-recovery guarantees.
+
+## Test plan
+- Phase 3 red test that fails because the restart-persistence validation doc/contract does not yet exist.
+- One hard-fail docs contract asserting required restart-proof links and bounded-language markers.
+- Re-run the referenced restart-persistence integration targets and touched-Rust policy before publish.
+
+## Execution notes
+This issue exists to make current restart persistence claims defensible. If current `main` cannot support a coherent restart-persistence proof, the issue must record the exact gap rather than overstating recovery maturity.


### PR DESCRIPTION
Closes #6978

Issue: #6978
Spec: specs/6978-restart-persistence-proof.md

## Summary
- publish an operator-facing restart persistence proof for the current service-api path on main
- add a hard-fail docs contract that binds the proof to executable restart-persistence coverage
- wire the proof into the current proven runtime slices index

## Test evidence
- cargo test -p kamn-node --test restart_persistence_proof_contract -- --nocapture
- cargo test -p kamn-node integration_service_api_endpoint_persists_message_state_across_restart -- --exact --nocapture
- cargo test -p kamn-node integration_service_api_endpoint_persists_task_and_escrow_state_across_restart -- --exact --nocapture
- cargo test -p kamn-node integration_service_api_endpoint_persists_channel_creation_state_across_restart -- --exact --nocapture
- cargo test -p kamn-node integration_service_api_endpoint_persists_agent_profile_query_state_across_restart -- --exact --nocapture
- cargo test -p kamn-node integration_service_api_endpoint_recipient_mailbox_and_delivery_status_contract -- --exact --nocapture
- cargo test -p kamn-node regression_service_api_endpoint_non_recipient_query_keeps_relayed_status_across_restart -- --exact --nocapture
- python3 scripts/ci/check_touched_rust_size_policy.py --repo-root /home/n/Code/kamn --base-ref origin/main --output-json /tmp/6978-touched-size.json
- touched-Rust: policy_decision=GO
