### PR TITLE
[6995] Prove bounded live escrow settlement slice on main

### DIFF
--- a/crates/kamn-e2e-harness/tests/live_s05_sdk_direct_external_execution.rs
+++ b/crates/kamn-e2e-harness/tests/live_s05_sdk_direct_external_execution.rs
@@ -1,0 +1,26 @@
+use kamn_e2e_harness::drivers::sdk_direct::SdkDirectDriver;
+use kamn_e2e_harness::drivers::HarnessDriver;
+
+#[test]
+#[ignore = "requires local Kolme + KAMN runtime with explicit live env"]
+fn integration_live_s05_sdk_direct_escrow_settlement_probe_against_local_runtime() {
+    require_env("KAMN_E2E_SDK_DIRECT_LIVE");
+    require_env("KAMN_ENDPOINT");
+    require_env("KAMN_KOLME_ENDPOINT");
+    require_env("KAMN_AGENT_NAME");
+
+    let driver = SdkDirectDriver::from_env();
+    let result = driver.execute("S-05");
+
+    assert_eq!(result.scenario_id, "S-05");
+    assert_eq!(result.status, "pass", "live sdk-direct S-05 failed: {:?}", result.detail);
+}
+
+fn require_env(key: &str) {
+    let value = std::env::var(key)
+        .unwrap_or_else(|_| panic!("required env missing for live S-05 probe: {key}"));
+    assert!(
+        !value.trim().is_empty(),
+        "required env must not be empty for live S-05 probe: {key}"
+    );
+}

--- a/crates/kamn-node/tests/live_escrow_settlement_slice_contract.rs
+++ b/crates/kamn-node/tests/live_escrow_settlement_slice_contract.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 
 const DOC_PATH: &str = "docs/validation/live-escrow-settlement-slice.md";
 const INDEX_PATH: &str = "docs/validation/current-proven-runtime-slices.md";
+const SLICE_LABEL: &str = "live escrow settlement slice: `docs/validation/live-escrow-settlement-slice.md`";
 const REQUIRED_DOC_MARKERS: &[&str] = &[
     "external-execution `sdk-direct` S-05",
     "--enable-external-execution",
@@ -11,10 +12,10 @@ const REQUIRED_DOC_MARKERS: &[&str] = &[
     "does not prove Solana-backed settlement",
     "does not prove bridge settlement",
     "does not prove external-chain settlement",
-    "live escrow settlement slice: `docs/validation/live-escrow-settlement-slice.md`",
+    SLICE_LABEL,
 ];
 const REQUIRED_INDEX_MARKERS: &[&str] = &[
-    "live escrow settlement slice: `docs/validation/live-escrow-settlement-slice.md`",
+    SLICE_LABEL,
     "proves one bounded live escrow settlement execution lane through external-execution `sdk-direct` S-05",
 ];
 

--- a/crates/kamn-node/tests/live_escrow_settlement_slice_contract.rs
+++ b/crates/kamn-node/tests/live_escrow_settlement_slice_contract.rs
@@ -6,8 +6,9 @@ const INDEX_PATH: &str = "docs/validation/current-proven-runtime-slices.md";
 const SLICE_LABEL: &str = "live escrow settlement slice: `docs/validation/live-escrow-settlement-slice.md`";
 const REQUIRED_DOC_MARKERS: &[&str] = &[
     "external-execution `sdk-direct` S-05",
-    "--enable-external-execution",
-    "--scenarios S-05",
+    "live_s05_sdk_direct_external_execution",
+    "integration_live_s05_sdk_direct_escrow_settlement_probe_against_local_runtime",
+    "-- --ignored --exact --nocapture",
     "target/debug/kamn-e2e-harness verify",
     "does not prove Solana-backed settlement",
     "does not prove bridge settlement",

--- a/crates/kamn-node/tests/live_escrow_settlement_slice_contract.rs
+++ b/crates/kamn-node/tests/live_escrow_settlement_slice_contract.rs
@@ -1,0 +1,36 @@
+use std::fs;
+
+const DOC_PATH: &str = "docs/validation/live-escrow-settlement-slice.md";
+const INDEX_PATH: &str = "docs/validation/current-proven-runtime-slices.md";
+const REQUIRED_DOC_MARKERS: &[&str] = &[
+    "external-execution `sdk-direct` S-05",
+    "--enable-external-execution",
+    "--scenarios S-05",
+    "target/debug/kamn-e2e-harness verify",
+    "not prove Solana-backed settlement",
+    "not bridge settlement",
+    "not external-chain settlement",
+    "live escrow settlement slice: `docs/validation/live-escrow-settlement-slice.md`",
+];
+
+#[test]
+fn live_escrow_settlement_doc_exists_and_stays_bounded() {
+    let doc = fs::read_to_string(DOC_PATH)
+        .unwrap_or_else(|error| panic!("live escrow settlement slice doc missing: {error}"));
+    for marker in REQUIRED_DOC_MARKERS {
+        assert!(
+            doc.contains(marker),
+            "live escrow settlement doc missing marker: {marker}"
+        );
+    }
+}
+
+#[test]
+fn runtime_proof_index_includes_live_escrow_settlement_slice() {
+    let index = fs::read_to_string(INDEX_PATH)
+        .unwrap_or_else(|error| panic!("runtime proof index missing: {error}"));
+    assert!(
+        index.contains("live escrow settlement slice: `docs/validation/live-escrow-settlement-slice.md`"),
+        "runtime proof index must link the live escrow settlement slice"
+    );
+}

--- a/crates/kamn-node/tests/live_escrow_settlement_slice_contract.rs
+++ b/crates/kamn-node/tests/live_escrow_settlement_slice_contract.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use std::path::{Path, PathBuf};
 
 const DOC_PATH: &str = "docs/validation/live-escrow-settlement-slice.md";
 const INDEX_PATH: &str = "docs/validation/current-proven-runtime-slices.md";
@@ -7,30 +8,44 @@ const REQUIRED_DOC_MARKERS: &[&str] = &[
     "--enable-external-execution",
     "--scenarios S-05",
     "target/debug/kamn-e2e-harness verify",
-    "not prove Solana-backed settlement",
-    "not bridge settlement",
-    "not external-chain settlement",
+    "does not prove Solana-backed settlement",
+    "does not prove bridge settlement",
+    "does not prove external-chain settlement",
     "live escrow settlement slice: `docs/validation/live-escrow-settlement-slice.md`",
+];
+const REQUIRED_INDEX_MARKERS: &[&str] = &[
+    "live escrow settlement slice: `docs/validation/live-escrow-settlement-slice.md`",
+    "proves one bounded live escrow settlement execution lane through external-execution `sdk-direct` S-05",
 ];
 
 #[test]
 fn live_escrow_settlement_doc_exists_and_stays_bounded() {
-    let doc = fs::read_to_string(DOC_PATH)
-        .unwrap_or_else(|error| panic!("live escrow settlement slice doc missing: {error}"));
-    for marker in REQUIRED_DOC_MARKERS {
-        assert!(
-            doc.contains(marker),
-            "live escrow settlement doc missing marker: {marker}"
-        );
-    }
+    let doc = read_workspace_file(DOC_PATH);
+    assert_contains_all(doc.as_str(), REQUIRED_DOC_MARKERS, "live escrow settlement doc");
 }
 
 #[test]
 fn runtime_proof_index_includes_live_escrow_settlement_slice() {
-    let index = fs::read_to_string(INDEX_PATH)
-        .unwrap_or_else(|error| panic!("runtime proof index missing: {error}"));
-    assert!(
-        index.contains("live escrow settlement slice: `docs/validation/live-escrow-settlement-slice.md`"),
-        "runtime proof index must link the live escrow settlement slice"
-    );
+    let index = read_workspace_file(INDEX_PATH);
+    assert_contains_all(index.as_str(), REQUIRED_INDEX_MARKERS, "runtime proof index");
+}
+
+fn assert_contains_all(doc: &str, markers: &[&str], label: &str) {
+    for marker in markers {
+        assert!(doc.contains(marker), "{label} missing marker: {marker}");
+    }
+}
+
+fn read_workspace_file(relative_path: &str) -> String {
+    let path = workspace_root().join(relative_path);
+    assert!(path.exists(), "expected path to exist: {}", path.display());
+    fs::read_to_string(&path)
+        .unwrap_or_else(|error| panic!("failed to read {}: {}", path.display(), error))
+}
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("workspace root should resolve")
 }

--- a/docs/review/corrected-audit-response-2026-03-14.md
+++ b/docs/review/corrected-audit-response-2026-03-14.md
@@ -97,6 +97,8 @@ Current build-health status for the specific blockers that audit called out:
 ### Live Solana Bridge Websocket Slice
 `docs/validation/live-solana-bridge-websocket-slice.md` proves that the same live Solana-backed bridge evidence lane reaches the real websocket event stream as a `service-api.bridge.forwarded` event carrying non-placeholder `target_message_id` and `forward_tx_hash` values, without claiming settlement or finality.
 
+`docs/validation/live-escrow-settlement-slice.md` proves one bounded live escrow settlement execution lane through external-execution `sdk-direct` S-05 on current `main`, while staying explicit that the claim is not Solana-backed settlement, bridge settlement, or external-chain settlement.
+
 ## Bottom Line
 The strongest version of the external critique is strategic, not numerical.
 

--- a/docs/validation/current-proven-runtime-slices.md
+++ b/docs/validation/current-proven-runtime-slices.md
@@ -25,12 +25,15 @@ This index summarizes the runtime behavior that current `main` proves today thro
   - proves a bounded live Solana-backed bridge evidence lane on the service-api path
 - live solana bridge websocket slice: `docs/validation/live-solana-bridge-websocket-slice.md`
   - proves the live Solana-backed bridge evidence lane reaches the websocket event stream
+- live escrow settlement slice: `docs/validation/live-escrow-settlement-slice.md`
+  - proves one bounded live escrow settlement execution lane through external-execution `sdk-direct` S-05
 
 ## What Remains Unproven
 - broad production readiness
 - consensus or multi-node finality
 - live chain-backed bridge finality or external settlement
 - live Solana settlement over the KAMN bridge path
+- broad multi-driver live economic-settlement parity
 - global fault tolerance under arbitrary partitions
 
 ## How To Use This Index

--- a/docs/validation/live-escrow-settlement-slice.md
+++ b/docs/validation/live-escrow-settlement-slice.md
@@ -12,6 +12,7 @@ This runbook documents one bounded live escrow settlement slice on current `main
 - `crates/kamn-e2e-harness/src/drivers/sdk_direct/live_probe_tranche_one/escrow_probe_support.rs`
 - `crates/kamn-e2e-harness/src/drivers/cli_scripted/live_probe_tranche_one/escrow_probe_support.rs`
 - `crates/kamn-e2e-harness/src/drivers/mcp_agent/live_probe_tranche_one/escrow_settlement_probe.rs`
+- `crates/kamn-e2e-harness/tests/live_s05_sdk_direct_external_execution.rs`
 
 ## What This Proves
 - the external-execution `sdk-direct` driver can execute S-05 escrow settlement on current `main`
@@ -81,16 +82,26 @@ target/debug/kamn-node \
 ```
 
 ## Operator Commands
-Enable the live `sdk-direct` lane and run S-05 only:
+Enable the live `sdk-direct` lane and run the explicit local-heavy S-05 probe:
 
 ```bash
 export KAMN_E2E_SDK_DIRECT_LIVE=true
-export KAMN_ENDPOINT=http://127.0.0.1:8080
-export KAMN_KOLME_ENDPOINT=http://127.0.0.1:3000
+export KAMN_ENDPOINT=http://127.0.0.1:18080
+export KAMN_KOLME_ENDPOINT=http://127.0.0.1:13000
+export KAMN_AGENT_NAME=kamn-live-s05-proof
 export KAMN_E2E_EXTERNAL_KAMN_PROCESSOR_BINARY=/home/n/Code/kamn/target/debug/kamn-node
 export KAMN_E2E_EXTERNAL_KAMN_LISTENER_BINARY=/home/n/Code/kamn/target/debug/kamn-node
 export KAMN_E2E_EXTERNAL_KAMN_APPROVER_BINARY=/home/n/Code/kamn/target/debug/kamn-node
 
+cargo test -p kamn-e2e-harness \
+  --test live_s05_sdk_direct_external_execution \
+  integration_live_s05_sdk_direct_escrow_settlement_probe_against_local_runtime \
+  -- --ignored --exact --nocapture
+```
+
+Optional harness external-execution contract run for the surrounding orchestration surface:
+
+```bash
 target/debug/kamn-e2e-harness run \
   --mode sdk-direct \
   --kolme-binary /tmp/kolme/target/release/example-p2p \
@@ -99,7 +110,7 @@ target/debug/kamn-e2e-harness run \
   --scenarios S-05 > /tmp/kamn-e2e-live-s05-run.json
 ```
 
-Verify the generated evidence:
+Verify the generated evidence contract output:
 
 ```bash
 target/debug/kamn-e2e-harness verify \
@@ -109,8 +120,10 @@ target/debug/kamn-e2e-harness verify \
 ```
 
 ## Expected Evidence
-- run output records exactly one selected scenario: `S-05`
-- S-05 status is `PASS`
+- explicit live probe test passes for `S-05`
+- the explicit live probe uses the real `sdk-direct` driver against the running local endpoints
+- optional harness `run` output records exactly one selected scenario: `S-05`
+- optional harness `run` output records `S-05` status as `PASS`
 - evidence bundle contains the scenario-declared artifacts:
   - `evidence/s05/escrow_lifecycle_trace.json`
   - `evidence/s05/settlement_breakdown.json`
@@ -121,4 +134,5 @@ target/debug/kamn-e2e-harness verify \
 ## Notes
 - live escrow settlement slice: `docs/validation/live-escrow-settlement-slice.md`
 - This slice is intentionally bounded to external-execution `sdk-direct` S-05 on current `main`.
+- The explicit proof command is the ignored local-heavy integration test, not the harness scaffold alone.
 - It does not prove Solana-backed settlement, bridge settlement, or external-chain settlement.

--- a/docs/validation/live-escrow-settlement-slice.md
+++ b/docs/validation/live-escrow-settlement-slice.md
@@ -1,0 +1,124 @@
+# Live Escrow Settlement Slice
+
+This runbook documents one bounded live escrow settlement slice on current `main`. It is anchored to external-execution `sdk-direct` S-05 on the checked-in `kamn-e2e-harness` surface. It proves one live escrow settlement execution lane through the existing harness driver path. It does not prove Solana-backed settlement, bridge settlement, or external-chain settlement.
+
+## Scope
+- one real external-execution `sdk-direct` S-05 harness run on current `main`
+- local Kolme plus three local KAMN API nodes on loopback
+- one `verify` pass over the generated evidence bundle
+
+## Proof Anchors
+- `crates/kamn-e2e-harness/src/scenarios/s05_escrow.rs`
+- `crates/kamn-e2e-harness/src/drivers/sdk_direct/live_probe_tranche_one/escrow_probe_support.rs`
+- `crates/kamn-e2e-harness/src/drivers/cli_scripted/live_probe_tranche_one/escrow_probe_support.rs`
+- `crates/kamn-e2e-harness/src/drivers/mcp_agent/live_probe_tranche_one/escrow_settlement_probe.rs`
+
+## What This Proves
+- the external-execution `sdk-direct` driver can execute S-05 escrow settlement on current `main`
+- the run is exercised through the real harness `run` command with `--enable-external-execution`
+- the generated evidence bundle can be checked by the real harness `verify` command
+- current `main` has one operator-comprehensible live escrow settlement slice beyond the earlier service-api persistence-only escrow proof
+
+## What This Does Not Prove
+- does not prove Solana-backed settlement
+- does not prove bridge settlement
+- does not prove external-chain settlement
+- does not prove Byzantine-safe dispute resolution
+- does not prove production readiness across all drivers
+- CLI-scripted and MCP-agent parity probes exist, but this slice records `sdk-direct` execution evidence only unless separately run
+
+## Local Setup
+Build the required KAMN binaries:
+
+```bash
+cargo build -p kamn-node -p kamn-e2e-harness
+```
+
+Build local Kolme once:
+
+```bash
+git clone https://github.com/fpco/kolme /tmp/kolme
+cd /tmp/kolme
+RUSTFLAGS="-C link-arg=-fuse-ld=bfd" cargo build --release -p example-p2p
+```
+
+Start Kolme API:
+
+```bash
+/tmp/kolme/target/release/example-p2p api-server --bind 127.0.0.1:3000
+```
+
+Start three local KAMN nodes in separate shells:
+
+```bash
+target/debug/kamn-node \
+  --runtime-mode api \
+  --role processor \
+  --api-bind 127.0.0.1:8080 \
+  --api-max-requests 1000 \
+  --api-idle-timeout-ms 600000 \
+  --storage-dir /tmp/kamn-node-live-processor
+```
+
+```bash
+target/debug/kamn-node \
+  --runtime-mode api \
+  --role listener \
+  --api-bind 127.0.0.1:8081 \
+  --api-max-requests 1000 \
+  --api-idle-timeout-ms 600000 \
+  --storage-dir /tmp/kamn-node-live-listener
+```
+
+```bash
+target/debug/kamn-node \
+  --runtime-mode api \
+  --role approver \
+  --api-bind 127.0.0.1:8082 \
+  --api-max-requests 1000 \
+  --api-idle-timeout-ms 600000 \
+  --storage-dir /tmp/kamn-node-live-approver
+```
+
+## Operator Commands
+Enable the live `sdk-direct` lane and run S-05 only:
+
+```bash
+export KAMN_E2E_SDK_DIRECT_LIVE=true
+export KAMN_ENDPOINT=http://127.0.0.1:8080
+export KAMN_KOLME_ENDPOINT=http://127.0.0.1:3000
+export KAMN_E2E_EXTERNAL_KAMN_PROCESSOR_BINARY=/home/n/Code/kamn/target/debug/kamn-node
+export KAMN_E2E_EXTERNAL_KAMN_LISTENER_BINARY=/home/n/Code/kamn/target/debug/kamn-node
+export KAMN_E2E_EXTERNAL_KAMN_APPROVER_BINARY=/home/n/Code/kamn/target/debug/kamn-node
+
+target/debug/kamn-e2e-harness run \
+  --mode sdk-direct \
+  --kolme-binary /tmp/kolme/target/release/example-p2p \
+  --enable-external-execution \
+  --evidence-dir /tmp/kamn-e2e-live-s05-evidence \
+  --scenarios S-05 > /tmp/kamn-e2e-live-s05-run.json
+```
+
+Verify the generated evidence:
+
+```bash
+target/debug/kamn-e2e-harness verify \
+  --evidence-dir /tmp/kamn-e2e-live-s05-evidence \
+  --kolme-chain-dump /tmp/kamn-e2e-live-s05-evidence/kolme_chain_dump.json \
+  --output /tmp/kamn-e2e-live-s05-verify-report.json > /tmp/kamn-e2e-live-s05-verify.json
+```
+
+## Expected Evidence
+- run output records exactly one selected scenario: `S-05`
+- S-05 status is `PASS`
+- evidence bundle contains the scenario-declared artifacts:
+  - `evidence/s05/escrow_lifecycle_trace.json`
+  - `evidence/s05/settlement_breakdown.json`
+  - `evidence/s05/dispute_resolution.json`
+  - `evidence/s05/kolme_escrow_anchors.json`
+- verify output completes without fail-closed evidence errors
+
+## Notes
+- live escrow settlement slice: `docs/validation/live-escrow-settlement-slice.md`
+- This slice is intentionally bounded to external-execution `sdk-direct` S-05 on current `main`.
+- It does not prove Solana-backed settlement, bridge settlement, or external-chain settlement.

--- a/specs/6995-live-escrow-settlement-slice.md
+++ b/specs/6995-live-escrow-settlement-slice.md
@@ -1,7 +1,7 @@
 # 6995-live-escrow-settlement-slice
 
 ## Objective
-Prove one bounded live escrow settlement slice on current `main` by executing the existing `kamn-e2e-harness` S-05 escrow-settlement scenario in real external-execution `sdk-direct` mode against a local Kolme runtime and three local KAMN API nodes. Publish one operator-facing validation runbook and one hard-fail docs contract that capture the exact commands and the exact limits of the claim.
+Prove one bounded live escrow settlement slice on current `main` by executing the existing `kamn-e2e-harness` S-05 escrow-settlement probe through a real local-heavy `sdk-direct` integration test against a local Kolme runtime and three local KAMN API nodes. Publish one operator-facing validation runbook and one hard-fail docs contract that capture the exact commands and the exact limits of the claim.
 
 ## Inputs/Outputs
 ### Inputs
@@ -10,15 +10,16 @@ Prove one bounded live escrow settlement slice on current `main` by executing th
   - `target/debug/kamn-e2e-harness`
 - Upstream Kolme `example-p2p` binary built locally
 - Local loopback runtime endpoints:
-  - Kolme API on `127.0.0.1:3000`
-  - KAMN processor API on `127.0.0.1:8080`
-  - KAMN listener API on `127.0.0.1:8081`
-  - KAMN approver API on `127.0.0.1:8082`
+  - Kolme API on `127.0.0.1:13000`
+  - KAMN processor API on `127.0.0.1:18080`
+  - KAMN listener API on `127.0.0.1:18081`
+  - KAMN approver API on `127.0.0.1:18082`
 - External-execution live env toggles for `sdk-direct`
 
 ### Outputs
 - Validation runbook: `docs/validation/live-escrow-settlement-slice.md`
 - Hard-fail docs contract: `crates/kamn-node/tests/live_escrow_settlement_slice_contract.rs`
+- Explicit local-heavy integration proof: `crates/kamn-e2e-harness/tests/live_s05_sdk_direct_external_execution.rs`
 - Runtime proof index update: `docs/validation/current-proven-runtime-slices.md`
 - Review-surface wiring if needed: `docs/review/corrected-audit-response-2026-03-14.md`
 - Final spec evidence in this file
@@ -29,6 +30,7 @@ Prove one bounded live escrow settlement slice on current `main` by executing th
 - Do not claim Byzantine-safe or adversarial economic settlement.
 - Do not add new drivers, shell lanes, or CI/workflow changes.
 - Do not represent non-external-execution harness `run` output as live proof.
+- Do not represent the harness external-execution orchestration shell alone as the live settlement proof; the explicit local-heavy integration test is the proof anchor.
 - Do not claim CLI-scripted or MCP-agent proof completion in this issue unless they are actually executed.
 
 ## Failure modes
@@ -36,6 +38,7 @@ Prove one bounded live escrow settlement slice on current `main` by executing th
 - Missing or invalid external KAMN node binary env fails the live run.
 - Missing live env toggle for `sdk-direct` causes the scenario execution to fail instead of silently passing.
 - Missing or unhealthy local endpoints fail the live run.
+- The explicit local-heavy integration test fails against the running local runtime.
 - `verify` fails if evidence markers or chain dump are missing.
 - The runbook overstates the proof as Solana-backed, bridge-backed, or external-chain settlement.
 - The proof index omits the new slice.
@@ -43,11 +46,13 @@ Prove one bounded live escrow settlement slice on current `main` by executing th
 ## Acceptance criteria (testable booleans)
 - [ ] `docs/validation/live-escrow-settlement-slice.md` exists.
 - [ ] The runbook states that the proof is anchored to external-execution `sdk-direct` S-05 on current `main`.
+- [ ] The runbook names the explicit local-heavy integration test command as the proof anchor.
 - [ ] The runbook includes the exact `run` command with `--enable-external-execution` and `--scenarios S-05`.
 - [ ] The runbook includes the exact `verify` command against the generated evidence directory.
 - [ ] The runbook names bounded evidence markers for S-05 task/escrow settlement execution.
 - [ ] The runbook states explicitly that it does not prove Solana-backed settlement, bridge settlement, or external-chain settlement.
 - [ ] `crates/kamn-node/tests/live_escrow_settlement_slice_contract.rs` fails red before the runbook exists and passes green after wiring.
+- [ ] `crates/kamn-e2e-harness/tests/live_s05_sdk_direct_external_execution.rs` executes `S-05` against the running local runtime when invoked explicitly with `--ignored`.
 - [ ] `docs/validation/current-proven-runtime-slices.md` links the new runbook.
 - [ ] The spec records exact local evidence commands and whether the executed proof was limited to `sdk-direct` only.
 
@@ -57,10 +62,12 @@ Prove one bounded live escrow settlement slice on current `main` by executing th
 - `docs/validation/current-proven-runtime-slices.md`
 - `docs/review/corrected-audit-response-2026-03-14.md`
 - `crates/kamn-node/tests/live_escrow_settlement_slice_contract.rs`
+- `crates/kamn-e2e-harness/tests/live_s05_sdk_direct_external_execution.rs`
 
 ## Error semantics
 - The docs contract fails hard if the runbook or index wiring is missing.
 - The runbook must distinguish real external-execution proof from contract-only harness execution.
+- The explicit local-heavy integration test must fail loud on missing live env or unavailable local runtime.
 - Operator commands in the runbook must fail loudly on missing binaries, env, or evidence files.
 - No silent fallback from live external-execution to contract-only execution is allowed in the proof claim.
 
@@ -77,10 +84,34 @@ Prove one bounded live escrow settlement slice on current `main` by executing th
    - build `kamn-node` and `kamn-e2e-harness`
    - build local Kolme `example-p2p`
    - start Kolme and three KAMN nodes on loopback
-   - run:
+   - run the explicit local-heavy proof:
+     - `cargo test -p kamn-e2e-harness --test live_s05_sdk_direct_external_execution integration_live_s05_sdk_direct_escrow_settlement_probe_against_local_runtime -- --ignored --exact --nocapture`
+   - record the surrounding external-execution contract output:
      - `target/debug/kamn-e2e-harness run --mode sdk-direct --kolme-binary /tmp/kolme/target/release/example-p2p --enable-external-execution --evidence-dir /tmp/kamn-e2e-live-s05-evidence --scenarios S-05`
-   - verify:
+   - verify the generated evidence contract output:
      - `target/debug/kamn-e2e-harness verify --evidence-dir /tmp/kamn-e2e-live-s05-evidence --kolme-chain-dump /tmp/kamn-e2e-live-s05-evidence/kolme_chain_dump.json --output /tmp/kamn-e2e-live-s05-verify-report.json`
 4. Final checks:
    - `cargo test -p kamn-node --test live_escrow_settlement_slice_contract -- --nocapture`
+   - `cargo test -p kamn-e2e-harness --test live_s05_sdk_direct_external_execution integration_live_s05_sdk_direct_escrow_settlement_probe_against_local_runtime -- --ignored --exact --nocapture`
    - `python3 scripts/ci/check_touched_rust_size_policy.py --repo-root /home/n/Code/kamn --base-ref origin/main --output-json /tmp/6995-touched-size.json`
+
+## Deviations / Final evidence
+- The initial plan treated the external-execution harness `run` surface as the likely proof anchor. The actual runtime work showed that `run` still records scaffolded orchestration/evidence sections even when scenario execution is real.
+- To keep the claim honest, the explicit proof anchor became `crates/kamn-e2e-harness/tests/live_s05_sdk_direct_external_execution.rs`, which calls the real `sdk-direct` S-05 probe against the running local runtime.
+- The proof executed only `sdk-direct`; CLI-scripted and MCP-agent parity remain out of scope for this issue.
+- Exact executed commands:
+  - `cargo build -q -p kamn-node -p kamn-e2e-harness`
+  - `git clone https://github.com/fpco/kolme /tmp/kolme` (if absent)
+  - `cd /tmp/kolme && RUSTFLAGS='-C link-arg=-fuse-ld=bfd' cargo build --release -p example-p2p`
+  - `/tmp/kolme/target/release/example-p2p api-server --bind 127.0.0.1:13000`
+  - `KAMN_SERVICE_API_TLS_MODE=disabled target/debug/kamn-node --runtime-mode api --role processor --api-bind 127.0.0.1:18080 --api-max-requests 1000 --api-idle-timeout-ms 600000 --storage-dir /tmp/kamn-node-live-processor-6995`
+  - `KAMN_SERVICE_API_TLS_MODE=disabled target/debug/kamn-node --runtime-mode api --role listener --api-bind 127.0.0.1:18081 --api-max-requests 1000 --api-idle-timeout-ms 600000 --storage-dir /tmp/kamn-node-live-listener-6995`
+  - `KAMN_SERVICE_API_TLS_MODE=disabled target/debug/kamn-node --runtime-mode api --role approver --api-bind 127.0.0.1:18082 --api-max-requests 1000 --api-idle-timeout-ms 600000 --storage-dir /tmp/kamn-node-live-approver-6995`
+  - `KAMN_E2E_SDK_DIRECT_LIVE=true KAMN_ENDPOINT=http://127.0.0.1:18080 KAMN_KOLME_ENDPOINT=http://127.0.0.1:13000 KAMN_AGENT_NAME=kamn-live-s05-proof cargo test -p kamn-e2e-harness --test live_s05_sdk_direct_external_execution integration_live_s05_sdk_direct_escrow_settlement_probe_against_local_runtime -- --ignored --exact --nocapture`
+  - `KAMN_E2E_SDK_DIRECT_LIVE=true KAMN_ENDPOINT=http://127.0.0.1:18080 KAMN_KOLME_ENDPOINT=http://127.0.0.1:13000 KAMN_E2E_EXTERNAL_KAMN_PROCESSOR_BINARY=/home/n/Code/kamn/target/debug/kamn-node KAMN_E2E_EXTERNAL_KAMN_LISTENER_BINARY=/home/n/Code/kamn/target/debug/kamn-node KAMN_E2E_EXTERNAL_KAMN_APPROVER_BINARY=/home/n/Code/kamn/target/debug/kamn-node target/debug/kamn-e2e-harness run --mode sdk-direct --kolme-binary /tmp/kolme/target/release/example-p2p --enable-external-execution --evidence-dir /tmp/kamn-e2e-live-s05-evidence --scenarios S-05 > /tmp/kamn-e2e-live-s05-run.json`
+  - `target/debug/kamn-e2e-harness verify --evidence-dir /tmp/kamn-e2e-live-s05-evidence --kolme-chain-dump /tmp/kamn-e2e-live-s05-evidence/kolme_chain_dump.json --output /tmp/kamn-e2e-live-s05-verify-report.json > /tmp/kamn-e2e-live-s05-verify.json`
+- Results:
+  - explicit live `sdk-direct` S-05 integration test: `PASS`
+  - harness external-execution `run` command: `PASS` with `scenario_results=[{\"id\":\"S-05\",\"status\":\"PASS\"}]`
+  - harness `verify` command: `schema_check=PASS`, `proof_check=PASS`, `chain_check=PASS`, `content_check=PASS`
+  - touched-Rust: `policy_decision=GO`

--- a/specs/6995-live-escrow-settlement-slice.md
+++ b/specs/6995-live-escrow-settlement-slice.md
@@ -1,0 +1,86 @@
+# 6995-live-escrow-settlement-slice
+
+## Objective
+Prove one bounded live escrow settlement slice on current `main` by executing the existing `kamn-e2e-harness` S-05 escrow-settlement scenario in real external-execution `sdk-direct` mode against a local Kolme runtime and three local KAMN API nodes. Publish one operator-facing validation runbook and one hard-fail docs contract that capture the exact commands and the exact limits of the claim.
+
+## Inputs/Outputs
+### Inputs
+- Current `main` binaries for:
+  - `target/debug/kamn-node`
+  - `target/debug/kamn-e2e-harness`
+- Upstream Kolme `example-p2p` binary built locally
+- Local loopback runtime endpoints:
+  - Kolme API on `127.0.0.1:3000`
+  - KAMN processor API on `127.0.0.1:8080`
+  - KAMN listener API on `127.0.0.1:8081`
+  - KAMN approver API on `127.0.0.1:8082`
+- External-execution live env toggles for `sdk-direct`
+
+### Outputs
+- Validation runbook: `docs/validation/live-escrow-settlement-slice.md`
+- Hard-fail docs contract: `crates/kamn-node/tests/live_escrow_settlement_slice_contract.rs`
+- Runtime proof index update: `docs/validation/current-proven-runtime-slices.md`
+- Review-surface wiring if needed: `docs/review/corrected-audit-response-2026-03-14.md`
+- Final spec evidence in this file
+
+## Boundaries/Non-goals
+- Do not claim Solana-backed settlement.
+- Do not claim bridge settlement, bridge finality, or external chain settlement.
+- Do not claim Byzantine-safe or adversarial economic settlement.
+- Do not add new drivers, shell lanes, or CI/workflow changes.
+- Do not represent non-external-execution harness `run` output as live proof.
+- Do not claim CLI-scripted or MCP-agent proof completion in this issue unless they are actually executed.
+
+## Failure modes
+- Missing or invalid Kolme binary path fails the live run.
+- Missing or invalid external KAMN node binary env fails the live run.
+- Missing live env toggle for `sdk-direct` causes the scenario execution to fail instead of silently passing.
+- Missing or unhealthy local endpoints fail the live run.
+- `verify` fails if evidence markers or chain dump are missing.
+- The runbook overstates the proof as Solana-backed, bridge-backed, or external-chain settlement.
+- The proof index omits the new slice.
+
+## Acceptance criteria (testable booleans)
+- [ ] `docs/validation/live-escrow-settlement-slice.md` exists.
+- [ ] The runbook states that the proof is anchored to external-execution `sdk-direct` S-05 on current `main`.
+- [ ] The runbook includes the exact `run` command with `--enable-external-execution` and `--scenarios S-05`.
+- [ ] The runbook includes the exact `verify` command against the generated evidence directory.
+- [ ] The runbook names bounded evidence markers for S-05 task/escrow settlement execution.
+- [ ] The runbook states explicitly that it does not prove Solana-backed settlement, bridge settlement, or external-chain settlement.
+- [ ] `crates/kamn-node/tests/live_escrow_settlement_slice_contract.rs` fails red before the runbook exists and passes green after wiring.
+- [ ] `docs/validation/current-proven-runtime-slices.md` links the new runbook.
+- [ ] The spec records exact local evidence commands and whether the executed proof was limited to `sdk-direct` only.
+
+## Files to touch
+- `specs/6995-live-escrow-settlement-slice.md`
+- `docs/validation/live-escrow-settlement-slice.md`
+- `docs/validation/current-proven-runtime-slices.md`
+- `docs/review/corrected-audit-response-2026-03-14.md`
+- `crates/kamn-node/tests/live_escrow_settlement_slice_contract.rs`
+
+## Error semantics
+- The docs contract fails hard if the runbook or index wiring is missing.
+- The runbook must distinguish real external-execution proof from contract-only harness execution.
+- Operator commands in the runbook must fail loudly on missing binaries, env, or evidence files.
+- No silent fallback from live external-execution to contract-only execution is allowed in the proof claim.
+
+## Test plan
+1. Phase 3 red test:
+   - add `crates/kamn-node/tests/live_escrow_settlement_slice_contract.rs`
+   - require the new runbook path, the external-execution `sdk-direct` markers, the bounded non-goal markers, and proof-index presence
+   - verify the test fails before the runbook exists
+2. Green/docs wiring:
+   - publish `docs/validation/live-escrow-settlement-slice.md`
+   - add the slice to `docs/validation/current-proven-runtime-slices.md`
+   - wire the corrected audit response if needed
+3. Runtime evidence:
+   - build `kamn-node` and `kamn-e2e-harness`
+   - build local Kolme `example-p2p`
+   - start Kolme and three KAMN nodes on loopback
+   - run:
+     - `target/debug/kamn-e2e-harness run --mode sdk-direct --kolme-binary /tmp/kolme/target/release/example-p2p --enable-external-execution --evidence-dir /tmp/kamn-e2e-live-s05-evidence --scenarios S-05`
+   - verify:
+     - `target/debug/kamn-e2e-harness verify --evidence-dir /tmp/kamn-e2e-live-s05-evidence --kolme-chain-dump /tmp/kamn-e2e-live-s05-evidence/kolme_chain_dump.json --output /tmp/kamn-e2e-live-s05-verify-report.json`
+4. Final checks:
+   - `cargo test -p kamn-node --test live_escrow_settlement_slice_contract -- --nocapture`
+   - `python3 scripts/ci/check_touched_rust_size_policy.py --repo-root /home/n/Code/kamn --base-ref origin/main --output-json /tmp/6995-touched-size.json`


### PR DESCRIPTION
Closes #6995

Spec: [specs/6995-live-escrow-settlement-slice.md](https://github.com/njfio/kamn/blob/6995-live-escrow-settlement-slice/specs/6995-live-escrow-settlement-slice.md)

What changed
- added `docs/validation/live-escrow-settlement-slice.md`
- added `crates/kamn-node/tests/live_escrow_settlement_slice_contract.rs`
- added `crates/kamn-e2e-harness/tests/live_s05_sdk_direct_external_execution.rs`
- updated `docs/validation/current-proven-runtime-slices.md`
- updated `docs/review/corrected-audit-response-2026-03-14.md`
- recorded exact deviations and live evidence in the spec

Why
- current `main` already had a real `sdk-direct` S-05 probe surface, but no operator-facing proof for it
- the harness `run` surface alone still records scaffolded orchestration details, so this PR anchors the proof to an explicit local-heavy integration test and keeps the claim bounded

Test evidence
- `cargo test -p kamn-node --test live_escrow_settlement_slice_contract -- --nocapture`
- `cargo test -p kamn-e2e-harness --test live_s05_sdk_direct_external_execution integration_live_s05_sdk_direct_escrow_settlement_probe_against_local_runtime -- --ignored --exact --nocapture`
- `target/debug/kamn-e2e-harness verify --evidence-dir /tmp/kamn-e2e-live-s05-evidence --kolme-chain-dump /tmp/kamn-e2e-live-s05-evidence/kolme_chain_dump.json --output /tmp/kamn-e2e-live-s05-verify-report.json`
- `python3 scripts/ci/check_touched_rust_size_policy.py --repo-root /home/n/Code/kamn --base-ref origin/main --output-json /tmp/6995-touched-size-final.json`
