### PR TITLE
[7001] Prove bounded live task-lifecycle slice on main

### DIFF
--- a/crates/kamn-e2e-harness/tests/live_s04_sdk_direct_execution.rs
+++ b/crates/kamn-e2e-harness/tests/live_s04_sdk_direct_execution.rs
@@ -1,0 +1,40 @@
+use kamn_e2e_harness::drivers::sdk_direct::SdkDirectDriver;
+use kamn_e2e_harness::drivers::HarnessDriver;
+
+const REQUIRED_ENV_KEYS: &[&str] = &[
+    "KAMN_E2E_SDK_DIRECT_LIVE",
+    "KAMN_ENDPOINT",
+    "KAMN_KOLME_ENDPOINT",
+    "KAMN_AGENT_NAME",
+];
+
+#[test]
+#[ignore = "requires local Kolme + KAMN runtime with explicit live env"]
+fn integration_live_s04_sdk_direct_task_lifecycle_probe_against_local_runtime() {
+    require_envs(REQUIRED_ENV_KEYS);
+
+    let driver = SdkDirectDriver::from_env();
+    let result = driver.execute("S-04");
+
+    assert_eq!(result.scenario_id, "S-04");
+    assert_eq!(
+        result.status, "pass",
+        "live sdk-direct S-04 failed: {:?}",
+        result.detail
+    );
+}
+
+fn require_envs(keys: &[&str]) {
+    for key in keys {
+        require_env(key);
+    }
+}
+
+fn require_env(key: &str) {
+    let value = std::env::var(key)
+        .unwrap_or_else(|_| panic!("required env missing for live S-04 probe: {key}"));
+    assert!(
+        !value.trim().is_empty(),
+        "required env must not be empty for live S-04 probe: {key}"
+    );
+}

--- a/crates/kamn-node/tests/live_task_lifecycle_slice_contract.rs
+++ b/crates/kamn-node/tests/live_task_lifecycle_slice_contract.rs
@@ -1,0 +1,57 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const DOC_PATH: &str = "docs/validation/live-task-lifecycle-slice.md";
+const INDEX_PATH: &str = "docs/validation/current-proven-runtime-slices.md";
+const SLICE_LABEL: &str = "live task-lifecycle slice: `docs/validation/live-task-lifecycle-slice.md`";
+const REQUIRED_DOC_MARKERS: &[&str] = &[
+    "sdk-direct` S-04",
+    "live_s04_sdk_direct_execution",
+    "integration_live_s04_sdk_direct_task_lifecycle_probe_against_local_runtime",
+    "KAMN_E2E_SDK_DIRECT_LIVE",
+    "KAMN_ENDPOINT",
+    "KAMN_KOLME_ENDPOINT",
+    "KAMN_AGENT_NAME",
+    "-- --ignored --exact --nocapture",
+    "does not prove crash recovery",
+    "does not prove Solana-backed settlement",
+    "does not prove bridge settlement",
+    "does not prove production readiness",
+    SLICE_LABEL,
+];
+const REQUIRED_INDEX_MARKERS: &[&str] = &[
+    SLICE_LABEL,
+    "proves one bounded live task-lifecycle execution lane through `sdk-direct` S-04",
+];
+
+#[test]
+fn live_task_lifecycle_doc_exists_and_stays_bounded() {
+    let doc = read_workspace_file(DOC_PATH);
+    assert_contains_all(doc.as_str(), REQUIRED_DOC_MARKERS, "live task lifecycle doc");
+}
+
+#[test]
+fn runtime_proof_index_includes_live_task_lifecycle_slice() {
+    let index = read_workspace_file(INDEX_PATH);
+    assert_contains_all(index.as_str(), REQUIRED_INDEX_MARKERS, "runtime proof index");
+}
+
+fn assert_contains_all(doc: &str, markers: &[&str], label: &str) {
+    for marker in markers {
+        assert!(doc.contains(marker), "{label} missing marker: {marker}");
+    }
+}
+
+fn read_workspace_file(relative_path: &str) -> String {
+    let path = workspace_root().join(relative_path);
+    assert!(path.exists(), "expected path to exist: {}", path.display());
+    fs::read_to_string(&path)
+        .unwrap_or_else(|error| panic!("failed to read {}: {}", path.display(), error))
+}
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("workspace root should resolve")
+}

--- a/docs/validation/current-proven-runtime-slices.md
+++ b/docs/validation/current-proven-runtime-slices.md
@@ -11,6 +11,8 @@ This index summarizes the runtime behavior that current `main` proves today thro
   - proves durable sender spool enqueue, fail-closed pending spool preservation, later successful relay projection, and recipient-visible delivered state across fresh boot
 - restart persistence slice: `docs/validation/restart-persistence-slice.md`
   - proves restart persistence across message state, task and escrow state, directory state, and relayed or delivered status continuity
+- live task-lifecycle slice: `docs/validation/live-task-lifecycle-slice.md`
+  - proves one bounded live task-lifecycle execution lane through `sdk-direct` S-04
 - escrow settlement slice: `docs/validation/escrow-settlement-slice.md`
   - proves service-api escrow lifecycle persistence through fund, release, and restart-visible released state
 - bridge finality slice: `docs/validation/bridge-finality-slice.md`

--- a/docs/validation/live-task-lifecycle-slice.md
+++ b/docs/validation/live-task-lifecycle-slice.md
@@ -60,8 +60,8 @@ KAMN_SERVICE_API_TLS_MODE=disabled target/debug/kamn-node \
   --storage-dir /tmp/kamn-node-live-s04
 ```
 
-## Operator Commands
-Export the live `sdk-direct` env:
+## Required Environment
+Export the live `sdk-direct` env before running the proof:
 
 ```bash
 export KAMN_E2E_SDK_DIRECT_LIVE=true
@@ -70,6 +70,7 @@ export KAMN_KOLME_ENDPOINT=http://127.0.0.1:13100
 export KAMN_AGENT_NAME=kamn-live-s04-proof
 ```
 
+## Proof Command
 Run the explicit ignored proof test:
 
 ```bash

--- a/docs/validation/live-task-lifecycle-slice.md
+++ b/docs/validation/live-task-lifecycle-slice.md
@@ -1,0 +1,91 @@
+# Live Task Lifecycle Slice
+
+This runbook documents one bounded live task-lifecycle slice on current `main`. It is anchored to the checked-in `sdk-direct` S-04 probe in `kamn-e2e-harness`. It proves one local-heavy `sdk-direct` S-04 execution lane against a running local Kolme runtime and local KAMN API runtime. It does not prove crash recovery, Solana-backed settlement, bridge settlement, or production readiness.
+
+## Scope
+- one real local-heavy `sdk-direct` S-04 probe on current `main`
+- local Kolme plus local KAMN API runtime on loopback
+- one bounded task-lifecycle lane: create task, fund escrow, accept task, complete task, release escrow
+
+## Proof Anchors
+- `crates/kamn-e2e-harness/src/scenarios/s04_task.rs`
+- `crates/kamn-e2e-harness/src/drivers/sdk_direct/live_probe_tranche_one/channel_task_probes.rs`
+- `crates/kamn-e2e-harness/tests/live_s04_sdk_direct_execution.rs`
+- `docs/validation/working-vertical-slice.md`
+
+## What This Proves
+- the checked-in `sdk-direct` driver can execute S-04 task lifecycle on current `main`
+- the proof is exercised through the explicit ignored integration test `integration_live_s04_sdk_direct_task_lifecycle_probe_against_local_runtime`
+- the live lane creates a real task, funds one real escrow, advances the task through accept and complete, and releases the escrow
+- current `main` has one operator-comprehensible live task-lifecycle slice beyond the earlier service-api vertical slice
+
+## What This Does Not Prove
+- does not prove crash recovery
+- does not prove Solana-backed settlement
+- does not prove bridge settlement
+- does not prove production readiness
+- does not prove external-chain settlement
+- does not prove MCP or CLI parity
+
+## Local Setup
+Build the required binaries:
+
+```bash
+cargo build -p kamn-node -p kamn-e2e-harness
+```
+
+Build local Kolme once:
+
+```bash
+git clone https://github.com/fpco/kolme /tmp/kolme
+cd /tmp/kolme
+RUSTFLAGS="-C link-arg=-fuse-ld=bfd" cargo build --release -p example-p2p
+```
+
+Start Kolme API:
+
+```bash
+/tmp/kolme/target/release/example-p2p api-server --bind 127.0.0.1:13100
+```
+
+Start one local KAMN API node:
+
+```bash
+KAMN_SERVICE_API_TLS_MODE=disabled target/debug/kamn-node \
+  --runtime-mode api \
+  --role processor \
+  --api-bind 127.0.0.1:18180 \
+  --api-max-requests 1000 \
+  --api-idle-timeout-ms 600000 \
+  --storage-dir /tmp/kamn-node-live-s04
+```
+
+## Operator Commands
+Export the live `sdk-direct` env:
+
+```bash
+export KAMN_E2E_SDK_DIRECT_LIVE=true
+export KAMN_ENDPOINT=http://127.0.0.1:18180
+export KAMN_KOLME_ENDPOINT=http://127.0.0.1:13100
+export KAMN_AGENT_NAME=kamn-live-s04-proof
+```
+
+Run the explicit ignored proof test:
+
+```bash
+cargo test -p kamn-e2e-harness \
+  --test live_s04_sdk_direct_execution \
+  integration_live_s04_sdk_direct_task_lifecycle_probe_against_local_runtime \
+  -- --ignored --exact --nocapture
+```
+
+## Expected Evidence
+- the ignored proof test passes for `S-04`
+- the live `sdk-direct` driver executes create-task, fund-escrow, accept-task, complete-task, and release-escrow
+- task and escrow identifiers are non-empty through the checked-in probe validators
+- state-bearing responses remain non-empty through the checked-in probe validators
+
+## Notes
+- live task-lifecycle slice: `docs/validation/live-task-lifecycle-slice.md`
+- The proof anchor is the explicit ignored integration test, not the harness scaffold alone.
+- This slice is intentionally bounded to one local-heavy `sdk-direct` S-04 lane on current `main`.

--- a/specs/7001-live-task-lifecycle-slice.md
+++ b/specs/7001-live-task-lifecycle-slice.md
@@ -1,0 +1,75 @@
+# 7001 Live Task Lifecycle Slice
+
+## Objective
+Prove one bounded live task-lifecycle slice on current `main` by executing the existing `kamn-e2e-harness` `sdk-direct` S-04 task-lifecycle probe against a real local Kolme runtime and local KAMN API runtime. Publish one operator-facing validation runbook and one hard-fail docs contract that capture the exact command, exact env, and exact limits of the claim.
+
+## Inputs/Outputs
+- Inputs:
+  - running local KAMN API runtime reachable through `KAMN_ENDPOINT`
+  - running local Kolme API runtime reachable through `KAMN_KOLME_ENDPOINT`
+  - live env gate `KAMN_E2E_SDK_DIRECT_LIVE=true`
+  - live agent name via `KAMN_AGENT_NAME`
+- Outputs:
+  - one passing ignored integration test for `sdk-direct` S-04 task lifecycle
+  - one validation runbook under `docs/validation/`
+  - one hard-fail docs contract under `crates/kamn-node/tests/`
+  - one runtime-proof index entry linking the new runbook
+
+## Boundaries/Non-goals
+- Do not claim MCP or CLI parity in this issue.
+- Do not claim crash recovery.
+- Do not claim Solana-backed settlement or bridge settlement.
+- Do not add a new harness scenario or new runtime mode.
+- Do not weaken the existing service-api vertical slice proof.
+
+## Failure Modes
+- required live env vars are missing or empty
+- local KAMN API endpoint is unavailable
+- local Kolme runtime is unavailable
+- create-task response is missing `task_id`
+- fund-escrow response is missing `escrow_id`
+- accept-task or complete-task response is missing `state`
+- release-escrow response is missing `state`
+- runbook overstates the proof beyond one bounded local-heavy `sdk-direct` S-04 lane
+- runtime-proof index omits the new slice
+
+## Acceptance Criteria (testable booleans)
+- [ ] `crates/kamn-e2e-harness/tests/live_s04_sdk_direct_execution.rs` exists and executes the real `sdk-direct` S-04 probe when invoked explicitly with `--ignored`.
+- [ ] `cargo test -p kamn-node --test live_task_lifecycle_slice_contract -- --nocapture` passes.
+- [ ] `docs/validation/live-task-lifecycle-slice.md` exists and states the proof is bounded to one local-heavy `sdk-direct` S-04 lane on current `main`.
+- [ ] The runbook contains the exact ignored test command and required live env names, including `KAMN_E2E_SDK_DIRECT_LIVE`, `KAMN_ENDPOINT`, `KAMN_KOLME_ENDPOINT`, and `KAMN_AGENT_NAME`.
+- [ ] The runbook explicitly states that the slice does not prove crash recovery, Solana-backed settlement, bridge settlement, or production readiness.
+- [ ] `docs/validation/current-proven-runtime-slices.md` links the new runbook.
+
+## Files to Touch
+- `specs/7001-live-task-lifecycle-slice.md`
+- `docs/validation/live-task-lifecycle-slice.md`
+- `docs/validation/current-proven-runtime-slices.md`
+- `crates/kamn-node/tests/live_task_lifecycle_slice_contract.rs`
+- `crates/kamn-e2e-harness/tests/live_s04_sdk_direct_execution.rs`
+- optionally `docs/review/corrected-audit-response-2026-03-14.md` if the proof index wording needs to mention the new slice
+
+## Error Semantics
+- The explicit ignored integration test must fail hard when required live env vars are missing or empty.
+- The explicit ignored integration test must fail hard when live task-lifecycle probe output is missing required identifiers or states.
+- The docs contract must fail hard when the runbook or proof index omits required markers or overstates the claim.
+- No silent fallback from `sdk-direct` live execution to another driver is allowed.
+
+## Test Plan
+1. Red:
+   - add docs contract asserting the new runbook and proof-index markers; confirm it fails because the doc is absent
+2. Green:
+   - publish the runbook
+   - add the ignored integration proof test that invokes `SdkDirectDriver::from_env().execute("S-04")`
+   - wire the runtime-proof index entry
+3. Verification:
+   - `cargo test -p kamn-node --test live_task_lifecycle_slice_contract -- --nocapture`
+   - `cargo test -p kamn-e2e-harness --test live_s04_sdk_direct_execution -- --ignored --exact --nocapture`
+   - `python3 scripts/ci/check_touched_rust_size_policy.py --repo-root /home/n/Code/kamn --base-ref origin/main --output-json /tmp/7001-touched-size.json`
+4. Local live evidence:
+   - build `kamn-node` and `kamn-e2e-harness`
+   - run the ignored `sdk-direct` S-04 proof test against local Kolme and local KAMN API runtime
+
+## Notes
+- The proof anchor is the explicit ignored integration test, not the harness scaffold alone.
+- This issue is intentionally bounded to one `sdk-direct` live task-lifecycle lane.

--- a/specs/7001-live-task-lifecycle-slice.md
+++ b/specs/7001-live-task-lifecycle-slice.md
@@ -73,3 +73,13 @@ Prove one bounded live task-lifecycle slice on current `main` by executing the e
 ## Notes
 - The proof anchor is the explicit ignored integration test, not the harness scaffold alone.
 - This issue is intentionally bounded to one `sdk-direct` live task-lifecycle lane.
+
+## Final Evidence
+- `cargo test -p kamn-node --test live_task_lifecycle_slice_contract -- --nocapture`
+- `cargo test -p kamn-e2e-harness --test live_s04_sdk_direct_execution --no-run`
+- `KAMN_E2E_SDK_DIRECT_LIVE=true KAMN_ENDPOINT=http://127.0.0.1:18180 KAMN_KOLME_ENDPOINT=http://127.0.0.1:13100 KAMN_AGENT_NAME=kamn-live-s04-proof cargo test -p kamn-e2e-harness --test live_s04_sdk_direct_execution integration_live_s04_sdk_direct_task_lifecycle_probe_against_local_runtime -- --ignored --exact --nocapture`
+- `python3 scripts/ci/check_touched_rust_size_policy.py --repo-root /home/n/Code/kamn --base-ref origin/main --output-json /tmp/7001-touched-size.json`
+- touched-Rust result: `policy_decision=GO`
+
+## Deviations
+- None. The proof remained bounded to one local-heavy `sdk-direct` S-04 lane and did not claim MCP or CLI parity.


### PR DESCRIPTION
Closes #7001

Issue: #7001
Spec: specs/7001-live-task-lifecycle-slice.md

What changed:
- published a bounded live task-lifecycle runbook for the checked-in `sdk-direct` S-04 probe
- added runtime-proof index wiring for the new slice
- recorded final live proof evidence in the issue spec

Why:
- current `main` needed one explicit operator-facing proof for a live task lifecycle beyond the earlier service-api vertical slice
- the claim stays bounded to one local-heavy `sdk-direct` S-04 lane and does not claim crash recovery, Solana-backed settlement, bridge settlement, or parity with other drivers

Test evidence:
- `cargo test -p kamn-node --test live_task_lifecycle_slice_contract -- --nocapture`
- `cargo test -p kamn-e2e-harness --test live_s04_sdk_direct_execution --no-run`
- `KAMN_E2E_SDK_DIRECT_LIVE=true KAMN_ENDPOINT=http://127.0.0.1:18180 KAMN_KOLME_ENDPOINT=http://127.0.0.1:13100 KAMN_AGENT_NAME=kamn-live-s04-proof cargo test -p kamn-e2e-harness --test live_s04_sdk_direct_execution integration_live_s04_sdk_direct_task_lifecycle_probe_against_local_runtime -- --ignored --exact --nocapture`
- `python3 scripts/ci/check_touched_rust_size_policy.py --repo-root /home/n/Code/kamn --base-ref origin/main --output-json /tmp/7001-touched-size.json`
- touched-Rust result: `policy_decision=GO`
