### PR TITLE
[6980] Prove service API escrow settlement slice on main

### DIFF
--- a/crates/kamn-node/tests/escrow_settlement_slice_contract.rs
+++ b/crates/kamn-node/tests/escrow_settlement_slice_contract.rs
@@ -1,0 +1,40 @@
+use std::fs;
+
+const DOC: &str = "docs/validation/escrow-settlement-slice.md";
+const INDEX: &str = "docs/validation/current-proven-runtime-slices.md";
+const REQUIRED_DOC_MARKERS: &[&str] = &[
+    "# Escrow Settlement Slice",
+    "integration_service_api_endpoint_persists_task_and_escrow_state_across_routes",
+    "integration_service_api_endpoint_persists_task_and_escrow_state_across_restart",
+    "service-api escrow lifecycle persistence",
+    "not bridge finality",
+    "not external chain settlement",
+];
+const REQUIRED_INDEX_MARKERS: &[&str] = &[
+    "escrow settlement slice: `docs/validation/escrow-settlement-slice.md`",
+    "proves service-api escrow lifecycle persistence through fund, release, and restart-visible released state",
+];
+
+#[test]
+fn escrow_settlement_validation_doc_exists_and_stays_bounded() {
+    let doc = fs::read_to_string(DOC).expect("escrow settlement validation doc should exist");
+
+    for marker in REQUIRED_DOC_MARKERS {
+        assert!(
+            doc.contains(marker),
+            "escrow settlement validation doc missing marker: {marker}"
+        );
+    }
+}
+
+#[test]
+fn runtime_proof_index_includes_escrow_settlement_slice() {
+    let index = fs::read_to_string(INDEX).expect("runtime proof index should exist");
+
+    for marker in REQUIRED_INDEX_MARKERS {
+        assert!(
+            index.contains(marker),
+            "runtime proof index missing escrow settlement marker: {marker}"
+        );
+    }
+}

--- a/crates/kamn-node/tests/escrow_settlement_slice_contract.rs
+++ b/crates/kamn-node/tests/escrow_settlement_slice_contract.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use std::path::{Path, PathBuf};
 
 const DOC: &str = "docs/validation/escrow-settlement-slice.md";
 const INDEX: &str = "docs/validation/current-proven-runtime-slices.md";
@@ -17,7 +18,7 @@ const REQUIRED_INDEX_MARKERS: &[&str] = &[
 
 #[test]
 fn escrow_settlement_validation_doc_exists_and_stays_bounded() {
-    let doc = fs::read_to_string(DOC).expect("escrow settlement validation doc should exist");
+    let doc = read_workspace_file(DOC);
 
     for marker in REQUIRED_DOC_MARKERS {
         assert!(
@@ -29,7 +30,7 @@ fn escrow_settlement_validation_doc_exists_and_stays_bounded() {
 
 #[test]
 fn runtime_proof_index_includes_escrow_settlement_slice() {
-    let index = fs::read_to_string(INDEX).expect("runtime proof index should exist");
+    let index = read_workspace_file(INDEX);
 
     for marker in REQUIRED_INDEX_MARKERS {
         assert!(
@@ -37,4 +38,18 @@ fn runtime_proof_index_includes_escrow_settlement_slice() {
             "runtime proof index missing escrow settlement marker: {marker}"
         );
     }
+}
+
+fn read_workspace_file(relative_path: &str) -> String {
+    let path = workspace_root().join(relative_path);
+    assert!(path.exists(), "expected path to exist: {}", path.display());
+    fs::read_to_string(&path)
+        .unwrap_or_else(|error| panic!("failed to read {}: {}", path.display(), error))
+}
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("workspace root should resolve")
 }

--- a/crates/kamn-node/tests/escrow_settlement_slice_contract.rs
+++ b/crates/kamn-node/tests/escrow_settlement_slice_contract.rs
@@ -18,25 +18,25 @@ const REQUIRED_INDEX_MARKERS: &[&str] = &[
 
 #[test]
 fn escrow_settlement_validation_doc_exists_and_stays_bounded() {
-    let doc = read_workspace_file(DOC);
-
-    for marker in REQUIRED_DOC_MARKERS {
-        assert!(
-            doc.contains(marker),
-            "escrow settlement validation doc missing marker: {marker}"
-        );
-    }
+    assert_contains_all(
+        read_workspace_file(DOC).as_str(),
+        REQUIRED_DOC_MARKERS,
+        "escrow settlement validation doc",
+    );
 }
 
 #[test]
 fn runtime_proof_index_includes_escrow_settlement_slice() {
-    let index = read_workspace_file(INDEX);
+    assert_contains_all(
+        read_workspace_file(INDEX).as_str(),
+        REQUIRED_INDEX_MARKERS,
+        "runtime proof index",
+    );
+}
 
-    for marker in REQUIRED_INDEX_MARKERS {
-        assert!(
-            index.contains(marker),
-            "runtime proof index missing escrow settlement marker: {marker}"
-        );
+fn assert_contains_all(doc: &str, markers: &[&str], label: &str) {
+    for marker in markers {
+        assert!(doc.contains(marker), "{label} missing marker: {marker}");
     }
 }
 

--- a/docs/review/corrected-audit-response-2026-03-14.md
+++ b/docs/review/corrected-audit-response-2026-03-14.md
@@ -3,12 +3,17 @@
 ## Scope
 This response evaluates one recent external KAMN audit against current `main` as of 2026-03-14. It is not a release review and it does not rewrite the historical `gaps-and-issues-r*.md` artifacts.
 
-The two current proof anchors on `main` are:
+The current proof entrypoint on `main` is:
 - `docs/validation/current-proven-runtime-slices.md`
+
+The current proof anchors on `main` include:
 - `docs/validation/working-vertical-slice.md`
 - `docs/validation/sdk-tcp-vertical-slice.md`
+- `docs/validation/durable-cross-node-relay-slice.md`
+- `docs/validation/restart-persistence-slice.md`
+- `docs/validation/escrow-settlement-slice.md`
 
-Those two proofs matter because they establish that current `main` is not only type definitions and wrappers. The node path proves one real service-API vertical slice. The SDK path proves one real TCP signed-relay vertical slice.
+Those proofs matter because they establish that current `main` is not only type definitions and wrappers. The node path proves one real service-API vertical slice. The SDK path proves one real TCP signed-relay vertical slice. The newer relay, restart, and escrow proofs make the bounded persistence and settlement claims easier to inspect from one place.
 
 ## Accurate Claims
 - `kamn-core` is still too large and too central.
@@ -61,6 +66,13 @@ Current build-health status for the specific blockers that audit called out:
 - explicit replay rejection
 - explicit forged-handshake rejection
 
+### Durable Relay, Restart, And Escrow Slices
+`docs/validation/durable-cross-node-relay-slice.md` proves durable spool preservation, later relay projection, and recipient-visible delivery continuity.
+
+`docs/validation/restart-persistence-slice.md` proves restart persistence across message state, task and escrow state, directory state, and relayed or delivered continuity.
+
+`docs/validation/escrow-settlement-slice.md` proves bounded service-api escrow lifecycle persistence through fund, release, and restart-visible released state.
+
 ## Bottom Line
 The strongest version of the external critique is strategic, not numerical.
 
@@ -69,4 +81,4 @@ The critique is right that KAMN has too much protocol and process surface relati
 The correct current reading is:
 - KAMN is larger and more implemented than the audit claims.
 - KAMN still needs more runtime-proof depth than the repo currently demonstrates.
-- There are now at least two real proof anchors on `main`, so the repo can no longer be described honestly as only paper architecture.
+- There are now multiple real proof anchors on `main`, so the repo can no longer be described honestly as only paper architecture.

--- a/docs/validation/current-proven-runtime-slices.md
+++ b/docs/validation/current-proven-runtime-slices.md
@@ -11,11 +11,13 @@ This index summarizes the runtime behavior that current `main` proves today thro
   - proves durable sender spool enqueue, fail-closed pending spool preservation, later successful relay projection, and recipient-visible delivered state across fresh boot
 - restart persistence slice: `docs/validation/restart-persistence-slice.md`
   - proves restart persistence across message state, task and escrow state, directory state, and relayed or delivered status continuity
+- escrow settlement slice: `docs/validation/escrow-settlement-slice.md`
+  - proves service-api escrow lifecycle persistence through fund, release, and restart-visible released state
 
 ## What Remains Unproven
 - broad production readiness
 - consensus or multi-node finality
-- bridge finality or escrow settlement
+- bridge finality or external chain settlement
 - global fault tolerance under arbitrary partitions
 
 ## How To Use This Index

--- a/docs/validation/escrow-settlement-slice.md
+++ b/docs/validation/escrow-settlement-slice.md
@@ -1,0 +1,43 @@
+# Escrow Settlement Slice
+
+This runbook documents one current KAMN service-API slice on `main` that proves service-api escrow lifecycle persistence through fund, release, and restart-visible released state. It is deliberately narrower than external chain settlement or bridge finality claims.
+
+## Scope
+- task create and accept on the current service-api path
+- escrow fund and release on the current service-api path
+- released escrow state remaining queryable after restart
+
+## Proof Anchors
+This slice is grounded in current-main tests:
+- `integration_service_api_endpoint_persists_task_and_escrow_state_across_routes`
+- `integration_service_api_endpoint_persists_task_and_escrow_state_across_restart`
+
+## What This Proves
+- the service API can create and accept a task before funding escrow on the same persisted state path
+- the service API can fund escrow and return `state=funded`
+- the service API can release escrow and return `state=released`
+- released escrow state remains persisted across restart on the current service-api storage path
+- the proof is anchored to executable route and restart coverage, not API shape alone
+
+## What This Does Not Prove
+- not bridge finality
+- not external chain settlement
+- not Byzantine-safe or adversarial settlement
+- not cross-node escrow consensus
+- not production deployment readiness
+
+## Operator Commands
+Run the exact escrow proof targets from a clean checkout:
+
+```bash
+cargo test -p kamn-node integration_service_api_endpoint_persists_task_and_escrow_state_across_routes -- --exact --nocapture
+cargo test -p kamn-node integration_service_api_endpoint_persists_task_and_escrow_state_across_restart -- --exact --nocapture
+```
+
+## Expected Evidence
+- route-level evidence shows one task entering `accepted`, one escrow entering `funded`, and the same escrow reaching `released`
+- restart-level evidence shows persisted task state remains `accepted` and persisted escrow state remains `released`
+
+## Notes
+- This slice proves service-api escrow lifecycle persistence.
+- It does not prove external chain receipt finality or cross-chain settlement semantics.

--- a/specs/6980-service-api-escrow-settlement-slice.md
+++ b/specs/6980-service-api-escrow-settlement-slice.md
@@ -48,3 +48,27 @@ Prove one current, operator-comprehensible KAMN service-API escrow settlement sl
 - Phase 3 red test that fails because the escrow-settlement validation doc and contract do not yet exist.
 - One hard-fail docs contract asserting required escrow proof links and bounded-language markers.
 - Re-run the referenced service-api task/escrow route and restart targets and touched-Rust policy before publish.
+
+## Final implementation
+- Validation runbook: [docs/validation/escrow-settlement-slice.md](/home/n/Code/kamn/docs/validation/escrow-settlement-slice.md)
+- Hard-fail docs contract: [escrow_settlement_slice_contract.rs](/home/n/Code/kamn/crates/kamn-node/tests/escrow_settlement_slice_contract.rs)
+- Runtime proof index wiring: [current-proven-runtime-slices.md](/home/n/Code/kamn/docs/validation/current-proven-runtime-slices.md)
+- Review-surface wiring: [corrected-audit-response-2026-03-14.md](/home/n/Code/kamn/docs/review/corrected-audit-response-2026-03-14.md)
+
+## Final evidence
+- `cargo test -p kamn-node --test escrow_settlement_slice_contract -- --nocapture`
+- `cargo test -p kamn-node integration_service_api_endpoint_persists_task_and_escrow_state_across_routes -- --exact --nocapture`
+- `cargo test -p kamn-node integration_service_api_endpoint_persists_task_and_escrow_state_across_restart -- --exact --nocapture`
+- `cargo test -p kamn-core --test corrected_audit_response_docs -- --nocapture`
+- `python3 scripts/ci/check_touched_rust_size_policy.py --repo-root /home/n/Code/kamn --base-ref origin/main --output-json /tmp/6980-touched-size.json`
+- touched-Rust result: `policy_decision=GO`
+
+## Observed proof
+- the service API can create and accept a task before funding escrow on the current persisted state path
+- the service API can fund escrow and return `state=funded`
+- the service API can release escrow and return `state=released`
+- released escrow state remains persisted and queryable across restart on the current service-api storage path
+- the proof is explicitly bounded to service-api escrow lifecycle persistence rather than external chain settlement semantics
+
+## Deviations
+- None. Current `main` already contained the necessary route and restart coverage; this issue formalized it as one operator-readable escrow proof and linked it from the existing proof surfaces.

--- a/specs/6980-service-api-escrow-settlement-slice.md
+++ b/specs/6980-service-api-escrow-settlement-slice.md
@@ -1,0 +1,50 @@
+# 6980-service-api-escrow-settlement-slice
+
+## Objective
+Prove one current, operator-comprehensible KAMN service-API escrow settlement slice on `main` that states exactly which escrow lifecycle behavior is executable today through the service API, using existing route and restart integration tests rather than broader settlement or chain-finality claims.
+
+## Inputs/Outputs
+- Inputs:
+  - current service-api task and escrow route tests under `crates/kamn-node/src/main_tests/service_api_endpoint_tests/`
+  - current restart-persistence proof and runtime proof index docs on `main`
+  - current service-api audit export behavior for task and escrow lifecycle operations
+- Outputs:
+  - one dedicated escrow-settlement validation doc under `docs/validation/`
+  - one hard-fail docs contract binding that doc to the exact executable escrow proof anchors
+  - minimal docs wiring so the proof is discoverable from the current proven runtime slices index
+
+## Boundaries/Non-goals
+- Do not claim external chain finality.
+- Do not claim Byzantine-safe or adversarial escrow settlement.
+- Do not redesign task or escrow persistence.
+- Do not add dependencies.
+- Do not expand this into bridge finality or multi-node consensus claims.
+
+## Failure modes
+- The proof claims escrow settlement guarantees stronger than the current service-api tests actually provide.
+- The proof omits either the route-level fund/release evidence or the restart-persistence evidence for released escrow state.
+- The docs contract can pass while the validation doc drifts away from the executable escrow anchors.
+- The runtime proof index continues to list escrow settlement as unproven after this bounded proof is added.
+
+## Acceptance criteria (testable booleans)
+- [ ] A dedicated escrow-settlement proof doc exists under `docs/validation/`.
+- [ ] The proof links current executable coverage for task create/accept, escrow fund, and escrow release on the real service-api path.
+- [ ] The proof links current executable coverage for released escrow state remaining persisted across restart.
+- [ ] The proof states clearly that it proves service-api escrow lifecycle persistence, not bridge finality, external chain settlement, or adversarial settlement.
+- [ ] A hard-fail docs contract enforces the required proof anchors and bounded language.
+- [ ] The finished proof is wired into `docs/validation/current-proven-runtime-slices.md`.
+
+## Files to touch
+- `specs/6980-service-api-escrow-settlement-slice.md`
+- one new validation doc under `docs/validation/`
+- one new docs contract under `crates/kamn-node/tests/`
+- `docs/validation/current-proven-runtime-slices.md`
+
+## Error semantics
+- Missing proof anchors or missing boundary markers must fail loudly.
+- The proof must not silently equate service-api escrow lifecycle persistence with chain-backed settlement finality.
+
+## Test plan
+- Phase 3 red test that fails because the escrow-settlement validation doc and contract do not yet exist.
+- One hard-fail docs contract asserting required escrow proof links and bounded-language markers.
+- Re-run the referenced service-api task/escrow route and restart targets and touched-Rust policy before publish.


### PR DESCRIPTION
Closes #6980

Issue: #6980
Spec: specs/6980-service-api-escrow-settlement-slice.md

## Summary
- publish a bounded operator-facing proof for the current service-api escrow settlement slice on main
- add a hard-fail docs contract that binds the proof to executable route and restart anchors
- wire the proof into the runtime proof index and corrected audit response surface

## Test evidence
- cargo test -p kamn-node --test escrow_settlement_slice_contract -- --nocapture
- cargo test -p kamn-node integration_service_api_endpoint_persists_task_and_escrow_state_across_routes -- --exact --nocapture
- cargo test -p kamn-node integration_service_api_endpoint_persists_task_and_escrow_state_across_restart -- --exact --nocapture
- cargo test -p kamn-core --test corrected_audit_response_docs -- --nocapture
- python3 scripts/ci/check_touched_rust_size_policy.py --repo-root /home/n/Code/kamn --base-ref origin/main --output-json /tmp/6980-touched-size.json
- touched-Rust: policy_decision=GO
