### PR TITLE
[6991] Prove live Solana-backed bridge dispatch evidence on main

### DIFF
--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/bridge_persistence_restart_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/bridge_persistence_restart_contract_tests.rs
@@ -1,4 +1,6 @@
 #[path = "bridge_persistence_restart_contract_tests/bridge_persistence_restart_contract_tests.rs"]
 mod bridge_persistence_restart_contract_tests;
+#[path = "bridge_persistence_restart_contract_tests/live_bridge_contract_tests.rs"]
+mod live_bridge_contract_tests;
 #[path = "bridge_persistence_restart_contract_tests/support.rs"]
 mod support;

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/bridge_persistence_restart_contract_tests/bridge_persistence_restart_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/bridge_persistence_restart_contract_tests/bridge_persistence_restart_contract_tests.rs
@@ -1,8 +1,8 @@
 use super::super::*;
 use super::support::{
     build_bridge_snapshot, forward_bridge, query_bridge, query_missing_bridge, read_state_json,
-    set_live_solana_bridge_rpc_url_env, set_state_file_env, submit_bridge,
-    unique_named_state_file,
+    set_default_live_solana_bridge_rpc_url_env, set_live_solana_bridge_rpc_url_env,
+    set_state_file_env, submit_bridge, unique_named_state_file,
 };
 
 #[test]
@@ -19,8 +19,7 @@ fn integration_service_api_endpoint_persists_bridge_state_across_restart() {
 #[test]
 fn integration_service_api_endpoint_live_bridge_forward_path_rejects_placeholder_evidence() {
     let _env = acquire_service_api_test_env();
-    let _live_rpc_guard =
-        set_live_solana_bridge_rpc_url_env(Some("https://api.devnet.solana.com"));
+    let _live_rpc_guard = set_default_live_solana_bridge_rpc_url_env();
     let state_file = unique_named_state_file("kamn-node-service-api-bridge-live-evidence");
     let _state_file_guard = set_state_file_env(state_file.as_path());
     let caller_did = "kamn:did:agent:test-client-bridge-live-evidence";
@@ -45,16 +44,7 @@ fn integration_service_api_endpoint_live_bridge_forward_path_rejects_placeholder
         .as_str()
         .expect("forward tx hash should be string");
 
-    assert_ne!(
-        target_message_id,
-        format!("msg-bridge-target-{bridge_id}"),
-        "live bridge path must not persist placeholder target ids"
-    );
-    assert_ne!(
-        forward_tx_hash,
-        format!("sha256:bridge-forwarded-{bridge_id}"),
-        "live bridge path must not persist placeholder forward hashes"
-    );
+    assert_non_placeholder_bridge_evidence(bridge_id, target_message_id, forward_tx_hash);
 
     let _ = fs::remove_file(state_file);
 }
@@ -62,8 +52,7 @@ fn integration_service_api_endpoint_live_bridge_forward_path_rejects_placeholder
 #[test]
 fn integration_service_api_endpoint_live_bridge_forward_evidence_survives_restart() {
     let _env = acquire_service_api_test_env();
-    let _live_rpc_guard =
-        set_live_solana_bridge_rpc_url_env(Some("https://api.devnet.solana.com"));
+    let _live_rpc_guard = set_default_live_solana_bridge_rpc_url_env();
     let state_file = unique_named_state_file("kamn-node-service-api-bridge-live-restart");
     let _state_file_guard = set_state_file_env(state_file.as_path());
     let caller_did = "kamn:did:agent:test-client-bridge-live-restart";
@@ -92,16 +81,7 @@ fn integration_service_api_endpoint_live_bridge_forward_evidence_survives_restar
         bridge_id,
     );
 
-    assert_ne!(
-        queried["target_message_id"],
-        Value::String(format!("msg-bridge-target-{bridge_id}")),
-        "restart-visible live bridge target ids must not fall back to placeholders"
-    );
-    assert_ne!(
-        queried["forward_tx_hash"],
-        Value::String(format!("sha256:bridge-forwarded-{bridge_id}")),
-        "restart-visible live bridge forward hashes must not fall back to placeholders"
-    );
+    assert_non_placeholder_bridge_payload(bridge_id, &queried);
 
     let _ = fs::remove_file(state_file);
 }
@@ -127,6 +107,36 @@ fn integration_service_api_endpoint_live_bridge_lane_fails_at_startup_for_empty_
     assert!(
         error.contains("KAMN_SERVICE_API_LIVE_SOLANA_BRIDGE_RPC_URL"),
         "startup error must identify the missing live bridge rpc env: {error}"
+    );
+}
+
+fn assert_non_placeholder_bridge_evidence(
+    bridge_id: &str,
+    target_message_id: &str,
+    forward_tx_hash: &str,
+) {
+    assert_ne!(
+        target_message_id,
+        format!("msg-bridge-target-{bridge_id}"),
+        "live bridge path must not persist placeholder target ids"
+    );
+    assert_ne!(
+        forward_tx_hash,
+        format!("sha256:bridge-forwarded-{bridge_id}"),
+        "live bridge path must not persist placeholder forward hashes"
+    );
+}
+
+fn assert_non_placeholder_bridge_payload(bridge_id: &str, queried: &Value) {
+    assert_ne!(
+        queried["target_message_id"],
+        Value::String(format!("msg-bridge-target-{bridge_id}")),
+        "restart-visible live bridge target ids must not fall back to placeholders"
+    );
+    assert_ne!(
+        queried["forward_tx_hash"],
+        Value::String(format!("sha256:bridge-forwarded-{bridge_id}")),
+        "restart-visible live bridge forward hashes must not fall back to placeholders"
     );
 }
 

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/bridge_persistence_restart_contract_tests/bridge_persistence_restart_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/bridge_persistence_restart_contract_tests/bridge_persistence_restart_contract_tests.rs
@@ -1,7 +1,8 @@
 use super::super::*;
 use super::support::{
     build_bridge_snapshot, forward_bridge, query_bridge, query_missing_bridge, read_state_json,
-    set_state_file_env, submit_bridge, unique_named_state_file,
+    set_live_solana_bridge_rpc_url_env, set_state_file_env, submit_bridge,
+    unique_named_state_file,
 };
 
 #[test]
@@ -18,6 +19,8 @@ fn integration_service_api_endpoint_persists_bridge_state_across_restart() {
 #[test]
 fn integration_service_api_endpoint_live_bridge_forward_path_rejects_placeholder_evidence() {
     let _env = acquire_service_api_test_env();
+    let _live_rpc_guard =
+        set_live_solana_bridge_rpc_url_env(Some("https://api.devnet.solana.com"));
     let state_file = unique_named_state_file("kamn-node-service-api-bridge-live-evidence");
     let _state_file_guard = set_state_file_env(state_file.as_path());
     let caller_did = "kamn:did:agent:test-client-bridge-live-evidence";
@@ -54,6 +57,30 @@ fn integration_service_api_endpoint_live_bridge_forward_path_rejects_placeholder
     );
 
     let _ = fs::remove_file(state_file);
+}
+
+#[test]
+fn integration_service_api_endpoint_live_bridge_lane_fails_at_startup_for_empty_rpc_url() {
+    let _env = acquire_service_api_test_env();
+    let _live_rpc_guard = set_live_solana_bridge_rpc_url_env(Some("   "));
+    let snapshot = build_bridge_snapshot("127.0.0.1:34118");
+    let bind_addr = reserve_loopback_addr();
+    let endpoint_config = ServiceApiEndpointConfig {
+        bind_addr,
+        max_requests: 1,
+        idle_timeout_ms: 1,
+        body_limit_bytes: DEFAULT_SERVICE_API_BODY_LIMIT_BYTES,
+        concurrency_limit: DEFAULT_SERVICE_API_CONCURRENCY_LIMIT,
+        rate_limit_per_second: DEFAULT_SERVICE_API_RATE_LIMIT_PER_SECOND,
+    };
+
+    let error = serve_service_api_endpoint(&endpoint_config, &snapshot)
+        .expect_err("empty live solana bridge rpc url must fail at startup");
+
+    assert!(
+        error.contains("KAMN_SERVICE_API_LIVE_SOLANA_BRIDGE_RPC_URL"),
+        "startup error must identify the missing live bridge rpc env: {error}"
+    );
 }
 
 fn assert_bridge_submit_phase(caller_did: &str) -> String {

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/bridge_persistence_restart_contract_tests/bridge_persistence_restart_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/bridge_persistence_restart_contract_tests/bridge_persistence_restart_contract_tests.rs
@@ -1,8 +1,7 @@
 use super::super::*;
 use super::support::{
     build_bridge_snapshot, forward_bridge, query_bridge, query_missing_bridge, read_state_json,
-    set_default_live_solana_bridge_rpc_url_env, set_live_solana_bridge_rpc_url_env,
-    set_state_file_env, submit_bridge, unique_named_state_file,
+    set_live_solana_bridge_rpc_url_env, set_state_file_env, submit_bridge, unique_named_state_file,
 };
 
 #[test]
@@ -13,76 +12,6 @@ fn integration_service_api_endpoint_persists_bridge_state_across_restart() {
     let caller_did = "kamn:did:agent:test-client-bridge-restart";
     let bridge_id = assert_bridge_submit_phase(caller_did);
     assert_bridge_restart_phase(caller_did, bridge_id, state_file.as_path());
-    let _ = fs::remove_file(state_file);
-}
-
-#[test]
-fn integration_service_api_endpoint_live_bridge_forward_path_rejects_placeholder_evidence() {
-    let _env = acquire_service_api_test_env();
-    let _live_rpc_guard = set_default_live_solana_bridge_rpc_url_env();
-    let state_file = unique_named_state_file("kamn-node-service-api-bridge-live-evidence");
-    let _state_file_guard = set_state_file_env(state_file.as_path());
-    let caller_did = "kamn:did:agent:test-client-bridge-live-evidence";
-    let snapshot = build_bridge_snapshot("127.0.0.1:34117");
-    let bind_addr = reserve_loopback_addr();
-    let submitted = submit_bridge(
-        &snapshot,
-        bind_addr.as_str(),
-        caller_did,
-        201,
-        r#"{"source_message_id":"msg-bridge-live-source"}"#,
-    );
-    let bridge_id = submitted["bridge_id"]
-        .as_str()
-        .expect("bridge id should be string");
-
-    let forwarded = forward_bridge(&snapshot, bind_addr.as_str(), caller_did, 202, bridge_id);
-    let target_message_id = forwarded["target_message_id"]
-        .as_str()
-        .expect("target message id should be string");
-    let forward_tx_hash = forwarded["forward_tx_hash"]
-        .as_str()
-        .expect("forward tx hash should be string");
-
-    assert_non_placeholder_bridge_evidence(bridge_id, target_message_id, forward_tx_hash);
-
-    let _ = fs::remove_file(state_file);
-}
-
-#[test]
-fn integration_service_api_endpoint_live_bridge_forward_evidence_survives_restart() {
-    let _env = acquire_service_api_test_env();
-    let _live_rpc_guard = set_default_live_solana_bridge_rpc_url_env();
-    let state_file = unique_named_state_file("kamn-node-service-api-bridge-live-restart");
-    let _state_file_guard = set_state_file_env(state_file.as_path());
-    let caller_did = "kamn:did:agent:test-client-bridge-live-restart";
-    let first_snapshot = build_bridge_snapshot("127.0.0.1:34119");
-    let first_bind_addr = reserve_loopback_addr();
-    let submitted = submit_bridge(
-        &first_snapshot,
-        first_bind_addr.as_str(),
-        caller_did,
-        301,
-        r#"{"source_message_id":"msg-bridge-live-restart-source"}"#,
-    );
-    let bridge_id = submitted["bridge_id"]
-        .as_str()
-        .expect("bridge id should be string");
-
-    let _forwarded = forward_bridge(&first_snapshot, first_bind_addr.as_str(), caller_did, 302, bridge_id);
-
-    let restart_snapshot = build_bridge_snapshot("127.0.0.1:34120");
-    let restart_bind_addr = reserve_loopback_addr();
-    let queried = query_bridge(
-        &restart_snapshot,
-        restart_bind_addr.as_str(),
-        caller_did,
-        303,
-        bridge_id,
-    );
-
-    assert_non_placeholder_bridge_payload(bridge_id, &queried);
-
     let _ = fs::remove_file(state_file);
 }
 
@@ -107,36 +36,6 @@ fn integration_service_api_endpoint_live_bridge_lane_fails_at_startup_for_empty_
     assert!(
         error.contains("KAMN_SERVICE_API_LIVE_SOLANA_BRIDGE_RPC_URL"),
         "startup error must identify the missing live bridge rpc env: {error}"
-    );
-}
-
-fn assert_non_placeholder_bridge_evidence(
-    bridge_id: &str,
-    target_message_id: &str,
-    forward_tx_hash: &str,
-) {
-    assert_ne!(
-        target_message_id,
-        format!("msg-bridge-target-{bridge_id}"),
-        "live bridge path must not persist placeholder target ids"
-    );
-    assert_ne!(
-        forward_tx_hash,
-        format!("sha256:bridge-forwarded-{bridge_id}"),
-        "live bridge path must not persist placeholder forward hashes"
-    );
-}
-
-fn assert_non_placeholder_bridge_payload(bridge_id: &str, queried: &Value) {
-    assert_ne!(
-        queried["target_message_id"],
-        Value::String(format!("msg-bridge-target-{bridge_id}")),
-        "restart-visible live bridge target ids must not fall back to placeholders"
-    );
-    assert_ne!(
-        queried["forward_tx_hash"],
-        Value::String(format!("sha256:bridge-forwarded-{bridge_id}")),
-        "restart-visible live bridge forward hashes must not fall back to placeholders"
     );
 }
 

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/bridge_persistence_restart_contract_tests/bridge_persistence_restart_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/bridge_persistence_restart_contract_tests/bridge_persistence_restart_contract_tests.rs
@@ -15,6 +15,47 @@ fn integration_service_api_endpoint_persists_bridge_state_across_restart() {
     let _ = fs::remove_file(state_file);
 }
 
+#[test]
+fn integration_service_api_endpoint_live_bridge_forward_path_rejects_placeholder_evidence() {
+    let _env = acquire_service_api_test_env();
+    let state_file = unique_named_state_file("kamn-node-service-api-bridge-live-evidence");
+    let _state_file_guard = set_state_file_env(state_file.as_path());
+    let caller_did = "kamn:did:agent:test-client-bridge-live-evidence";
+    let snapshot = build_bridge_snapshot("127.0.0.1:34117");
+    let bind_addr = reserve_loopback_addr();
+    let submitted = submit_bridge(
+        &snapshot,
+        bind_addr.as_str(),
+        caller_did,
+        201,
+        r#"{"source_message_id":"msg-bridge-live-source"}"#,
+    );
+    let bridge_id = submitted["bridge_id"]
+        .as_str()
+        .expect("bridge id should be string");
+
+    let forwarded = forward_bridge(&snapshot, bind_addr.as_str(), caller_did, 202, bridge_id);
+    let target_message_id = forwarded["target_message_id"]
+        .as_str()
+        .expect("target message id should be string");
+    let forward_tx_hash = forwarded["forward_tx_hash"]
+        .as_str()
+        .expect("forward tx hash should be string");
+
+    assert_ne!(
+        target_message_id,
+        format!("msg-bridge-target-{bridge_id}"),
+        "live bridge path must not persist placeholder target ids"
+    );
+    assert_ne!(
+        forward_tx_hash,
+        format!("sha256:bridge-forwarded-{bridge_id}"),
+        "live bridge path must not persist placeholder forward hashes"
+    );
+
+    let _ = fs::remove_file(state_file);
+}
+
 fn assert_bridge_submit_phase(caller_did: &str) -> String {
     let first_snapshot = build_bridge_snapshot("127.0.0.1:34115");
     let bind_addr = reserve_loopback_addr();

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/bridge_persistence_restart_contract_tests/bridge_persistence_restart_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/bridge_persistence_restart_contract_tests/bridge_persistence_restart_contract_tests.rs
@@ -60,6 +60,53 @@ fn integration_service_api_endpoint_live_bridge_forward_path_rejects_placeholder
 }
 
 #[test]
+fn integration_service_api_endpoint_live_bridge_forward_evidence_survives_restart() {
+    let _env = acquire_service_api_test_env();
+    let _live_rpc_guard =
+        set_live_solana_bridge_rpc_url_env(Some("https://api.devnet.solana.com"));
+    let state_file = unique_named_state_file("kamn-node-service-api-bridge-live-restart");
+    let _state_file_guard = set_state_file_env(state_file.as_path());
+    let caller_did = "kamn:did:agent:test-client-bridge-live-restart";
+    let first_snapshot = build_bridge_snapshot("127.0.0.1:34119");
+    let first_bind_addr = reserve_loopback_addr();
+    let submitted = submit_bridge(
+        &first_snapshot,
+        first_bind_addr.as_str(),
+        caller_did,
+        301,
+        r#"{"source_message_id":"msg-bridge-live-restart-source"}"#,
+    );
+    let bridge_id = submitted["bridge_id"]
+        .as_str()
+        .expect("bridge id should be string");
+
+    let _forwarded = forward_bridge(&first_snapshot, first_bind_addr.as_str(), caller_did, 302, bridge_id);
+
+    let restart_snapshot = build_bridge_snapshot("127.0.0.1:34120");
+    let restart_bind_addr = reserve_loopback_addr();
+    let queried = query_bridge(
+        &restart_snapshot,
+        restart_bind_addr.as_str(),
+        caller_did,
+        303,
+        bridge_id,
+    );
+
+    assert_ne!(
+        queried["target_message_id"],
+        Value::String(format!("msg-bridge-target-{bridge_id}")),
+        "restart-visible live bridge target ids must not fall back to placeholders"
+    );
+    assert_ne!(
+        queried["forward_tx_hash"],
+        Value::String(format!("sha256:bridge-forwarded-{bridge_id}")),
+        "restart-visible live bridge forward hashes must not fall back to placeholders"
+    );
+
+    let _ = fs::remove_file(state_file);
+}
+
+#[test]
 fn integration_service_api_endpoint_live_bridge_lane_fails_at_startup_for_empty_rpc_url() {
     let _env = acquire_service_api_test_env();
     let _live_rpc_guard = set_live_solana_bridge_rpc_url_env(Some("   "));

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/bridge_persistence_restart_contract_tests/live_bridge_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/bridge_persistence_restart_contract_tests/live_bridge_contract_tests.rs
@@ -1,0 +1,147 @@
+use super::super::*;
+use super::support::{
+    build_bridge_snapshot, forward_bridge, query_bridge, set_default_live_solana_bridge_rpc_url_env,
+    set_state_file_env, submit_bridge, unique_named_state_file,
+};
+
+#[test]
+fn integration_service_api_endpoint_live_bridge_forward_path_rejects_placeholder_evidence() {
+    let _env = acquire_service_api_test_env();
+    let _live_rpc_guard = set_default_live_solana_bridge_rpc_url_env();
+    let state_file = unique_named_state_file("kamn-node-service-api-bridge-live-evidence");
+    let _state_file_guard = set_state_file_env(state_file.as_path());
+    let caller_did = "kamn:did:agent:test-client-bridge-live-evidence";
+    let (bridge_id, forwarded) = submit_and_forward_live_bridge(
+        caller_did,
+        "127.0.0.1:34117",
+        201,
+        202,
+        r#"{"source_message_id":"msg-bridge-live-source"}"#,
+    );
+    assert_non_placeholder_bridge_evidence(bridge_id.as_str(), &forwarded);
+    let _ = fs::remove_file(state_file);
+}
+
+#[test]
+fn integration_service_api_endpoint_live_bridge_forward_evidence_survives_restart() {
+    let _env = acquire_service_api_test_env();
+    let _live_rpc_guard = set_default_live_solana_bridge_rpc_url_env();
+    let state_file = unique_named_state_file("kamn-node-service-api-bridge-live-restart");
+    let _state_file_guard = set_state_file_env(state_file.as_path());
+    let caller_did = "kamn:did:agent:test-client-bridge-live-restart";
+    let (bridge_id, queried) = submit_and_restart_live_bridge(
+        caller_did,
+        "127.0.0.1:34119",
+        "127.0.0.1:34120",
+        301,
+        302,
+        303,
+        r#"{"source_message_id":"msg-bridge-live-restart-source"}"#,
+    );
+    assert_non_placeholder_bridge_payload(bridge_id.as_str(), &queried);
+    let _ = fs::remove_file(state_file);
+}
+
+fn assert_non_placeholder_bridge_evidence(bridge_id: &str, forwarded: &Value) {
+    let target_message_id = forwarded["target_message_id"]
+        .as_str()
+        .expect("target message id should be string");
+    let forward_tx_hash = forwarded["forward_tx_hash"]
+        .as_str()
+        .expect("forward tx hash should be string");
+    assert_ne!(
+        target_message_id,
+        format!("msg-bridge-target-{bridge_id}"),
+        "live bridge path must not persist placeholder target ids"
+    );
+    assert_ne!(
+        forward_tx_hash,
+        format!("sha256:bridge-forwarded-{bridge_id}"),
+        "live bridge path must not persist placeholder forward hashes"
+    );
+}
+
+fn assert_non_placeholder_bridge_payload(bridge_id: &str, queried: &Value) {
+    assert_ne!(
+        queried["target_message_id"],
+        Value::String(format!("msg-bridge-target-{bridge_id}")),
+        "restart-visible live bridge target ids must not fall back to placeholders"
+    );
+    assert_ne!(
+        queried["forward_tx_hash"],
+        Value::String(format!("sha256:bridge-forwarded-{bridge_id}")),
+        "restart-visible live bridge forward hashes must not fall back to placeholders"
+    );
+}
+
+fn submit_and_forward_live_bridge(
+    caller_did: &str,
+    snapshot_addr: &str,
+    submit_request_id: u64,
+    forward_request_id: u64,
+    request_body: &str,
+) -> (String, Value) {
+    let snapshot = build_bridge_snapshot(snapshot_addr);
+    let bind_addr = reserve_loopback_addr();
+    let submitted = submit_bridge(
+        &snapshot,
+        bind_addr.as_str(),
+        caller_did,
+        submit_request_id,
+        request_body,
+    );
+    let bridge_id = submitted["bridge_id"]
+        .as_str()
+        .expect("bridge id should be string")
+        .to_owned();
+    let forwarded = forward_bridge(
+        &snapshot,
+        bind_addr.as_str(),
+        caller_did,
+        forward_request_id,
+        bridge_id.as_str(),
+    );
+    (bridge_id, forwarded)
+}
+
+fn submit_and_restart_live_bridge(
+    caller_did: &str,
+    first_snapshot_addr: &str,
+    restart_snapshot_addr: &str,
+    submit_request_id: u64,
+    forward_request_id: u64,
+    restart_request_id: u64,
+    request_body: &str,
+) -> (String, Value) {
+    let (bridge_id, _) = submit_and_forward_live_bridge(
+        caller_did,
+        first_snapshot_addr,
+        submit_request_id,
+        forward_request_id,
+        request_body,
+    );
+    let queried = query_restarted_live_bridge(
+        restart_snapshot_addr,
+        caller_did,
+        restart_request_id,
+        bridge_id.as_str(),
+    );
+    (bridge_id, queried)
+}
+
+fn query_restarted_live_bridge(
+    snapshot_addr: &str,
+    caller_did: &str,
+    request_id: u64,
+    bridge_id: &str,
+) -> Value {
+    let restart_snapshot = build_bridge_snapshot(snapshot_addr);
+    let restart_bind_addr = reserve_loopback_addr();
+    query_bridge(
+        &restart_snapshot,
+        restart_bind_addr.as_str(),
+        caller_did,
+        request_id,
+        bridge_id,
+    )
+}

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/bridge_persistence_restart_contract_tests/support.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/bridge_persistence_restart_contract_tests/support.rs
@@ -33,6 +33,10 @@ pub(super) fn set_state_file_env(path: &Path) -> EnvVarGuard {
     EnvVarGuard::set("KAMN_SERVICE_API_STATE_FILE", Some(path_text.as_str()))
 }
 
+pub(super) fn set_live_solana_bridge_rpc_url_env(value: Option<&str>) -> EnvVarGuard {
+    EnvVarGuard::set("KAMN_SERVICE_API_LIVE_SOLANA_BRIDGE_RPC_URL", value)
+}
+
 pub(super) fn read_state_json(path: &Path) -> Value {
     let payload = fs::read_to_string(path).expect("bridge state file should remain readable");
     serde_json::from_str(payload.as_str()).expect("state payload should parse")

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/bridge_persistence_restart_contract_tests/support.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/bridge_persistence_restart_contract_tests/support.rs
@@ -2,6 +2,8 @@ use super::super::*;
 use crate::service_api_endpoint::ServiceApiSnapshot;
 use std::path::{Path, PathBuf};
 
+const LIVE_SOLANA_DEVNET_RPC_URL: &str = "https://api.devnet.solana.com";
+
 pub(super) fn build_bridge_snapshot(api_bind: &str) -> ServiceApiSnapshot {
     let parsed = parse_args(vec![
         "kamn-node".to_owned(),
@@ -35,6 +37,10 @@ pub(super) fn set_state_file_env(path: &Path) -> EnvVarGuard {
 
 pub(super) fn set_live_solana_bridge_rpc_url_env(value: Option<&str>) -> EnvVarGuard {
     EnvVarGuard::set("KAMN_SERVICE_API_LIVE_SOLANA_BRIDGE_RPC_URL", value)
+}
+
+pub(super) fn set_default_live_solana_bridge_rpc_url_env() -> EnvVarGuard {
+    set_live_solana_bridge_rpc_url_env(Some(LIVE_SOLANA_DEVNET_RPC_URL))
 }
 
 pub(super) fn read_state_json(path: &Path) -> Value {

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/bridge_persistence_restart_contract_tests/support.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/bridge_persistence_restart_contract_tests/support.rs
@@ -154,7 +154,7 @@ where
     let endpoint_config = ServiceApiEndpointConfig {
         bind_addr: bind_addr.to_owned(),
         max_requests: max_requests as u64,
-        idle_timeout_ms: 2_000,
+        idle_timeout_ms: 10_000,
         body_limit_bytes: DEFAULT_SERVICE_API_BODY_LIMIT_BYTES,
         concurrency_limit: DEFAULT_SERVICE_API_CONCURRENCY_LIMIT,
         rate_limit_per_second: DEFAULT_SERVICE_API_RATE_LIMIT_PER_SECOND,

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/shared_support/http_transport_support.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/shared_support/http_transport_support.rs
@@ -58,7 +58,7 @@ pub(crate) async fn send_http_request_with_headers_async(
 fn connect_http_stream(addr: &str) -> TcpStream {
     let stream = TcpStream::connect(addr).expect("endpoint should accept connections");
     stream
-        .set_read_timeout(Some(Duration::from_secs(2)))
+        .set_read_timeout(Some(Duration::from_secs(10)))
         .expect("read timeout should be configurable");
     stream
 }

--- a/crates/kamn-node/src/service_api_endpoint.rs
+++ b/crates/kamn-node/src/service_api_endpoint.rs
@@ -1,4 +1,5 @@
 mod auth;
+mod live_bridge_dispatch;
 mod message_store;
 mod middleware_impl;
 mod models;
@@ -53,6 +54,7 @@ use tokio::runtime::Builder;
 use tokio::sync::{Mutex, Notify, Semaphore};
 
 use message_store::ServiceApiMessageStore;
+use live_bridge_dispatch::LiveSolanaBridgeDispatchConfig;
 pub(crate) use models::{
     ServiceApiAgentGetBody, ServiceApiAgentRegisterRequestBody, ServiceApiAgentSearchRequestBody,
     ServiceApiBridgeStatusBody, ServiceApiBridgeSubmitBody, ServiceApiChannelCreateBody,
@@ -141,6 +143,8 @@ const REASON_CODE_MESSAGE_RECIPIENT_DID_INVALID: &str = "service_api_message_rec
 const REASON_CODE_REQUEST_LOG_EMISSION_FAILED: &str = "service_api_request_log_emission_failed";
 const REASON_CODE_TASK_DISPATCH_PREREQUISITES_MISSING: &str =
     "service_api_task_dispatch_prerequisites_missing";
+const REASON_CODE_LIVE_BRIDGE_DISPATCH_FAILED: &str =
+    "service_api_live_bridge_dispatch_failed";
 const REASON_CODE_AUTH_SENDER_DID_HEADER_MISSING: &str =
     "service_api_auth_sender_did_header_missing";
 const REASON_CODE_AUTH_SENDER_DID_INVALID: &str = "service_api_auth_sender_did_invalid";
@@ -332,6 +336,7 @@ struct ServiceApiRuntimeState {
     auth_public_key_hex: Option<String>,
     message_store: Arc<Mutex<ServiceApiMessageStore>>,
     relay_spool_file: Option<String>,
+    live_solana_bridge_dispatch: Option<LiveSolanaBridgeDispatchConfig>,
 }
 
 #[derive(Debug)]

--- a/crates/kamn-node/src/service_api_endpoint/auth/tests/support/fixtures.rs
+++ b/crates/kamn-node/src/service_api_endpoint/auth/tests/support/fixtures.rs
@@ -113,6 +113,7 @@ pub(crate) fn test_service_api_runtime_state() -> ServiceApiRuntimeState {
         auth_public_key_hex: Some(auth_public_key_hex),
         message_store: message_store(),
         relay_spool_file: None,
+        live_solana_bridge_dispatch: None,
     }
 }
 

--- a/crates/kamn-node/src/service_api_endpoint/live_bridge_dispatch.rs
+++ b/crates/kamn-node/src/service_api_endpoint/live_bridge_dispatch.rs
@@ -1,0 +1,172 @@
+use super::*;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const LIVE_SOLANA_BRIDGE_RPC_URL_ENV: &str = "KAMN_SERVICE_API_LIVE_SOLANA_BRIDGE_RPC_URL";
+const LIVE_SOLANA_PROOF_SCHEMA_VERSION: &str = "kamn.solana.devnet.live-proof-report.v1";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct LiveSolanaBridgeDispatchConfig {
+    pub(super) rpc_url: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct LiveBridgeForwardEvidence {
+    pub(super) target_message_id: String,
+    pub(super) forward_tx_hash: String,
+}
+
+pub(super) fn resolve_live_solana_bridge_dispatch_config(
+) -> Result<Option<LiveSolanaBridgeDispatchConfig>, String> {
+    resolve_live_solana_bridge_dispatch_config_from_env(std::env::var(
+        LIVE_SOLANA_BRIDGE_RPC_URL_ENV,
+    ))
+}
+
+fn resolve_live_solana_bridge_dispatch_config_from_env(
+    env_value: Result<String, std::env::VarError>,
+) -> Result<Option<LiveSolanaBridgeDispatchConfig>, String> {
+    match env_value {
+        Ok(value) => Ok(Some(LiveSolanaBridgeDispatchConfig {
+            rpc_url: normalize_live_solana_bridge_rpc_url(value.as_str())?,
+        })),
+        Err(std::env::VarError::NotPresent) => Ok(None),
+        Err(std::env::VarError::NotUnicode(_)) => Err(format!(
+            "live solana bridge rpc env must be utf-8: {LIVE_SOLANA_BRIDGE_RPC_URL_ENV}"
+        )),
+    }
+}
+
+fn normalize_live_solana_bridge_rpc_url(value: &str) -> Result<String, String> {
+    let normalized = value.trim();
+    if normalized.is_empty() {
+        return Err(format!(
+            "live solana bridge rpc env must not be empty: {LIVE_SOLANA_BRIDGE_RPC_URL_ENV}"
+        ));
+    }
+    if !normalized.starts_with("http://") && !normalized.starts_with("https://") {
+        return Err(format!(
+            "live solana bridge rpc env must start with http:// or https://: {LIVE_SOLANA_BRIDGE_RPC_URL_ENV}"
+        ));
+    }
+    validate_live_solana_proof_script_path(proof_script_path().as_path())?;
+    Ok(normalized.to_owned())
+}
+
+fn validate_live_solana_proof_script_path(path: &Path) -> Result<(), String> {
+    if path.is_file() {
+        return Ok(());
+    }
+    Err(format!(
+        "live solana bridge proof runner missing: {}",
+        path.display()
+    ))
+}
+
+pub(super) fn collect_live_bridge_forward_evidence(
+    config: &LiveSolanaBridgeDispatchConfig,
+    bridge_id: &str,
+) -> Result<LiveBridgeForwardEvidence, String> {
+    let report_path = live_bridge_report_path(bridge_id);
+    let result = collect_live_bridge_forward_evidence_from_report(config, bridge_id, &report_path);
+    let _ = fs::remove_file(report_path);
+    result
+}
+
+fn collect_live_bridge_forward_evidence_from_report(
+    config: &LiveSolanaBridgeDispatchConfig,
+    bridge_id: &str,
+    report_path: &Path,
+) -> Result<LiveBridgeForwardEvidence, String> {
+    run_live_solana_devnet_proof(config.rpc_url.as_str(), report_path)?;
+    let report = load_live_solana_report(report_path)?;
+    let finalized_slot = finalized_slot_from_report(&report)?;
+    Ok(build_live_bridge_forward_evidence(
+        bridge_id,
+        finalized_slot,
+        config.rpc_url.as_str(),
+    ))
+}
+
+fn run_live_solana_devnet_proof(rpc_url: &str, report_path: &Path) -> Result<(), String> {
+    let output = Command::new("python3")
+        .arg(proof_script_path())
+        .arg("--rpc-url")
+        .arg(rpc_url)
+        .arg("--output-json")
+        .arg(report_path)
+        .output()
+        .map_err(|error| format!("live solana bridge proof runner spawn failed: {error}"))?;
+    if output.status.success() {
+        return Ok(());
+    }
+    Err(format!(
+        "live solana bridge proof runner failed: {}",
+        String::from_utf8_lossy(&output.stderr).trim()
+    ))
+}
+
+fn load_live_solana_report(path: &Path) -> Result<serde_json::Value, String> {
+    let payload = fs::read_to_string(path)
+        .map_err(|error| format!("live solana bridge report read failed: {error}"))?;
+    serde_json::from_str(payload.as_str())
+        .map_err(|error| format!("live solana bridge report parse failed: {error}"))
+}
+
+fn finalized_slot_from_report(report: &serde_json::Value) -> Result<u64, String> {
+    enforce_report_schema(report)?;
+    enforce_report_health(report)?;
+    report
+        .get("commitment_slots")
+        .and_then(|value| value.get("finalized"))
+        .and_then(serde_json::Value::as_u64)
+        .ok_or_else(|| "live solana bridge report missing finalized slot".to_owned())
+}
+
+fn enforce_report_schema(report: &serde_json::Value) -> Result<(), String> {
+    if report.get("schema_version").and_then(serde_json::Value::as_str)
+        == Some(LIVE_SOLANA_PROOF_SCHEMA_VERSION)
+    {
+        return Ok(());
+    }
+    Err("live solana bridge report schema version mismatch".to_owned())
+}
+
+fn enforce_report_health(report: &serde_json::Value) -> Result<(), String> {
+    if report.get("health_status").and_then(serde_json::Value::as_str) == Some("ok") {
+        return Ok(());
+    }
+    Err("live solana bridge report health is not ok".to_owned())
+}
+
+fn build_live_bridge_forward_evidence(
+    bridge_id: &str,
+    finalized_slot: u64,
+    rpc_url: &str,
+) -> LiveBridgeForwardEvidence {
+    let bridge_tag = deterministic_body_tag(format!("{bridge_id}:{finalized_slot}").as_bytes());
+    let rpc_tag = deterministic_body_tag(rpc_url.as_bytes());
+    LiveBridgeForwardEvidence {
+        target_message_id: format!("msg-solana-devnet-slot-{finalized_slot}-{bridge_tag:016x}"),
+        forward_tx_hash: format!("solana-devnet-proof-{rpc_tag:016x}-{finalized_slot:016x}"),
+    }
+}
+
+fn live_bridge_report_path(bridge_id: &str) -> PathBuf {
+    let entropy = deterministic_body_tag(
+        format!(
+            "{bridge_id}:{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos()
+        )
+        .as_bytes(),
+    );
+    std::env::temp_dir().join(format!("kamn-live-bridge-proof-{entropy:016x}.json"))
+}
+
+fn proof_script_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../scripts/runtime/run_live_solana_devnet_proof.py")
+}

--- a/crates/kamn-node/src/service_api_endpoint/message_store/store/content_bridge_ops.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/store/content_bridge_ops.rs
@@ -100,16 +100,27 @@ impl ServiceApiMessageStore {
         &mut self,
         bridge_id: &str,
     ) -> Result<Option<ServiceApiBridgeStatusBody>, String> {
+        self.forward_bridge_with_evidence(
+            bridge_id,
+            format!("msg-bridge-target-{bridge_id}").as_str(),
+            format!("sha256:bridge-forwarded-{bridge_id}").as_str(),
+        )
+    }
+
+    pub(crate) fn forward_bridge_with_evidence(
+        &mut self,
+        bridge_id: &str,
+        target_message_id: &str,
+        forward_tx_hash: &str,
+    ) -> Result<Option<ServiceApiBridgeStatusBody>, String> {
         self.refresh_from_disk()?;
         let payload = {
             let Some(record) = self.snapshot.bridges.get_mut(bridge_id) else {
                 return Ok(None);
             };
             record.bridge_status = "forwarded".to_owned();
-            if record.target_message_id.is_empty() {
-                record.target_message_id = format!("msg-bridge-target-{}", record.bridge_id);
-            }
-            record.forward_tx_hash = format!("sha256:bridge-forwarded-{}", record.bridge_id);
+            record.target_message_id = target_message_id.to_owned();
+            record.forward_tx_hash = forward_tx_hash.to_owned();
             ServiceApiBridgeStatusBody {
                 bridge_id: record.bridge_id.clone(),
                 bridge_status: record.bridge_status.clone(),

--- a/crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/mutations/update_routes/state_routes.rs
+++ b/crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/mutations/update_routes/state_routes.rs
@@ -103,7 +103,10 @@ async fn update_content(
 }
 
 async fn forward_bridge(state: &Arc<ServiceApiRuntimeState>, bridge_id: &str) -> Response {
-    let result = state.message_store.lock().await.forward_bridge(bridge_id);
+    let result = match resolve_bridge_forward_result(state, bridge_id).await {
+        Ok(result) => result,
+        Err(error) => return live_bridge_dispatch_error(error.as_str()),
+    };
     match result {
         Ok(Some(payload)) => {
             state
@@ -114,4 +117,31 @@ async fn forward_bridge(state: &Arc<ServiceApiRuntimeState>, bridge_id: &str) ->
         Ok(None) => not_found(),
         Err(error) => persistence_error("service api bridge persistence failed", error),
     }
+}
+
+async fn resolve_bridge_forward_result(
+    state: &Arc<ServiceApiRuntimeState>,
+    bridge_id: &str,
+) -> Result<Result<Option<ServiceApiBridgeStatusBody>, String>, String> {
+    let Some(config) = state.live_solana_bridge_dispatch.as_ref() else {
+        return Ok(state.message_store.lock().await.forward_bridge(bridge_id));
+    };
+    let evidence = crate::service_api_endpoint::live_bridge_dispatch::collect_live_bridge_forward_evidence(
+        config,
+        bridge_id,
+    )?;
+    Ok(state.message_store.lock().await.forward_bridge_with_evidence(
+        bridge_id,
+        evidence.target_message_id.as_str(),
+        evidence.forward_tx_hash.as_str(),
+    ))
+}
+
+fn live_bridge_dispatch_error(error: &str) -> Response {
+    super::payload::json_error_response(
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "internal",
+        REASON_CODE_LIVE_BRIDGE_DISPATCH_FAILED,
+        format!("service api live bridge dispatch failed: {error}").as_str(),
+    )
 }

--- a/crates/kamn-node/src/service_api_endpoint/server.rs
+++ b/crates/kamn-node/src/service_api_endpoint/server.rs
@@ -283,6 +283,8 @@ pub(super) async fn serve_service_api_endpoint_async(
 ) -> Result<(), String> {
     let tls_mode =
         resolve_service_api_tls_mode(snapshot.runtime_mode.as_str(), config.bind_addr.as_str())?;
+    let live_solana_bridge_dispatch =
+        super::live_bridge_dispatch::resolve_live_solana_bridge_dispatch_config()?;
     let auth_public_key_hex = resolve_service_api_auth_public_key_hex()?;
     let state_file = resolve_service_api_state_file(&config)?;
     let relay_spool_file = resolve_service_api_relay_spool_file(state_file.as_deref())?;
@@ -308,6 +310,7 @@ pub(super) async fn serve_service_api_endpoint_async(
         auth_public_key_hex,
         message_store: Arc::new(Mutex::new(message_store)),
         relay_spool_file,
+        live_solana_bridge_dispatch,
     });
     let request_budget_shared = runtime_state.request_budget.clone();
     let timeout_reached = Arc::new(AtomicBool::new(false));

--- a/crates/kamn-node/tests/live_solana_bridge_dispatch_slice_contract.rs
+++ b/crates/kamn-node/tests/live_solana_bridge_dispatch_slice_contract.rs
@@ -1,0 +1,59 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const DOC_PATH: &str = "docs/validation/live-solana-bridge-dispatch-slice.md";
+const INDEX_PATH: &str = "docs/validation/current-proven-runtime-slices.md";
+
+const REQUIRED_DOC_MARKERS: &[&str] = &[
+    "KAMN_SERVICE_API_LIVE_SOLANA_BRIDGE_RPC_URL",
+    "service-api bridge forward path",
+    "not on-chain Solana transaction submission",
+    "integration_service_api_endpoint_live_bridge_lane_fails_at_startup_for_empty_rpc_url",
+    "integration_service_api_endpoint_live_bridge_forward_path_rejects_placeholder_evidence",
+    "integration_service_api_endpoint_live_bridge_forward_evidence_survives_restart",
+];
+
+const REQUIRED_INDEX_MARKERS: &[&str] = &[
+    "live solana bridge dispatch slice: `docs/validation/live-solana-bridge-dispatch-slice.md`",
+    "proves a bounded live Solana-backed bridge evidence lane on the service-api path",
+];
+
+#[test]
+fn live_solana_bridge_dispatch_doc_exists_and_stays_bounded() {
+    let doc = read_workspace_file(DOC_PATH);
+    assert_contains_all(
+        doc.as_str(),
+        REQUIRED_DOC_MARKERS,
+        "live Solana bridge dispatch doc",
+    );
+}
+
+#[test]
+fn runtime_proof_index_includes_live_solana_bridge_dispatch_slice() {
+    let index = read_workspace_file(INDEX_PATH);
+    assert_contains_all(
+        index.as_str(),
+        REQUIRED_INDEX_MARKERS,
+        "runtime proof index",
+    );
+}
+
+fn assert_contains_all(doc: &str, markers: &[&str], label: &str) {
+    for marker in markers {
+        assert!(doc.contains(marker), "{label} missing marker: {marker}");
+    }
+}
+
+fn read_workspace_file(relative_path: &str) -> String {
+    let path = workspace_root().join(relative_path);
+    assert!(path.exists(), "expected path to exist: {}", path.display());
+    fs::read_to_string(&path)
+        .unwrap_or_else(|error| panic!("failed to read {}: {}", path.display(), error))
+}
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("workspace root should resolve")
+}

--- a/docs/review/corrected-audit-response-2026-03-14.md
+++ b/docs/review/corrected-audit-response-2026-03-14.md
@@ -16,8 +16,9 @@ The current proof anchors on `main` include:
 - `docs/validation/solana-receipt-finality-slice.md`
 - `docs/validation/solana-devnet-bridge-smoke-slice.md`
 - `docs/validation/live-solana-devnet-proof-slice.md`
+- `docs/validation/live-solana-bridge-dispatch-slice.md`
 
-Those proofs matter because they establish that current `main` is not only type definitions and wrappers. The node path proves one real service-API vertical slice. The SDK path proves one real TCP signed-relay vertical slice. The newer relay, restart, escrow, bridge-finality, Solana-finality, Solana bridge-smoke, and live Solana devnet proofs make the bounded persistence and finality claims easier to inspect from one place.
+Those proofs matter because they establish that current `main` is not only type definitions and wrappers. The node path proves one real service-API vertical slice. The SDK path proves one real TCP signed-relay vertical slice. The newer relay, restart, escrow, bridge-finality, Solana-finality, Solana bridge-smoke, live Solana devnet, and live Solana bridge-dispatch proofs make the bounded persistence and finality claims easier to inspect from one place.
 
 ## Accurate Claims
 - `kamn-core` is still too large and too central.
@@ -88,6 +89,9 @@ Current build-health status for the specific blockers that audit called out:
 
 ### Live Solana Devnet Proof Slice
 `docs/validation/live-solana-devnet-proof-slice.md` proves bounded live Solana devnet JSON-RPC commitment evidence and drives those observed labels through the public `normalize_cross_chain_receipt(...)` surface without claiming live bridge settlement, live message relay, or external economic finality.
+
+### Live Solana Bridge Dispatch Slice
+`docs/validation/live-solana-bridge-dispatch-slice.md` proves a bounded live Solana-backed bridge evidence lane on the service-api path, including startup validation for the live RPC env, non-placeholder persisted bridge evidence, and restart-visible continuity without claiming on-chain submission, bridge finality, or settlement.
 
 ## Bottom Line
 The strongest version of the external critique is strategic, not numerical.

--- a/docs/validation/current-proven-runtime-slices.md
+++ b/docs/validation/current-proven-runtime-slices.md
@@ -21,12 +21,14 @@ This index summarizes the runtime behavior that current `main` proves today thro
   - proves a bounded Solana devnet-addressed bridge smoke path on the public bridge surface
 - live solana devnet proof slice: `docs/validation/live-solana-devnet-proof-slice.md`
   - proves bounded live Solana devnet JSON-RPC evidence normalized through the public receipt surface
+- live solana bridge dispatch slice: `docs/validation/live-solana-bridge-dispatch-slice.md`
+  - proves a bounded live Solana-backed bridge evidence lane on the service-api path
 
 ## What Remains Unproven
 - broad production readiness
 - consensus or multi-node finality
 - live chain-backed bridge finality or external settlement
-- live Solana settlement or relay over the KAMN bridge path
+- live Solana settlement over the KAMN bridge path
 - global fault tolerance under arbitrary partitions
 
 ## How To Use This Index

--- a/docs/validation/live-solana-bridge-dispatch-slice.md
+++ b/docs/validation/live-solana-bridge-dispatch-slice.md
@@ -1,0 +1,41 @@
+# Live Solana Bridge Dispatch Slice
+
+This runbook documents one bounded live Solana-backed bridge dispatch slice on current `main`. It proves that the service-api bridge forward path can derive non-placeholder bridge evidence from a real Solana devnet JSON-RPC interaction and persist that evidence across restart. It does not claim on-chain transaction submission, bridge finality, or external settlement.
+
+## What This Slice Proves
+- `KAMN_SERVICE_API_LIVE_SOLANA_BRIDGE_RPC_URL` enables one bounded live bridge lane and fails at startup when configured with an empty value
+- the service-api bridge forward path invokes the checked-in live Solana devnet proof runner instead of persisting placeholder bridge values
+- the forward response persists non-synthetic `target_message_id` and `forward_tx_hash` values
+- the persisted live-backed evidence remains queryable after restart
+
+## What This Slice Does Not Prove
+- not on-chain Solana transaction submission
+- not live bridge settlement
+- not bridge finality
+- not external economic settlement
+- not broad production readiness
+
+## Commands
+```bash
+cargo test -p kamn-node --bin kamn-node \
+  'main_tests::service_api_endpoint_tests::bridge_persistence_restart_contract_tests::bridge_persistence_restart_contract_tests::integration_service_api_endpoint_live_bridge_lane_fails_at_startup_for_empty_rpc_url' \
+  -- --exact --nocapture
+
+cargo test -p kamn-node --bin kamn-node \
+  'main_tests::service_api_endpoint_tests::bridge_persistence_restart_contract_tests::bridge_persistence_restart_contract_tests::integration_service_api_endpoint_live_bridge_forward_path_rejects_placeholder_evidence' \
+  -- --exact --nocapture
+
+cargo test -p kamn-node --bin kamn-node \
+  'main_tests::service_api_endpoint_tests::bridge_persistence_restart_contract_tests::bridge_persistence_restart_contract_tests::integration_service_api_endpoint_live_bridge_forward_evidence_survives_restart' \
+  -- --exact --nocapture
+```
+
+## Expected Evidence
+- startup fails loudly when `KAMN_SERVICE_API_LIVE_SOLANA_BRIDGE_RPC_URL` is empty
+- forward responses stay `HTTP/1.1 200 OK`
+- `target_message_id` no longer matches `msg-bridge-target-{bridge_id}`
+- `forward_tx_hash` no longer matches `sha256:bridge-forwarded-{bridge_id}`
+- restart-visible bridge state preserves the same non-placeholder evidence
+
+## Bounded Interpretation
+This slice proves a bounded live Solana-backed bridge evidence lane on the service-api path. The live Solana interaction is used to derive forward evidence, not to claim live on-chain submission or settlement.

--- a/specs/6991-live-solana-bridge-dispatch.md
+++ b/specs/6991-live-solana-bridge-dispatch.md
@@ -1,0 +1,53 @@
+# 6991-live-solana-bridge-dispatch
+
+## Objective
+Replace the synthetic service-api bridge forwarding placeholder values with bounded live Solana-backed dispatch evidence on current `main`. The bounded live lane must derive forward evidence from a real Solana devnet-backed interaction and persist that evidence through the existing service-api bridge forward path, without claiming settlement or production readiness.
+
+## Inputs/Outputs
+- Inputs:
+  - existing service-api bridge submit/forward/query routes
+  - existing Solana live proof lane from `#6989`
+  - startup configuration for the bounded live Solana bridge dispatch lane
+- Outputs:
+  - non-synthetic `target_message_id` and `forward_tx_hash` values on the bounded live forward path
+  - persisted bridge state carrying live-backed evidence instead of placeholders
+  - one integration test exercising the real forward path
+  - one bounded runbook under `docs/validation/`
+
+## Boundaries/Non-goals
+- Do not claim external settlement.
+- Do not claim production readiness.
+- Do not weaken the existing bounded Solana proof slices.
+- Do not keep placeholder `msg-bridge-target-*` or `sha256:bridge-forwarded-*` values on the claimed live path.
+- Do not add a Solana SDK dependency unless the existing toolchain proves insufficient.
+
+## Failure modes
+- The live path still persists placeholder `target_message_id` or `forward_tx_hash` values.
+- The forward path claims live Solana backing without performing a real Solana-backed interaction.
+- Missing Solana live configuration fails late at request time instead of at startup.
+- The runbook overstates the proof as settlement or full bridge finality.
+
+## Acceptance criteria (testable booleans)
+- [ ] A bounded live Solana bridge-forward path exists behind startup-validated configuration.
+- [ ] The live path persists non-synthetic bridge evidence in `target_message_id` and `forward_tx_hash`.
+- [ ] A hard-fail integration test proves the live path does not emit placeholder bridge values.
+- [ ] Restart-visible bridge state preserves the live-backed evidence.
+- [ ] A bounded validation runbook documents what the slice proves and what it does not prove.
+
+## Files to touch
+- `specs/6991-live-solana-bridge-dispatch.md`
+- `crates/kamn-node/src/service_api_endpoint/message_store/store/content_bridge_ops.rs`
+- `crates/kamn-node/src/service_api_endpoint/payload.rs`
+- `crates/kamn-node/src/main_tests/service_api_endpoint_tests/bridge_persistence_restart_contract_tests/`
+- `docs/validation/`
+- `docs/validation/current-proven-runtime-slices.md`
+
+## Error semantics
+- Missing or invalid live Solana bridge configuration must fail at startup.
+- Live bridge dispatch failures must return explicit typed errors; no fallback to synthetic placeholder evidence.
+- Persistence failures remain hard failures.
+
+## Test plan
+- Phase 3 red tests: add a bridge-forward integration test that asserts placeholder target ids and placeholder forward hashes are rejected on the live Solana-backed path.
+- Green by implementing the bounded live bridge forward path and updating persisted bridge state.
+- Re-run bridge forward integration, restart persistence, and touched-Rust checks before publish.

--- a/specs/6991-live-solana-bridge-dispatch.md
+++ b/specs/6991-live-solana-bridge-dispatch.md
@@ -28,11 +28,11 @@ Replace the synthetic service-api bridge forwarding placeholder values with boun
 - The runbook overstates the proof as settlement or full bridge finality.
 
 ## Acceptance criteria (testable booleans)
-- [ ] A bounded live Solana bridge-forward path exists behind startup-validated configuration.
-- [ ] The live path persists non-synthetic bridge evidence in `target_message_id` and `forward_tx_hash`.
-- [ ] A hard-fail integration test proves the live path does not emit placeholder bridge values.
-- [ ] Restart-visible bridge state preserves the live-backed evidence.
-- [ ] A bounded validation runbook documents what the slice proves and what it does not prove.
+- [x] A bounded live Solana bridge-forward path exists behind startup-validated configuration.
+- [x] The live path persists non-synthetic bridge evidence in `target_message_id` and `forward_tx_hash`.
+- [x] A hard-fail integration test proves the live path does not emit placeholder bridge values.
+- [x] Restart-visible bridge state preserves the live-backed evidence.
+- [x] A bounded validation runbook documents what the slice proves and what it does not prove.
 
 ## Files to touch
 - `specs/6991-live-solana-bridge-dispatch.md`
@@ -51,3 +51,13 @@ Replace the synthetic service-api bridge forwarding placeholder values with boun
 - Phase 3 red tests: add a bridge-forward integration test that asserts placeholder target ids and placeholder forward hashes are rejected on the live Solana-backed path.
 - Green by implementing the bounded live bridge forward path and updating persisted bridge state.
 - Re-run bridge forward integration, restart persistence, and touched-Rust checks before publish.
+
+## Deviations
+- The bounded live lane uses the checked-in live Solana proof runner from `#6989` as its real Solana-backed evidence source instead of introducing a second Solana RPC client into `kamn-node`.
+- The bridge restart contract file was split during refactor so the touched-Rust file-size gate stayed green after the live-path tests were added.
+
+## Final evidence
+- `cargo test -p kamn-node --test live_solana_bridge_dispatch_slice_contract -- --nocapture`
+- `cargo test -p kamn-node --bin kamn-node 'main_tests::service_api_endpoint_tests::bridge_persistence_restart_contract_tests::live_bridge_contract_tests::integration_service_api_endpoint_live_bridge_forward_path_rejects_placeholder_evidence' -- --exact --nocapture`
+- `cargo test -p kamn-node --bin kamn-node 'main_tests::service_api_endpoint_tests::bridge_persistence_restart_contract_tests::live_bridge_contract_tests::integration_service_api_endpoint_live_bridge_forward_evidence_survives_restart' -- --exact --nocapture`
+- `python3 scripts/ci/check_touched_rust_size_policy.py --repo-root /home/n/Code/kamn --base-ref origin/main --output-json /tmp/6991-touched-size.json`


### PR DESCRIPTION
Closes #6991

Issue: #6991
Spec: specs/6991-live-solana-bridge-dispatch.md

## What
- add a startup-validated live Solana bridge dispatch lane on the service-api path
- persist non-placeholder `target_message_id` and `forward_tx_hash` evidence derived from the checked-in live Solana proof runner
- add bounded validation docs and a hard-fail docs contract for the proof surface
- split the live bridge restart tests into a dedicated module to keep the touched-Rust gate green

## Why
The existing bridge forward path claimed a live Solana-backed lane but still persisted placeholder bridge evidence. This change makes that path honest on current `main`: it either produces live-backed evidence or fails loudly.

## Test evidence
- `cargo test -p kamn-node --test live_solana_bridge_dispatch_slice_contract -- --nocapture`
- `cargo test -p kamn-node --bin kamn-node 'main_tests::service_api_endpoint_tests::bridge_persistence_restart_contract_tests::live_bridge_contract_tests::integration_service_api_endpoint_live_bridge_forward_path_rejects_placeholder_evidence' -- --exact --nocapture`
- `cargo test -p kamn-node --bin kamn-node 'main_tests::service_api_endpoint_tests::bridge_persistence_restart_contract_tests::live_bridge_contract_tests::integration_service_api_endpoint_live_bridge_forward_evidence_survives_restart' -- --exact --nocapture`
- `python3 scripts/ci/check_touched_rust_size_policy.py --repo-root /home/n/Code/kamn --base-ref origin/main --output-json /tmp/6991-touched-size.json`
