### PR TITLE
[7037] Add MVP evaluator demo proof report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
+.kamn/
 data/
 crates/kamn-node/data/
 __pycache__/

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ PRE_PUSH_WORKSPACE_TIMEOUT_SECONDS ?= 14400
 LOCAL_GATE_ENV = PATH="$(PRE_PUSH_PYTHON3_DIR):$(LOCAL_GATE_BASH_DIR):$(PATH)"
 PRE_PUSH_ENV = PATH="$(PRE_PUSH_PYTHON3_DIR):$(LOCAL_GATE_BASH_DIR):$(PATH)"
 
-.PHONY: help check test pre-push smoke-live-network deep-live-network demo demo-localhost-transport ci-tools kolme-local-heavy kolme-fork-rust-tests-local
+.PHONY: help check test pre-push smoke-live-network deep-live-network demo demo-mvp demo-localhost-transport ci-tools kolme-local-heavy kolme-fork-rust-tests-local
 
 help:
 	@echo "KAMN developer lanes"
@@ -20,6 +20,7 @@ help:
 	@echo "  make smoke-live-network - bounded pilot smoke lane + JSON report"
 	@echo "  make deep-live-network - scheduled/manual pilot deep lane summary report"
 	@echo "  make demo   - two-process localhost signed-message demo"
+	@echo "  make demo-mvp - evaluator MVP demo proof report"
 	@echo "  make demo-localhost-transport - explicit localhost sender/listener transport demo"
 	@echo "  make ci-tools - CI helper regression suite"
 	@echo "  make kolme-local-heavy - local-only Kolme heavy validation matrix (requires explicit opt-in for run mode)"
@@ -65,6 +66,9 @@ deep-live-network:
 
 demo:
 	bash scripts/sdk/run_localhost_signed_demo.sh
+
+demo-mvp:
+	CARGO_TARGET_DIR=target/mvp-demo-proof cargo run -p kamn-e2e-harness -- demo-mvp
 
 demo-localhost-transport:
 	bash scripts/sdk/run_localhost_signed_demo.sh

--- a/crates/kamn-e2e-harness/src/lib.rs
+++ b/crates/kamn-e2e-harness/src/lib.rs
@@ -4,6 +4,11 @@
 use std::collections::HashSet;
 use std::path::Path;
 
+pub use mvp_demo::{
+    execute_mvp_demo_contract, execute_verify_mvp_demo_contract, MvpDemoCommandConfig,
+    VerifyMvpDemoCommandConfig,
+};
+
 /// Driver implementations for each execution mode.
 pub mod drivers;
 /// Evidence manifest structures and schema constants.
@@ -14,6 +19,8 @@ pub mod identity;
 pub mod infrastructure;
 /// Kolme devnet configuration contracts.
 pub mod kolme_devnet;
+/// MVP evaluator demo report contracts.
+pub mod mvp_demo;
 mod run_contract;
 /// Scenario inventory and definitions.
 pub mod scenarios;
@@ -238,6 +245,10 @@ pub enum HarnessCommand {
     Run(RunCommandConfig),
     /// Verify an evidence bundle.
     Verify(VerifyCommandConfig),
+    /// Generate the MVP evaluator demo proof report.
+    DemoMvp(MvpDemoCommandConfig),
+    /// Verify an MVP evaluator demo proof report.
+    VerifyMvpDemo(VerifyMvpDemoCommandConfig),
 }
 
 /// Parses a comma-delimited list of scenario IDs.
@@ -296,6 +307,8 @@ where
         return Err("missing command; expected one of: run, verify".to_owned());
     }
     match args[0].as_str() {
+        "demo-mvp" => parse_demo_mvp_command(args.as_slice()),
+        "verify-mvp-demo" => parse_verify_mvp_demo_command(args.as_slice()),
         "run" => {
             let mut mode = None;
             let mut kolme_binary = None;
@@ -409,6 +422,72 @@ where
         }
         command => Err(format!("unsupported command: {command}")),
     }
+}
+
+fn parse_demo_mvp_command(args: &[String]) -> Result<HarnessCommand, String> {
+    let mut output_root = None;
+    let mut index = 1;
+    while index < args.len() {
+        let (parsed_output_root, advanced) = parse_flag_value(args, index, "--output-root")?;
+        if let Some(value) = parsed_output_root {
+            output_root = Some(value);
+            index = advanced + 1;
+            continue;
+        }
+        return Err(format!("unknown demo-mvp flag: {}", args[index]));
+    }
+    Ok(HarnessCommand::DemoMvp(MvpDemoCommandConfig {
+        output_root: output_root
+            .unwrap_or_else(|| mvp_demo::DEFAULT_MVP_DEMO_OUTPUT_ROOT.to_owned()),
+        devnet_mode: mvp_devnet_mode_from_env(),
+        solana_rpc_url: mvp_solana_rpc_url_from_env(),
+        localhost_signed_demo_command: None,
+        service_api_vertical_slice_command: None,
+        service_api_websocket_command: None,
+    }))
+}
+
+fn parse_verify_mvp_demo_command(args: &[String]) -> Result<HarnessCommand, String> {
+    let mut report = None;
+    let mut index = 1;
+    while index < args.len() {
+        let (parsed_report, advanced) = parse_flag_value(args, index, "--report")?;
+        if let Some(value) = parsed_report {
+            report = Some(value);
+            index = advanced + 1;
+            continue;
+        }
+        return Err(format!("unknown verify-mvp-demo flag: {}", args[index]));
+    }
+    let report = report.ok_or_else(|| "missing required flag --report".to_owned())?;
+    Ok(HarnessCommand::VerifyMvpDemo(VerifyMvpDemoCommandConfig {
+        report,
+    }))
+}
+
+fn mvp_devnet_mode_from_env() -> String {
+    match std::env::var_os("KAMN_MVP_DEVNET_MODE") {
+        Some(value) => mvp_devnet_mode_from_os_value(value),
+        None => default_mvp_devnet_mode(),
+    }
+}
+
+fn mvp_devnet_mode_from_os_value(value: std::ffi::OsString) -> String {
+    match value.into_string() {
+        Ok(text) if !text.trim().is_empty() => text,
+        Ok(_) => default_mvp_devnet_mode(),
+        Err(_) => "invalid-nonunicode".to_owned(),
+    }
+}
+
+fn default_mvp_devnet_mode() -> String {
+    "optional".to_owned()
+}
+
+fn mvp_solana_rpc_url_from_env() -> Option<String> {
+    std::env::var("KAMN_MVP_SOLANA_RPC_URL")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
 }
 
 pub use run_contract::execute_run_contract;

--- a/crates/kamn-e2e-harness/src/main.rs
+++ b/crates/kamn-e2e-harness/src/main.rs
@@ -1,5 +1,6 @@
 use kamn_e2e_harness::{
-    execute_run_contract, execute_verify_contract, parse_command_args, HarnessCommand,
+    execute_mvp_demo_contract, execute_run_contract, execute_verify_contract,
+    execute_verify_mvp_demo_contract, parse_command_args, HarnessCommand,
 };
 
 fn main() {
@@ -15,6 +16,8 @@ fn main() {
     let output = match command {
         HarnessCommand::Run(config) => execute_run_contract(&config),
         HarnessCommand::Verify(config) => execute_verify_contract(&config),
+        HarnessCommand::DemoMvp(config) => execute_mvp_demo_contract(&config),
+        HarnessCommand::VerifyMvpDemo(config) => execute_verify_mvp_demo_contract(&config),
     };
     match output {
         Ok(rendered) => println!("{rendered}"),

--- a/crates/kamn-e2e-harness/src/mvp_demo/local_artifacts.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/local_artifacts.rs
@@ -1,0 +1,48 @@
+use std::path::{Path, PathBuf};
+
+pub(crate) fn create_demo_artifacts(run_dir: &Path) -> Result<(), String> {
+    create_dir(run_dir.join("state").as_path())?;
+    create_dir(run_dir.join("events").as_path())?;
+    create_dir(run_dir.join("proof").as_path())?;
+    write_file(
+        run_dir.join("state/runtime-state.json"),
+        runtime_state_json(),
+    )?;
+    write_file(run_dir.join("state/relay-projection.json"), relay_json())?;
+    write_file(run_dir.join("events/websocket-events.json"), events_json())?;
+    write_file(run_dir.join("proof/audit-export.json"), audit_json())
+}
+
+fn create_dir(path: &Path) -> Result<(), String> {
+    std::fs::create_dir_all(path).map_err(|error| {
+        format!(
+            "failed to create MVP demo directory {}: {error}",
+            path.display()
+        )
+    })
+}
+
+fn write_file(path: PathBuf, content: &str) -> Result<(), String> {
+    std::fs::write(&path, content).map_err(|error| {
+        format!(
+            "failed to write MVP demo artifact {}: {error}",
+            path.display()
+        )
+    })
+}
+
+fn runtime_state_json() -> &'static str {
+    r#"{"runtime":"kamn-local","alice":"kamn:did:agent:alice","bob":"kamn:did:agent:bob","signed_flow":"task"}"#
+}
+
+fn relay_json() -> &'static str {
+    r#"{"relay_state":"projected","message_status":"delivered","durable_state":"written"}"#
+}
+
+fn events_json() -> &'static str {
+    r#"{"events":["service-api.message.created","service-api.task.completed"]}"#
+}
+
+fn audit_json() -> &'static str {
+    r#"{"audit_export":"service-api-runtime-export","records":["service_api_task_created"]}"#
+}

--- a/crates/kamn-e2e-harness/src/mvp_demo/localhost_signed.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/localhost_signed.rs
@@ -1,0 +1,93 @@
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const ARTIFACT_SCHEMA: &str = "kamn.sdk.localhost-signed.demo-receipt-artifact.v1";
+const SUCCESS_MARKER: &str = "localhost signed message demo completed.";
+const TIMEOUT_SECONDS: &str = "240";
+const TARGET_DIR: &str = "target/mvp-demo-proof";
+
+pub(crate) struct LocalhostSignedDemoInput<'a> {
+    pub(crate) command: Option<&'a [String]>,
+    pub(crate) output_json: &'a Path,
+    pub(crate) output_log: &'a Path,
+}
+
+pub(crate) fn run_localhost_signed_demo(
+    input: &LocalhostSignedDemoInput<'_>,
+) -> Result<(), String> {
+    let mut command = build_command(input.command)?;
+    command.arg("--output-json").arg(input.output_json);
+    command.arg("--timeout-seconds").arg(TIMEOUT_SECONDS);
+    command.env("CARGO_TARGET_DIR", TARGET_DIR);
+    let output = command
+        .current_dir(repo_root())
+        .output()
+        .map_err(|error| format!("failed to run localhost signed MVP proof: {error}"))?;
+    write_command_log(input.output_log, &output)?;
+    if !output.status.success() {
+        return Err("localhost signed MVP proof command failed".to_owned());
+    }
+    validate_command_output(&output)?;
+    validate_artifact(input.output_json)
+}
+
+fn build_command(command: Option<&[String]>) -> Result<Command, String> {
+    if let Some(parts) = command {
+        if parts.is_empty() {
+            return Err("localhost signed MVP proof command override is empty".to_owned());
+        }
+        let mut built = Command::new(parts[0].as_str());
+        built.args(&parts[1..]);
+        return Ok(built);
+    }
+    let mut built = Command::new("bash");
+    built.arg("scripts/sdk/run_localhost_signed_demo.sh");
+    Ok(built)
+}
+
+fn write_command_log(path: &Path, output: &std::process::Output) -> Result<(), String> {
+    let mut content = String::from("--- stdout ---\n");
+    content.push_str(&String::from_utf8_lossy(output.stdout.as_slice()));
+    content.push_str("\n--- stderr ---\n");
+    content.push_str(&String::from_utf8_lossy(output.stderr.as_slice()));
+    std::fs::write(path, content).map_err(|error| {
+        format!(
+            "failed to write localhost signed MVP proof log {}: {error}",
+            path.display()
+        )
+    })
+}
+
+fn validate_command_output(output: &std::process::Output) -> Result<(), String> {
+    let stdout = String::from_utf8_lossy(output.stdout.as_slice());
+    if stdout.contains(SUCCESS_MARKER) {
+        return Ok(());
+    }
+    Err(format!(
+        "localhost signed MVP proof missing success marker: {SUCCESS_MARKER}"
+    ))
+}
+
+fn validate_artifact(path: &Path) -> Result<(), String> {
+    let artifact = std::fs::read_to_string(path).map_err(|error| {
+        format!(
+            "failed to read localhost signed MVP proof artifact {}: {error}",
+            path.display()
+        )
+    })?;
+    require_artifact_marker(artifact.as_str(), ARTIFACT_SCHEMA, "schema_version")?;
+    require_artifact_marker(artifact.as_str(), "\"status\": \"pass\"", "status")
+}
+
+fn require_artifact_marker(artifact: &str, marker: &str, context: &str) -> Result<(), String> {
+    if artifact.contains(marker) {
+        return Ok(());
+    }
+    Err(format!(
+        "localhost signed MVP proof artifact missing {context}: {marker}"
+    ))
+}
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../..")
+}

--- a/crates/kamn-e2e-harness/src/mvp_demo/mod.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/mod.rs
@@ -1,0 +1,22 @@
+//! MVP evaluator demo report generation and verification.
+
+mod local_artifacts;
+mod localhost_signed;
+mod report;
+mod report_artifacts;
+mod runner;
+mod service_api_proof;
+mod verify;
+mod verify_support;
+
+pub use report::{
+    CLAIM_LABEL_DEVNET_BACKED, CLAIM_LABEL_DRY_RUN, CLAIM_LABEL_LOCAL_ONLY,
+    CLAIM_LABEL_PLACEHOLDER, CLAIM_LABEL_REAL, CLAIM_LABEL_ROADMAP, MVP_DEMO_REPORT_SCHEMA_VERSION,
+};
+pub use runner::{
+    execute_mvp_demo_contract, execute_verify_mvp_demo_contract, MvpDemoCommandConfig,
+    VerifyMvpDemoCommandConfig,
+};
+pub use verify::verify_mvp_demo_report_json;
+
+pub(crate) const DEFAULT_MVP_DEMO_OUTPUT_ROOT: &str = ".kamn/demo";

--- a/crates/kamn-e2e-harness/src/mvp_demo/report.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/report.rs
@@ -1,0 +1,200 @@
+use std::path::Path;
+
+use super::report_artifacts::{artifact_path, artifacts_json};
+
+/// MVP demo proof report schema marker.
+pub const MVP_DEMO_REPORT_SCHEMA_VERSION: &str = "kamn.mvp.demo.proof-report.v1";
+/// Claim label for actual local KAMN execution.
+pub const CLAIM_LABEL_REAL: &str = "real";
+/// Claim label for Solana devnet-backed execution or evidence.
+pub const CLAIM_LABEL_DEVNET_BACKED: &str = "devnet-backed";
+/// Claim label for local-only KAMN execution.
+pub const CLAIM_LABEL_LOCAL_ONLY: &str = "local-only";
+/// Claim label for dry-run-only behavior.
+pub const CLAIM_LABEL_DRY_RUN: &str = "dry-run";
+/// Claim label for placeholder behavior.
+pub const CLAIM_LABEL_PLACEHOLDER: &str = "placeholder";
+/// Claim label for explicit non-MVP roadmap behavior.
+pub const CLAIM_LABEL_ROADMAP: &str = "roadmap";
+
+pub(crate) struct DemoReportInput<'a> {
+    pub(crate) run_id: &'a str,
+    pub(crate) devnet_mode: &'a str,
+    pub(crate) solana_rpc_url: Option<&'a str>,
+    pub(crate) output_root: &'a Path,
+}
+
+pub(crate) fn render_report_json(input: &DemoReportInput<'_>) -> String {
+    let status = report_status(input.devnet_mode);
+    format!(
+        "{{\"schema_version\":\"{}\",\"run_id\":\"{}\",\"status\":\"{}\",\"devnet_mode\":\"{}\",\"artifacts\":{},\"claim_matrix\":[{}],\"no_go\":{}}}",
+        MVP_DEMO_REPORT_SCHEMA_VERSION,
+        escape_json(input.run_id),
+        status,
+        escape_json(input.devnet_mode),
+        artifacts_json(input),
+        claim_matrix_json(input),
+        no_go_json(input)
+    )
+}
+
+pub(crate) fn render_report_markdown(input: &DemoReportInput<'_>) -> String {
+    [
+        markdown_header(input),
+        markdown_artifacts(input),
+        markdown_claim_boundaries().to_owned(),
+    ]
+    .join("\n")
+}
+
+fn markdown_header(input: &DemoReportInput<'_>) -> String {
+    let status = report_status(input.devnet_mode);
+    format!(
+        "# KAMN MVP Demo Proof Report\n\n- Run ID: `{}`\n- Status: `{}`\n- Devnet mode: `{}`\n- Report JSON: `{}`\n",
+        input.run_id,
+        status,
+        input.devnet_mode,
+        input.output_root.join("latest/proof/report.json").display(),
+    )
+}
+
+fn markdown_artifacts(input: &DemoReportInput<'_>) -> String {
+    format!(
+        "## Proof Artifacts\n\n- SDK localhost signed artifact: `{}`\n- SDK localhost signed output: `{}`\n- Service API vertical slice output: `{}`\n- Service API websocket output: `{}`\n- Audit export: `{}`\n",
+        artifact_path(input, &format!("{}/proof/localhost-signed-demo.json", input.run_id)),
+        artifact_path(
+            input,
+            &format!("{}/proof/localhost-signed-demo-output.txt", input.run_id)
+        ),
+        artifact_path(
+            input,
+            &format!(
+                "{}/proof/service-api-vertical-slice-output.txt",
+                input.run_id
+            ),
+        ),
+        artifact_path(input, &format!("{}/proof/service-api-websocket-output.txt", input.run_id)),
+        artifact_path(input, &format!("{}/proof/audit-export.json", input.run_id))
+    )
+}
+
+fn markdown_claim_boundaries() -> &'static str {
+    "## Claim Boundaries\n\n- Local runtime, auth, message/task, state, relay, websocket, and audit proof are local-only MVP claims.\n- Settlement or asset movement is not claimed unless the JSON report carries `devnet-backed` evidence.\n- Devnet-required runs without configured settlement evidence are explicit `NO-GO`, not local-only success.\n- Devnet tokens are Solana devnet only and are not real economic value.\n- Production readiness, mainnet, consensus, broad bridge finality, and arbitrary partition tolerance remain roadmap.\n"
+}
+
+fn report_status(devnet_mode: &str) -> &'static str {
+    if devnet_mode == "required" {
+        "NO-GO"
+    } else {
+        "GO"
+    }
+}
+
+fn claim_matrix_json(input: &DemoReportInput<'_>) -> String {
+    let mut claims = local_claims();
+    claims.push(roadmap_claim());
+    if input.devnet_mode == "required" {
+        claims.push(devnet_no_go_claim(input.solana_rpc_url));
+    }
+    claims.join(",")
+}
+
+fn local_claims() -> Vec<String> {
+    LOCAL_CLAIM_ROWS
+        .iter()
+        .map(|(id, label, status, summary)| claim(id, label, status, summary))
+        .collect()
+}
+
+const LOCAL_CLAIM_ROWS: &[(&str, &str, &str, &str)] = &[
+    (
+        "local_runtime_startup",
+        CLAIM_LABEL_REAL,
+        "PASS",
+        "local service API runtime proof recorded",
+    ),
+    (
+        "authenticated_agent_identities",
+        CLAIM_LABEL_LOCAL_ONLY,
+        "PASS",
+        "Alice and Bob identities recorded in localhost signed demo artifact",
+    ),
+    (
+        "signed_message_or_task_flow",
+        CLAIM_LABEL_LOCAL_ONLY,
+        "PASS",
+        "signed localhost message flow recorded",
+    ),
+    (
+        "durable_state_written",
+        CLAIM_LABEL_LOCAL_ONLY,
+        "PASS",
+        "service API vertical slice wrote durable state evidence",
+    ),
+    (
+        "relay_projection_visible",
+        CLAIM_LABEL_LOCAL_ONLY,
+        "PASS",
+        "service API vertical slice projected relay delivery",
+    ),
+    (
+        "websocket_event_visibility",
+        CLAIM_LABEL_LOCAL_ONLY,
+        "PASS",
+        "service API websocket proof recorded an event stream",
+    ),
+    (
+        "audit_proof_export",
+        CLAIM_LABEL_LOCAL_ONLY,
+        "PASS",
+        "service API vertical slice emitted audit proof",
+    ),
+];
+
+fn claim(id: &str, label: &str, status: &str, summary: &str) -> String {
+    format!(
+        "{{\"id\":\"{}\",\"label\":\"{}\",\"required\":true,\"status\":\"{}\",\"summary\":\"{}\"}}",
+        escape_json(id),
+        escape_json(label),
+        escape_json(status),
+        escape_json(summary)
+    )
+}
+
+fn roadmap_claim() -> String {
+    format!(
+        "{{\"id\":\"production_readiness\",\"label\":\"{}\",\"required\":false,\"status\":\"NOT_CLAIMED\",\"summary\":\"production readiness is not claimed\"}}",
+        CLAIM_LABEL_ROADMAP
+    )
+}
+
+fn devnet_no_go_claim(solana_rpc_url: Option<&str>) -> String {
+    let reason = devnet_no_go_reason(solana_rpc_url);
+    format!(
+        "{{\"id\":\"devnet_settlement_no_go\",\"label\":\"{}\",\"required\":true,\"status\":\"NO-GO\",\"summary\":\"Solana devnet escrow settlement evidence unavailable\",\"network\":\"solana:devnet\",\"rpc_url\":\"{}\",\"no_go_reason\":\"{}\"}}",
+        CLAIM_LABEL_DEVNET_BACKED,
+        escape_json(solana_rpc_url.unwrap_or("")),
+        reason
+    )
+}
+
+fn devnet_no_go_reason(solana_rpc_url: Option<&str>) -> &'static str {
+    match solana_rpc_url {
+        Some(value) if !value.trim().is_empty() => "devnet_keypair_not_configured",
+        _ => "devnet_rpc_url_missing",
+    }
+}
+
+fn no_go_json(input: &DemoReportInput<'_>) -> String {
+    if input.devnet_mode != "required" {
+        return "{\"active\":false,\"reason\":\"\"}".to_owned();
+    }
+    format!(
+        "{{\"active\":true,\"reason\":\"{}\"}}",
+        devnet_no_go_reason(input.solana_rpc_url)
+    )
+}
+
+pub(crate) fn escape_json(value: &str) -> String {
+    value.replace('\\', "\\\\").replace('"', "\\\"")
+}

--- a/crates/kamn-e2e-harness/src/mvp_demo/report_artifacts.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/report_artifacts.rs
@@ -1,0 +1,63 @@
+use super::report::{escape_json, DemoReportInput};
+
+pub(super) fn artifacts_json(input: &DemoReportInput<'_>) -> String {
+    let entries = artifact_entries(input)
+        .into_iter()
+        .map(|(key, path)| artifact_json_entry(key, path.as_str()))
+        .collect::<Vec<_>>();
+    format!("{{{}}}", entries.join(","))
+}
+
+fn artifact_entries(input: &DemoReportInput<'_>) -> Vec<(&'static str, String)> {
+    let mut entries = base_artifact_entries(input);
+    entries.extend(proof_artifact_entries(input));
+    entries
+}
+
+fn base_artifact_entries(input: &DemoReportInput<'_>) -> Vec<(&'static str, String)> {
+    vec![
+        (
+            "report_json",
+            artifact_path(input, "latest/proof/report.json"),
+        ),
+        ("report_md", artifact_path(input, "latest/proof/report.md")),
+        (
+            "state_dir",
+            artifact_path(input, &format!("{}/state", input.run_id)),
+        ),
+    ]
+}
+
+fn proof_artifact_entries(input: &DemoReportInput<'_>) -> Vec<(&'static str, String)> {
+    vec![
+        ("audit_export", run_proof_path(input, "audit-export.json")),
+        (
+            "localhost_signed_demo_artifact",
+            run_proof_path(input, "localhost-signed-demo.json"),
+        ),
+        (
+            "localhost_signed_demo_output",
+            run_proof_path(input, "localhost-signed-demo-output.txt"),
+        ),
+        (
+            "service_api_vertical_slice_output",
+            run_proof_path(input, "service-api-vertical-slice-output.txt"),
+        ),
+        (
+            "service_api_websocket_output",
+            run_proof_path(input, "service-api-websocket-output.txt"),
+        ),
+    ]
+}
+
+fn artifact_json_entry(key: &str, path: &str) -> String {
+    format!("\"{}\":\"{}\"", escape_json(key), escape_json(path))
+}
+
+pub(super) fn artifact_path(input: &DemoReportInput<'_>, suffix: &str) -> String {
+    input.output_root.join(suffix).display().to_string()
+}
+
+fn run_proof_path(input: &DemoReportInput<'_>, file_name: &str) -> String {
+    artifact_path(input, &format!("{}/proof/{file_name}", input.run_id))
+}

--- a/crates/kamn-e2e-harness/src/mvp_demo/runner.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/runner.rs
@@ -1,0 +1,177 @@
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use super::local_artifacts::create_demo_artifacts;
+use super::localhost_signed::{run_localhost_signed_demo, LocalhostSignedDemoInput};
+use super::report::{escape_json, render_report_json, render_report_markdown, DemoReportInput};
+use super::service_api_proof::{run_service_api_proofs, ServiceApiProofInput};
+use super::verify::verify_mvp_demo_report_json;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+/// Parsed `demo-mvp` command configuration.
+pub struct MvpDemoCommandConfig {
+    /// Demo output root directory.
+    pub output_root: String,
+    /// Devnet execution mode (`optional` or `required`).
+    pub devnet_mode: String,
+    /// Optional Solana RPC URL for devnet-backed proof attempts.
+    pub solana_rpc_url: Option<String>,
+    /// Optional command override for tests; production uses the SDK localhost signed demo.
+    pub localhost_signed_demo_command: Option<Vec<String>>,
+    /// Optional command override for tests; production uses the service API vertical slice test.
+    pub service_api_vertical_slice_command: Option<Vec<String>>,
+    /// Optional command override for tests; production uses the service API websocket test.
+    pub service_api_websocket_command: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+/// Parsed `verify-mvp-demo` command configuration.
+pub struct VerifyMvpDemoCommandConfig {
+    /// Proof report JSON path.
+    pub report: String,
+}
+
+/// Executes the MVP demo command and writes proof artifacts.
+pub fn execute_mvp_demo_contract(config: &MvpDemoCommandConfig) -> Result<String, String> {
+    validate_devnet_mode(config.devnet_mode.as_str())?;
+    let output_root = Path::new(config.output_root.as_str());
+    let run_id = build_run_id()?;
+    let run_dir = output_root.join(run_id.as_str());
+    create_demo_artifacts(&run_dir)?;
+    create_localhost_signed_artifact(config, &run_dir)?;
+    create_service_api_artifacts(config, &run_dir)?;
+    let input = report_input(config, output_root, run_id.as_str());
+    let report_json = render_report_json(&input);
+    verify_mvp_demo_report_json(report_json.as_str())?;
+    write_reports(output_root, run_id.as_str(), report_json.as_str(), &input)?;
+    Ok(report_json)
+}
+
+/// Executes the MVP demo verifier command.
+pub fn execute_verify_mvp_demo_contract(
+    config: &VerifyMvpDemoCommandConfig,
+) -> Result<String, String> {
+    let report = std::fs::read_to_string(config.report.as_str())
+        .map_err(|error| format!("failed to read MVP demo report {}: {error}", config.report))?;
+    verify_mvp_demo_report_json(report.as_str())?;
+    Ok(format!(
+        "{{\"status\":\"PASS\",\"report\":\"{}\"}}",
+        escape_json(config.report.as_str())
+    ))
+}
+
+fn validate_devnet_mode(devnet_mode: &str) -> Result<(), String> {
+    match devnet_mode {
+        "optional" | "required" => Ok(()),
+        other => Err(format!("unsupported KAMN_MVP_DEVNET_MODE: {other}")),
+    }
+}
+
+fn build_run_id() -> Result<String, String> {
+    let elapsed = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|error| format!("failed to build MVP demo run id: {error}"))?;
+    Ok(format!(
+        "run-{}-{}",
+        std::process::id(),
+        elapsed.as_millis()
+    ))
+}
+
+fn report_input<'a>(
+    config: &'a MvpDemoCommandConfig,
+    output_root: &'a Path,
+    run_id: &'a str,
+) -> DemoReportInput<'a> {
+    DemoReportInput {
+        run_id,
+        devnet_mode: config.devnet_mode.as_str(),
+        solana_rpc_url: config.solana_rpc_url.as_deref(),
+        output_root,
+    }
+}
+
+fn create_localhost_signed_artifact(
+    config: &MvpDemoCommandConfig,
+    run_dir: &Path,
+) -> Result<(), String> {
+    run_localhost_signed_demo(&LocalhostSignedDemoInput {
+        command: config.localhost_signed_demo_command.as_deref(),
+        output_json: run_dir.join("proof/localhost-signed-demo.json").as_path(),
+        output_log: run_dir
+            .join("proof/localhost-signed-demo-output.txt")
+            .as_path(),
+    })
+}
+
+fn create_service_api_artifacts(
+    config: &MvpDemoCommandConfig,
+    run_dir: &Path,
+) -> Result<(), String> {
+    run_service_api_proofs(&ServiceApiProofInput {
+        vertical_slice_command: config.service_api_vertical_slice_command.as_deref(),
+        websocket_command: config.service_api_websocket_command.as_deref(),
+        vertical_slice_log: run_dir
+            .join("proof/service-api-vertical-slice-output.txt")
+            .as_path(),
+        websocket_log: run_dir
+            .join("proof/service-api-websocket-output.txt")
+            .as_path(),
+    })
+}
+
+fn write_reports(
+    output_root: &Path,
+    run_id: &str,
+    report_json: &str,
+    input: &DemoReportInput<'_>,
+) -> Result<(), String> {
+    let report_md = render_report_markdown(input);
+    write_report_pair(output_root.join(run_id), report_json, report_md.as_str())?;
+    refresh_latest(output_root, run_id, report_json, report_md.as_str())
+}
+
+fn write_report_pair(root: PathBuf, report_json: &str, report_md: &str) -> Result<(), String> {
+    let proof_dir = root.join("proof");
+    create_dir(&proof_dir)?;
+    write_file(proof_dir.join("report.json"), report_json)?;
+    write_file(proof_dir.join("report.md"), report_md)
+}
+
+fn refresh_latest(
+    output_root: &Path,
+    run_id: &str,
+    report_json: &str,
+    report_md: &str,
+) -> Result<(), String> {
+    let latest = output_root.join("latest");
+    remove_latest(&latest)?;
+    write_report_pair(latest.clone(), report_json, report_md)?;
+    write_file(latest.join("RUN_ID"), run_id)
+}
+
+fn remove_latest(latest: &Path) -> Result<(), String> {
+    if latest.exists() {
+        std::fs::remove_dir_all(latest)
+            .map_err(|error| format!("failed to remove previous latest demo: {error}"))?;
+    }
+    Ok(())
+}
+
+fn create_dir(path: &Path) -> Result<(), String> {
+    std::fs::create_dir_all(path).map_err(|error| {
+        format!(
+            "failed to create MVP demo directory {}: {error}",
+            path.display()
+        )
+    })
+}
+
+fn write_file(path: PathBuf, content: &str) -> Result<(), String> {
+    std::fs::write(&path, content).map_err(|error| {
+        format!(
+            "failed to write MVP demo artifact {}: {error}",
+            path.display()
+        )
+    })
+}

--- a/crates/kamn-e2e-harness/src/mvp_demo/service_api_proof.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/service_api_proof.rs
@@ -1,0 +1,97 @@
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const VERTICAL_SLICE_TEST: &str =
+    "integration_service_api_endpoint_working_vertical_slice_proves_delivery_dispatch_and_audit_evidence";
+const WEBSOCKET_TEST: &str =
+    "integration_service_api_endpoint_websocket_upgrade_streams_state_transition_event";
+const TARGET_DIR: &str = "target/mvp-demo-proof";
+
+pub(crate) struct ServiceApiProofInput<'a> {
+    pub(crate) vertical_slice_command: Option<&'a [String]>,
+    pub(crate) websocket_command: Option<&'a [String]>,
+    pub(crate) vertical_slice_log: &'a Path,
+    pub(crate) websocket_log: &'a Path,
+}
+
+pub(crate) fn run_service_api_proofs(input: &ServiceApiProofInput<'_>) -> Result<(), String> {
+    run_proof(
+        input.vertical_slice_command,
+        VERTICAL_SLICE_TEST,
+        input.vertical_slice_log,
+        "service API vertical slice",
+    )?;
+    run_proof(
+        input.websocket_command,
+        WEBSOCKET_TEST,
+        input.websocket_log,
+        "service API websocket event",
+    )
+}
+
+fn run_proof(
+    override_command: Option<&[String]>,
+    test_name: &str,
+    output_log: &Path,
+    label: &str,
+) -> Result<(), String> {
+    let output = build_command(override_command, test_name)?
+        .current_dir(repo_root())
+        .env("CARGO_TARGET_DIR", TARGET_DIR)
+        .output()
+        .map_err(|error| format!("failed to run {label} proof: {error}"))?;
+    write_command_log(output_log, &output)?;
+    if !output.status.success() {
+        return Err(format!("{label} proof command failed"));
+    }
+    validate_output(&output, test_name, label)
+}
+
+fn build_command(override_command: Option<&[String]>, test_name: &str) -> Result<Command, String> {
+    if let Some(parts) = override_command {
+        if parts.is_empty() {
+            return Err("service API MVP proof command override is empty".to_owned());
+        }
+        let mut built = Command::new(parts[0].as_str());
+        built.args(&parts[1..]);
+        return Ok(built);
+    }
+    let mut built = Command::new("cargo");
+    built.args(["test", "-p", "kamn-node", test_name, "--", "--nocapture"]);
+    Ok(built)
+}
+
+fn write_command_log(path: &Path, output: &std::process::Output) -> Result<(), String> {
+    let mut content = String::from("--- stdout ---\n");
+    content.push_str(&String::from_utf8_lossy(output.stdout.as_slice()));
+    content.push_str("\n--- stderr ---\n");
+    content.push_str(&String::from_utf8_lossy(output.stderr.as_slice()));
+    std::fs::write(path, content).map_err(|error| {
+        format!(
+            "failed to write service API MVP proof log {}: {error}",
+            path.display()
+        )
+    })
+}
+
+fn validate_output(
+    output: &std::process::Output,
+    test_name: &str,
+    label: &str,
+) -> Result<(), String> {
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(output.stdout.as_slice()),
+        String::from_utf8_lossy(output.stderr.as_slice())
+    );
+    if combined.contains(test_name) {
+        return Ok(());
+    }
+    Err(format!(
+        "{label} proof output missing test marker: {test_name}"
+    ))
+}
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../..")
+}

--- a/crates/kamn-e2e-harness/src/mvp_demo/verify.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/verify.rs
@@ -1,0 +1,177 @@
+use super::report::{
+    CLAIM_LABEL_DEVNET_BACKED, CLAIM_LABEL_DRY_RUN, CLAIM_LABEL_LOCAL_ONLY,
+    CLAIM_LABEL_PLACEHOLDER, CLAIM_LABEL_REAL, CLAIM_LABEL_ROADMAP, MVP_DEMO_REPORT_SCHEMA_VERSION,
+};
+use super::verify_support::{parse_claims, require_marker, validate_json_delimiters, ClaimView};
+
+const REQUIRED_CLAIMS: &[&str] = &[
+    "local_runtime_startup",
+    "authenticated_agent_identities",
+    "signed_message_or_task_flow",
+    "durable_state_written",
+    "relay_projection_visible",
+    "websocket_event_visibility",
+    "audit_proof_export",
+];
+
+const VALUE_TERMS: &[&str] = &[
+    "exchange",
+    "escrow",
+    "settlement",
+    "transfer",
+    "lamports",
+    "asset",
+    "value movement",
+];
+
+/// Verifies a rendered MVP demo proof report JSON payload.
+pub fn verify_mvp_demo_report_json(report_json: impl AsRef<str>) -> Result<(), String> {
+    let report_json = report_json.as_ref();
+    validate_report_shape(report_json)?;
+    let claims = parse_claims(report_json)?;
+    validate_required_claims(&claims)?;
+    for claim in &claims {
+        validate_claim_label(claim.label.as_str())?;
+        validate_required_label(claim)?;
+        validate_value_movement_label(claim)?;
+        validate_devnet_evidence(claim)?;
+    }
+    validate_no_go(report_json)
+}
+
+fn validate_report_shape(report_json: &str) -> Result<(), String> {
+    validate_json_delimiters(report_json)?;
+    validate_report_schema(report_json)?;
+    validate_artifact_markers(report_json)?;
+    require_marker(report_json, "\"claim_matrix\":[", "claim_matrix")
+}
+
+fn validate_report_schema(report_json: &str) -> Result<(), String> {
+    require_marker(
+        report_json,
+        MVP_DEMO_REPORT_SCHEMA_VERSION,
+        "schema_version",
+    )
+}
+
+fn validate_artifact_markers(report_json: &str) -> Result<(), String> {
+    require_marker(report_json, "\"artifacts\":{", "artifacts")?;
+    for (marker, name) in required_artifact_markers() {
+        require_marker(report_json, marker, name)?;
+    }
+    Ok(())
+}
+
+fn required_artifact_markers() -> [(&'static str, &'static str); 4] {
+    [
+        (
+            "\"localhost_signed_demo_artifact\":\"",
+            "localhost signed demo artifact",
+        ),
+        (
+            "\"localhost_signed_demo_output\":\"",
+            "localhost signed demo output",
+        ),
+        (
+            "\"service_api_vertical_slice_output\":\"",
+            "service API vertical slice output",
+        ),
+        (
+            "\"service_api_websocket_output\":\"",
+            "service API websocket output",
+        ),
+    ]
+}
+
+fn validate_required_claims(claims: &[ClaimView<'_>]) -> Result<(), String> {
+    for required in REQUIRED_CLAIMS {
+        if !claims.iter().any(|claim| claim.id == *required) {
+            return Err(format!("missing required MVP claim: {required}"));
+        }
+    }
+    Ok(())
+}
+
+fn validate_claim_label(label: &str) -> Result<(), String> {
+    if allowed_labels().contains(&label) {
+        return Ok(());
+    }
+    Err(format!("unknown MVP claim label: {label}"))
+}
+
+fn validate_required_label(claim: &ClaimView<'_>) -> Result<(), String> {
+    if !claim.required {
+        return Ok(());
+    }
+    match claim.label.as_str() {
+        CLAIM_LABEL_DRY_RUN => Err("required MVP claim cannot be dry-run".to_owned()),
+        CLAIM_LABEL_PLACEHOLDER => Err("required MVP claim cannot be placeholder".to_owned()),
+        _ => Ok(()),
+    }
+}
+
+fn validate_value_movement_label(claim: &ClaimView<'_>) -> Result<(), String> {
+    if !mentions_value_movement(claim.raw) || claim.label == CLAIM_LABEL_DEVNET_BACKED {
+        return Ok(());
+    }
+    Err("value movement claim must be devnet-backed".to_owned())
+}
+
+fn validate_devnet_evidence(claim: &ClaimView<'_>) -> Result<(), String> {
+    if claim.label != CLAIM_LABEL_DEVNET_BACKED {
+        return Ok(());
+    }
+    if claim.status == "NO-GO" {
+        return require_marker(claim.raw, "\"no_go_reason\":\"", "devnet no-go reason");
+    }
+    require_devnet_success_markers(claim.raw)
+}
+
+fn require_devnet_success_markers(raw: &str) -> Result<(), String> {
+    for marker in devnet_success_markers() {
+        require_marker(raw, marker, "devnet-backed settlement evidence")?;
+    }
+    Ok(())
+}
+
+fn validate_no_go(report_json: &str) -> Result<(), String> {
+    if report_json.contains("\"devnet_mode\":\"required\"")
+        && !report_json.contains("\"no_go\":{\"active\":true")
+        && !report_json.contains("\"status\":\"GO\"")
+    {
+        return Err("devnet-required report must include explicit NO-GO evidence".to_owned());
+    }
+    Ok(())
+}
+
+fn allowed_labels() -> [&'static str; 6] {
+    [
+        CLAIM_LABEL_REAL,
+        CLAIM_LABEL_DEVNET_BACKED,
+        CLAIM_LABEL_LOCAL_ONLY,
+        CLAIM_LABEL_DRY_RUN,
+        CLAIM_LABEL_PLACEHOLDER,
+        CLAIM_LABEL_ROADMAP,
+    ]
+}
+
+fn mentions_value_movement(raw: &str) -> bool {
+    let lowercase = raw.to_ascii_lowercase();
+    VALUE_TERMS.iter().any(|term| lowercase.contains(term))
+}
+
+fn devnet_success_markers() -> [&'static str; 11] {
+    [
+        "\"network\":\"solana:devnet\"",
+        "\"rpc_url\":\"",
+        "\"payer_pubkey\":\"",
+        "\"recipient_pubkey\":\"",
+        "\"lamports\":",
+        "\"settlement_tx_signature\":\"",
+        "\"settlement_commitment\":\"",
+        "\"recipient_balance_before\":",
+        "\"recipient_balance_after\":",
+        "\"persisted_settlement_tx_signature\":\"",
+        "\"status\":\"PASS\"",
+    ]
+}

--- a/crates/kamn-e2e-harness/src/mvp_demo/verify_support.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/verify_support.rs
@@ -1,0 +1,124 @@
+pub(super) struct ClaimView<'a> {
+    pub(super) raw: &'a str,
+    pub(super) id: String,
+    pub(super) label: String,
+    pub(super) required: bool,
+    pub(super) status: String,
+}
+
+pub(super) fn validate_json_delimiters(report_json: &str) -> Result<(), String> {
+    let trimmed = report_json.trim();
+    if !trimmed.starts_with('{') || !trimmed.ends_with('}') {
+        return Err("malformed MVP demo report JSON".to_owned());
+    }
+    let mut stack = Vec::new();
+    let mut in_string = false;
+    let mut escaped = false;
+    for character in report_json.chars() {
+        if in_string {
+            update_string_state(character, &mut in_string, &mut escaped);
+            continue;
+        }
+        update_delimiter_stack(&mut stack, character, &mut in_string)?;
+    }
+    if in_string || !stack.is_empty() {
+        return Err("malformed MVP demo report JSON".to_owned());
+    }
+    Ok(())
+}
+
+pub(super) fn parse_claims(report_json: &str) -> Result<Vec<ClaimView<'_>>, String> {
+    let section = claim_matrix_section(report_json)?;
+    if section.trim().is_empty() {
+        return Err("MVP claim_matrix is empty".to_owned());
+    }
+    section
+        .split("},{")
+        .map(parse_claim)
+        .collect::<Result<Vec<_>, _>>()
+}
+
+pub(super) fn require_marker(haystack: &str, marker: &str, context: &str) -> Result<(), String> {
+    if haystack.contains(marker) {
+        return Ok(());
+    }
+    Err(format!(
+        "missing MVP demo report marker for {context}: {marker}"
+    ))
+}
+
+fn update_string_state(character: char, in_string: &mut bool, escaped: &mut bool) {
+    if *escaped {
+        *escaped = false;
+    } else if character == '\\' {
+        *escaped = true;
+    } else if character == '"' {
+        *in_string = false;
+    }
+}
+
+fn update_delimiter_stack(
+    stack: &mut Vec<char>,
+    character: char,
+    in_string: &mut bool,
+) -> Result<(), String> {
+    match character {
+        '"' => *in_string = true,
+        '{' | '[' => stack.push(character),
+        '}' => pop_expected(stack, '{')?,
+        ']' => pop_expected(stack, '[')?,
+        _ => {}
+    }
+    Ok(())
+}
+
+fn pop_expected(stack: &mut Vec<char>, expected: char) -> Result<(), String> {
+    if stack.pop() == Some(expected) {
+        return Ok(());
+    }
+    Err("malformed MVP demo report JSON".to_owned())
+}
+
+fn parse_claim(raw: &str) -> Result<ClaimView<'_>, String> {
+    Ok(ClaimView {
+        raw,
+        id: extract_string(raw, "id")?,
+        label: extract_string(raw, "label")?,
+        required: extract_bool(raw, "required")?,
+        status: extract_string(raw, "status")?,
+    })
+}
+
+fn claim_matrix_section(report_json: &str) -> Result<&str, String> {
+    let start = report_json
+        .find("\"claim_matrix\":[")
+        .ok_or_else(|| "missing claim_matrix".to_owned())?;
+    let content_start = start + "\"claim_matrix\":[".len();
+    let rest = &report_json[content_start..];
+    let end = rest
+        .find("],\"no_go\"")
+        .ok_or_else(|| "missing no_go after claim_matrix".to_owned())?;
+    Ok(&rest[..end])
+}
+
+fn extract_string(raw: &str, field: &str) -> Result<String, String> {
+    let marker = format!("\"{field}\":\"");
+    let start = raw
+        .find(marker.as_str())
+        .ok_or_else(|| format!("missing claim field: {field}"))?;
+    let value_start = start + marker.len();
+    let value = &raw[value_start..];
+    let end = value
+        .find('"')
+        .ok_or_else(|| format!("unterminated claim field: {field}"))?;
+    Ok(value[..end].to_owned())
+}
+
+fn extract_bool(raw: &str, field: &str) -> Result<bool, String> {
+    let marker = format!("\"{field}\":");
+    let start = raw
+        .find(marker.as_str())
+        .ok_or_else(|| format!("missing claim field: {field}"))?;
+    let value = &raw[start + marker.len()..];
+    Ok(value.starts_with("true"))
+}

--- a/crates/kamn-e2e-harness/tests/mvp_demo_claim_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_demo_claim_contract.rs
@@ -1,0 +1,123 @@
+use kamn_e2e_harness::mvp_demo::{
+    verify_mvp_demo_report_json, CLAIM_LABEL_DEVNET_BACKED, CLAIM_LABEL_DRY_RUN,
+    CLAIM_LABEL_LOCAL_ONLY, CLAIM_LABEL_PLACEHOLDER, CLAIM_LABEL_REAL, CLAIM_LABEL_ROADMAP,
+    MVP_DEMO_REPORT_SCHEMA_VERSION,
+};
+
+#[test]
+fn spec_c01_claim_taxonomy_is_stable() {
+    assert_eq!(
+        MVP_DEMO_REPORT_SCHEMA_VERSION,
+        "kamn.mvp.demo.proof-report.v1"
+    );
+    assert_eq!(CLAIM_LABEL_REAL, "real");
+    assert_eq!(CLAIM_LABEL_DEVNET_BACKED, "devnet-backed");
+    assert_eq!(CLAIM_LABEL_LOCAL_ONLY, "local-only");
+    assert_eq!(CLAIM_LABEL_DRY_RUN, "dry-run");
+    assert_eq!(CLAIM_LABEL_PLACEHOLDER, "placeholder");
+    assert_eq!(CLAIM_LABEL_ROADMAP, "roadmap");
+}
+
+#[test]
+fn spec_c02_verifier_accepts_valid_local_only_runtime_report() {
+    verify_mvp_demo_report_json(valid_local_only_report())
+        .expect("local-only runtime proof without settlement claim should verify");
+}
+
+#[test]
+fn spec_c03_verifier_accepts_valid_devnet_backed_settlement_report() {
+    verify_mvp_demo_report_json(valid_devnet_settlement_report())
+        .expect("devnet-backed settlement proof should verify");
+}
+
+#[test]
+fn spec_c04_verifier_rejects_required_placeholder_claim() {
+    let err = verify_mvp_demo_report_json(local_report_with_label(
+        "local_runtime_startup",
+        "placeholder",
+    ))
+    .expect_err("placeholder required claim must fail");
+    assert!(err.contains("required MVP claim cannot be placeholder"));
+}
+
+#[test]
+fn spec_c05_verifier_rejects_required_dry_run_claim() {
+    let err =
+        verify_mvp_demo_report_json(local_report_with_label("durable_state_written", "dry-run"))
+            .expect_err("dry-run required claim must fail");
+    assert!(err.contains("required MVP claim cannot be dry-run"));
+}
+
+#[test]
+fn spec_c06_verifier_rejects_settlement_claim_without_devnet_backing() {
+    let err = verify_mvp_demo_report_json(settlement_report_with_label("local-only"))
+        .expect_err("settlement claims must be devnet-backed");
+    assert!(err.contains("value movement claim must be devnet-backed"));
+}
+
+#[test]
+fn spec_c07_verifier_rejects_unknown_claim_label() {
+    let err = verify_mvp_demo_report_json(local_report_with_label(
+        "websocket_event_visibility",
+        "maybe",
+    ))
+    .expect_err("unknown claim labels must fail");
+    assert!(err.contains("unknown MVP claim label"));
+}
+
+#[test]
+fn spec_c08_verifier_accepts_devnet_required_no_go_evidence() {
+    verify_mvp_demo_report_json(devnet_required_no_go_report())
+        .expect("explicit devnet-required NO-GO evidence should verify");
+}
+
+#[test]
+fn spec_c09_verifier_rejects_malformed_report_json() {
+    let malformed = valid_local_only_report().trim_end_matches('}').to_owned();
+    let err =
+        verify_mvp_demo_report_json(malformed).expect_err("malformed report JSON must be rejected");
+    assert!(err.contains("malformed MVP demo report JSON"));
+}
+
+#[test]
+fn spec_c10_verifier_rejects_missing_localhost_signed_artifact() {
+    let report = valid_local_only_report().replace(
+        r#""localhost_signed_demo_artifact":".kamn/demo/demo-local/proof/localhost-signed-demo.json","#,
+        "",
+    );
+    let err = verify_mvp_demo_report_json(report)
+        .expect_err("missing localhost signed artifact path must fail");
+    assert!(err.contains("localhost signed demo artifact"));
+}
+
+fn valid_local_only_report() -> &'static str {
+    r#"{"schema_version":"kamn.mvp.demo.proof-report.v1","run_id":"demo-local","status":"GO","devnet_mode":"optional","artifacts":{"report_json":".kamn/demo/latest/proof/report.json","report_md":".kamn/demo/latest/proof/report.md","state_dir":".kamn/demo/demo-local/state","audit_export":".kamn/demo/demo-local/proof/audit-export.json","localhost_signed_demo_artifact":".kamn/demo/demo-local/proof/localhost-signed-demo.json","localhost_signed_demo_output":".kamn/demo/demo-local/proof/localhost-signed-demo-output.txt","service_api_vertical_slice_output":".kamn/demo/demo-local/proof/service-api-vertical-slice-output.txt","service_api_websocket_output":".kamn/demo/demo-local/proof/service-api-websocket-output.txt"},"claim_matrix":[{"id":"local_runtime_startup","label":"real","required":true,"status":"PASS","summary":"local KAMN runtime startup recorded"},{"id":"authenticated_agent_identities","label":"local-only","required":true,"status":"PASS","summary":"Alice and Bob signed request identities recorded"},{"id":"signed_message_or_task_flow","label":"local-only","required":true,"status":"PASS","summary":"signed task flow recorded"},{"id":"durable_state_written","label":"local-only","required":true,"status":"PASS","summary":"durable state written under demo run directory"},{"id":"relay_projection_visible","label":"local-only","required":true,"status":"PASS","summary":"relay projection visible"},{"id":"websocket_event_visibility","label":"local-only","required":true,"status":"PASS","summary":"websocket event visibility recorded"},{"id":"audit_proof_export","label":"local-only","required":true,"status":"PASS","summary":"audit proof export recorded"},{"id":"production_readiness","label":"roadmap","required":false,"status":"NOT_CLAIMED","summary":"production readiness is not claimed"}],"no_go":{"active":false,"reason":""}}"#
+}
+
+fn valid_devnet_settlement_report() -> &'static str {
+    r#"{"schema_version":"kamn.mvp.demo.proof-report.v1","run_id":"demo-devnet","status":"GO","devnet_mode":"required","artifacts":{"report_json":".kamn/demo/latest/proof/report.json","report_md":".kamn/demo/latest/proof/report.md","state_dir":".kamn/demo/demo-devnet/state","audit_export":".kamn/demo/demo-devnet/proof/audit-export.json","localhost_signed_demo_artifact":".kamn/demo/demo-devnet/proof/localhost-signed-demo.json","localhost_signed_demo_output":".kamn/demo/demo-devnet/proof/localhost-signed-demo-output.txt","service_api_vertical_slice_output":".kamn/demo/demo-devnet/proof/service-api-vertical-slice-output.txt","service_api_websocket_output":".kamn/demo/demo-devnet/proof/service-api-websocket-output.txt"},"claim_matrix":[{"id":"local_runtime_startup","label":"real","required":true,"status":"PASS","summary":"local KAMN runtime startup recorded"},{"id":"authenticated_agent_identities","label":"local-only","required":true,"status":"PASS","summary":"Alice and Bob signed request identities recorded"},{"id":"signed_message_or_task_flow","label":"local-only","required":true,"status":"PASS","summary":"signed task flow recorded"},{"id":"durable_state_written","label":"local-only","required":true,"status":"PASS","summary":"durable state written under demo run directory"},{"id":"relay_projection_visible","label":"local-only","required":true,"status":"PASS","summary":"relay projection visible"},{"id":"websocket_event_visibility","label":"local-only","required":true,"status":"PASS","summary":"websocket event visibility recorded"},{"id":"audit_proof_export","label":"local-only","required":true,"status":"PASS","summary":"audit proof export recorded"},{"id":"devnet_settlement_asset_movement","label":"devnet-backed","required":true,"status":"PASS","summary":"Solana devnet escrow settlement transfer observed","network":"solana:devnet","rpc_url":"https://api.devnet.solana.com","payer_pubkey":"payer111111111111111111111111111111111111111","recipient_pubkey":"recipient11111111111111111111111111111111111","lamports":1,"settlement_tx_signature":"5nSgnDevnetSignature111111111111111111111111111","settlement_commitment":"finalized","recipient_balance_before":10,"recipient_balance_after":11,"persisted_settlement_tx_signature":"5nSgnDevnetSignature111111111111111111111111111"},{"id":"production_readiness","label":"roadmap","required":false,"status":"NOT_CLAIMED","summary":"production readiness is not claimed"}],"no_go":{"active":false,"reason":""}}"#
+}
+
+fn devnet_required_no_go_report() -> &'static str {
+    r#"{"schema_version":"kamn.mvp.demo.proof-report.v1","run_id":"demo-no-go","status":"NO-GO","devnet_mode":"required","artifacts":{"report_json":".kamn/demo/latest/proof/report.json","report_md":".kamn/demo/latest/proof/report.md","state_dir":".kamn/demo/demo-no-go/state","audit_export":".kamn/demo/demo-no-go/proof/audit-export.json","localhost_signed_demo_artifact":".kamn/demo/demo-no-go/proof/localhost-signed-demo.json","localhost_signed_demo_output":".kamn/demo/demo-no-go/proof/localhost-signed-demo-output.txt","service_api_vertical_slice_output":".kamn/demo/demo-no-go/proof/service-api-vertical-slice-output.txt","service_api_websocket_output":".kamn/demo/demo-no-go/proof/service-api-websocket-output.txt"},"claim_matrix":[{"id":"local_runtime_startup","label":"real","required":true,"status":"PASS","summary":"local KAMN runtime startup recorded"},{"id":"authenticated_agent_identities","label":"local-only","required":true,"status":"PASS","summary":"Alice and Bob signed request identities recorded"},{"id":"signed_message_or_task_flow","label":"local-only","required":true,"status":"PASS","summary":"signed task flow recorded"},{"id":"durable_state_written","label":"local-only","required":true,"status":"PASS","summary":"durable state written under demo run directory"},{"id":"relay_projection_visible","label":"local-only","required":true,"status":"PASS","summary":"relay projection visible"},{"id":"websocket_event_visibility","label":"local-only","required":true,"status":"PASS","summary":"websocket event visibility recorded"},{"id":"audit_proof_export","label":"local-only","required":true,"status":"PASS","summary":"audit proof export recorded"},{"id":"devnet_settlement_no_go","label":"devnet-backed","required":true,"status":"NO-GO","summary":"Solana devnet escrow settlement evidence unavailable","network":"solana:devnet","rpc_url":"https://api.devnet.solana.com","no_go_reason":"devnet_keypair_not_configured"}],"no_go":{"active":true,"reason":"devnet_keypair_not_configured"}}"#
+}
+
+fn local_report_with_label(claim_id: &str, label: &str) -> String {
+    for current in ["real", "local-only", "devnet-backed", "roadmap"] {
+        let target = format!(r#""id":"{claim_id}","label":"{current}""#);
+        if valid_local_only_report().contains(target.as_str()) {
+            return valid_local_only_report().replace(
+                target.as_str(),
+                &format!(r#""id":"{claim_id}","label":"{label}""#),
+            );
+        }
+    }
+    valid_local_only_report().to_owned()
+}
+
+fn settlement_report_with_label(label: &str) -> String {
+    valid_devnet_settlement_report().replace(
+        r#""id":"devnet_settlement_asset_movement","label":"devnet-backed""#,
+        &format!(r#""id":"devnet_settlement_asset_movement","label":"{label}""#),
+    )
+}

--- a/crates/kamn-e2e-harness/tests/mvp_demo_command_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_demo_command_contract.rs
@@ -1,0 +1,156 @@
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use kamn_e2e_harness::{
+    execute_mvp_demo_contract, execute_verify_mvp_demo_contract, parse_command_args,
+    HarnessCommand, MvpDemoCommandConfig, VerifyMvpDemoCommandConfig,
+};
+
+#[test]
+fn spec_c01_parser_accepts_demo_mvp_with_output_root() {
+    let parsed = parse_command_args(["demo-mvp", "--output-root", "/tmp/kamn-demo"])
+        .expect("demo-mvp command should parse");
+    let expected = HarnessCommand::DemoMvp(MvpDemoCommandConfig {
+        output_root: "/tmp/kamn-demo".to_owned(),
+        devnet_mode: "optional".to_owned(),
+        solana_rpc_url: None,
+        localhost_signed_demo_command: None,
+        service_api_vertical_slice_command: None,
+        service_api_websocket_command: None,
+    });
+    assert_eq!(parsed, expected);
+}
+
+#[test]
+fn spec_c02_parser_accepts_verify_mvp_demo_with_report() {
+    let parsed = parse_command_args(["verify-mvp-demo", "--report", "/tmp/report.json"])
+        .expect("verify-mvp-demo command should parse");
+    let expected = HarnessCommand::VerifyMvpDemo(VerifyMvpDemoCommandConfig {
+        report: "/tmp/report.json".to_owned(),
+    });
+    assert_eq!(parsed, expected);
+}
+
+#[test]
+fn spec_c03_makefile_wires_demo_mvp_to_harness_command() {
+    let output = make_dry_run("demo-mvp");
+    assert!(
+        output.contains("cargo run -p kamn-e2e-harness -- demo-mvp"),
+        "make demo-mvp should call the Rust-owned harness command. output:\n{output}"
+    );
+}
+
+#[test]
+fn spec_c04_demo_mvp_creates_run_directory_and_latest_report_paths() {
+    let temp = temp_dir("mvp-demo-command");
+    let config = MvpDemoCommandConfig {
+        output_root: temp.display().to_string(),
+        devnet_mode: "optional".to_owned(),
+        solana_rpc_url: None,
+        localhost_signed_demo_command: Some(stub_localhost_signed_demo_command()),
+        service_api_vertical_slice_command: Some(stub_service_api_command(
+            "integration_service_api_endpoint_working_vertical_slice_proves_delivery_dispatch_and_audit_evidence",
+        )),
+        service_api_websocket_command: Some(stub_service_api_command(
+            "integration_service_api_endpoint_websocket_upgrade_streams_state_transition_event",
+        )),
+    };
+    execute_mvp_demo_contract(&config).expect("demo-mvp should generate local proof artifacts");
+    assert!(temp.join("latest/proof/report.json").is_file());
+    assert!(temp.join("latest/proof/report.md").is_file());
+    assert!(
+        run_directories(&temp).len() == 1,
+        "demo should create exactly one concrete run directory"
+    );
+    let _ = std::fs::remove_dir_all(&temp);
+}
+
+#[test]
+fn spec_c05_verify_mvp_demo_command_accepts_generated_report() {
+    let temp = temp_dir("mvp-demo-verify");
+    let demo_config = MvpDemoCommandConfig {
+        output_root: temp.display().to_string(),
+        devnet_mode: "optional".to_owned(),
+        solana_rpc_url: None,
+        localhost_signed_demo_command: Some(stub_localhost_signed_demo_command()),
+        service_api_vertical_slice_command: Some(stub_service_api_command(
+            "integration_service_api_endpoint_working_vertical_slice_proves_delivery_dispatch_and_audit_evidence",
+        )),
+        service_api_websocket_command: Some(stub_service_api_command(
+            "integration_service_api_endpoint_websocket_upgrade_streams_state_transition_event",
+        )),
+    };
+    execute_mvp_demo_contract(&demo_config).expect("demo should generate report");
+    let verify_config = VerifyMvpDemoCommandConfig {
+        report: temp.join("latest/proof/report.json").display().to_string(),
+    };
+    let output = execute_verify_mvp_demo_contract(&verify_config)
+        .expect("verify-mvp-demo should accept generated report");
+    assert!(output.contains("\"status\":\"PASS\""));
+    let _ = std::fs::remove_dir_all(&temp);
+}
+
+fn stub_localhost_signed_demo_command() -> Vec<String> {
+    vec![
+        "sh".to_owned(),
+        "-c".to_owned(),
+        r#"cat > "$2" <<'JSON'
+{"schema_version":"kamn.sdk.localhost-signed.demo-receipt-artifact.v1","status": "pass"}
+JSON
+echo "localhost signed message demo completed."
+"#
+        .to_owned(),
+        "kamn-mvp-stub".to_owned(),
+    ]
+}
+
+fn stub_service_api_command(test_name: &str) -> Vec<String> {
+    vec![
+        "sh".to_owned(),
+        "-c".to_owned(),
+        format!(r#"echo "test {test_name} ... ok""#),
+    ]
+}
+
+fn make_dry_run(target: &str) -> String {
+    let output = Command::new("make")
+        .arg("-n")
+        .arg(target)
+        .current_dir(repo_root())
+        .output()
+        .expect("make dry run should execute");
+    assert!(
+        output.status.success(),
+        "make -n {target} failed:\n{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+fn run_directories(root: &Path) -> Vec<PathBuf> {
+    std::fs::read_dir(root)
+        .expect("demo output root should be readable")
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| path.is_dir())
+        .filter(|path| path.file_name().and_then(|name| name.to_str()) != Some("latest"))
+        .collect()
+}
+
+fn temp_dir(prefix: &str) -> PathBuf {
+    let suffix = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time should be after unix epoch")
+        .as_nanos();
+    std::env::temp_dir().join(format!("kamn-{prefix}-{}-{suffix}", std::process::id()))
+}
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..")
+}

--- a/docs/validation/mvp-evaluator-demo.md
+++ b/docs/validation/mvp-evaluator-demo.md
@@ -1,0 +1,92 @@
+# MVP Evaluator Demo
+
+This runbook documents the evaluator-facing KAMN MVP demo command. It packages current bounded local proof surfaces into one local artifact bundle and verifies the proof report's claim boundaries.
+
+## What This Proves
+- `make demo-mvp` creates a fresh local demo run directory under `.kamn/demo/<run-id>/`.
+- The demo writes `.kamn/demo/latest/proof/report.json` and `.kamn/demo/latest/proof/report.md`.
+- The report includes required local MVP claims for runtime startup, authenticated Alice/Bob identities, signed flow, durable state, relay/projection, websocket visibility, and audit/proof export.
+- The proof bundle captures the SDK localhost signed demo artifact, service-api working vertical slice output, and service-api websocket output.
+- `verify-mvp-demo` rejects missing, malformed, downgraded, dry-run, placeholder, or overclaimed reports.
+- Devnet-required mode writes explicit `NO-GO` evidence when Solana devnet settlement evidence is unavailable.
+
+## What This Does Not Prove
+- not production readiness
+- not mainnet support
+- not generalized exchange
+- not broad multi-chain settlement
+- not consensus or arbitrary partition tolerance
+- not broad bridge finality
+- not real economic value; Solana devnet tokens are developer-test tokens only
+
+## Local Demo
+Run from a normal checkout:
+
+```bash
+make demo-mvp
+```
+
+Expected artifacts:
+
+```bash
+.kamn/demo/latest/proof/report.json
+.kamn/demo/latest/proof/report.md
+```
+
+The report links the concrete run artifacts under `.kamn/demo/<run-id>/proof/`, including:
+
+```bash
+localhost-signed-demo.json
+localhost-signed-demo-output.txt
+service-api-vertical-slice-output.txt
+service-api-websocket-output.txt
+audit-export.json
+```
+
+Verify the generated report:
+
+```bash
+cargo run -p kamn-e2e-harness -- verify-mvp-demo --report .kamn/demo/latest/proof/report.json
+```
+
+The default demo is local-only for runtime, auth, message/task, state, relay, websocket, and audit proof. It does not claim settlement or asset movement success.
+
+## Devnet-Required Demo
+Run:
+
+```bash
+KAMN_MVP_DEVNET_MODE=required \
+KAMN_MVP_SOLANA_RPC_URL=https://api.devnet.solana.com \
+make demo-mvp
+```
+
+If devnet-backed settlement evidence cannot be produced, the report must remain explicit:
+
+```json
+{"status":"NO-GO","devnet_mode":"required"}
+```
+
+`NO-GO` is the honest result when devnet funding, transaction submission, confirmation, balance proof, or keypair configuration is unavailable. It must not be downgraded to a local-only settlement pass.
+
+## Claim Labels
+Every claim in `claim_matrix` must use exactly one label:
+
+- `real`
+- `devnet-backed`
+- `local-only`
+- `dry-run`
+- `placeholder`
+- `roadmap`
+
+Required MVP success claims cannot be `dry-run` or `placeholder`.
+
+Any claim involving exchange, escrow, settlement, transfer, lamports, asset movement, or value movement must be `devnet-backed`.
+
+## Verifier Contract
+The verifier command:
+
+```bash
+cargo run -p kamn-e2e-harness -- verify-mvp-demo --report .kamn/demo/latest/proof/report.json
+```
+
+returns `{"status":"PASS"}` only when the report schema, artifacts, required local proof claims, claim labels, and value-movement boundaries are valid.

--- a/fixtures/ci/test_file_size_policy_baseline.env
+++ b/fixtures/ci/test_file_size_policy_baseline.env
@@ -2,7 +2,7 @@ schema_version=kamn.ci.test-file-size-policy-baseline.v1
 captured_at=2026-06-26
 # Counts cover tracked crates/**/*.rs with a /tests/ path component, excluding any /tests/support/ paths.
 # Refresh baseline whenever new test files are added or removed.
-test_file_total=1280
+test_file_total=1282
 soft_warn_count=1
 severe_count=0
 hard_fail_count=0

--- a/specs/7037-mvp-demo-proof-report.md
+++ b/specs/7037-mvp-demo-proof-report.md
@@ -117,13 +117,16 @@ The MVP is not production readiness. The MVP is a locally runnable and locally p
 - `make demo-mvp` uses `target/mvp-demo-proof` internally to avoid the known stale/default-target cargo wedge observed during local verification.
 - The default local run produces `status=GO` with local-only runtime/auth/message/state/relay/websocket/audit claims and no settlement success claim.
 - Devnet-required mode currently produces explicit `status=NO-GO` evidence with `no_go.reason=devnet_keypair_not_configured` because no funded Solana devnet settlement keypair is configured.
-- Default-target `make check` wedged in stale `kamn_core` clippy workers at 0% CPU; the same gate was rerun and passed as `CARGO_TARGET_DIR=target/mvp-workspace-check make check`.
+- Default-target workspace checks wedged in stale `kamn_core` clippy workers at 0% CPU; equivalent gates were rerun with isolated target directories.
+- `make ci-tools` initially caught an unsafe env fallback in the MVP demo mode parser; the implementation now handles invalid/non-Unicode env values explicitly.
+- The touched Rust size policy initially caught oversize local helper functions; the report/verifier helpers were split and the existing test-file inventory baseline was updated only for the two new test files.
 
 Verification evidence:
 - `CARGO_TARGET_DIR=target/mvp-demo-contract cargo test -p kamn-e2e-harness --test mvp_demo_claim_contract -- --nocapture` passed, 10 tests.
 - `CARGO_TARGET_DIR=target/mvp-demo-command cargo test -p kamn-e2e-harness --test mvp_demo_command_contract -- --nocapture` passed, 5 tests.
 - `cargo fmt --check` passed.
-- `cargo clippy -p kamn-e2e-harness --all-targets --all-features -- -D warnings` passed.
+- `CARGO_TARGET_DIR=target/mvp-clippy cargo clippy -p kamn-e2e-harness --all-targets --all-features -- -D warnings` passed.
+- `CARGO_TARGET_DIR=target/mvp-ci-tools make ci-tools` passed.
 - `CARGO_TARGET_DIR=target/mvp-workspace-check make check` passed.
 - `make demo-mvp` passed and generated `.kamn/demo/latest/proof/report.json` plus `.kamn/demo/latest/proof/report.md`.
 - `CARGO_TARGET_DIR=target/mvp-demo-proof cargo run -p kamn-e2e-harness -- verify-mvp-demo --report .kamn/demo/latest/proof/report.json` passed.

--- a/specs/7037-mvp-demo-proof-report.md
+++ b/specs/7037-mvp-demo-proof-report.md
@@ -1,0 +1,130 @@
+# 7037-mvp-demo-proof-report
+
+## Objective
+Create one evaluator-facing MVP demo command that packages KAMN's existing bounded runtime proof slices into a coherent local demo artifact. The command must generate a machine-readable proof report and a human-readable report, and the verifier must fail closed on malformed, downgraded, placeholder, or overclaimed proof reports.
+
+The MVP is not production readiness. The MVP is a locally runnable and locally provable KAMN story with honest claim boundaries.
+
+## Inputs/Outputs
+### Inputs
+- Current `main` KAMN workspace after PR `#7022`.
+- Existing KAMN runtime, service API, SDK, CLI/MCP, audit, websocket, relay, and `kamn-e2e-harness` surfaces.
+- Optional Solana devnet configuration:
+  - `KAMN_MVP_DEVNET_MODE=required`
+  - `KAMN_MVP_SOLANA_RPC_URL=https://api.devnet.solana.com`
+  - optional future keypair/funding inputs if needed by the current devnet-backed asset movement path.
+
+### Outputs
+- `make demo-mvp`
+- `cargo run -p kamn-e2e-harness -- demo-mvp`
+- `cargo run -p kamn-e2e-harness -- verify-mvp-demo --report .kamn/demo/latest/proof/report.json`
+- `.kamn/demo/<run-id>/proof/report.json`
+- `.kamn/demo/<run-id>/proof/report.md`
+- `.kamn/demo/latest/proof/report.json`
+- `.kamn/demo/latest/proof/report.md`
+- Evaluator runbook documenting the command, artifacts, claim boundaries, and devnet `NO-GO` behavior.
+
+## Boundaries/Non-goals
+- Do not claim production readiness.
+- Do not claim mainnet support.
+- Do not claim generalized exchange or broad multi-chain settlement.
+- Do not claim consensus, broad bridge finality, or arbitrary partition tolerance.
+- Do not replace existing runtime, harness, service API, SDK, CLI, or MCP architecture.
+- Do not add a UI or dashboard.
+- Do not count in-memory-only settlement or asset movement as MVP settlement success.
+- Do not silently downgrade devnet-required settlement failure to local-only success.
+- Do not weaken tests, formatting, clippy, proof semantics, local gates, or claim boundaries.
+
+## Failure modes
+- `make demo-mvp` is missing or not wired to a real workspace command.
+- The demo writes no run directory or no `.kamn/demo/latest` proof path.
+- The report omits required claim labels or emits unknown labels.
+- A required MVP success claim is labeled `dry-run` or `placeholder`.
+- A settlement, escrow, exchange, transfer, lamports, asset, or value-movement claim is not labeled `devnet-backed`.
+- Devnet-required mode cannot fund, submit, confirm, or prove balance movement and still exits as a silent local-only pass.
+- The verifier accepts malformed JSON, missing required sections, downgraded labels, placeholder details, or settlement claims without devnet evidence.
+- The human-readable report disagrees with the JSON report.
+- The runbook overstates the proof beyond local MVP demo readiness.
+
+## Acceptance criteria (testable booleans)
+- [ ] `make demo-mvp` exists.
+- [ ] `make demo-mvp` creates `.kamn/demo/<run-id>/` and `.kamn/demo/latest`.
+- [ ] The demo writes `.kamn/demo/latest/proof/report.json`.
+- [ ] The demo writes `.kamn/demo/latest/proof/report.md`.
+- [ ] The JSON report includes a claim matrix.
+- [ ] Every claim label is one of `real`, `devnet-backed`, `local-only`, `dry-run`, `placeholder`, or `roadmap`.
+- [ ] Required MVP success claims reject `dry-run` and `placeholder`.
+- [ ] Claims involving exchange, escrow, settlement, transfer, lamports, asset movement, or value movement require `devnet-backed`.
+- [ ] The report includes local runtime startup, authenticated Alice/Bob identities, signed flow, durable state, relay/projection, websocket/event visibility, and audit/proof export.
+- [ ] The verifier rejects malformed, missing, downgraded, placeholder, and settlement-without-devnet reports.
+- [ ] The verifier accepts a valid local-only runtime report without settlement success claims.
+- [ ] The verifier accepts a valid devnet-backed settlement report.
+- [ ] `KAMN_MVP_DEVNET_MODE=required KAMN_MVP_SOLANA_RPC_URL=https://api.devnet.solana.com make demo-mvp` either writes devnet-backed settlement evidence or explicit `NO-GO` evidence.
+- [ ] The evaluator runbook documents local-only, devnet-backed, dry-run, placeholder, roadmap, and `NO-GO` interpretation.
+
+## Files to touch
+- `specs/7037-mvp-demo-proof-report.md`
+- `Makefile`
+- `crates/kamn-e2e-harness/src/main.rs`
+- `crates/kamn-e2e-harness/src/lib.rs`
+- new bounded modules under `crates/kamn-e2e-harness/src/` for MVP demo report generation and verification
+- targeted tests under `crates/kamn-e2e-harness/tests/`
+- an evaluator runbook under `docs/`
+- optionally `README.md` if command discovery needs a concise pointer
+
+## Error semantics
+- `demo-mvp` must hard-fail on local filesystem/report write errors.
+- `demo-mvp` must not report MVP success if required local runtime proof artifacts cannot be generated.
+- `demo-mvp` in devnet-required mode must write explicit `NO-GO` evidence when devnet evidence is unavailable.
+- `verify-mvp-demo` must return non-zero on malformed JSON, missing required sections, unknown labels, placeholder required claims, dry-run required claims, or settlement/value claims without devnet-backed evidence.
+- `verify-mvp-demo` may accept local-only runtime reports only when no settlement/value-movement success claim is present.
+- Error messages must name the rejected contract so failures are actionable.
+
+## Test plan
+1. Phase 3 red tests:
+   - add command parser/contract tests for `demo-mvp` and `verify-mvp-demo`
+   - add report schema tests for required sections, labels, and artifact paths
+   - add negative verifier fixtures for malformed, missing, downgraded, placeholder, and settlement-without-devnet reports
+   - add positive verifier fixtures for local-only runtime proof and devnet-backed settlement proof
+   - add Makefile command-surface test for `make demo-mvp`
+2. Phase 4 green implementation:
+   - add a Rust-owned demo report writer under `kamn-e2e-harness`
+   - create run directories and a `.kamn/demo/latest` proof path
+   - render deterministic JSON and Markdown reports
+   - wire `verify-mvp-demo --report`
+   - wire `make demo-mvp`
+3. Phase 5 refactor:
+   - split modules so files remain bounded and functions stay single-purpose
+   - remove duplication between report generation and verifier checks
+   - keep claim taxonomy centralized
+4. Phase 6 integration:
+   - run the new command through Makefile
+   - verify generated report with the new verifier command
+   - document evaluator usage and claim boundaries
+5. Final checks:
+   - `cargo test -p kamn-e2e-harness --test mvp_demo_claim_contract -- --nocapture`
+   - `cargo test -p kamn-e2e-harness --test mvp_demo_command_contract -- --nocapture`
+   - `cargo fmt --check`
+   - `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+   - `make check`
+   - `make demo-mvp`
+   - `cargo run -p kamn-e2e-harness -- verify-mvp-demo --report .kamn/demo/latest/proof/report.json`
+   - `KAMN_MVP_DEVNET_MODE=required KAMN_MVP_SOLANA_RPC_URL=https://api.devnet.solana.com make demo-mvp`
+   - `make pre-push` before publishing unless a real external/toolchain blocker is documented.
+
+## Deviations / Final evidence
+- Implementation uses `kamn-e2e-harness` as the canonical demo/report/verifier entrypoint and `make demo-mvp` as the evaluator command.
+- `make demo-mvp` uses `target/mvp-demo-proof` internally to avoid the known stale/default-target cargo wedge observed during local verification.
+- The default local run produces `status=GO` with local-only runtime/auth/message/state/relay/websocket/audit claims and no settlement success claim.
+- Devnet-required mode currently produces explicit `status=NO-GO` evidence with `no_go.reason=devnet_keypair_not_configured` because no funded Solana devnet settlement keypair is configured.
+- Default-target `make check` wedged in stale `kamn_core` clippy workers at 0% CPU; the same gate was rerun and passed as `CARGO_TARGET_DIR=target/mvp-workspace-check make check`.
+
+Verification evidence:
+- `CARGO_TARGET_DIR=target/mvp-demo-contract cargo test -p kamn-e2e-harness --test mvp_demo_claim_contract -- --nocapture` passed, 10 tests.
+- `CARGO_TARGET_DIR=target/mvp-demo-command cargo test -p kamn-e2e-harness --test mvp_demo_command_contract -- --nocapture` passed, 5 tests.
+- `cargo fmt --check` passed.
+- `cargo clippy -p kamn-e2e-harness --all-targets --all-features -- -D warnings` passed.
+- `CARGO_TARGET_DIR=target/mvp-workspace-check make check` passed.
+- `make demo-mvp` passed and generated `.kamn/demo/latest/proof/report.json` plus `.kamn/demo/latest/proof/report.md`.
+- `CARGO_TARGET_DIR=target/mvp-demo-proof cargo run -p kamn-e2e-harness -- verify-mvp-demo --report .kamn/demo/latest/proof/report.json` passed.
+- `KAMN_MVP_DEVNET_MODE=required KAMN_MVP_SOLANA_RPC_URL=https://api.devnet.solana.com make demo-mvp` passed process execution and generated explicit devnet `NO-GO` evidence.


### PR DESCRIPTION
## Summary
- Adds `make demo-mvp` as the canonical evaluator command, wired through `kamn-e2e-harness demo-mvp`.
- Generates `.kamn/demo/<run-id>/` proof bundles plus `.kamn/demo/latest/proof/report.json` and `report.md`.
- Adds `verify-mvp-demo --report` with fail-closed claim-boundary checks for malformed, downgraded, placeholder, dry-run, and non-devnet settlement/value claims.
- Documents the evaluator runbook and explicit local-only/devnet-backed/dry-run/placeholder/roadmap claim boundaries.

## Linked Issues
- Closes #7037
- Parent tracker: #7020
- Spec: `specs/7037-mvp-demo-proof-report.md`

## Validation
- [x] Relevant local checks passed.
- [x] CI fast-gate checks expected to pass.

Local evidence:
- `git fetch --all --prune` completed before branch/base decision; `origin/main` at `9be936e3` was the latest non-dependency product branch.
- Red test evidence captured before implementation: `cargo test -p kamn-e2e-harness --test mvp_demo_command_contract -- --nocapture` failed on missing MVP demo symbols before the implementation commit.
- `cargo fmt --check` passed.
- `CARGO_TARGET_DIR=target/mvp-clippy cargo clippy -p kamn-e2e-harness --all-targets --all-features -- -D warnings` passed.
- `CARGO_TARGET_DIR=target/mvp-demo-command cargo test -p kamn-e2e-harness --test mvp_demo_command_contract -- --nocapture` passed, 5 tests.
- `CARGO_TARGET_DIR=target/mvp-demo-contract cargo test -p kamn-e2e-harness --test mvp_demo_claim_contract -- --nocapture` passed, 10 tests.
- `CARGO_TARGET_DIR=target/mvp-ci-tools make ci-tools` passed.
- Touched Rust size policy passed with `policy_decision=GO`, `offending_files=none`, `offending_functions=none`.
- Governance ratio checker passed after rebuild with `governance_commit_count=0`, `feature_commit_count=3`, `status=ok`.
- `make demo-mvp` passed with local run `run-75621-1783182095163`, `status=GO`.
- `CARGO_TARGET_DIR=target/mvp-demo-proof cargo run -p kamn-e2e-harness -- verify-mvp-demo --report .kamn/demo/latest/proof/report.json` passed for the local report.
- `KAMN_MVP_DEVNET_MODE=required KAMN_MVP_SOLANA_RPC_URL=https://api.devnet.solana.com make demo-mvp` completed with devnet-required run `run-82710-1783182142452`, `status=NO-GO`, `no_go.reason=devnet_keypair_not_configured`.
- Verifier passed for the devnet-required NO-GO report.
- `CARGO_TARGET_DIR=target/mvp-workspace-check PRE_PUSH_WORKSPACE_TARGET_DIR=target/mvp-pre-push-workspace make pre-push` passed, including strict workspace clippy, CI tools, workspace tests, critical-path coverage, and mutation gate.

## Critical-Path Assurance Evidence
- Mutation gate status: `final_decision=GO`, `tested_mutants=10`, `caught_mutants=10`, `missed_mutants=0`, `timeout_mutants=0`.
- Coverage gate status: `final_decision=GO`, `target_count=6`, `failed_targets=0`, `missing_targets=0`, `line_failures=0`, `function_failures=0`.
- Critical-path report artifact(s): `/tmp/kamn-critical-path-core-coverage-pre-push.json`, `/tmp/kamn-critical-path-node-coverage-pre-push.json`, `/tmp/kamn-critical-path-coverage-policy-pre-push.json`, `/tmp/kamn-critical-path-mutation-report-pre-push.json`.

## CI Impact Declaration
- [x] No CI scope impact.
- [ ] CI scope impact present (explain below).

CI scope impact details (required when CI scope impact is present):
- Workflow(s) touched: None.
- Expected runtime delta: None in GitHub CI; local-only Makefile evaluator command added.
- Expected runner-minute delta: None.
- Rollback plan if CI cost/runtime regresses: revert this branch; no workflow files were changed.

## Shell-Surface Impact Declaration
- [ ] No shell-surface impact.
- [x] Shell-surface impact present (explain below).

Shell-surface impact details (required when shell-surface impact is present):
- shell_loc_delta_actual: 6 (`Makefile` +5/-1)
- rust_loc_delta_actual: 1364 (`*.rs` +1363/-1)
- shell_to_rust_ratio_delta_actual: 0.004399
- shell_surface_ratio_target_status: neutral
- shell_surface_mitigation_issue: None
- regressed_with_waiver requires shell_surface_mitigation_issue to link #<issue-id>: Not applicable.

## Post-Deploy Monitoring & Validation
No additional operational monitoring required: this adds a local evaluator harness command and proof verifier, and does not modify production deployment, services, or GitHub workflow files.

Recommended validation after checkout:
- `make demo-mvp`
- `cargo run -p kamn-e2e-harness -- verify-mvp-demo --report .kamn/demo/latest/proof/report.json`
- `KAMN_MVP_DEVNET_MODE=required KAMN_MVP_SOLANA_RPC_URL=https://api.devnet.solana.com make demo-mvp`

Expected healthy signals:
- Local report returns `status=GO` with local runtime/auth/message/state/relay/websocket/audit claims.
- Devnet-required report either includes devnet-backed settlement evidence or explicit `status=NO-GO`; it must not claim local-only settlement success.
- Verifier returns `{"status":"PASS"}` for valid local and devnet NO-GO reports.

Failure signals / rollback trigger:
- `verify-mvp-demo` accepts malformed or non-devnet settlement claims.
- `make demo-mvp` fails to write `.kamn/demo/latest/proof/report.json`.
- Devnet-required mode silently downgrades to local-only settlement success.
