### PR TITLE
[7005] Prove CLI parity for bounded live task-lifecycle slice on main

### DIFF
--- a/crates/kamn-e2e-harness/tests/live_s04_cli_scripted_execution.rs
+++ b/crates/kamn-e2e-harness/tests/live_s04_cli_scripted_execution.rs
@@ -1,0 +1,41 @@
+use kamn_e2e_harness::drivers::cli_scripted::CliScriptedDriver;
+use kamn_e2e_harness::drivers::HarnessDriver;
+
+const REQUIRED_ENV_KEYS: &[&str] = &[
+    "KAMN_E2E_CLI_SCRIPTED_LIVE",
+    "KAMN_E2E_CLI_BINARY",
+    "KAMN_ENDPOINT",
+    "KAMN_KOLME_ENDPOINT",
+    "KAMN_AGENT_NAME",
+];
+
+#[test]
+#[ignore = "requires local Kolme + KAMN runtime with explicit live env"]
+fn integration_live_s04_cli_scripted_task_lifecycle_probe_against_local_runtime() {
+    require_envs(REQUIRED_ENV_KEYS);
+
+    let driver = CliScriptedDriver::from_env();
+    let result = driver.execute("S-04");
+
+    assert_eq!(result.scenario_id, "S-04");
+    assert_eq!(
+        result.status, "pass",
+        "live cli-scripted S-04 failed: {:?}",
+        result.detail
+    );
+}
+
+fn require_envs(keys: &[&str]) {
+    for key in keys {
+        require_env(key);
+    }
+}
+
+fn require_env(key: &str) {
+    let value = std::env::var(key)
+        .unwrap_or_else(|_| panic!("required env missing for live CLI S-04 probe: {key}"));
+    assert!(
+        !value.trim().is_empty(),
+        "required env must not be empty for live CLI S-04 probe: {key}"
+    );
+}

--- a/crates/kamn-node/tests/live_task_lifecycle_cli_parity_slice_contract.rs
+++ b/crates/kamn-node/tests/live_task_lifecycle_cli_parity_slice_contract.rs
@@ -1,0 +1,60 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const DOC_PATH: &str = "docs/validation/live-task-lifecycle-cli-parity-slice.md";
+const INDEX_PATH: &str = "docs/validation/current-proven-runtime-slices.md";
+const SLICE_LABEL: &str =
+    "live task-lifecycle CLI parity slice: `docs/validation/live-task-lifecycle-cli-parity-slice.md`";
+const REQUIRED_DOC_MARKERS: &[&str] = &[
+    "CLI-scripted S-04",
+    "live_s04_cli_scripted_execution",
+    "integration_live_s04_cli_scripted_task_lifecycle_probe_against_local_runtime",
+    "KAMN_E2E_CLI_SCRIPTED_LIVE",
+    "KAMN_E2E_CLI_BINARY",
+    "KAMN_ENDPOINT",
+    "KAMN_KOLME_ENDPOINT",
+    "KAMN_AGENT_NAME",
+    "-- --ignored --exact --nocapture",
+    "does not prove crash recovery",
+    "does not prove Solana-backed settlement",
+    "does not prove bridge settlement",
+    "does not prove MCP parity",
+    "does not prove production readiness",
+    SLICE_LABEL,
+];
+const REQUIRED_INDEX_MARKERS: &[&str] = &[
+    SLICE_LABEL,
+    "proves one bounded live task-lifecycle execution lane through CLI-scripted S-04 parity",
+];
+
+#[test]
+fn live_task_lifecycle_cli_parity_doc_exists_and_stays_bounded() {
+    let doc = read_workspace_file(DOC_PATH);
+    assert_contains_all(doc.as_str(), REQUIRED_DOC_MARKERS, "live task-lifecycle cli parity doc");
+}
+
+#[test]
+fn runtime_proof_index_includes_live_task_lifecycle_cli_parity_slice() {
+    let index = read_workspace_file(INDEX_PATH);
+    assert_contains_all(index.as_str(), REQUIRED_INDEX_MARKERS, "runtime proof index");
+}
+
+fn assert_contains_all(doc: &str, markers: &[&str], label: &str) {
+    for marker in markers {
+        assert!(doc.contains(marker), "{label} missing marker: {marker}");
+    }
+}
+
+fn read_workspace_file(relative_path: &str) -> String {
+    let path = workspace_root().join(relative_path);
+    assert!(path.exists(), "expected path to exist: {}", path.display());
+    fs::read_to_string(&path)
+        .unwrap_or_else(|error| panic!("failed to read {}: {}", path.display(), error))
+}
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("workspace root should resolve")
+}

--- a/docs/validation/current-proven-runtime-slices.md
+++ b/docs/validation/current-proven-runtime-slices.md
@@ -15,6 +15,8 @@ This index summarizes the runtime behavior that current `main` proves today thro
   - proves one bounded live task-lifecycle execution lane through `sdk-direct` S-04
 - live task-lifecycle MCP parity slice: `docs/validation/live-task-lifecycle-mcp-parity-slice.md`
   - proves one bounded live task-lifecycle execution lane through MCP-agent S-04 parity
+- live task-lifecycle CLI parity slice: `docs/validation/live-task-lifecycle-cli-parity-slice.md`
+  - proves one bounded live task-lifecycle execution lane through CLI-scripted S-04 parity
 - escrow settlement slice: `docs/validation/escrow-settlement-slice.md`
   - proves service-api escrow lifecycle persistence through fund, release, and restart-visible released state
 - bridge finality slice: `docs/validation/bridge-finality-slice.md`

--- a/docs/validation/live-task-lifecycle-cli-parity-slice.md
+++ b/docs/validation/live-task-lifecycle-cli-parity-slice.md
@@ -1,0 +1,91 @@
+# Live Task-Lifecycle CLI Parity Slice
+
+This runbook documents one bounded CLI-scripted parity slice for live task lifecycle on current `main`. It is anchored to the checked-in CLI-scripted S-04 probe in `kamn-e2e-harness`. It proves one local-heavy CLI execution lane against a running local Kolme runtime and local KAMN API runtime. It does not prove crash recovery, Solana-backed settlement, bridge settlement, MCP parity, or production readiness.
+
+## Scope
+- one real local-heavy CLI-scripted S-04 probe on current `main`
+- local Kolme plus local KAMN API runtime on loopback
+- explicit parity proof against the existing live task-lifecycle slice
+
+## Proof Anchors
+- `crates/kamn-e2e-harness/src/drivers/cli_scripted/live_probe_tranche_one/channel_task_probes/task_lifecycle_probe.rs`
+- `crates/kamn-e2e-harness/tests/live_s04_cli_scripted_execution.rs`
+- `docs/validation/live-task-lifecycle-slice.md`
+
+## What This Proves
+- the checked-in CLI-scripted driver can execute S-04 task lifecycle on current `main`
+- the proof is exercised through the explicit ignored integration test `integration_live_s04_cli_scripted_task_lifecycle_probe_against_local_runtime`
+- current `main` has one operator-comprehensible CLI parity lane for the same bounded live task-lifecycle slice already proven through `sdk-direct`
+
+## What This Does Not Prove
+- does not prove crash recovery
+- does not prove Solana-backed settlement
+- does not prove bridge settlement
+- does not prove MCP parity
+- does not prove production readiness
+- does not prove external-chain settlement
+
+## Local Setup
+Build the required binaries:
+
+```bash
+cargo build -p kamn-node -p kamn-cli -p kamn-e2e-harness
+```
+
+Build local Kolme once:
+
+```bash
+git clone https://github.com/fpco/kolme /tmp/kolme
+cd /tmp/kolme
+RUSTFLAGS="-C link-arg=-fuse-ld=bfd" cargo build --release -p example-p2p
+```
+
+Start Kolme API:
+
+```bash
+/tmp/kolme/target/release/example-p2p api-server --bind 127.0.0.1:13100
+```
+
+Start one local KAMN API node:
+
+```bash
+KAMN_SERVICE_API_TLS_MODE=disabled target/debug/kamn-node \
+  --runtime-mode api \
+  --role processor \
+  --api-bind 127.0.0.1:18180 \
+  --api-max-requests 1000 \
+  --api-idle-timeout-ms 600000 \
+  --storage-dir /tmp/kamn-node-live-cli-s04
+```
+
+## Required Environment
+Export the live CLI parity env before running the proof:
+
+```bash
+export KAMN_E2E_CLI_SCRIPTED_LIVE=true
+export KAMN_E2E_CLI_BINARY=/home/n/Code/kamn/target/debug/kamn-cli
+export KAMN_ENDPOINT=http://127.0.0.1:18180
+export KAMN_KOLME_ENDPOINT=http://127.0.0.1:13100
+export KAMN_AGENT_NAME=kamn-live-cli-s04-proof
+```
+
+## Proof Command
+Run the explicit ignored proof test:
+
+```bash
+cargo test -p kamn-e2e-harness \
+  --test live_s04_cli_scripted_execution \
+  integration_live_s04_cli_scripted_task_lifecycle_probe_against_local_runtime \
+  -- --ignored --exact --nocapture
+```
+
+## Expected Evidence
+- the ignored proof test passes for `S-04`
+- the live CLI driver invokes `create-task`, `fund-escrow`, `accept-task`, `complete-task`, and `release-escrow`
+- CLI output includes non-empty `task_id` and `escrow_id`
+- CLI output returns the `state` values required by the checked-in probe validators
+
+## Notes
+- live task-lifecycle CLI parity slice: `docs/validation/live-task-lifecycle-cli-parity-slice.md`
+- The proof anchor is the explicit ignored integration test, not the harness scaffold alone.
+- This slice is parity-only for the bounded live task-lifecycle lane already proven through `sdk-direct`.

--- a/docs/validation/live-task-lifecycle-cli-parity-slice.md
+++ b/docs/validation/live-task-lifecycle-cli-parity-slice.md
@@ -17,6 +17,10 @@ This runbook documents one bounded CLI-scripted parity slice for live task lifec
 - the proof is exercised through the explicit ignored integration test `integration_live_s04_cli_scripted_task_lifecycle_probe_against_local_runtime`
 - current `main` has one operator-comprehensible CLI parity lane for the same bounded live task-lifecycle slice already proven through `sdk-direct`
 
+## Parity Bound
+- this slice adds CLI parity only
+- it does not widen the underlying S-04 claim beyond the existing bounded local-heavy task-lifecycle lane
+
 ## What This Does Not Prove
 - does not prove crash recovery
 - does not prove Solana-backed settlement

--- a/specs/7005-live-task-lifecycle-cli-parity.md
+++ b/specs/7005-live-task-lifecycle-cli-parity.md
@@ -1,0 +1,79 @@
+# 7005 Live Task-Lifecycle CLI Parity
+
+## Objective
+Prove one bounded CLI-scripted parity slice for the existing live S-04 task-lifecycle lane on current `main`. The proof must be anchored to one explicit local-heavy ignored integration test that executes the checked-in CLI-scripted S-04 live probe against a running local Kolme runtime and local KAMN API runtime. Publish one operator-facing validation runbook and one hard-fail docs contract that capture the exact commands and the exact limits of the claim.
+
+## Inputs/Outputs
+- Inputs:
+  - running local Kolme API runtime reachable through `KAMN_KOLME_ENDPOINT`
+  - running local KAMN API node reachable through `KAMN_ENDPOINT`
+  - built `kamn-cli` binary at a deterministic path via `KAMN_E2E_CLI_BINARY`
+  - live CLI env gate `KAMN_E2E_CLI_SCRIPTED_LIVE=true`
+  - live agent name via `KAMN_AGENT_NAME`
+- Outputs:
+  - one passing ignored integration test for CLI-scripted S-04 parity
+  - one validation runbook under `docs/validation/`
+  - one hard-fail docs contract under `crates/kamn-node/tests/`
+  - updated runtime-proof index entry linking the runbook
+
+## Boundaries/Non-goals
+- Do not claim MCP parity in this issue.
+- Do not claim crash recovery.
+- Do not claim Solana-backed settlement or bridge settlement.
+- Do not add a new harness scenario, new runtime mode, or new CLI surface.
+- Do not weaken or replace the existing `sdk-direct` or MCP-agent live S-04 proofs.
+- Do not rely on the harness `run` scaffold alone as the proof anchor.
+
+## Failure Modes
+- required live env vars are missing or empty
+- `kamn-cli` binary path is missing or not executable
+- local Kolme runtime is unavailable
+- local KAMN API endpoint is unavailable
+- CLI `create-task` output is missing `task_id`
+- CLI `fund-escrow` output is missing `escrow_id` or `state`
+- CLI `accept-task` or `complete-task` output is missing `state`
+- CLI `release-escrow` output is missing `state`
+- runbook overstates the proof beyond CLI parity on local runtime
+- runtime-proof index omits the new runbook
+
+## Acceptance Criteria (testable booleans)
+- [ ] `crates/kamn-e2e-harness/tests/live_s04_cli_scripted_execution.rs` exists and executes the real CLI-scripted S-04 probe when invoked explicitly with `--ignored`.
+- [ ] `cargo test -p kamn-node --test live_task_lifecycle_cli_parity_slice_contract -- --nocapture` passes.
+- [ ] `docs/validation/live-task-lifecycle-cli-parity-slice.md` exists and states the proof is bounded to local-heavy CLI-scripted S-04 parity on current `main`.
+- [ ] The runbook contains the exact ignored test command and required live env names, including `KAMN_E2E_CLI_SCRIPTED_LIVE`, `KAMN_E2E_CLI_BINARY`, `KAMN_ENDPOINT`, `KAMN_KOLME_ENDPOINT`, and `KAMN_AGENT_NAME`.
+- [ ] The runbook explicitly states that the slice does not prove crash recovery, Solana-backed settlement, bridge settlement, MCP parity, or production readiness.
+- [ ] `docs/validation/current-proven-runtime-slices.md` links the CLI parity runbook.
+- [ ] The existing `sdk-direct` and MCP-agent live task-lifecycle proofs remain intact and unchanged in meaning.
+
+## Files to Touch
+- `specs/7005-live-task-lifecycle-cli-parity.md`
+- `docs/validation/live-task-lifecycle-cli-parity-slice.md`
+- `docs/validation/current-proven-runtime-slices.md`
+- `crates/kamn-node/tests/live_task_lifecycle_cli_parity_slice_contract.rs`
+- `crates/kamn-e2e-harness/tests/live_s04_cli_scripted_execution.rs`
+- optionally `docs/review/corrected-audit-response-2026-03-14.md` if the proof-index wording needs to mention the new slice
+
+## Error Semantics
+- The explicit ignored integration test must fail hard when required live env vars are missing or empty.
+- The explicit ignored integration test must fail hard when CLI output omits required fields or returns invalid state.
+- The docs contract must fail hard when the runbook or proof index omits required markers or overstates the claim.
+- No silent fallback from CLI-scripted live execution to another driver is allowed.
+
+## Test Plan
+1. Red:
+   - add docs contract asserting the new runbook and proof-index markers; confirm it fails because the doc is absent
+2. Green:
+   - publish the runbook
+   - add the ignored integration proof test that invokes `CliScriptedDriver::from_env().execute("S-04")`
+   - wire the runtime-proof index entry
+3. Verification:
+   - `cargo test -p kamn-node --test live_task_lifecycle_cli_parity_slice_contract -- --nocapture`
+   - `cargo test -p kamn-e2e-harness --test live_s04_cli_scripted_execution -- --ignored --exact --nocapture`
+   - `python3 scripts/ci/check_touched_rust_size_policy.py --repo-root /home/n/Code/kamn --base-ref origin/main --output-json /tmp/7005-touched-size.json`
+4. Local live evidence:
+   - build `kamn-node`, `kamn-cli`, and `kamn-e2e-harness`
+   - run the ignored CLI-scripted S-04 proof test against local Kolme and KAMN API runtime
+
+## Notes
+- The proof anchor is the explicit ignored integration test, not the harness scaffold alone.
+- This issue is parity-only for the existing bounded local-heavy task-lifecycle slice.

--- a/specs/7005-live-task-lifecycle-cli-parity.md
+++ b/specs/7005-live-task-lifecycle-cli-parity.md
@@ -77,3 +77,14 @@ Prove one bounded CLI-scripted parity slice for the existing live S-04 task-life
 ## Notes
 - The proof anchor is the explicit ignored integration test, not the harness scaffold alone.
 - This issue is parity-only for the existing bounded local-heavy task-lifecycle slice.
+
+## Final Evidence
+- `cargo test -p kamn-node --test live_task_lifecycle_cli_parity_slice_contract -- --nocapture`
+- `cargo test -p kamn-e2e-harness --test live_s04_cli_scripted_execution --no-run`
+- `cargo build -p kamn-node -p kamn-cli -p kamn-e2e-harness`
+- `KAMN_E2E_CLI_SCRIPTED_LIVE=true KAMN_E2E_CLI_BINARY=/home/n/Code/kamn/target/debug/kamn-cli KAMN_ENDPOINT=http://127.0.0.1:18180 KAMN_KOLME_ENDPOINT=http://127.0.0.1:13100 KAMN_AGENT_NAME=kamn-live-cli-s04-proof cargo test -p kamn-e2e-harness --test live_s04_cli_scripted_execution integration_live_s04_cli_scripted_task_lifecycle_probe_against_local_runtime -- --ignored --exact --nocapture`
+- `python3 scripts/ci/check_touched_rust_size_policy.py --repo-root /home/n/Code/kamn --base-ref origin/main --output-json /tmp/7005-touched-size.json`
+- touched-Rust result: `policy_decision=GO`
+
+## Deviations
+- None. The proof remained bounded to CLI parity for the existing local-heavy S-04 task-lifecycle lane and did not claim MCP parity, crash recovery, or external settlement.


### PR DESCRIPTION
Closes #7005

Issue: #7005
Spec: specs/7005-live-task-lifecycle-cli-parity.md

What changed:
- published a bounded CLI-scripted parity runbook for the checked-in S-04 task-lifecycle probe
- added a hard-fail docs contract and explicit ignored CLI S-04 proof test
- wired the runtime-proof index and recorded final live evidence in the issue spec

Why:
- current `main` already proved the bounded `sdk-direct` and MCP-agent S-04 lanes, but CLI-scripted parity for the same runtime behavior was still unproven
- this keeps the claim narrow: one local-heavy CLI-scripted S-04 lane against local Kolme and local KAMN API runtime

Test evidence:
- `cargo test -p kamn-node --test live_task_lifecycle_cli_parity_slice_contract -- --nocapture`
- `cargo test -p kamn-e2e-harness --test live_s04_cli_scripted_execution --no-run`
- `cargo build -p kamn-node -p kamn-cli -p kamn-e2e-harness`
- `KAMN_E2E_CLI_SCRIPTED_LIVE=true KAMN_E2E_CLI_BINARY=/home/n/Code/kamn/target/debug/kamn-cli KAMN_ENDPOINT=http://127.0.0.1:18180 KAMN_KOLME_ENDPOINT=http://127.0.0.1:13100 KAMN_AGENT_NAME=kamn-live-cli-s04-proof cargo test -p kamn-e2e-harness --test live_s04_cli_scripted_execution integration_live_s04_cli_scripted_task_lifecycle_probe_against_local_runtime -- --ignored --exact --nocapture`
- `python3 scripts/ci/check_touched_rust_size_policy.py --repo-root /home/n/Code/kamn --base-ref origin/main --output-json /tmp/7005-touched-size.json`
- touched-Rust result: `policy_decision=GO`
