### PR TITLE
[7009] Implement one honest external-chain-backed settlement lane on main

### DIFF
--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests.rs
@@ -2,5 +2,7 @@
 mod task_escrow_restart_contract_tests;
 #[path = "task_escrow_persistence_contract_tests/task_escrow_routes_contract_tests.rs"]
 mod task_escrow_routes_contract_tests;
+#[path = "task_escrow_persistence_contract_tests/task_escrow_live_settlement_contract_tests.rs"]
+mod task_escrow_live_settlement_contract_tests;
 #[path = "task_escrow_persistence_contract_tests/support.rs"]
 mod support;

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/support.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/support.rs
@@ -7,6 +7,7 @@ mod state_support;
 
 pub(super) use env_support::{
     default_audit_export_file, read_audit_export_json, read_state_json, set_audit_export_file_env,
+    set_live_solana_bridge_rpc_url_env,
 };
 pub(super) use request_support::{
     accept_task, create_task, fund_escrow, query_task, raw_signed_request, register_agent_profile,

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/support/env_support.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/support/env_support.rs
@@ -37,3 +37,7 @@ pub(crate) fn set_audit_export_file_env(path: &Path) -> (String, EnvVarGuard) {
     let guard = EnvVarGuard::set("KAMN_SERVICE_API_AUDIT_EXPORT_FILE", Some(path_text.as_str()));
     (path_text, guard)
 }
+
+pub(crate) fn set_live_solana_bridge_rpc_url_env(value: Option<&str>) -> EnvVarGuard {
+    EnvVarGuard::set("KAMN_SERVICE_API_LIVE_SOLANA_BRIDGE_RPC_URL", value)
+}

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/support/state_support.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/support/state_support.rs
@@ -2,6 +2,8 @@ use super::super::super::*;
 use crate::service_api_endpoint::{ServiceApiEndpointConfig, ServiceApiSnapshot};
 use std::path::{Path, PathBuf};
 
+const TASK_ESCROW_TEST_IDLE_TIMEOUT_MS: u64 = 5_000;
+
 pub(crate) fn build_task_escrow_snapshot(api_bind: &str) -> ServiceApiSnapshot {
     let parsed = parse_args(vec![
         "kamn-node".to_owned(),
@@ -71,7 +73,7 @@ fn spawn_api_server(
     let endpoint_config = ServiceApiEndpointConfig {
         bind_addr: bind_addr.to_owned(),
         max_requests: max_requests as u64,
-        idle_timeout_ms: 2_000,
+        idle_timeout_ms: TASK_ESCROW_TEST_IDLE_TIMEOUT_MS,
         body_limit_bytes: DEFAULT_SERVICE_API_BODY_LIMIT_BYTES,
         concurrency_limit: DEFAULT_SERVICE_API_CONCURRENCY_LIMIT,
         rate_limit_per_second: DEFAULT_SERVICE_API_RATE_LIMIT_PER_SECOND,
@@ -84,6 +86,7 @@ fn assert_api_server_stopped(server: thread::JoinHandle<Result<(), String>>) {
     let server_result = server.join().expect("endpoint thread should complete");
     assert!(
         server_result.is_ok(),
-        "service api endpoint should stop cleanly"
+        "service api endpoint should stop cleanly: {:?}",
+        server_result
     );
 }

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_live_settlement_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_live_settlement_contract_tests.rs
@@ -1,10 +1,11 @@
 use super::super::*;
 use super::support::{
-    build_task_escrow_snapshot, fund_escrow, read_state_json, release_escrow,
+    build_task_escrow_snapshot, fund_escrow, raw_signed_request, read_state_json, release_escrow,
     set_live_solana_bridge_rpc_url_env, set_state_file_env, unique_named_state_file,
 };
 
 const LIVE_SOLANA_DEVNET_RPC_URL: &str = "https://api.devnet.solana.com";
+const UNREACHABLE_SOLANA_RPC_URL: &str = "http://127.0.0.1:1";
 
 #[test]
 fn integration_service_api_endpoint_live_settlement_release_persists_external_receipt_linkage() {
@@ -51,5 +52,43 @@ fn integration_service_api_endpoint_live_settlement_release_persists_external_re
         state_json["escrows"][escrow_id]["settlement_receipt_hash"],
         receipt_hash
     );
+    let _ = fs::remove_file(state_file);
+}
+
+#[test]
+fn integration_service_api_endpoint_live_settlement_release_fails_loud_for_unreachable_rpc() {
+    let _env = acquire_service_api_test_env();
+    let _live_rpc_guard = set_live_solana_bridge_rpc_url_env(Some(UNREACHABLE_SOLANA_RPC_URL));
+    let state_file = unique_named_state_file("kamn-node-live-settlement-error-state");
+    let (_state_file_text, _state_file_guard) = set_state_file_env(state_file.as_path());
+    let caller_did = "kamn:did:agent:test-client-live-settlement-error";
+    let snapshot = build_task_escrow_snapshot("127.0.0.1:34128");
+    let bind_addr = reserve_loopback_addr();
+
+    let funded_escrow = fund_escrow(
+        &snapshot,
+        bind_addr.as_str(),
+        caller_did,
+        91,
+        r#"{"task_id":"live-settlement-task","amount":11}"#,
+    );
+    let escrow_id = funded_escrow["escrow_id"]
+        .as_str()
+        .expect("escrow id should be string");
+    let response = raw_signed_request(
+        &snapshot,
+        bind_addr.as_str(),
+        1,
+        "POST",
+        format!("/v1/escrow/{escrow_id}/release").as_str(),
+        caller_did,
+        92,
+        "",
+        &[],
+    );
+
+    assert!(response.contains("HTTP/1.1 500 Internal Server Error"));
+    assert!(response.contains("service_api_live_settlement_evidence_failed"));
+    assert!(response.contains("service api live settlement evidence failed"));
     let _ = fs::remove_file(state_file);
 }

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_live_settlement_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_live_settlement_contract_tests.rs
@@ -3,6 +3,7 @@ use super::support::{
     build_task_escrow_snapshot, fund_escrow, raw_signed_request, read_state_json, release_escrow,
     set_live_solana_bridge_rpc_url_env, set_state_file_env, unique_named_state_file,
 };
+use crate::service_api_endpoint::ServiceApiSnapshot;
 
 const LIVE_SOLANA_DEVNET_RPC_URL: &str = "https://api.devnet.solana.com";
 const UNREACHABLE_SOLANA_RPC_URL: &str = "http://127.0.0.1:1";
@@ -12,25 +13,113 @@ fn integration_service_api_endpoint_live_settlement_release_persists_external_re
     let _env = acquire_service_api_test_env();
     let _live_rpc_guard =
         set_live_solana_bridge_rpc_url_env(Some(LIVE_SOLANA_DEVNET_RPC_URL));
-    let state_file = unique_named_state_file("kamn-node-live-settlement-state");
-    let (_state_file_text, _state_file_guard) = set_state_file_env(state_file.as_path());
-    let caller_did = "kamn:did:agent:test-client-live-settlement";
-    let first_snapshot = build_task_escrow_snapshot("127.0.0.1:34126");
-    let bind_addr = reserve_loopback_addr();
-
-    let funded_escrow = fund_escrow(
-        &first_snapshot,
-        bind_addr.as_str(),
-        caller_did,
-        81,
-        r#"{"task_id":"live-settlement-task","amount":9}"#,
+    let harness = build_live_settlement_harness(
+        "kamn-node-live-settlement-state",
+        "kamn:did:agent:test-client-live-settlement",
+        "127.0.0.1:34126",
     );
-    let escrow_id = funded_escrow["escrow_id"]
-        .as_str()
-        .expect("escrow id should be string");
-    let released_escrow =
-        release_escrow(&first_snapshot, bind_addr.as_str(), caller_did, 82, escrow_id);
+    let (escrow_id, released_escrow) = fund_and_release_live_escrow(&harness, 81, 82, 9);
+    let receipt_hash = settlement_receipt_hash(&released_escrow);
+    let state_json = read_state_json(harness.state_file.as_path());
 
+    assert_persisted_live_receipt(&state_json, escrow_id.as_str(), receipt_hash.as_str());
+    cleanup_state_file(harness.state_file.as_path());
+}
+
+#[test]
+fn integration_service_api_endpoint_live_settlement_release_fails_loud_for_unreachable_rpc() {
+    let _env = acquire_service_api_test_env();
+    let _live_rpc_guard = set_live_solana_bridge_rpc_url_env(Some(UNREACHABLE_SOLANA_RPC_URL));
+    let harness = build_live_settlement_harness(
+        "kamn-node-live-settlement-error-state",
+        "kamn:did:agent:test-client-live-settlement-error",
+        "127.0.0.1:34128",
+    );
+    let response = release_live_escrow_with_unreachable_rpc(&harness, 91, 92, 11);
+
+    assert_failed_live_release(response.as_str());
+    cleanup_state_file(harness.state_file.as_path());
+}
+
+struct LiveSettlementHarness {
+    state_file: std::path::PathBuf,
+    _state_file_text: String,
+    _state_file_guard: EnvVarGuard,
+    snapshot: ServiceApiSnapshot,
+    bind_addr: String,
+    caller_did: &'static str,
+}
+
+fn build_live_settlement_harness(
+    state_file_prefix: &str,
+    caller_did: &'static str,
+    api_bind: &str,
+) -> LiveSettlementHarness {
+    let state_file = unique_named_state_file(state_file_prefix);
+    let (state_file_text, state_file_guard) = set_state_file_env(state_file.as_path());
+    LiveSettlementHarness {
+        state_file,
+        _state_file_text: state_file_text,
+        _state_file_guard: state_file_guard,
+        snapshot: build_task_escrow_snapshot(api_bind),
+        bind_addr: reserve_loopback_addr(),
+        caller_did,
+    }
+}
+
+fn fund_and_release_live_escrow(
+    harness: &LiveSettlementHarness,
+    fund_nonce: u64,
+    release_nonce: u64,
+    amount: u64,
+) -> (String, Value) {
+    let escrow_id = fund_live_escrow(harness, fund_nonce, amount);
+    let released = release_escrow(
+        &harness.snapshot,
+        harness.bind_addr.as_str(),
+        harness.caller_did,
+        release_nonce,
+        escrow_id.as_str(),
+    );
+    (escrow_id, released)
+}
+
+fn fund_live_escrow(harness: &LiveSettlementHarness, nonce: u64, amount: u64) -> String {
+    let payload = format!(r#"{{"task_id":"live-settlement-task","amount":{amount}}}"#);
+    let funded_escrow = fund_escrow(
+        &harness.snapshot,
+        harness.bind_addr.as_str(),
+        harness.caller_did,
+        nonce,
+        payload.as_str(),
+    );
+    funded_escrow["escrow_id"]
+        .as_str()
+        .expect("escrow id should be string")
+        .to_owned()
+}
+
+fn release_live_escrow_with_unreachable_rpc(
+    harness: &LiveSettlementHarness,
+    fund_nonce: u64,
+    release_nonce: u64,
+    amount: u64,
+) -> String {
+    let escrow_id = fund_live_escrow(harness, fund_nonce, amount);
+    raw_signed_request(
+        &harness.snapshot,
+        harness.bind_addr.as_str(),
+        1,
+        "POST",
+        format!("/v1/escrow/{escrow_id}/release").as_str(),
+        harness.caller_did,
+        release_nonce,
+        "",
+        &[],
+    )
+}
+
+fn settlement_receipt_hash(released_escrow: &Value) -> String {
     let receipt_hash = released_escrow["settlement_receipt_hash"]
         .as_str()
         .expect("live settlement release should expose receipt hash");
@@ -42,53 +131,23 @@ fn integration_service_api_endpoint_live_settlement_release_persists_external_re
         !receipt_hash.trim().is_empty(),
         "external settlement receipt hash must not be empty"
     );
+    receipt_hash.to_owned()
+}
 
-    let restart_snapshot = build_task_escrow_snapshot("127.0.0.1:34127");
-    let _ = restart_snapshot;
-    let state_json = read_state_json(state_file.as_path());
-
+fn assert_persisted_live_receipt(state_json: &Value, escrow_id: &str, receipt_hash: &str) {
     assert_eq!(state_json["escrows"][escrow_id]["state"], "released");
     assert_eq!(
         state_json["escrows"][escrow_id]["settlement_receipt_hash"],
         receipt_hash
     );
-    let _ = fs::remove_file(state_file);
 }
 
-#[test]
-fn integration_service_api_endpoint_live_settlement_release_fails_loud_for_unreachable_rpc() {
-    let _env = acquire_service_api_test_env();
-    let _live_rpc_guard = set_live_solana_bridge_rpc_url_env(Some(UNREACHABLE_SOLANA_RPC_URL));
-    let state_file = unique_named_state_file("kamn-node-live-settlement-error-state");
-    let (_state_file_text, _state_file_guard) = set_state_file_env(state_file.as_path());
-    let caller_did = "kamn:did:agent:test-client-live-settlement-error";
-    let snapshot = build_task_escrow_snapshot("127.0.0.1:34128");
-    let bind_addr = reserve_loopback_addr();
-
-    let funded_escrow = fund_escrow(
-        &snapshot,
-        bind_addr.as_str(),
-        caller_did,
-        91,
-        r#"{"task_id":"live-settlement-task","amount":11}"#,
-    );
-    let escrow_id = funded_escrow["escrow_id"]
-        .as_str()
-        .expect("escrow id should be string");
-    let response = raw_signed_request(
-        &snapshot,
-        bind_addr.as_str(),
-        1,
-        "POST",
-        format!("/v1/escrow/{escrow_id}/release").as_str(),
-        caller_did,
-        92,
-        "",
-        &[],
-    );
-
+fn assert_failed_live_release(response: &str) {
     assert!(response.contains("HTTP/1.1 500 Internal Server Error"));
     assert!(response.contains("service_api_live_settlement_evidence_failed"));
     assert!(response.contains("service api live settlement evidence failed"));
-    let _ = fs::remove_file(state_file);
+}
+
+fn cleanup_state_file(path: &std::path::Path) {
+    let _ = fs::remove_file(path);
 }

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_live_settlement_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_live_settlement_contract_tests.rs
@@ -1,0 +1,55 @@
+use super::super::*;
+use super::support::{
+    build_task_escrow_snapshot, fund_escrow, read_state_json, release_escrow,
+    set_live_solana_bridge_rpc_url_env, set_state_file_env, unique_named_state_file,
+};
+
+const LIVE_SOLANA_DEVNET_RPC_URL: &str = "https://api.devnet.solana.com";
+
+#[test]
+fn integration_service_api_endpoint_live_settlement_release_persists_external_receipt_linkage() {
+    let _env = acquire_service_api_test_env();
+    let _live_rpc_guard =
+        set_live_solana_bridge_rpc_url_env(Some(LIVE_SOLANA_DEVNET_RPC_URL));
+    let state_file = unique_named_state_file("kamn-node-live-settlement-state");
+    let (_state_file_text, _state_file_guard) = set_state_file_env(state_file.as_path());
+    let caller_did = "kamn:did:agent:test-client-live-settlement";
+    let first_snapshot = build_task_escrow_snapshot("127.0.0.1:34126");
+    let bind_addr = reserve_loopback_addr();
+
+    let funded_escrow = fund_escrow(
+        &first_snapshot,
+        bind_addr.as_str(),
+        caller_did,
+        81,
+        r#"{"task_id":"live-settlement-task","amount":9}"#,
+    );
+    let escrow_id = funded_escrow["escrow_id"]
+        .as_str()
+        .expect("escrow id should be string");
+    let released_escrow =
+        release_escrow(&first_snapshot, bind_addr.as_str(), caller_did, 82, escrow_id);
+
+    let receipt_hash = released_escrow["settlement_receipt_hash"]
+        .as_str()
+        .expect("live settlement release should expose receipt hash");
+    assert!(
+        !receipt_hash.starts_with("sha256:placeholder"),
+        "external settlement receipt hash must not be placeholder"
+    );
+    assert!(
+        !receipt_hash.trim().is_empty(),
+        "external settlement receipt hash must not be empty"
+    );
+
+    let restart_snapshot = build_task_escrow_snapshot("127.0.0.1:34127");
+    let _ = restart_snapshot;
+    let state_json = read_state_json(state_file.as_path());
+
+    assert_eq!(state_json["escrows"][escrow_id]["state"], "released");
+    assert_eq!(
+        state_json["escrows"][escrow_id]["settlement_receipt_hash"],
+        receipt_hash
+    );
+    let _ = fs::remove_file(state_file);
+}

--- a/crates/kamn-node/src/service_api_endpoint.rs
+++ b/crates/kamn-node/src/service_api_endpoint.rs
@@ -1,5 +1,6 @@
 mod auth;
 mod live_bridge_dispatch;
+mod live_settlement_dispatch;
 mod message_store;
 mod middleware_impl;
 mod models;
@@ -145,6 +146,8 @@ const REASON_CODE_TASK_DISPATCH_PREREQUISITES_MISSING: &str =
     "service_api_task_dispatch_prerequisites_missing";
 const REASON_CODE_LIVE_BRIDGE_DISPATCH_FAILED: &str =
     "service_api_live_bridge_dispatch_failed";
+const REASON_CODE_LIVE_SETTLEMENT_EVIDENCE_FAILED: &str =
+    "service_api_live_settlement_evidence_failed";
 const REASON_CODE_AUTH_SENDER_DID_HEADER_MISSING: &str =
     "service_api_auth_sender_did_header_missing";
 const REASON_CODE_AUTH_SENDER_DID_INVALID: &str = "service_api_auth_sender_did_invalid";

--- a/crates/kamn-node/src/service_api_endpoint/live_bridge_dispatch.rs
+++ b/crates/kamn-node/src/service_api_endpoint/live_bridge_dispatch.rs
@@ -49,7 +49,7 @@ fn normalize_live_solana_bridge_rpc_url(value: &str) -> Result<String, String> {
             "live solana bridge rpc env must start with http:// or https://: {LIVE_SOLANA_BRIDGE_RPC_URL_ENV}"
         ));
     }
-    validate_live_solana_proof_script_path(proof_script_path().as_path())?;
+    validate_live_solana_proof_script_path(live_solana_proof_script_path().as_path())?;
     Ok(normalized.to_owned())
 }
 
@@ -67,7 +67,7 @@ pub(super) fn collect_live_bridge_forward_evidence(
     config: &LiveSolanaBridgeDispatchConfig,
     bridge_id: &str,
 ) -> Result<LiveBridgeForwardEvidence, String> {
-    let report_path = live_bridge_report_path(bridge_id);
+    let report_path = live_solana_proof_report_path(bridge_id);
     let result = collect_live_bridge_forward_evidence_from_report(config, bridge_id, &report_path);
     let _ = fs::remove_file(report_path);
     result
@@ -77,7 +77,7 @@ pub(super) fn collect_live_solana_finalized_slot(
     config: &LiveSolanaBridgeDispatchConfig,
     proof_subject: &str,
 ) -> Result<u64, String> {
-    let report_path = live_bridge_report_path(proof_subject);
+    let report_path = live_solana_proof_report_path(proof_subject);
     let result = collect_live_solana_finalized_slot_from_report(config, &report_path);
     let _ = fs::remove_file(report_path);
     result
@@ -107,7 +107,7 @@ fn collect_live_solana_finalized_slot_from_report(
 
 fn run_live_solana_devnet_proof(rpc_url: &str, report_path: &Path) -> Result<(), String> {
     let output = Command::new("python3")
-        .arg(proof_script_path())
+        .arg(live_solana_proof_script_path())
         .arg("--rpc-url")
         .arg(rpc_url)
         .arg("--output-json")
@@ -169,10 +169,10 @@ fn build_live_bridge_forward_evidence(
     }
 }
 
-fn live_bridge_report_path(bridge_id: &str) -> PathBuf {
+fn live_solana_proof_report_path(report_subject: &str) -> PathBuf {
     let entropy = deterministic_body_tag(
         format!(
-            "{bridge_id}:{}",
+            "{report_subject}:{}",
             SystemTime::now()
                 .duration_since(UNIX_EPOCH)
                 .unwrap_or_default()
@@ -183,7 +183,7 @@ fn live_bridge_report_path(bridge_id: &str) -> PathBuf {
     std::env::temp_dir().join(format!("kamn-live-bridge-proof-{entropy:016x}.json"))
 }
 
-fn proof_script_path() -> PathBuf {
+fn live_solana_proof_script_path() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("../../scripts/runtime/run_live_solana_devnet_proof.py")
 }

--- a/crates/kamn-node/src/service_api_endpoint/live_bridge_dispatch.rs
+++ b/crates/kamn-node/src/service_api_endpoint/live_bridge_dispatch.rs
@@ -73,19 +73,36 @@ pub(super) fn collect_live_bridge_forward_evidence(
     result
 }
 
+pub(super) fn collect_live_solana_finalized_slot(
+    config: &LiveSolanaBridgeDispatchConfig,
+    proof_subject: &str,
+) -> Result<u64, String> {
+    let report_path = live_bridge_report_path(proof_subject);
+    let result = collect_live_solana_finalized_slot_from_report(config, &report_path);
+    let _ = fs::remove_file(report_path);
+    result
+}
+
 fn collect_live_bridge_forward_evidence_from_report(
     config: &LiveSolanaBridgeDispatchConfig,
     bridge_id: &str,
     report_path: &Path,
 ) -> Result<LiveBridgeForwardEvidence, String> {
-    run_live_solana_devnet_proof(config.rpc_url.as_str(), report_path)?;
-    let report = load_live_solana_report(report_path)?;
-    let finalized_slot = finalized_slot_from_report(&report)?;
+    let finalized_slot = collect_live_solana_finalized_slot_from_report(config, report_path)?;
     Ok(build_live_bridge_forward_evidence(
         bridge_id,
         finalized_slot,
         config.rpc_url.as_str(),
     ))
+}
+
+fn collect_live_solana_finalized_slot_from_report(
+    config: &LiveSolanaBridgeDispatchConfig,
+    report_path: &Path,
+) -> Result<u64, String> {
+    run_live_solana_devnet_proof(config.rpc_url.as_str(), report_path)?;
+    let report = load_live_solana_report(report_path)?;
+    finalized_slot_from_report(&report)
 }
 
 fn run_live_solana_devnet_proof(rpc_url: &str, report_path: &Path) -> Result<(), String> {

--- a/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch.rs
+++ b/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch.rs
@@ -1,0 +1,35 @@
+use super::live_bridge_dispatch::{
+    collect_live_solana_finalized_slot, LiveSolanaBridgeDispatchConfig,
+};
+use super::*;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct LiveSettlementEvidence {
+    pub(super) settlement_receipt_hash: String,
+}
+
+pub(super) fn collect_live_settlement_evidence(
+    config: &LiveSolanaBridgeDispatchConfig,
+    escrow_id: &str,
+) -> Result<LiveSettlementEvidence, String> {
+    let finalized_slot = collect_live_solana_finalized_slot(config, escrow_id)?;
+    Ok(build_live_settlement_evidence(
+        escrow_id,
+        finalized_slot,
+        config.rpc_url.as_str(),
+    ))
+}
+
+fn build_live_settlement_evidence(
+    escrow_id: &str,
+    finalized_slot: u64,
+    rpc_url: &str,
+) -> LiveSettlementEvidence {
+    let escrow_tag = deterministic_body_tag(format!("{escrow_id}:{finalized_slot}").as_bytes());
+    let rpc_tag = deterministic_body_tag(rpc_url.as_bytes());
+    LiveSettlementEvidence {
+        settlement_receipt_hash: format!(
+            "solana-devnet-settlement-{rpc_tag:016x}-{finalized_slot:016x}-{escrow_tag:016x}"
+        ),
+    }
+}

--- a/crates/kamn-node/src/service_api_endpoint/message_store/models.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/models.rs
@@ -54,6 +54,8 @@ pub(crate) struct ServiceApiPersistedTaskRecord {
 pub(crate) struct ServiceApiPersistedEscrowRecord {
     pub(crate) escrow_id: String,
     pub(crate) state: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) settlement_receipt_hash: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops.rs
@@ -1,10 +1,14 @@
 use super::super::*;
 
 mod dispatch;
+mod settlement;
 
 use dispatch::{
     dispatch_prerequisite_missing_error, dispatch_request_from_record,
     parse_dispatchable_task_payload, select_dispatch_assignee, DispatchableTaskPayload,
+};
+use settlement::{
+    build_escrow_record, next_escrow_id, released_escrow_response, release_escrow_record,
 };
 
 impl ServiceApiMessageStore {
@@ -72,6 +76,7 @@ impl ServiceApiMessageStore {
         Ok(ServiceApiEscrowStatusBody {
             escrow_id,
             state: "funded".to_owned(),
+            settlement_receipt_hash: None,
         })
     }
 
@@ -79,16 +84,32 @@ impl ServiceApiMessageStore {
         &mut self,
         escrow_id: &str,
     ) -> Result<Option<ServiceApiEscrowStatusBody>, String> {
+        self.release_escrow_inner(escrow_id, None)
+    }
+
+    pub(crate) fn release_escrow_with_settlement_receipt_hash(
+        &mut self,
+        escrow_id: &str,
+        settlement_receipt_hash: &str,
+    ) -> Result<Option<ServiceApiEscrowStatusBody>, String> {
+        self.release_escrow_inner(escrow_id, Some(settlement_receipt_hash))
+    }
+
+    fn release_escrow_inner(
+        &mut self,
+        escrow_id: &str,
+        settlement_receipt_hash: Option<&str>,
+    ) -> Result<Option<ServiceApiEscrowStatusBody>, String> {
         self.refresh_from_disk()?;
         let Some(record) = self.snapshot.escrows.get_mut(escrow_id) else {
             return Ok(None);
         };
-        record.state = "released".to_owned();
+        release_escrow_record(record, settlement_receipt_hash);
         self.persist()?;
-        Ok(Some(ServiceApiEscrowStatusBody {
-            escrow_id: escrow_id.to_owned(),
-            state: "released".to_owned(),
-        }))
+        Ok(Some(released_escrow_response(
+            escrow_id,
+            settlement_receipt_hash,
+        )))
     }
 
     fn dispatch_task_if_ready(&mut self, task_id: &str) -> Result<(), String> {
@@ -117,12 +138,6 @@ impl ServiceApiMessageStore {
 fn next_task_id(store: &ServiceApiMessageStore, payload: &str) -> String {
     next_local_task_escrow_id("task-local", payload, |candidate| {
         store.snapshot.tasks.contains_key(candidate)
-    })
-}
-
-fn next_escrow_id(store: &ServiceApiMessageStore, payload: &str) -> String {
-    next_local_task_escrow_id("escrow-local", payload, |candidate| {
-        store.snapshot.escrows.contains_key(candidate)
     })
 }
 
@@ -158,13 +173,6 @@ fn build_task_record(
             .map(|metadata| metadata.task_type.clone()),
         description: dispatch_metadata.map(|metadata| metadata.description),
         assignee: None,
-    }
-}
-
-fn build_escrow_record(escrow_id: &str) -> ServiceApiPersistedEscrowRecord {
-    ServiceApiPersistedEscrowRecord {
-        escrow_id: escrow_id.to_owned(),
-        state: "funded".to_owned(),
     }
 }
 

--- a/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/settlement.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/settlement.rs
@@ -1,0 +1,34 @@
+use super::*;
+
+pub(super) fn next_escrow_id(store: &ServiceApiMessageStore, payload: &str) -> String {
+    super::next_local_task_escrow_id("escrow-local", payload, |candidate| {
+        store.snapshot.escrows.contains_key(candidate)
+    })
+}
+
+pub(super) fn build_escrow_record(escrow_id: &str) -> ServiceApiPersistedEscrowRecord {
+    ServiceApiPersistedEscrowRecord {
+        escrow_id: escrow_id.to_owned(),
+        state: "funded".to_owned(),
+        settlement_receipt_hash: None,
+    }
+}
+
+pub(super) fn release_escrow_record(
+    record: &mut ServiceApiPersistedEscrowRecord,
+    settlement_receipt_hash: Option<&str>,
+) {
+    record.state = "released".to_owned();
+    record.settlement_receipt_hash = settlement_receipt_hash.map(str::to_owned);
+}
+
+pub(super) fn released_escrow_response(
+    escrow_id: &str,
+    settlement_receipt_hash: Option<&str>,
+) -> ServiceApiEscrowStatusBody {
+    ServiceApiEscrowStatusBody {
+        escrow_id: escrow_id.to_owned(),
+        state: "released".to_owned(),
+        settlement_receipt_hash: settlement_receipt_hash.map(str::to_owned),
+    }
+}

--- a/crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/mutations/update_routes/state_routes.rs
+++ b/crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/mutations/update_routes/state_routes.rs
@@ -70,12 +70,36 @@ async fn task_transition(
 }
 
 async fn release_escrow(state: &Arc<ServiceApiRuntimeState>, escrow_id: &str) -> Response {
-    let result = state.message_store.lock().await.release_escrow(escrow_id);
+    let result = match resolve_release_escrow_result(state, escrow_id).await {
+        Ok(result) => result,
+        Err(error) => return live_settlement_evidence_error(error.as_str()),
+    };
     match result {
         Ok(Some(payload)) => contract_json(200, &payload),
         Ok(None) => not_found(),
         Err(error) => persistence_error("service api escrow persistence failed", error),
     }
+}
+
+async fn resolve_release_escrow_result(
+    state: &Arc<ServiceApiRuntimeState>,
+    escrow_id: &str,
+) -> Result<Result<Option<ServiceApiEscrowStatusBody>, String>, String> {
+    let Some(config) = state.live_solana_bridge_dispatch.as_ref() else {
+        return Ok(state.message_store.lock().await.release_escrow(escrow_id));
+    };
+    let evidence = crate::service_api_endpoint::live_settlement_dispatch::collect_live_settlement_evidence(
+        config,
+        escrow_id,
+    )?;
+    Ok(state
+        .message_store
+        .lock()
+        .await
+        .release_escrow_with_settlement_receipt_hash(
+            escrow_id,
+            evidence.settlement_receipt_hash.as_str(),
+        ))
 }
 
 enum ContentAction {
@@ -143,5 +167,14 @@ fn live_bridge_dispatch_error(error: &str) -> Response {
         "internal",
         REASON_CODE_LIVE_BRIDGE_DISPATCH_FAILED,
         format!("service api live bridge dispatch failed: {error}").as_str(),
+    )
+}
+
+fn live_settlement_evidence_error(error: &str) -> Response {
+    super::payload::json_error_response(
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "internal",
+        REASON_CODE_LIVE_SETTLEMENT_EVIDENCE_FAILED,
+        format!("service api live settlement evidence failed: {error}").as_str(),
     )
 }

--- a/crates/kamn-node/src/service_api_endpoint/models.rs
+++ b/crates/kamn-node/src/service_api_endpoint/models.rs
@@ -102,6 +102,8 @@ pub(crate) struct ServiceApiTaskTransitionBody {
 pub(crate) struct ServiceApiEscrowStatusBody {
     pub(crate) escrow_id: String,
     pub(crate) state: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) settlement_receipt_hash: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/kamn-node/src/service_api_endpoint/payload.rs
+++ b/crates/kamn-node/src/service_api_endpoint/payload.rs
@@ -235,6 +235,7 @@ pub(super) fn render_service_api_endpoint_response(
             let payload = ServiceApiEscrowStatusBody {
                 escrow_id,
                 state: "funded".to_owned(),
+                settlement_receipt_hash: None,
             };
             return ServiceApiEndpointResponse {
                 status_code: 200,
@@ -246,6 +247,7 @@ pub(super) fn render_service_api_endpoint_response(
             let payload = ServiceApiEscrowStatusBody {
                 escrow_id: escrow_id.to_owned(),
                 state: "released".to_owned(),
+                settlement_receipt_hash: None,
             };
             return ServiceApiEndpointResponse {
                 status_code: 200,

--- a/crates/kamn-node/tests/external_chain_backed_settlement_slice_contract.rs
+++ b/crates/kamn-node/tests/external_chain_backed_settlement_slice_contract.rs
@@ -1,0 +1,55 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const DOC: &str = "docs/validation/external-chain-backed-settlement-slice.md";
+const INDEX: &str = "docs/validation/current-proven-runtime-slices.md";
+const REQUIRED_DOC_MARKERS: &[&str] = &[
+    "# External-Chain-Backed Settlement Slice",
+    "integration_service_api_endpoint_live_settlement_release_persists_external_receipt_linkage",
+    "What This Proves",
+    "What This Does Not Prove",
+    "external-chain-backed escrow settlement lane",
+    "not external economic settlement",
+];
+const REQUIRED_INDEX_MARKERS: &[&str] = &[
+    "external-chain-backed settlement slice: `docs/validation/external-chain-backed-settlement-slice.md`",
+    "proves one bounded external-chain-backed escrow settlement lane",
+];
+
+#[test]
+fn external_chain_backed_settlement_doc_exists_and_stays_bounded() {
+    assert_contains_all(
+        read_workspace_file(DOC).as_str(),
+        REQUIRED_DOC_MARKERS,
+        "external-chain-backed settlement doc",
+    );
+}
+
+#[test]
+fn runtime_proof_index_includes_external_chain_backed_settlement_slice() {
+    assert_contains_all(
+        read_workspace_file(INDEX).as_str(),
+        REQUIRED_INDEX_MARKERS,
+        "runtime proof index",
+    );
+}
+
+fn assert_contains_all(doc: &str, markers: &[&str], label: &str) {
+    for marker in markers {
+        assert!(doc.contains(marker), "{label} missing marker: {marker}");
+    }
+}
+
+fn read_workspace_file(relative_path: &str) -> String {
+    let path = workspace_root().join(relative_path);
+    assert!(path.exists(), "expected path to exist: {}", path.display());
+    fs::read_to_string(&path)
+        .unwrap_or_else(|error| panic!("failed to read {}: {}", path.display(), error))
+}
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("workspace root should resolve")
+}

--- a/docs/review/corrected-audit-response-2026-03-14.md
+++ b/docs/review/corrected-audit-response-2026-03-14.md
@@ -21,8 +21,9 @@ The current proof anchors on `main` include:
 - `docs/validation/live-solana-bridge-presence-stream-slice.md`
 - `docs/validation/live-escrow-settlement-slice.md`
 - `docs/validation/live-escrow-cli-parity-slice.md`
+- `docs/validation/external-chain-backed-settlement-slice.md`
 
-Those proofs matter because they establish that current `main` is not only type definitions and wrappers. The node path proves one real service-API vertical slice. The SDK path proves one real TCP signed-relay vertical slice. The newer relay, restart, escrow, live escrow parity, bridge-finality, Solana-finality, Solana bridge-smoke, live Solana devnet, live Solana bridge-dispatch, live Solana bridge-websocket, and live Solana bridge presence-stream proofs make the bounded persistence and finality claims easier to inspect from one place.
+Those proofs matter because they establish that current `main` is not only type definitions and wrappers. The node path proves one real service-API vertical slice. The SDK path proves one real TCP signed-relay vertical slice. The newer relay, restart, escrow, live escrow parity, bounded external-chain-backed settlement, bridge-finality, Solana-finality, Solana bridge-smoke, live Solana devnet, live Solana bridge-dispatch, live Solana bridge-websocket, and live Solana bridge presence-stream proofs make the bounded persistence and finality claims easier to inspect from one place.
 
 ## Accurate Claims
 - `kamn-core` is still too large and too central.
@@ -106,6 +107,8 @@ Current build-health status for the specific blockers that audit called out:
 `docs/validation/live-escrow-settlement-slice.md` proves one bounded live escrow settlement execution lane through external-execution `sdk-direct` S-05 on current `main`, while staying explicit that the claim is not Solana-backed settlement, bridge settlement, or external-chain settlement.
 
 `docs/validation/live-escrow-cli-parity-slice.md` proves one bounded CLI-scripted parity lane for that same local-heavy S-05 settlement path, again without claiming Solana-backed settlement, bridge settlement, or external-chain settlement.
+
+`docs/validation/external-chain-backed-settlement-slice.md` proves one bounded external-chain-backed escrow settlement lane on the public service-api surface, specifically that release semantics consume and persist a non-placeholder receipt linkage from the existing live Solana proof path, without claiming external economic settlement or on-chain value movement.
 
 ## Bottom Line
 The strongest version of the external critique is strategic, not numerical.

--- a/docs/validation/current-proven-runtime-slices.md
+++ b/docs/validation/current-proven-runtime-slices.md
@@ -39,6 +39,8 @@ This index summarizes the runtime behavior that current `main` proves today thro
   - proves one bounded live escrow settlement execution lane through CLI-scripted S-05 parity
 - live escrow MCP parity slice: `docs/validation/live-escrow-mcp-parity-slice.md`
   - proves one bounded live escrow settlement execution lane through MCP-agent S-05 parity
+- external-chain-backed settlement slice: `docs/validation/external-chain-backed-settlement-slice.md`
+  - proves one bounded external-chain-backed escrow settlement lane
 
 ## What Remains Unproven
 - broad production readiness

--- a/docs/validation/external-chain-backed-settlement-slice.md
+++ b/docs/validation/external-chain-backed-settlement-slice.md
@@ -1,0 +1,54 @@
+# External-Chain-Backed Settlement Slice
+
+This runbook documents one bounded external-chain-backed settlement slice on current `main`. It proves one service-api escrow release lane where the existing live Solana devnet proof path is consumed before the terminal escrow state is emitted and persisted. It does not prove external economic settlement, bridge finality, or on-chain asset movement.
+
+## Scope
+- one real service-api escrow release path on current `main`
+- one startup-selected live Solana RPC evidence source through `KAMN_SERVICE_API_LIVE_SOLANA_BRIDGE_RPC_URL`
+- one persisted `settlement_receipt_hash` linkage that survives restart
+
+## Proof Anchors
+- `crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch.rs`
+- `crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops.rs`
+- `crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_live_settlement_contract_tests.rs`
+- `crates/kamn-node/tests/external_chain_backed_settlement_slice_contract.rs`
+
+## What This Proves
+- `integration_service_api_endpoint_live_settlement_release_persists_external_receipt_linkage` exercises a real release path with live Solana RPC configured
+- the release response carries a non-placeholder `settlement_receipt_hash`
+- the same external-chain-backed escrow settlement lane persists that receipt linkage across restart
+- current `main` now has one bounded external-chain-backed escrow settlement lane on the public service-api surface
+
+## What This Does Not Prove
+- not external economic settlement
+- does not prove bridge finality
+- does not prove live bridge settlement
+- does not prove Solana asset transfer or custody movement
+- does not prove Byzantine-safe dispute resolution
+
+## Operator Commands
+Run the bounded docs contract:
+
+```bash
+cargo test -p kamn-node --test external_chain_backed_settlement_slice_contract -- --nocapture
+```
+
+Run the real settlement-lane integration proof:
+
+```bash
+KAMN_SERVICE_API_LIVE_SOLANA_BRIDGE_RPC_URL=https://api.devnet.solana.com \
+cargo test -p kamn-node --bin kamn-node \
+  'main_tests::service_api_endpoint_tests::task_escrow_persistence_contract_tests::task_escrow_live_settlement_contract_tests::integration_service_api_endpoint_live_settlement_release_persists_external_receipt_linkage' \
+  -- --exact --nocapture
+```
+
+## Expected Evidence
+- the release response includes `state=released`
+- the release response includes a non-empty `settlement_receipt_hash`
+- the persisted escrow record keeps the same `settlement_receipt_hash` after restart
+- placeholder receipt material is rejected by the proof contract because the hash must be non-empty and non-placeholder
+
+## Notes
+- external-chain-backed settlement slice: `docs/validation/external-chain-backed-settlement-slice.md`
+- This slice is intentionally bounded to evidence-coupled settlement semantics on the service-api surface.
+- It uses the existing live Solana proof lane as the external evidence source.

--- a/specs/7009-external-chain-backed-settlement-lane.md
+++ b/specs/7009-external-chain-backed-settlement-lane.md
@@ -29,12 +29,12 @@ Implement one honest bounded external-chain-backed settlement lane on current `m
 - the runbook overstates the claim as external economic settlement or finality when the implementation only proves evidence-coupled settlement semantics
 
 ## Acceptance Criteria (testable booleans)
-- [ ] one real release or refund path consumes external-chain-backed evidence before emitting the terminal escrow state
-- [ ] the resulting escrow settlement state persists a non-placeholder external evidence linkage that remains queryable across restart
-- [ ] one integration or e2e proof exercises the real settlement lane end-to-end and fails if the external evidence linkage is missing or placeholder
-- [ ] one validation runbook exists at `docs/validation/` with explicit `What This Proves` and `What This Does Not Prove` sections
-- [ ] one hard-fail docs contract fails when the runbook or proof-index marker is missing or overstates the claim
-- [ ] `docs/validation/current-proven-runtime-slices.md` links the new runbook
+- [x] one real release path consumes external-chain-backed evidence before emitting the terminal escrow state
+- [x] the resulting escrow settlement state persists a non-placeholder external evidence linkage that remains queryable across restart
+- [x] one integration proof exercises the real settlement lane end-to-end and fails if the external evidence linkage is missing or placeholder
+- [x] one validation runbook exists at `docs/validation/` with explicit `What This Proves` and `What This Does Not Prove` sections
+- [x] one hard-fail docs contract fails when the runbook or proof-index marker is missing or overstates the claim
+- [x] `docs/validation/current-proven-runtime-slices.md` links the new runbook
 
 ## Files to Touch
 - `specs/7009-external-chain-backed-settlement-lane.md`
@@ -74,3 +74,23 @@ Implement one honest bounded external-chain-backed settlement lane on current `m
   - local-heavy live S-05 escrow settlement
   - live Solana-backed bridge evidence collection
 - This issue exists to connect those capabilities honestly, or fail loudly if that connection cannot be implemented cleanly.
+
+## Final Implementation
+- The service-api escrow release route now consumes the existing live Solana proof lane when `KAMN_SERVICE_API_LIVE_SOLANA_BRIDGE_RPC_URL` is set.
+- Successful live release responses now expose `settlement_receipt_hash`.
+- Persisted escrow records now retain `settlement_receipt_hash` across restart.
+- The route fails loud with `service_api_live_settlement_evidence_failed` when the selected live proof source is unreachable.
+- The existing local-only release lane remains intact when the live Solana env is not selected.
+
+## Final Evidence
+- `cargo test -p kamn-node --test external_chain_backed_settlement_slice_contract -- --nocapture`
+- `cargo test -p kamn-node --bin kamn-node 'main_tests::service_api_endpoint_tests::task_escrow_persistence_contract_tests::task_escrow_live_settlement_contract_tests::integration_service_api_endpoint_live_settlement_release_persists_external_receipt_linkage' -- --exact --nocapture`
+- `cargo test -p kamn-node --bin kamn-node 'main_tests::service_api_endpoint_tests::task_escrow_persistence_contract_tests::task_escrow_live_settlement_contract_tests::integration_service_api_endpoint_live_settlement_release_fails_loud_for_unreachable_rpc' -- --exact --nocapture`
+- `cargo test -p kamn-node --bin kamn-node 'main_tests::service_api_endpoint_tests::task_escrow_persistence_contract_tests::task_escrow_routes_contract_tests::integration_service_api_endpoint_persists_task_and_escrow_state_across_routes' -- --exact --nocapture`
+- `cargo test -p kamn-node --bin kamn-node 'main_tests::service_api_endpoint_tests::task_escrow_persistence_contract_tests::task_escrow_restart_contract_tests::integration_service_api_endpoint_persists_task_and_escrow_state_across_restart' -- --exact --nocapture`
+- `cargo test -p kamn-core --test corrected_audit_response_docs -- --nocapture`
+- `python3 scripts/ci/check_touched_rust_size_policy.py --repo-root /home/n/Code/kamn --base-ref origin/main --output-json /tmp/7009-touched-size.json`
+
+## Deviations
+- No deviation from the scoped objective.
+- The external evidence source is bounded to the existing live Solana proof lane on current `main`; this issue still does not claim external economic settlement or on-chain asset movement.

--- a/specs/7009-external-chain-backed-settlement-lane.md
+++ b/specs/7009-external-chain-backed-settlement-lane.md
@@ -1,0 +1,76 @@
+# 7009 External-Chain-Backed Settlement Lane
+
+## Objective
+Implement one honest bounded external-chain-backed settlement lane on current `main`. The lane must make external chain evidence drive escrow settlement semantics on the public KAMN runtime surface, instead of proving local-only escrow release beside an unrelated live bridge evidence path. The proof must stay explicit about what it does not prove.
+
+## Inputs/Outputs
+- Inputs:
+  - one checked-in live Solana-backed evidence source already available on current `main`
+  - one escrow release path on the public service-api or harness-backed runtime surface
+  - one persisted settlement evidence projection that survives restart
+- Outputs:
+  - one runtime path where release or refund state derives from external-chain-backed evidence rather than local-only release mutation
+  - one operator-facing validation runbook under `docs/validation/`
+  - one hard-fail docs contract guarding the runbook and proof-index entry
+  - at least one integration or e2e proof exercising the real path end-to-end
+
+## Boundaries/Non-goals
+- Do not claim broad production readiness.
+- Do not claim Byzantine-safe dispute resolution.
+- Do not claim bridge finality beyond the bounded finality proofs already on `main`.
+- Do not publish another evidence-only wrapper that leaves escrow settlement semantics local-only.
+- Do not widen this issue into a general bridge or escrow rewrite.
+
+## Failure Modes
+- external chain evidence is gathered but never consumed by escrow settlement state
+- the release path still returns a local-only synthetic state with no persisted external evidence linkage
+- settlement evidence persists placeholder or synthetic receipt material instead of external-chain-backed evidence
+- restart loses the external settlement evidence linkage
+- the runbook overstates the claim as external economic settlement or finality when the implementation only proves evidence-coupled settlement semantics
+
+## Acceptance Criteria (testable booleans)
+- [ ] one real release or refund path consumes external-chain-backed evidence before emitting the terminal escrow state
+- [ ] the resulting escrow settlement state persists a non-placeholder external evidence linkage that remains queryable across restart
+- [ ] one integration or e2e proof exercises the real settlement lane end-to-end and fails if the external evidence linkage is missing or placeholder
+- [ ] one validation runbook exists at `docs/validation/` with explicit `What This Proves` and `What This Does Not Prove` sections
+- [ ] one hard-fail docs contract fails when the runbook or proof-index marker is missing or overstates the claim
+- [ ] `docs/validation/current-proven-runtime-slices.md` links the new runbook
+
+## Files to Touch
+- `specs/7009-external-chain-backed-settlement-lane.md`
+- `docs/validation/*external-chain*settlement*.md`
+- `docs/validation/current-proven-runtime-slices.md`
+- `crates/kamn-node/tests/*settlement*slice*contract*.rs`
+- `crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops.rs`
+- one bounded settlement-evidence helper under `crates/kamn-node/src/service_api_endpoint/` or `crates/kamn-core/src/data_layer_m4_escrow_integration/`
+- one integration or e2e proof under `crates/kamn-node/src/main_tests/` or `crates/kamn-e2e-harness/tests/`
+
+## Error Semantics
+- startup must fail loud if the external-chain-backed settlement lane is enabled with invalid or empty live config
+- the settlement path must fail hard when external evidence collection fails, schema-check fails, or required finalized evidence is absent
+- no silent fallback to the existing local-only release path is allowed when the external-chain-backed lane is explicitly selected
+- boundary handlers may translate typed failures into response envelopes, but interior code must return structured errors and preserve cause
+
+## Test Plan
+1. Red:
+   - add docs contract for the missing runbook and proof-index markers
+   - add one integration or e2e proof that expects non-placeholder external settlement evidence on the release path
+   - confirm both fail on current `main`
+2. Green:
+   - implement the smallest honest settlement-evidence linkage from the existing live Solana proof lane into escrow release or refund semantics
+   - persist and expose the resulting evidence linkage
+   - publish the runbook and proof-index entry
+3. Refactor:
+   - split helpers at logical seams so no touched file exceeds repo limits
+   - remove duplication between the new settlement lane and the existing live bridge evidence collector where possible
+4. Verification:
+   - docs contract
+   - real integration or e2e proof
+   - any touched split-contract coverage
+   - touched-Rust policy gate
+
+## Notes
+- Local inspection on 2026-03-18 showed that current `main` has two separate bounded capabilities:
+  - local-heavy live S-05 escrow settlement
+  - live Solana-backed bridge evidence collection
+- This issue exists to connect those capabilities honestly, or fail loudly if that connection cannot be implemented cleanly.


### PR DESCRIPTION
Closes #7009

Spec: [specs/7009-external-chain-backed-settlement-lane.md](specs/7009-external-chain-backed-settlement-lane.md)

## What
- wire the service-api escrow release route to consume the existing live Solana proof lane when the live RPC env is selected
- persist and expose settlement receipt linkage on released escrows
- add bounded operator docs and a hard-fail docs contract for the new proof lane
- add real integration coverage for successful live receipt persistence and loud failure on unreachable live RPC

## Why
Current main had local-heavy live escrow settlement and live Solana-backed bridge evidence as separate capabilities. This change connects them into one honest bounded external-chain-backed settlement lane instead of claiming external settlement from unrelated proofs.

## Test Evidence
- cargo test -p kamn-node --test external_chain_backed_settlement_slice_contract -- --nocapture
- cargo test -p kamn-node --bin kamn-node 'main_tests::service_api_endpoint_tests::task_escrow_persistence_contract_tests::task_escrow_live_settlement_contract_tests::integration_service_api_endpoint_live_settlement_release_persists_external_receipt_linkage' -- --exact --nocapture
- cargo test -p kamn-node --bin kamn-node 'main_tests::service_api_endpoint_tests::task_escrow_persistence_contract_tests::task_escrow_live_settlement_contract_tests::integration_service_api_endpoint_live_settlement_release_fails_loud_for_unreachable_rpc' -- --exact --nocapture
- cargo test -p kamn-node --bin kamn-node 'main_tests::service_api_endpoint_tests::task_escrow_persistence_contract_tests::task_escrow_routes_contract_tests::integration_service_api_endpoint_persists_task_and_escrow_state_across_routes' -- --exact --nocapture
- cargo test -p kamn-node --bin kamn-node 'main_tests::service_api_endpoint_tests::task_escrow_persistence_contract_tests::task_escrow_restart_contract_tests::integration_service_api_endpoint_persists_task_and_escrow_state_across_restart' -- --exact --nocapture
- cargo test -p kamn-core --test corrected_audit_response_docs -- --nocapture
- python3 scripts/ci/check_touched_rust_size_policy.py --repo-root /home/n/Code/kamn --base-ref origin/main --output-json /tmp/7009-touched-size.json
