### PR TITLE
[6993] Prove live Solana bridge evidence reaches websocket stream on main

### DIFF
--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/websocket_contract_tests/support.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/websocket_contract_tests/support.rs
@@ -109,6 +109,31 @@ pub(super) fn send_signed_websocket_request(
     send_websocket_upgrade_request(bind_addr, WEBSOCKET_EVENTS_PATH, headers.as_slice())
 }
 
+pub(super) fn send_signed_websocket_request_with_read_timeout(
+    snapshot: &ServiceApiSnapshot,
+    bind_addr: &str,
+    sender_did: &str,
+    nonce: u64,
+    read_timeout: Duration,
+    extra_headers: &[(&str, &str)],
+) -> Vec<u8> {
+    let signature = websocket_signature(snapshot, sender_did, nonce);
+    let nonce_text = nonce.to_string();
+    let headers = signed_websocket_headers(
+        sender_did,
+        nonce_text.as_str(),
+        signature.as_str(),
+        extra_headers,
+    );
+    send_websocket_upgrade_request_with_timeout(
+        bind_addr,
+        WEBSOCKET_EVENTS_PATH,
+        "13",
+        read_timeout,
+        headers.as_slice(),
+    )
+}
+
 pub(super) fn send_signed_websocket_request_with_version(
     snapshot: &ServiceApiSnapshot,
     bind_addr: &str,

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/websocket_contract_tests/support.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/websocket_contract_tests/support.rs
@@ -109,31 +109,6 @@ pub(super) fn send_signed_websocket_request(
     send_websocket_upgrade_request(bind_addr, WEBSOCKET_EVENTS_PATH, headers.as_slice())
 }
 
-pub(super) fn send_signed_websocket_request_with_read_timeout(
-    snapshot: &ServiceApiSnapshot,
-    bind_addr: &str,
-    sender_did: &str,
-    nonce: u64,
-    read_timeout: Duration,
-    extra_headers: &[(&str, &str)],
-) -> Vec<u8> {
-    let signature = websocket_signature(snapshot, sender_did, nonce);
-    let nonce_text = nonce.to_string();
-    let headers = signed_websocket_headers(
-        sender_did,
-        nonce_text.as_str(),
-        signature.as_str(),
-        extra_headers,
-    );
-    send_websocket_upgrade_request_with_timeout(
-        bind_addr,
-        WEBSOCKET_EVENTS_PATH,
-        "13",
-        read_timeout,
-        headers.as_slice(),
-    )
-}
-
 pub(super) fn send_signed_websocket_request_with_version(
     snapshot: &ServiceApiSnapshot,
     bind_addr: &str,

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/websocket_contract_tests/support/request_support.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/websocket_contract_tests/support/request_support.rs
@@ -13,7 +13,7 @@ pub(crate) fn send_websocket_upgrade_request(
     path: &str,
     headers: &[(&str, &str)],
 ) -> Vec<u8> {
-    send_websocket_upgrade_request_with_version(addr, path, "13", headers)
+    send_websocket_upgrade_request_with_timeout(addr, path, "13", Duration::from_secs(2), headers)
 }
 
 pub(crate) fn send_websocket_upgrade_request_with_version(
@@ -22,10 +22,27 @@ pub(crate) fn send_websocket_upgrade_request_with_version(
     websocket_version: &str,
     headers: &[(&str, &str)],
 ) -> Vec<u8> {
-    send_websocket_upgrade_request_with_version_close_observation(
+    send_websocket_upgrade_request_with_timeout(
         addr,
         path,
         websocket_version,
+        Duration::from_secs(2),
+        headers,
+    )
+}
+
+pub(crate) fn send_websocket_upgrade_request_with_timeout(
+    addr: &str,
+    path: &str,
+    websocket_version: &str,
+    read_timeout: Duration,
+    headers: &[(&str, &str)],
+) -> Vec<u8> {
+    send_websocket_upgrade_request_with_version_close_observation_and_timeout(
+        addr,
+        path,
+        websocket_version,
+        read_timeout,
         headers,
     )
     .0
@@ -37,7 +54,23 @@ pub(crate) fn send_websocket_upgrade_request_with_version_close_observation(
     websocket_version: &str,
     headers: &[(&str, &str)],
 ) -> (Vec<u8>, bool) {
-    let mut stream = websocket_stream(addr);
+    send_websocket_upgrade_request_with_version_close_observation_and_timeout(
+        addr,
+        path,
+        websocket_version,
+        Duration::from_secs(2),
+        headers,
+    )
+}
+
+pub(crate) fn send_websocket_upgrade_request_with_version_close_observation_and_timeout(
+    addr: &str,
+    path: &str,
+    websocket_version: &str,
+    read_timeout: Duration,
+    headers: &[(&str, &str)],
+) -> (Vec<u8>, bool) {
+    let mut stream = websocket_stream(addr, read_timeout);
     let enriched_headers = enrich_signed_headers_with_scope("GET", path, headers);
     let header_lines = websocket_header_lines(&enriched_headers);
     let request = websocket_upgrade_request(addr, path, websocket_version, header_lines.as_str());
@@ -47,10 +80,10 @@ pub(crate) fn send_websocket_upgrade_request_with_version_close_observation(
     read_websocket_response(&mut stream)
 }
 
-fn websocket_stream(addr: &str) -> TcpStream {
+fn websocket_stream(addr: &str, read_timeout: Duration) -> TcpStream {
     let stream = TcpStream::connect(addr).expect("endpoint should accept websocket connection");
     stream
-        .set_read_timeout(Some(Duration::from_secs(2)))
+        .set_read_timeout(Some(read_timeout))
         .expect("websocket read timeout should be configurable");
     stream
 }

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/websocket_contract_tests/upgrade_delivery_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/websocket_contract_tests/upgrade_delivery_contract_tests.rs
@@ -1,5 +1,7 @@
 #[path = "upgrade_delivery_contract_tests/live_delivery_contract_tests.rs"]
 mod live_delivery_contract_tests;
+#[path = "upgrade_delivery_contract_tests/live_bridge_delivery_contract_tests.rs"]
+mod live_bridge_delivery_contract_tests;
 #[path = "upgrade_delivery_contract_tests/reason_taxonomy_contract_tests.rs"]
 mod reason_taxonomy_contract_tests;
 #[path = "upgrade_delivery_contract_tests/upgrade_flow_contract_tests.rs"]

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/websocket_contract_tests/upgrade_delivery_contract_tests/live_bridge_delivery_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/websocket_contract_tests/upgrade_delivery_contract_tests/live_bridge_delivery_contract_tests.rs
@@ -6,14 +6,9 @@ const LIVE_SOLANA_DEVNET_RPC_URL: &str = "https://api.devnet.solana.com";
 
 #[test]
 fn integration_service_api_endpoint_websocket_streams_live_bridge_forwarded_event_after_upgrade() {
-    let _env = acquire_service_api_test_env();
-    let _live_rpc_guard = EnvVarGuard::set(
-        "KAMN_SERVICE_API_LIVE_SOLANA_BRIDGE_RPC_URL",
-        Some(LIVE_SOLANA_DEVNET_RPC_URL),
-    );
-    let harness = build_websocket_harness("127.0.0.1:34072", 3);
+    let (_env, _live_rpc_guard, harness) = build_live_bridge_websocket_harness();
     let publisher = spawn_live_bridge_publish_thread(harness.bind_addr.clone(), harness.snapshot.clone());
-    let websocket_response = send_signed_websocket_request_with_read_timeout(
+    let websocket_response = send_signed_websocket_request_with_timeout(
         &harness.snapshot,
         harness.bind_addr.as_str(),
         "kamn:did:agent:ws-live-bridge-client",
@@ -30,6 +25,42 @@ fn integration_service_api_endpoint_websocket_streams_live_bridge_forwarded_even
         harness.server,
         "service api endpoint should end via request budget completion or idle-timeout fail-close after websocket live bridge test",
     );
+}
+
+fn build_live_bridge_websocket_harness(
+) -> (ServiceApiTestEnvGuards, EnvVarGuard, WebsocketHarness) {
+    let env = acquire_service_api_test_env();
+    let live_rpc_guard = EnvVarGuard::set(
+        "KAMN_SERVICE_API_LIVE_SOLANA_BRIDGE_RPC_URL",
+        Some(LIVE_SOLANA_DEVNET_RPC_URL),
+    );
+    let harness = build_websocket_harness("127.0.0.1:34072", 3);
+    (env, live_rpc_guard, harness)
+}
+
+fn send_signed_websocket_request_with_timeout(
+    snapshot: &ServiceApiSnapshot,
+    bind_addr: &str,
+    sender_did: &str,
+    nonce: u64,
+    read_timeout: Duration,
+    extra_headers: &[(&str, &str)],
+) -> Vec<u8> {
+    let signature = websocket_signature(snapshot, sender_did, nonce);
+    let nonce_text = nonce.to_string();
+    let mut headers = vec![
+        ("X-KAMN-Sender-DID", sender_did),
+        ("X-KAMN-Request-Nonce", nonce_text.as_str()),
+        ("X-KAMN-Request-Signature", signature.as_str()),
+    ];
+    headers.extend_from_slice(extra_headers);
+    send_websocket_upgrade_request_with_timeout(
+        bind_addr,
+        WEBSOCKET_EVENTS_PATH,
+        "13",
+        read_timeout,
+        headers.as_slice(),
+    )
 }
 
 fn spawn_live_bridge_publish_thread(
@@ -108,18 +139,30 @@ fn submitted_bridge_id(submit_response: &str) -> String {
 fn assert_live_bridge_forwarded_frame(response: &[u8]) {
     let (_header, frames) = parse_websocket_response_frames(response);
     let forwarded = bridge_forwarded_frames(frames.as_slice());
-    assert!(
-        !forwarded.is_empty(),
-        "websocket stream should include a bridge forwarded event after live bridge forward: {frames:?}",
-    );
+    assert_forwarded_event_present(frames.as_slice(), forwarded.as_slice());
     let payload = &forwarded[0];
     let bridge_id = payload["bridge_id"]
         .as_str()
         .expect("bridge forwarded frame must include bridge id");
+    assert_forwarded_event_identity(payload);
+    assert_forwarded_event_is_live(payload, bridge_id);
+}
+
+fn assert_forwarded_event_present(frames: &[String], forwarded: &[Value]) {
+    assert!(
+        !forwarded.is_empty(),
+        "websocket stream should include a bridge forwarded event after live bridge forward: {frames:?}",
+    );
+}
+
+fn assert_forwarded_event_identity(payload: &Value) {
     assert_eq!(
         payload["event"].as_str(),
         Some("service-api.bridge.forwarded")
     );
+}
+
+fn assert_forwarded_event_is_live(payload: &Value, bridge_id: &str) {
     assert_ne!(
         payload["target_message_id"],
         Value::String(format!("msg-bridge-target-{bridge_id}")),

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/websocket_contract_tests/upgrade_delivery_contract_tests/live_bridge_delivery_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/websocket_contract_tests/upgrade_delivery_contract_tests/live_bridge_delivery_contract_tests.rs
@@ -13,11 +13,12 @@ fn integration_service_api_endpoint_websocket_streams_live_bridge_forwarded_even
     );
     let harness = build_websocket_harness("127.0.0.1:34072", 3);
     let publisher = spawn_live_bridge_publish_thread(harness.bind_addr.clone(), harness.snapshot.clone());
-    let websocket_response = send_signed_websocket_request(
+    let websocket_response = send_signed_websocket_request_with_read_timeout(
         &harness.snapshot,
         harness.bind_addr.as_str(),
         "kamn:did:agent:ws-live-bridge-client",
         701,
+        Duration::from_secs(4),
         &[],
     );
     let (submit_response, forward_response) = publisher

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/websocket_contract_tests/upgrade_delivery_contract_tests/live_bridge_delivery_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/websocket_contract_tests/upgrade_delivery_contract_tests/live_bridge_delivery_contract_tests.rs
@@ -1,0 +1,145 @@
+use super::super::super::*;
+use super::super::support::*;
+use crate::service_api_endpoint::ServiceApiSnapshot;
+
+const LIVE_SOLANA_DEVNET_RPC_URL: &str = "https://api.devnet.solana.com";
+
+#[test]
+fn integration_service_api_endpoint_websocket_streams_live_bridge_forwarded_event_after_upgrade() {
+    let _env = acquire_service_api_test_env();
+    let _live_rpc_guard = EnvVarGuard::set(
+        "KAMN_SERVICE_API_LIVE_SOLANA_BRIDGE_RPC_URL",
+        Some(LIVE_SOLANA_DEVNET_RPC_URL),
+    );
+    let harness = build_websocket_harness("127.0.0.1:34072", 3);
+    let publisher = spawn_live_bridge_publish_thread(harness.bind_addr.clone(), harness.snapshot.clone());
+    let websocket_response = send_signed_websocket_request(
+        &harness.snapshot,
+        harness.bind_addr.as_str(),
+        "kamn:did:agent:ws-live-bridge-client",
+        701,
+        &[],
+    );
+    let (submit_response, forward_response) = publisher
+        .join()
+        .expect("bridge publish thread should complete");
+    assert_live_bridge_requests_accepted(submit_response.as_str(), forward_response.as_str());
+    assert_live_bridge_forwarded_frame(websocket_response.as_slice());
+    assert_server_ok_or_timeout(
+        harness.server,
+        "service api endpoint should end via request budget completion or idle-timeout fail-close after websocket live bridge test",
+    );
+}
+
+fn spawn_live_bridge_publish_thread(
+    bind_addr: String,
+    snapshot: ServiceApiSnapshot,
+) -> thread::JoinHandle<(String, String)> {
+    thread::spawn(move || {
+        thread::sleep(Duration::from_millis(75));
+        let state_hash = state_hash(&snapshot);
+        let submit_response = submit_live_bridge(bind_addr.as_str(), state_hash.as_str(), 702);
+        let bridge_id = submitted_bridge_id(submit_response.as_str());
+        let forward_response =
+            forward_live_bridge(bind_addr.as_str(), state_hash.as_str(), 703, bridge_id.as_str());
+        (submit_response, forward_response)
+    })
+}
+
+fn submit_live_bridge(bind_addr: &str, state_hash: &str, nonce: u64) -> String {
+    let sender_did = "kamn:did:agent:ws-live-bridge-publisher";
+    let body = r#"{"source_message_id":"msg-ws-live-bridge-source"}"#;
+    let signature = service_api_request_signature_for_fields(sender_did, nonce, state_hash, body);
+    let nonce_text = nonce.to_string();
+    send_http_request_with_headers(
+        bind_addr,
+        "POST",
+        "/v1/bridge/submit",
+        body,
+        &[
+            ("X-KAMN-Sender-DID", sender_did),
+            ("X-KAMN-Request-Nonce", nonce_text.as_str()),
+            ("X-KAMN-Request-Signature", signature.as_str()),
+            ("X-KAMN-Authz-Scope", "bridge:write"),
+        ],
+    )
+}
+
+fn forward_live_bridge(bind_addr: &str, state_hash: &str, nonce: u64, bridge_id: &str) -> String {
+    let sender_did = "kamn:did:agent:ws-live-bridge-publisher";
+    let signature = service_api_request_signature_for_fields(sender_did, nonce, state_hash, "");
+    let nonce_text = nonce.to_string();
+    send_http_request_with_headers(
+        bind_addr,
+        "POST",
+        format!("/v1/bridge/{bridge_id}/forward").as_str(),
+        "",
+        &[
+            ("X-KAMN-Sender-DID", sender_did),
+            ("X-KAMN-Request-Nonce", nonce_text.as_str()),
+            ("X-KAMN-Request-Signature", signature.as_str()),
+            ("X-KAMN-Authz-Scope", "bridge:write"),
+        ],
+    )
+}
+
+fn assert_live_bridge_requests_accepted(submit_response: &str, forward_response: &str) {
+    assert!(
+        submit_response.contains("HTTP/1.1 202 Accepted"),
+        "live bridge submit should be accepted: {submit_response}",
+    );
+    assert!(
+        forward_response.contains("HTTP/1.1 200 OK"),
+        "live bridge forward should be accepted: {forward_response}",
+    );
+}
+
+fn submitted_bridge_id(submit_response: &str) -> String {
+    let body = extract_http_response_body(submit_response);
+    let payload: Value =
+        parse_service_api_payload(body).expect("bridge submit payload should deserialize");
+    payload["bridge_id"]
+        .as_str()
+        .expect("bridge submit payload should include bridge id")
+        .to_owned()
+}
+
+fn assert_live_bridge_forwarded_frame(response: &[u8]) {
+    let (_header, frames) = parse_websocket_response_frames(response);
+    let forwarded = bridge_forwarded_frames(frames.as_slice());
+    assert!(
+        !forwarded.is_empty(),
+        "websocket stream should include a bridge forwarded event after live bridge forward: {frames:?}",
+    );
+    let payload = &forwarded[0];
+    let bridge_id = payload["bridge_id"]
+        .as_str()
+        .expect("bridge forwarded frame must include bridge id");
+    assert_eq!(
+        payload["event"].as_str(),
+        Some("service-api.bridge.forwarded")
+    );
+    assert_ne!(
+        payload["target_message_id"],
+        Value::String(format!("msg-bridge-target-{bridge_id}")),
+        "live websocket bridge target id must not be placeholder"
+    );
+    assert_ne!(
+        payload["forward_tx_hash"],
+        Value::String(format!("sha256:bridge-forwarded-{bridge_id}")),
+        "live websocket bridge forward hash must not be placeholder"
+    );
+}
+
+fn bridge_forwarded_frames(frames: &[String]) -> Vec<Value> {
+    frames
+        .iter()
+        .filter_map(|frame| {
+            let payload: Value = serde_json::from_str(frame).ok()?;
+            if payload.get("event").and_then(Value::as_str) != Some("service-api.bridge.forwarded") {
+                return None;
+            }
+            Some(payload)
+        })
+        .collect()
+}

--- a/crates/kamn-node/tests/live_solana_bridge_websocket_slice_contract.rs
+++ b/crates/kamn-node/tests/live_solana_bridge_websocket_slice_contract.rs
@@ -1,0 +1,58 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const DOC_PATH: &str = "docs/validation/live-solana-bridge-websocket-slice.md";
+const INDEX_PATH: &str = "docs/validation/current-proven-runtime-slices.md";
+
+const REQUIRED_DOC_MARKERS: &[&str] = &[
+    "service-api.bridge.forwarded",
+    "websocket event stream",
+    "KAMN_SERVICE_API_LIVE_SOLANA_BRIDGE_RPC_URL",
+    "not live on-chain settlement",
+    "integration_service_api_endpoint_websocket_streams_live_bridge_forwarded_event_after_upgrade",
+];
+
+const REQUIRED_INDEX_MARKERS: &[&str] = &[
+    "live solana bridge websocket slice: `docs/validation/live-solana-bridge-websocket-slice.md`",
+    "proves the live Solana-backed bridge evidence lane reaches the websocket event stream",
+];
+
+#[test]
+fn live_solana_bridge_websocket_doc_exists_and_stays_bounded() {
+    let doc = read_workspace_file(DOC_PATH);
+    assert_contains_all(
+        doc.as_str(),
+        REQUIRED_DOC_MARKERS,
+        "live Solana bridge websocket doc",
+    );
+}
+
+#[test]
+fn runtime_proof_index_includes_live_solana_bridge_websocket_slice() {
+    let index = read_workspace_file(INDEX_PATH);
+    assert_contains_all(
+        index.as_str(),
+        REQUIRED_INDEX_MARKERS,
+        "runtime proof index",
+    );
+}
+
+fn assert_contains_all(doc: &str, markers: &[&str], label: &str) {
+    for marker in markers {
+        assert!(doc.contains(marker), "{label} missing marker: {marker}");
+    }
+}
+
+fn read_workspace_file(relative_path: &str) -> String {
+    let path = workspace_root().join(relative_path);
+    assert!(path.exists(), "expected path to exist: {}", path.display());
+    fs::read_to_string(&path)
+        .unwrap_or_else(|error| panic!("failed to read {}: {}", path.display(), error))
+}
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("workspace root should resolve")
+}

--- a/docs/review/corrected-audit-response-2026-03-14.md
+++ b/docs/review/corrected-audit-response-2026-03-14.md
@@ -17,8 +17,9 @@ The current proof anchors on `main` include:
 - `docs/validation/solana-devnet-bridge-smoke-slice.md`
 - `docs/validation/live-solana-devnet-proof-slice.md`
 - `docs/validation/live-solana-bridge-dispatch-slice.md`
+- `docs/validation/live-solana-bridge-websocket-slice.md`
 
-Those proofs matter because they establish that current `main` is not only type definitions and wrappers. The node path proves one real service-API vertical slice. The SDK path proves one real TCP signed-relay vertical slice. The newer relay, restart, escrow, bridge-finality, Solana-finality, Solana bridge-smoke, live Solana devnet, and live Solana bridge-dispatch proofs make the bounded persistence and finality claims easier to inspect from one place.
+Those proofs matter because they establish that current `main` is not only type definitions and wrappers. The node path proves one real service-API vertical slice. The SDK path proves one real TCP signed-relay vertical slice. The newer relay, restart, escrow, bridge-finality, Solana-finality, Solana bridge-smoke, live Solana devnet, live Solana bridge-dispatch, and live Solana bridge-websocket proofs make the bounded persistence and finality claims easier to inspect from one place.
 
 ## Accurate Claims
 - `kamn-core` is still too large and too central.
@@ -92,6 +93,9 @@ Current build-health status for the specific blockers that audit called out:
 
 ### Live Solana Bridge Dispatch Slice
 `docs/validation/live-solana-bridge-dispatch-slice.md` proves a bounded live Solana-backed bridge evidence lane on the service-api path, including startup validation for the live RPC env, non-placeholder persisted bridge evidence, and restart-visible continuity without claiming on-chain submission, bridge finality, or settlement.
+
+### Live Solana Bridge Websocket Slice
+`docs/validation/live-solana-bridge-websocket-slice.md` proves that the same live Solana-backed bridge evidence lane reaches the real websocket event stream as a `service-api.bridge.forwarded` event carrying non-placeholder `target_message_id` and `forward_tx_hash` values, without claiming settlement or finality.
 
 ## Bottom Line
 The strongest version of the external critique is strategic, not numerical.

--- a/docs/validation/current-proven-runtime-slices.md
+++ b/docs/validation/current-proven-runtime-slices.md
@@ -23,6 +23,8 @@ This index summarizes the runtime behavior that current `main` proves today thro
   - proves bounded live Solana devnet JSON-RPC evidence normalized through the public receipt surface
 - live solana bridge dispatch slice: `docs/validation/live-solana-bridge-dispatch-slice.md`
   - proves a bounded live Solana-backed bridge evidence lane on the service-api path
+- live solana bridge websocket slice: `docs/validation/live-solana-bridge-websocket-slice.md`
+  - proves the live Solana-backed bridge evidence lane reaches the websocket event stream
 
 ## What Remains Unproven
 - broad production readiness

--- a/docs/validation/live-solana-bridge-websocket-slice.md
+++ b/docs/validation/live-solana-bridge-websocket-slice.md
@@ -1,0 +1,46 @@
+# Live Solana Bridge Websocket Slice
+
+This runbook documents one bounded live Solana-backed bridge websocket slice on current `main`. It proves that the existing live bridge forward lane reaches the real websocket event stream and emits a `service-api.bridge.forwarded` event with non-placeholder bridge evidence. It does not claim live on-chain settlement, bridge finality, or external economic settlement.
+
+## Scope
+- websocket upgrade on `/v1/events/ws`
+- service-api bridge submit and forward on the current node path
+- live Solana-backed bridge evidence enabled through `KAMN_SERVICE_API_LIVE_SOLANA_BRIDGE_RPC_URL`
+- forwarded websocket event projection carrying non-placeholder `target_message_id` and `forward_tx_hash`
+
+## Proof Anchors
+This slice is grounded in current-main tests:
+- `integration_service_api_endpoint_websocket_streams_live_bridge_forwarded_event_after_upgrade`
+- `cargo test -p kamn-node --test live_solana_bridge_websocket_slice_contract -- --nocapture`
+
+## What This Proves
+- the websocket event stream remains open long enough to observe the live bridge forward on the same server instance
+- a live Solana-backed bridge forward emits `service-api.bridge.forwarded` on the websocket event stream
+- the forwarded websocket event carries non-placeholder `target_message_id` and `forward_tx_hash` values
+- the proof uses the real websocket upgrade plus the real bridge submit/forward routes on current `main`
+
+## What This Does Not Prove
+- not live on-chain settlement
+- not bridge finality beyond the existing bounded proofs
+- not external economic settlement
+- not multi-node consensus or arbitrary partition tolerance
+
+## Operator Commands
+Run the exact proof targets from a clean checkout:
+
+```bash
+cargo test -p kamn-node --test live_solana_bridge_websocket_slice_contract -- --nocapture
+cargo test -p kamn-node --bin kamn-node \
+  'main_tests::service_api_endpoint_tests::websocket_contract_tests::upgrade_delivery_contract_tests::live_bridge_delivery_contract_tests::integration_service_api_endpoint_websocket_streams_live_bridge_forwarded_event_after_upgrade' \
+  -- --exact --nocapture
+```
+
+## Expected Evidence
+- websocket frames include `service-api.bridge.forwarded`
+- `target_message_id` does not match `msg-bridge-target-{bridge_id}`
+- `forward_tx_hash` does not match `sha256:bridge-forwarded-{bridge_id}`
+- live Solana bridge configuration is still anchored to `KAMN_SERVICE_API_LIVE_SOLANA_BRIDGE_RPC_URL`
+
+## Notes
+- This slice deepens the existing live bridge dispatch proof by showing the live-backed evidence reaches a downstream consumer surface.
+- It does not extend the claim to settlement or finality.

--- a/specs/6993-live-solana-bridge-websocket-slice.md
+++ b/specs/6993-live-solana-bridge-websocket-slice.md
@@ -28,11 +28,11 @@ Prove that the existing live Solana-backed service-api bridge forward lane reach
 - The runbook overstates the slice as settlement or finality proof.
 
 ## Acceptance criteria (testable booleans)
-- [ ] A websocket integration test proves a live Solana-backed bridge forward emits a `service-api.bridge.forwarded` event.
-- [ ] The forwarded websocket event carries non-placeholder `target_message_id` and `forward_tx_hash` values.
-- [ ] The integration test uses the real websocket upgrade plus the real bridge submit/forward routes on current `main`.
-- [ ] A bounded validation runbook documents what this slice proves and what it does not prove.
-- [ ] The runtime proof index links the websocket slice.
+- [x] A websocket integration test proves a live Solana-backed bridge forward emits a `service-api.bridge.forwarded` event.
+- [x] The forwarded websocket event carries non-placeholder `target_message_id` and `forward_tx_hash` values.
+- [x] The integration test uses the real websocket upgrade plus the real bridge submit/forward routes on current `main`.
+- [x] A bounded validation runbook documents what this slice proves and what it does not prove.
+- [x] The runtime proof index links the websocket slice.
 
 ## Files to touch
 - `specs/6993-live-solana-bridge-websocket-slice.md`
@@ -50,3 +50,12 @@ Prove that the existing live Solana-backed service-api bridge forward lane reach
 - Phase 3 red tests: add a docs contract for the missing runbook and add one websocket integration test covering upgrade plus live bridge forward.
 - Green by wiring any missing websocket test support and publishing the bounded runbook.
 - Re-run the new websocket slice test, the docs contract, and the touched-Rust size policy before publish.
+
+## Deviations
+- The runtime path itself already published bridge-forwarded websocket events; the missing behavior was proof coverage for the live Solana-backed lane. The only runtime-support change was a scoped websocket read-timeout helper so the test could observe the live proof runner completing without broadening unrelated websocket tests.
+
+## Final evidence
+- `cargo test -p kamn-node --test live_solana_bridge_websocket_slice_contract -- --nocapture`
+- `cargo test -p kamn-node --bin kamn-node 'main_tests::service_api_endpoint_tests::websocket_contract_tests::upgrade_delivery_contract_tests::live_bridge_delivery_contract_tests::integration_service_api_endpoint_websocket_streams_live_bridge_forwarded_event_after_upgrade' -- --exact --nocapture`
+- `cargo test -p kamn-core --test corrected_audit_response_docs -- --nocapture`
+- `python3 scripts/ci/check_touched_rust_size_policy.py --repo-root /home/n/Code/kamn --base-ref origin/main --output-json /tmp/6993-touched-size.json`

--- a/specs/6993-live-solana-bridge-websocket-slice.md
+++ b/specs/6993-live-solana-bridge-websocket-slice.md
@@ -1,0 +1,52 @@
+# 6993-live-solana-bridge-websocket-slice
+
+## Objective
+Prove that the existing live Solana-backed service-api bridge forward lane reaches the real websocket event stream on current `main`. The slice must show that a websocket subscriber observes a `service-api.bridge.forwarded` event carrying non-placeholder `target_message_id` and `forward_tx_hash` values after a live Solana-backed bridge forward.
+
+## Inputs/Outputs
+- Inputs:
+  - existing websocket upgrade route `/v1/events/ws`
+  - existing service-api bridge submit and forward routes
+  - existing live Solana bridge env `KAMN_SERVICE_API_LIVE_SOLANA_BRIDGE_RPC_URL`
+  - existing live Solana proof runner from `#6989`
+- Outputs:
+  - one websocket integration test exercising upgrade plus live bridge submit/forward on the same server
+  - one bounded validation runbook under `docs/validation/`
+  - one docs contract anchoring the runbook and runtime-proof index entry
+
+## Boundaries/Non-goals
+- Do not claim live on-chain settlement.
+- Do not claim bridge finality beyond the existing bounded proofs.
+- Do not add a Solana SDK dependency.
+- Do not weaken websocket auth, replay protection, or request signature requirements.
+- Do not replace the existing live bridge dispatch proof; this issue deepens it through a downstream consumer surface.
+
+## Failure modes
+- The websocket stream does not emit a `service-api.bridge.forwarded` event after live bridge forward.
+- The websocket event emits placeholder `msg-bridge-target-*` or `sha256:bridge-forwarded-*` values on the live lane.
+- Empty live Solana RPC configuration fails late instead of at startup.
+- The runbook overstates the slice as settlement or finality proof.
+
+## Acceptance criteria (testable booleans)
+- [ ] A websocket integration test proves a live Solana-backed bridge forward emits a `service-api.bridge.forwarded` event.
+- [ ] The forwarded websocket event carries non-placeholder `target_message_id` and `forward_tx_hash` values.
+- [ ] The integration test uses the real websocket upgrade plus the real bridge submit/forward routes on current `main`.
+- [ ] A bounded validation runbook documents what this slice proves and what it does not prove.
+- [ ] The runtime proof index links the websocket slice.
+
+## Files to touch
+- `specs/6993-live-solana-bridge-websocket-slice.md`
+- `crates/kamn-node/src/main_tests/service_api_endpoint_tests/websocket_contract_tests/`
+- `crates/kamn-node/tests/`
+- `docs/validation/`
+- `docs/review/corrected-audit-response-2026-03-14.md`
+
+## Error semantics
+- Missing or invalid `KAMN_SERVICE_API_LIVE_SOLANA_BRIDGE_RPC_URL` remains a startup failure.
+- Live bridge forward failures remain explicit `service_api_live_bridge_dispatch_failed` errors.
+- Websocket upgrade/auth failures remain fail-closed and unchanged.
+
+## Test plan
+- Phase 3 red tests: add a docs contract for the missing runbook and add one websocket integration test covering upgrade plus live bridge forward.
+- Green by wiring any missing websocket test support and publishing the bounded runbook.
+- Re-run the new websocket slice test, the docs contract, and the touched-Rust size policy before publish.


### PR DESCRIPTION
Closes #6993

Issue: #6993
Spec: specs/6993-live-solana-bridge-websocket-slice.md

## What
- add a bounded websocket proof slice for the live Solana-backed bridge lane
- add a websocket integration test that upgrades the real `/v1/events/ws` route and observes a live `service-api.bridge.forwarded` event
- add a hard-fail docs contract plus validation runbook and proof-index wiring
- update the corrected audit response to include the new websocket proof anchor

## Why
Current `main` already proved live Solana-backed bridge evidence on the service-api forward path, but not that this evidence reached a downstream consumer surface. This change closes that proof gap on the real websocket event stream.

## Test evidence
- `cargo test -p kamn-node --test live_solana_bridge_websocket_slice_contract -- --nocapture`
- `cargo test -p kamn-node --bin kamn-node 'main_tests::service_api_endpoint_tests::websocket_contract_tests::upgrade_delivery_contract_tests::live_bridge_delivery_contract_tests::integration_service_api_endpoint_websocket_streams_live_bridge_forwarded_event_after_upgrade' -- --exact --nocapture`
- `cargo test -p kamn-core --test corrected_audit_response_docs -- --nocapture`
- `python3 scripts/ci/check_touched_rust_size_policy.py --repo-root /home/n/Code/kamn --base-ref origin/main --output-json /tmp/6993-touched-size.json`
