### PR TITLE
[7043] test: rehearse MVP evaluator path

### DIFF
--- a/crates/kamn-e2e-harness/tests/mvp_evaluator_rehearsal_docs_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_evaluator_rehearsal_docs_contract.rs
@@ -1,30 +1,28 @@
 use std::path::PathBuf;
 
 const EVIDENCE_DOC: &str = "docs/validation/2026-07-07-mvp-evaluator-rehearsal.md";
+const REQUIRED_EVIDENCE: &[&str] = &[
+    "# MVP Evaluator Rehearsal Evidence - 2026-07-07",
+    "Issue: #7043",
+    "Clean Worktree",
+    "make demo-mvp",
+    "verify-mvp-demo",
+    "run-57898-1783463882414",
+    "run-73263-1783464071530",
+    "devnet-backed",
+    "2dWRAChLFzqAFxpNPYAb6ZGkP6Ms6yrLJm6ZGYXG7XmM8rXy2Emmy8myhva6gtCNbpkusCrCHfGa14oR7PamHGss",
+    "Secret Scan",
+    "Goose Harness",
+    "Pi Harness",
+    "Claim Boundaries",
+    "No private key, keypair JSON, env file, or private credential content was recorded",
+];
 
 #[test]
 fn spec_c01_evaluator_rehearsal_records_required_evidence() {
     let doc = read_evidence_doc();
 
-    require_all(
-        &doc,
-        &[
-            "# MVP Evaluator Rehearsal Evidence - 2026-07-07",
-            "Issue: #7043",
-            "Clean Worktree",
-            "make demo-mvp",
-            "verify-mvp-demo",
-            "run-57898-1783463882414",
-            "run-73263-1783464071530",
-            "devnet-backed",
-            "2dWRAChLFzqAFxpNPYAb6ZGkP6Ms6yrLJm6ZGYXG7XmM8rXy2Emmy8myhva6gtCNbpkusCrCHfGa14oR7PamHGss",
-            "Secret Scan",
-            "Goose Harness",
-            "Pi Harness",
-            "Claim Boundaries",
-            "No private key, keypair JSON, env file, or private credential content was recorded",
-        ],
-    );
+    require_all(&doc, REQUIRED_EVIDENCE);
 }
 
 #[test]

--- a/crates/kamn-e2e-harness/tests/mvp_evaluator_rehearsal_docs_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_evaluator_rehearsal_docs_contract.rs
@@ -1,0 +1,70 @@
+use std::path::PathBuf;
+
+const EVIDENCE_DOC: &str = "docs/validation/2026-07-07-mvp-evaluator-rehearsal.md";
+
+#[test]
+fn spec_c01_evaluator_rehearsal_records_required_evidence() {
+    let doc = read_evidence_doc();
+
+    require_all(
+        &doc,
+        &[
+            "# MVP Evaluator Rehearsal Evidence - 2026-07-07",
+            "Issue: #7043",
+            "Clean Worktree",
+            "make demo-mvp",
+            "verify-mvp-demo",
+            "run-57898-1783463882414",
+            "run-73263-1783464071530",
+            "devnet-backed",
+            "2dWRAChLFzqAFxpNPYAb6ZGkP6Ms6yrLJm6ZGYXG7XmM8rXy2Emmy8myhva6gtCNbpkusCrCHfGa14oR7PamHGss",
+            "Secret Scan",
+            "Goose Harness",
+            "Pi Harness",
+            "Claim Boundaries",
+            "No private key, keypair JSON, env file, or private credential content was recorded",
+        ],
+    );
+}
+
+#[test]
+fn spec_c02_evaluator_rehearsal_orders_evidence_before_risks() {
+    let doc = read_evidence_doc();
+
+    require_order(&doc, "Clean Worktree", "Local-Only Demo");
+    require_order(&doc, "Local-Only Demo", "Devnet-Required Demo");
+    require_order(&doc, "Devnet-Required Demo", "Agent Harness Evaluation");
+    require_order(&doc, "Agent Harness Evaluation", "Remaining Risks");
+}
+
+fn read_evidence_doc() -> String {
+    std::fs::read_to_string(repo_root().join(EVIDENCE_DOC))
+        .unwrap_or_else(|err| panic!("{EVIDENCE_DOC} should exist and be readable: {err}"))
+}
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..")
+}
+
+fn require_all(content: &str, needles: &[&str]) {
+    for needle in needles {
+        assert!(
+            content.contains(needle),
+            "{EVIDENCE_DOC} is missing required evidence: {needle}"
+        );
+    }
+}
+
+fn require_order(content: &str, before: &str, after: &str) {
+    let before_index = content
+        .find(before)
+        .unwrap_or_else(|| panic!("{EVIDENCE_DOC} is missing required heading: {before}"));
+    let after_index = content
+        .find(after)
+        .unwrap_or_else(|| panic!("{EVIDENCE_DOC} is missing required heading: {after}"));
+
+    assert!(
+        before_index < after_index,
+        "{EVIDENCE_DOC} should place `{before}` before `{after}`"
+    );
+}

--- a/docs/validation/2026-07-07-mvp-evaluator-rehearsal.md
+++ b/docs/validation/2026-07-07-mvp-evaluator-rehearsal.md
@@ -178,8 +178,10 @@ Result: run id `run-30651-1783468978384`, status `GO`, devnet mode
 
 - `cargo fmt --check`: `PASS`.
 - `cargo test -p kamn-e2e-harness --test mvp_evaluator_rehearsal_docs_contract -- --nocapture`: `PASS`.
-- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: blocked locally. Two `kamn-core` clippy-driver processes repeatedly wedged with no diagnostics or CPU progress.
-- `make check`: blocked for the same strict clippy wedge; it was interrupted rather than weakened.
+- Targeted MVP contracts with `CARGO_TARGET_DIR=target/mvp-demo-proof CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0`: `PASS`.
+- `cargo clippy --workspace --all-targets --all-features -- -D warnings` with the same target-dir env: `PASS`.
+- `make check` with the same target-dir env: `PASS`.
+- The default main target cache produced repeated idle `kamn-core` clippy-driver stalls; no gate was weakened.
 
 ## Remaining Risks
 

--- a/docs/validation/2026-07-07-mvp-evaluator-rehearsal.md
+++ b/docs/validation/2026-07-07-mvp-evaluator-rehearsal.md
@@ -1,0 +1,185 @@
+# MVP Evaluator Rehearsal Evidence - 2026-07-07
+
+Issue: #7043
+Spec: `specs/7043-mvp-evaluator-rehearsal.md`
+Branch: `7043-mvp-evaluator-rehearsal`
+Base checked for rehearsal: `origin/main` at `afc507a4a9c5`
+
+## Clean Worktree
+
+Fresh external worktree:
+
+```text
+/tmp/kamn-mvp-evaluator-7043-20260707-183715
+```
+
+The worktree was detached at `origin/main` and remained clean before the
+rehearsal-owned `.kamn/` demo artifacts were produced.
+
+No README, runbook, or env-example change was required. The existing root
+README and `docs/validation/mvp-evaluator-demo.md` were enough to run the local
+and funded devnet paths.
+
+## Local-Only Demo
+
+Command:
+
+```bash
+make demo-mvp
+```
+
+Result:
+
+- status: `GO`
+- run id: `run-57898-1783463882414`
+- report: `.kamn/demo/run-57898-1783463882414/proof/report.json`
+- devnet mode: `optional`
+- verifier:
+  `cargo run -p kamn-e2e-harness -- verify-mvp-demo --report /tmp/kamn-mvp-evaluator-7043-20260707-183715/.kamn/demo/run-57898-1783463882414/proof/report.json`
+- verifier result:
+  `{"status":"PASS","report":"/tmp/kamn-mvp-evaluator-7043-20260707-183715/.kamn/demo/run-57898-1783463882414/proof/report.json"}`
+
+Claim Boundaries:
+
+- `local_runtime_startup`: `real`, required, `PASS`
+- `authenticated_agent_identities`: `local-only`, required, `PASS`
+- `signed_message_or_task_flow`: `local-only`, required, `PASS`
+- `durable_state_written`: `local-only`, required, `PASS`
+- `relay_projection_visible`: `local-only`, required, `PASS`
+- `websocket_event_visibility`: `local-only`, required, `PASS`
+- `audit_proof_export`: `local-only`, required, `PASS`
+- `production_readiness`: `roadmap`, optional, `NOT_CLAIMED`
+
+The local-only run did not claim settlement, escrow execution, asset movement,
+or value movement success.
+
+## Devnet-Required Demo
+
+Command shape:
+
+```bash
+set -a
+. /Users/n/RustroverProjects/kamn/.kamn/devnet/mvp-demo-devnet.env
+set +a
+make demo-mvp
+```
+
+The env file is local and ignored. Its contents were not printed, copied, or
+committed.
+
+Result:
+
+- status: `GO`
+- run id: `run-73263-1783464071530`
+- report: `.kamn/demo/run-73263-1783464071530/proof/report.json`
+- devnet mode: `required`
+- verifier:
+  `cargo run -p kamn-e2e-harness -- verify-mvp-demo --report /tmp/kamn-mvp-evaluator-7043-20260707-183715/.kamn/demo/run-73263-1783464071530/proof/report.json`
+- verifier result:
+  `{"status":"PASS","report":"/tmp/kamn-mvp-evaluator-7043-20260707-183715/.kamn/demo/run-73263-1783464071530/proof/report.json"}`
+
+Devnet-backed settlement evidence:
+
+- claim: `devnet_settlement_asset_movement`
+- label: `devnet-backed`
+- network: `solana:devnet`
+- RPC URL: `https://api.devnet.solana.com`
+- payer: `2FjUiacAXtokhA8YzGiyfVEdu5D9LxKFhjptJLrz4V9T`
+- recipient: `FV5LvudLjZQGCrPwXUY2JaVr26sQE15K25BGvsKWvyFe`
+- lamports: `1000000`
+- signature:
+  `2dWRAChLFzqAFxpNPYAb6ZGkP6Ms6yrLJm6ZGYXG7XmM8rXy2Emmy8myhva6gtCNbpkusCrCHfGa14oR7PamHGss`
+- commitment: `finalized`
+- payer balance: `2492965000` before, `2491960000` after
+- recipient balance: `2507000000` before, `2508000000` after
+- persisted settlement signature matches the Solana signature
+
+Independent Solana confirmation:
+
+```bash
+solana confirm -v --url https://api.devnet.solana.com \
+  2dWRAChLFzqAFxpNPYAb6ZGkP6Ms6yrLJm6ZGYXG7XmM8rXy2Emmy8myhva6gtCNbpkusCrCHfGa14oR7PamHGss
+```
+
+The transaction executed in slot `474701354` with block time
+`2026-07-07T18:41:31-04:00`, status `Ok`, one system transfer of
+`1000000` lamports, and finality `Finalized`.
+
+## Secret Scan
+
+Command pattern:
+
+```bash
+rg -n 'KAMN_SERVICE_API_LIVE_SOLANA_SETTLEMENT_KEYPAIR_FILE|mvp-settlement-payer|BEGIN .*PRIVATE|\[[0-9]+,\s*[0-9]+,\s*[0-9]+,\s*[0-9]+' \
+  .kamn/demo/run-73263-1783464071530/proof \
+  .kamn/demo/run-73263-1783464071530/state \
+  .kamn/demo/run-73263-1783464071530/events
+```
+
+Result: `rg` exit code `1`, no matches.
+
+No private key, keypair JSON, env file, or private credential content was recorded
+in the inspected proof, state, or event artifacts.
+
+## Agent Harness Evaluation
+
+### Pi Harness
+
+Official sources checked:
+
+- `https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/quickstart.md`
+- `https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/providers.md`
+- `https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/usage.md`
+
+Local findings:
+
+- `pi` and `pi-acp` were not already installed on PATH.
+- `npx -y @earendil-works/pi-coding-agent --version` returned `0.80.3`.
+- `npx -y @earendil-works/pi-coding-agent --help` confirmed non-interactive
+  `-p`, `--provider`, `--model`, `--tools`, `--approve`, and context-file
+  loading support.
+- `~/.pi/agent/auth.json` was missing.
+- `OPENAI_API_KEY` was present, but a bounded Pi run using
+  `--provider openai --model gpt-4o-mini --tools read,bash,grep,find,ls`
+  failed with OpenAI `401 invalid_api_key`.
+
+Pi result: blocked by local auth. No committed secret was added, and no repo file
+was edited by Pi.
+
+### Goose Harness
+
+Official sources checked:
+
+- `https://goose-docs.ai/docs/guides/acp-providers/`
+- `https://github.com/aaif-goose/goose`
+
+Local findings:
+
+- `brew info block-goose-cli` reported stable `1.41.0`.
+- `brew install block-goose-cli` installed `/opt/homebrew/bin/goose`.
+- `npm install -g @agentclientprotocol/codex-acp` installed
+  `/Users/n/.nvm/versions/node/v22.22.0/bin/codex-acp`.
+- A minimal Goose/Codex ACP prompt succeeded with `GOOSE_MODE=approve`.
+- The full evaluator prompt reached `make demo-mvp` but failed before execution
+  because `approve` mode requires an interactive terminal in non-interactive
+  Goose runs.
+- `GOOSE_MODE=auto` and `GOOSE_MODE=smart-approve` failed before command
+  execution because Goose requested `full-access`, while the current Codex ACP
+  adapter advertises `read-only`, `agent`, and `agent-full-access`.
+- Installing the deprecated Goose-documented `@zed-industries/codex-acp`
+  adapter was not forced because it would overwrite the current `codex-acp`
+  binary globally.
+
+Goose result: blocked by non-interactive approval/mode mismatch, not by KAMN.
+
+## Remaining Risks
+
+- The MVP demo is credible as a local and Solana-devnet evaluator path, not as a
+  production-readiness claim.
+- Pi can likely be re-attempted after a valid Pi OAuth login or valid OpenAI API
+  key is available.
+- Goose can likely be re-attempted after its Codex ACP provider mode mapping is
+  configured or the adapter mismatch is resolved without globally overwriting a
+  working adapter.
+- The funded devnet path moves Solana devnet lamports only. It does not prove
+  mainnet settlement, generalized exchange, or real economic value.

--- a/docs/validation/2026-07-07-mvp-evaluator-rehearsal.md
+++ b/docs/validation/2026-07-07-mvp-evaluator-rehearsal.md
@@ -7,8 +7,6 @@ Base checked for rehearsal: `origin/main` at `afc507a4a9c5`
 
 ## Clean Worktree
 
-Fresh external worktree:
-
 ```text
 /tmp/kamn-mvp-evaluator-7043-20260707-183715
 ```
@@ -54,8 +52,6 @@ The local-only run did not claim settlement, escrow execution, asset movement,
 or value movement success.
 
 ## Devnet-Required Demo
-
-Command shape:
 
 ```bash
 set -a
@@ -131,8 +127,6 @@ Official sources checked:
 - `https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/providers.md`
 - `https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/usage.md`
 
-Local findings:
-
 - `pi` and `pi-acp` were not already installed on PATH.
 - `npx -y @earendil-works/pi-coding-agent --version` returned `0.80.3`.
 - `npx -y @earendil-works/pi-coding-agent --help` confirmed non-interactive
@@ -153,8 +147,6 @@ Official sources checked:
 - `https://goose-docs.ai/docs/guides/acp-providers/`
 - `https://github.com/aaif-goose/goose`
 
-Local findings:
-
 - `brew info block-goose-cli` reported stable `1.41.0`.
 - `brew install block-goose-cli` installed `/opt/homebrew/bin/goose`.
 - `npm install -g @agentclientprotocol/codex-acp` installed
@@ -171,6 +163,23 @@ Local findings:
   binary globally.
 
 Goose result: blocked by non-interactive approval/mode mismatch, not by KAMN.
+
+## Current-Branch Demo
+
+```bash
+make demo-mvp
+cargo run -p kamn-e2e-harness -- verify-mvp-demo --report .kamn/demo/latest/proof/report.json
+```
+
+Result: run id `run-30651-1783468978384`, status `GO`, devnet mode
+`optional`, verifier `PASS`.
+
+## Local Gate Status
+
+- `cargo fmt --check`: `PASS`.
+- `cargo test -p kamn-e2e-harness --test mvp_evaluator_rehearsal_docs_contract -- --nocapture`: `PASS`.
+- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: blocked locally. Two `kamn-core` clippy-driver processes repeatedly wedged with no diagnostics or CPU progress.
+- `make check`: blocked for the same strict clippy wedge; it was interrupted rather than weakened.
 
 ## Remaining Risks
 

--- a/specs/7043-mvp-evaluator-rehearsal.md
+++ b/specs/7043-mvp-evaluator-rehearsal.md
@@ -1,0 +1,122 @@
+# 7043 MVP Evaluator Rehearsal
+
+## Objective
+
+Validate KAMN from a clean evaluator perspective on current `main`: follow the
+root README and linked evaluator runbook, run the canonical MVP demo, verify the
+generated report, run the funded Solana devnet-required path when local
+non-committed devnet config is available, and record agent-harness feasibility
+for goose and pi without weakening proof boundaries.
+
+## Inputs/Outputs
+
+Inputs:
+- Current `main` checkout and clean external evaluator worktree
+- Root `README.md`
+- `docs/validation/mvp-evaluator-demo.md`
+- Local non-committed `.kamn/devnet/mvp-demo-devnet.env` when available
+- Current official goose/pi documentation and local CLI availability
+
+Outputs:
+- Fresh-checkout local-only MVP demo evidence
+- Fresh-checkout devnet-required MVP demo evidence or explicit `NO-GO` blocker
+- Goose/pi harness findings or exact blocker evidence
+- `docs/validation/2026-07-07-mvp-evaluator-rehearsal.md`
+- A docs contract test protecting the required evidence report shape
+
+## Boundaries/Non-goals
+
+- Do not change MVP demo behavior unless rehearsal exposes a real defect.
+- Do not commit devnet keypairs, private RPC credentials, `.kamn/` proof
+  artifacts, generated package metadata, or fresh-checkout build outputs.
+- Do not claim production readiness, mainnet settlement, generalized exchange,
+  or real economic value.
+- Do not weaken tests, lint, clippy, formatting, verifier semantics, proof
+  semantics, or claim boundaries.
+- Keep README human-first; put rehearsal evidence and deeper details in
+  validation docs.
+
+## Deferred to Implementation
+
+- Resolve whether goose and/or pi can run locally with existing machine auth
+  without new committed secrets.
+- Resolve whether a safe `.env.example` is needed after the clean evaluator
+  rehearsal. Add one only if a real evaluator gap appears.
+
+## Failure Modes
+
+- Clean worktree local demo fails from README/runbook instructions.
+- Report verifier rejects the generated local-only report.
+- Devnet-required run silently downgrades settlement to local-only instead of
+  explicit `GO` devnet-backed or honest `NO-GO`.
+- Proof report/logs leak private key contents, local keypair file contents, or
+  private credentials.
+- Agent harness setup requires unclear auth, secrets, or unsupported local
+  assumptions.
+- Evidence doc omits run ids, commands, report paths, transaction signature or
+  blocker, claim-boundary inspection, or harness findings.
+
+## Acceptance Criteria
+
+- [ ] Clean external worktree is created from current `main` and recorded.
+- [ ] Local-only `make demo-mvp` succeeds in that clean worktree.
+- [ ] Local-only report verifier returns `PASS`.
+- [ ] Funded Solana devnet-required run returns `GO` with `devnet-backed`
+  settlement evidence and verifier `PASS`, or records exact `NO-GO` blocker.
+- [ ] Proof artifacts are inspected for claim-boundary clarity and absence of
+  secret/keypair content.
+- [ ] Goose and pi are researched from current official sources and locally
+  attempted where feasible without committed secrets.
+- [ ] Blockers for goose/pi are documented with exact evidence if either harness
+  cannot complete the evaluator path.
+- [ ] Evidence report is protected by a docs contract test.
+- [ ] Local gates pass before PR.
+
+## Files to Touch
+
+Likely:
+- `docs/validation/2026-07-07-mvp-evaluator-rehearsal.md`
+- `crates/kamn-e2e-harness/tests/mvp_evaluator_rehearsal_docs_contract.rs`
+
+Only if a real evaluator gap is found:
+- `docs/validation/mvp-evaluator-demo.md`
+- `.env.example` or a narrowly scoped devnet env example
+
+## Error Semantics
+
+- Rehearsal commands must fail loudly in the evidence report; do not reinterpret
+  failures as success.
+- Devnet-required `NO-GO` is acceptable only when it is explicit and backed by
+  real blocker evidence.
+- Any settlement or asset-movement success must remain `devnet-backed`.
+
+## Test Plan
+
+Execution note: characterize first for external worktree/demo behavior, then use
+test-first discipline for the committed evidence report.
+
+Characterization:
+- `git fetch --all --prune`
+- Create a clean external worktree from `origin/main`.
+- Run `make demo-mvp` from the clean worktree.
+- Run `cargo run -p kamn-e2e-harness -- verify-mvp-demo --report .kamn/demo/latest/proof/report.json`.
+- Run funded devnet-required `make demo-mvp` from the clean worktree if local
+  non-committed devnet config is available.
+- Confirm Solana transaction status with CLI when devnet run succeeds.
+
+Red:
+- Add a docs contract test requiring the evidence report, command evidence,
+  run ids, claim-boundary findings, goose/pi findings, and secret-scan outcome.
+- Confirm it fails before the evidence report exists.
+
+Green:
+- Add the evidence report with exact commands, run ids, report paths, devnet
+  transaction or blocker, agent-harness findings, and remaining risks.
+
+Verification:
+- `cargo fmt --check`
+- `cargo test -p kamn-e2e-harness --test mvp_evaluator_rehearsal_docs_contract -- --nocapture`
+- `cargo test -p kamn-e2e-harness --test readme_mvp_front_door_contract --test mvp_demo_command_contract --test mvp_demo_claim_contract -- --nocapture`
+- `make check`
+- `make demo-mvp`
+- `cargo run -p kamn-e2e-harness -- verify-mvp-demo --report .kamn/demo/latest/proof/report.json`


### PR DESCRIPTION
## Human Summary

- Closes #7043 by recording a clean-checkout MVP evaluator rehearsal from `origin/main`.
- Adds a validation report covering local-only demo proof, devnet-backed Solana settlement proof, secret-scan results, and Pi/Goose harness attempts.
- Adds a docs contract test so the evaluator evidence report cannot silently drop required proof fields.
- Keeps README/runbook/env files unchanged because the fresh evaluator rehearsal succeeded with the existing instructions.

## Testing

- `cargo fmt --check`
- `CARGO_TARGET_DIR=target/mvp-demo-proof CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `CARGO_TARGET_DIR=target/mvp-demo-proof CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 make check`
- `CARGO_TARGET_DIR=target/mvp-demo-proof CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 cargo test -p kamn-e2e-harness --test readme_mvp_front_door_contract -- --nocapture`
- `CARGO_TARGET_DIR=target/mvp-demo-proof CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 cargo test -p kamn-e2e-harness --test mvp_demo_claim_contract -- --nocapture`
- `CARGO_TARGET_DIR=target/mvp-demo-proof CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 cargo test -p kamn-e2e-harness --test mvp_demo_command_contract -- --nocapture`
- `CARGO_TARGET_DIR=target/mvp-demo-proof CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 cargo test -p kamn-e2e-harness --test mvp_evaluator_rehearsal_docs_contract -- --nocapture`
- `make demo-mvp`
- `cargo run -p kamn-e2e-harness -- verify-mvp-demo --report .kamn/demo/latest/proof/report.json`
- Fresh worktree local-only demo/verifier: `PASS`, run `run-57898-1783463882414`
- Fresh worktree devnet-required demo/verifier: `PASS`, run `run-73263-1783464071530`, signature `2dWRAChLFzqAFxpNPYAb6ZGkP6Ms6yrLJm6ZGYXG7XmM8rXy2Emmy8myhva6gtCNbpkusCrCHfGa14oR7PamHGss`
- `solana confirm -v --url https://api.devnet.solana.com 2dWRAChLFzqAFxpNPYAb6ZGkP6Ms6yrLJm6ZGYXG7XmM8rXy2Emmy8myhva6gtCNbpkusCrCHfGa14oR7PamHGss`

## Notes for Reviewers

The default `target/debug` cache produced repeated idle `kamn-core` clippy-driver stalls locally. The same strict clippy and `make check` commands passed when run through the dedicated MVP demo target dir with one build job and incremental disabled. No lint, test, verifier, or proof semantics were weakened.

Pi was installable via `npx` but blocked by local auth: no Pi auth file and the present OpenAI API key was rejected. Goose was installed and could prompt through Codex ACP, but the full non-interactive command-driving run was blocked by Goose approval/mode mapping. Both blockers are documented in the validation report.

## Post-Deploy Monitoring & Validation

After merge, validate that `main` still produces:

- `make demo-mvp` status `GO`
- `cargo run -p kamn-e2e-harness -- verify-mvp-demo --report .kamn/demo/latest/proof/report.json` status `PASS`
- Funded devnet-required mode either `GO` with `devnet-backed` transfer evidence or explicit honest `NO-GO`
- No `.kamn/` proof artifacts, devnet keypairs, private credentials, or generated package metadata committed

## AI Agent Details

- Spec: `specs/7043-mvp-evaluator-rehearsal.md`
- Evidence report: `docs/validation/2026-07-07-mvp-evaluator-rehearsal.md`
- Contract test: `crates/kamn-e2e-harness/tests/mvp_evaluator_rehearsal_docs_contract.rs`
- Clean worktree used: `/tmp/kamn-mvp-evaluator-7043-20260707-183715`
- Local branch demo run: `run-30651-1783468978384`
- The validation report explicitly separates local-only, devnet-backed, roadmap, and non-claimed behavior.
