### PR TITLE
[7047] Add MCP agent harness evidence to MVP demo proof

### DIFF
--- a/crates/kamn-e2e-harness/src/lib.rs
+++ b/crates/kamn-e2e-harness/src/lib.rs
@@ -426,11 +426,19 @@ where
 
 fn parse_demo_mvp_command(args: &[String]) -> Result<HarnessCommand, String> {
     let mut output_root = None;
+    let mut agent_harness_evidence_path = None;
     let mut index = 1;
     while index < args.len() {
         let (parsed_output_root, advanced) = parse_flag_value(args, index, "--output-root")?;
         if let Some(value) = parsed_output_root {
             output_root = Some(value);
+            index = advanced + 1;
+            continue;
+        }
+        let (parsed_agent_harness, advanced) =
+            parse_flag_value(args, index, "--agent-harness-evidence")?;
+        if let Some(value) = parsed_agent_harness {
+            agent_harness_evidence_path = Some(value);
             index = advanced + 1;
             continue;
         }
@@ -445,6 +453,8 @@ fn parse_demo_mvp_command(args: &[String]) -> Result<HarnessCommand, String> {
         localhost_signed_demo_command: None,
         service_api_vertical_slice_command: None,
         service_api_websocket_command: None,
+        agent_harness_evidence_path: agent_harness_evidence_path
+            .or_else(mvp_agent_harness_evidence_path_from_env),
     }))
 }
 
@@ -487,6 +497,12 @@ fn default_mvp_devnet_mode() -> String {
 
 fn mvp_solana_rpc_url_from_env() -> Option<String> {
     std::env::var("KAMN_MVP_SOLANA_RPC_URL")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+}
+
+fn mvp_agent_harness_evidence_path_from_env() -> Option<String> {
+    std::env::var("KAMN_MVP_AGENT_HARNESS_EVIDENCE")
         .ok()
         .filter(|value| !value.trim().is_empty())
 }

--- a/crates/kamn-e2e-harness/src/mvp_demo/agent_harness.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/agent_harness.rs
@@ -1,0 +1,103 @@
+use super::report::CLAIM_LABEL_LOCAL_ONLY;
+use super::verify_support::{extract_optional_string, require_marker, ClaimView};
+
+const AGENT_HARNESS_CLAIM_ID: &str = "mcp_agent_harness_verification";
+const AGENT_HARNESS_ARTIFACT_FIELD: &str = "agent_harness_evidence";
+
+pub(crate) fn validate_agent_harness_claim_shape(
+    claims: &[ClaimView<'_>],
+) -> Result<(), String> {
+    if let Some(claim) = agent_harness_claim(claims) {
+        validate_agent_harness_claim(claim)?;
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_agent_harness_evidence_file(
+    report_json: &str,
+    report_path: &str,
+) -> Result<(), String> {
+    if !report_json.contains(AGENT_HARNESS_CLAIM_ID) {
+        return Ok(());
+    }
+    let artifact_path = extract_optional_string(report_json, AGENT_HARNESS_ARTIFACT_FIELD)
+        .ok_or_else(|| "missing agent harness evidence artifact path".to_owned())?;
+    let artifact = std::fs::read_to_string(artifact_path.as_str()).map_err(|error| {
+        format!(
+            "failed to read agent harness evidence {}: {error}",
+            artifact_path
+        )
+    })?;
+    validate_agent_harness_evidence(artifact.as_str(), report_path)
+}
+
+fn agent_harness_claim<'a>(claims: &'a [ClaimView<'a>]) -> Option<&'a ClaimView<'a>> {
+    claims.iter().find(|claim| claim.id == AGENT_HARNESS_CLAIM_ID)
+}
+
+fn validate_agent_harness_claim(claim: &ClaimView<'_>) -> Result<(), String> {
+    if claim.label != CLAIM_LABEL_LOCAL_ONLY {
+        return Err("agent harness claim must be local-only".to_owned());
+    }
+    if claim.status != "PASS" {
+        return Err("agent harness claim must be PASS when present".to_owned());
+    }
+    require_marker(claim.raw, "\"harness\":\"mcp-agent\"", "agent harness kind")
+}
+
+fn validate_agent_harness_evidence(artifact: &str, report_path: &str) -> Result<(), String> {
+    validate_evidence_markers(artifact)?;
+    validate_report_path(artifact, report_path)?;
+    validate_private_boundary(artifact)?;
+    validate_settlement_boundary(artifact)
+}
+
+fn validate_evidence_markers(artifact: &str) -> Result<(), String> {
+    for (marker, context) in required_evidence_markers() {
+        require_marker(artifact, marker, context)?;
+    }
+    Ok(())
+}
+
+fn required_evidence_markers() -> [(&'static str, &'static str); 12] {
+    [
+        (
+            "\"schema_version\":\"kamn.mvp.agent-harness-evidence.v1\"",
+            "agent harness schema",
+        ),
+        ("\"harness\":\"mcp-agent\"", "agent harness kind"),
+        ("\"execution_surface\":\"mcp-tools\"", "MCP tool surface"),
+        ("\"verifier_status\":\"PASS\"", "agent harness verifier status"),
+        ("\"agent_a\"", "agent A role"),
+        ("\"agent_b\"", "agent B role"),
+        ("\"agent_c_verifier\"", "agent C verifier role"),
+        ("\"register\"", "register tool marker"),
+        ("\"create_task\"", "create_task tool marker"),
+        ("\"fund_escrow\"", "fund_escrow tool marker"),
+        ("\"release_escrow\"", "release_escrow tool marker"),
+        ("\"verify_proof\"", "verify_proof tool marker"),
+    ]
+}
+
+fn validate_report_path(artifact: &str, report_path: &str) -> Result<(), String> {
+    let artifact_report_path = extract_optional_string(artifact, "report_path")
+        .ok_or_else(|| "missing agent harness report_path".to_owned())?;
+    if artifact_report_path == report_path {
+        return Ok(());
+    }
+    Err("agent harness report_path does not match verified report".to_owned())
+}
+
+fn validate_private_boundary(artifact: &str) -> Result<(), String> {
+    if artifact.contains("\"verifier_private_view_visible\":false") {
+        return Ok(());
+    }
+    Err("agent harness verifier_private_view_visible must be false".to_owned())
+}
+
+fn validate_settlement_boundary(artifact: &str) -> Result<(), String> {
+    if artifact.contains("\"settlement_claim_label\":\"devnet-backed\"") {
+        return Ok(());
+    }
+    Err("agent harness settlement_claim_label must be devnet-backed".to_owned())
+}

--- a/crates/kamn-e2e-harness/src/mvp_demo/agent_harness.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/agent_harness.rs
@@ -4,9 +4,13 @@ use super::verify_support::{extract_optional_string, require_marker, ClaimView};
 const AGENT_HARNESS_CLAIM_ID: &str = "mcp_agent_harness_verification";
 const AGENT_HARNESS_ARTIFACT_FIELD: &str = "agent_harness_evidence";
 
-pub(crate) fn validate_agent_harness_claim_shape(
-    claims: &[ClaimView<'_>],
-) -> Result<(), String> {
+pub(crate) fn agent_harness_claim_json() -> String {
+    format!(
+        "{{\"id\":\"{AGENT_HARNESS_CLAIM_ID}\",\"label\":\"{CLAIM_LABEL_LOCAL_ONLY}\",\"required\":false,\"status\":\"PASS\",\"summary\":\"MCP agent harness verified report boundaries\",\"harness\":\"mcp-agent\"}}"
+    )
+}
+
+pub(crate) fn validate_agent_harness_claim_shape(claims: &[ClaimView<'_>]) -> Result<(), String> {
     if let Some(claim) = agent_harness_claim(claims) {
         validate_agent_harness_claim(claim)?;
     }
@@ -32,7 +36,9 @@ pub(crate) fn validate_agent_harness_evidence_file(
 }
 
 fn agent_harness_claim<'a>(claims: &'a [ClaimView<'a>]) -> Option<&'a ClaimView<'a>> {
-    claims.iter().find(|claim| claim.id == AGENT_HARNESS_CLAIM_ID)
+    claims
+        .iter()
+        .find(|claim| claim.id == AGENT_HARNESS_CLAIM_ID)
 }
 
 fn validate_agent_harness_claim(claim: &ClaimView<'_>) -> Result<(), String> {
@@ -67,7 +73,10 @@ fn required_evidence_markers() -> [(&'static str, &'static str); 12] {
         ),
         ("\"harness\":\"mcp-agent\"", "agent harness kind"),
         ("\"execution_surface\":\"mcp-tools\"", "MCP tool surface"),
-        ("\"verifier_status\":\"PASS\"", "agent harness verifier status"),
+        (
+            "\"verifier_status\":\"PASS\"",
+            "agent harness verifier status",
+        ),
         ("\"agent_a\"", "agent A role"),
         ("\"agent_b\"", "agent B role"),
         ("\"agent_c_verifier\"", "agent C verifier role"),

--- a/crates/kamn-e2e-harness/src/mvp_demo/mod.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/mod.rs
@@ -1,5 +1,6 @@
 //! MVP evaluator demo report generation and verification.
 
+mod agent_harness;
 mod devnet_settlement;
 mod devnet_settlement_build;
 mod devnet_settlement_json;

--- a/crates/kamn-e2e-harness/src/mvp_demo/report.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/report.rs
@@ -1,5 +1,6 @@
 use std::path::Path;
 
+use super::agent_harness::agent_harness_claim_json;
 use super::devnet_settlement::{
     devnet_no_go_reason, devnet_settlement_claim_json, DevnetSettlementEvidence,
 };
@@ -28,6 +29,7 @@ pub(crate) struct DemoReportInput<'a> {
     pub(crate) output_root: &'a Path,
     pub(crate) devnet_settlement: Option<&'a DevnetSettlementEvidence>,
     pub(crate) devnet_no_go_reason: Option<&'a str>,
+    pub(crate) agent_harness_evidence_path: Option<&'a str>,
 }
 
 pub(crate) fn render_report_json(input: &DemoReportInput<'_>) -> String {
@@ -54,6 +56,9 @@ pub(crate) fn report_status(input: &DemoReportInput<'_>) -> &'static str {
 
 fn claim_matrix_json(input: &DemoReportInput<'_>) -> String {
     let mut claims = local_claims();
+    if input.agent_harness_evidence_path.is_some() {
+        claims.push(agent_harness_claim_json());
+    }
     if input.devnet_mode == "required" {
         claims.extend(devnet_required_claims(input));
     }

--- a/crates/kamn-e2e-harness/src/mvp_demo/report_artifacts.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/report_artifacts.rs
@@ -11,6 +11,9 @@ pub(super) fn artifacts_json(input: &DemoReportInput<'_>) -> String {
 fn artifact_entries(input: &DemoReportInput<'_>) -> Vec<(&'static str, String)> {
     let mut entries = base_artifact_entries(input);
     entries.extend(proof_artifact_entries(input));
+    if let Some(path) = input.agent_harness_evidence_path {
+        entries.push(("agent_harness_evidence", path.to_owned()));
+    }
     entries
 }
 

--- a/crates/kamn-e2e-harness/src/mvp_demo/runner.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/runner.rs
@@ -29,6 +29,8 @@ pub struct MvpDemoCommandConfig {
     pub service_api_vertical_slice_command: Option<Vec<String>>,
     /// Optional command override for tests; production uses the service API websocket test.
     pub service_api_websocket_command: Option<Vec<String>>,
+    /// Optional MCP-agent harness evidence artifact path.
+    pub agent_harness_evidence_path: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -51,6 +53,8 @@ pub fn execute_mvp_demo_contract(config: &MvpDemoCommandConfig) -> Result<String
     let input = report_input(config, output_root, run_id.as_str(), &devnet_settlement);
     let report_json = render_report_json(&input);
     verify_mvp_demo_report_json(report_json.as_str())?;
+    let latest_report = latest_report_path(output_root);
+    validate_agent_harness_evidence_file(report_json.as_str(), latest_report.as_str())?;
     write_reports(output_root, run_id.as_str(), report_json.as_str(), &input)?;
     Ok(report_json)
 }
@@ -100,7 +104,15 @@ fn report_input<'a>(
         output_root,
         devnet_settlement: settlement.evidence.as_ref(),
         devnet_no_go_reason: settlement.no_go_reason.as_deref(),
+        agent_harness_evidence_path: config.agent_harness_evidence_path.as_deref(),
     }
+}
+
+fn latest_report_path(output_root: &Path) -> String {
+    output_root
+        .join("latest/proof/report.json")
+        .display()
+        .to_string()
 }
 
 fn create_devnet_settlement_artifact(

--- a/crates/kamn-e2e-harness/src/mvp_demo/runner.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/runner.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use super::agent_harness::validate_agent_harness_evidence_file;
 use super::devnet_settlement::{
     collect_devnet_settlement_evidence, DevnetSettlementAttempt, DevnetSettlementInput,
 };
@@ -61,6 +62,7 @@ pub fn execute_verify_mvp_demo_contract(
     let report = std::fs::read_to_string(config.report.as_str())
         .map_err(|error| format!("failed to read MVP demo report {}: {error}", config.report))?;
     verify_mvp_demo_report_json(report.as_str())?;
+    validate_agent_harness_evidence_file(report.as_str(), config.report.as_str())?;
     Ok(format!(
         "{{\"status\":\"PASS\",\"report\":\"{}\"}}",
         escape_json(config.report.as_str())

--- a/crates/kamn-e2e-harness/src/mvp_demo/verify.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/verify.rs
@@ -1,3 +1,4 @@
+use super::agent_harness::validate_agent_harness_claim_shape;
 use super::report::{
     CLAIM_LABEL_DEVNET_BACKED, CLAIM_LABEL_DRY_RUN, CLAIM_LABEL_LOCAL_ONLY,
     CLAIM_LABEL_PLACEHOLDER, CLAIM_LABEL_REAL, CLAIM_LABEL_ROADMAP, MVP_DEMO_REPORT_SCHEMA_VERSION,
@@ -37,6 +38,7 @@ pub fn verify_mvp_demo_report_json(report_json: impl AsRef<str>) -> Result<(), S
         validate_value_movement_label(claim)?;
         validate_devnet_evidence(claim)?;
     }
+    validate_agent_harness_claim_shape(&claims)?;
     validate_three_agent_escrow_verification(&claims)?;
     validate_no_go(report_json)
 }

--- a/crates/kamn-e2e-harness/src/mvp_demo/verify_support.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/verify_support.rs
@@ -102,16 +102,16 @@ fn claim_matrix_section(report_json: &str) -> Result<&str, String> {
 }
 
 pub(super) fn extract_string(raw: &str, field: &str) -> Result<String, String> {
+    extract_optional_string(raw, field).ok_or_else(|| format!("missing claim field: {field}"))
+}
+
+pub(super) fn extract_optional_string(raw: &str, field: &str) -> Option<String> {
     let marker = format!("\"{field}\":\"");
-    let start = raw
-        .find(marker.as_str())
-        .ok_or_else(|| format!("missing claim field: {field}"))?;
+    let start = raw.find(marker.as_str())?;
     let value_start = start + marker.len();
     let value = &raw[value_start..];
-    let end = value
-        .find('"')
-        .ok_or_else(|| format!("unterminated claim field: {field}"))?;
-    Ok(value[..end].to_owned())
+    let end = value.find('"')?;
+    Some(value[..end].to_owned())
 }
 
 pub(super) fn extract_bool(raw: &str, field: &str) -> Result<bool, String> {

--- a/crates/kamn-e2e-harness/tests/mvp_demo_agent_harness_claim_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_demo_agent_harness_claim_contract.rs
@@ -1,6 +1,8 @@
-use std::path::{Path, PathBuf};
+#[path = "mvp_demo_agent_harness_claim_contract/support.rs"]
+mod support;
 
-use kamn_e2e_harness::{execute_verify_mvp_demo_contract, VerifyMvpDemoCommandConfig};
+use kamn_e2e_harness::{execute_mvp_demo_contract, execute_verify_mvp_demo_contract};
+use support::*;
 
 #[test]
 fn spec_c01_direct_report_without_agent_harness_still_passes() {
@@ -23,31 +25,36 @@ fn spec_c02_command_rejects_agent_harness_claim_without_artifact() {
 }
 
 #[test]
-fn spec_c03_command_rejects_verifier_private_leak_in_agent_harness_artifact() {
-    let root = temp_root("private-leak");
-    let artifact = write_artifact(&root, agent_artifact(&root, true, "devnet-backed"));
-    let report = write_report(&root, report_with_agent_claim(&root, Some(&artifact)));
+fn spec_c03_command_rejects_invalid_agent_harness_artifacts() {
+    for (stem, private_visible, settlement_label, expected) in [
+        (
+            "private-leak",
+            true,
+            "devnet-backed",
+            "verifier_private_view_visible",
+        ),
+        (
+            "local-settlement",
+            false,
+            "local-only",
+            "settlement_claim_label",
+        ),
+    ] {
+        let root = temp_root(stem);
+        let artifact = write_artifact(
+            &root,
+            agent_artifact(&root, private_visible, settlement_label),
+        );
+        let report = write_report(&root, report_with_agent_claim(&root, Some(&artifact)));
 
-    let err = execute_verify_mvp_demo_contract(&config(report.as_path()))
-        .expect_err("agent harness verifier view must stay restricted");
-
-    assert!(err.contains("verifier_private_view_visible"));
+        let err = execute_verify_mvp_demo_contract(&config(report.as_path()))
+            .expect_err("invalid agent harness evidence must fail");
+        assert!(err.contains(expected));
+    }
 }
 
 #[test]
-fn spec_c04_command_rejects_local_only_settlement_in_agent_harness_artifact() {
-    let root = temp_root("local-settlement");
-    let artifact = write_artifact(&root, agent_artifact(&root, false, "local-only"));
-    let report = write_report(&root, report_with_agent_claim(&root, Some(&artifact)));
-
-    let err = execute_verify_mvp_demo_contract(&config(report.as_path()))
-        .expect_err("agent harness cannot count local-only settlement success");
-
-    assert!(err.contains("settlement_claim_label"));
-}
-
-#[test]
-fn spec_c05_command_accepts_valid_agent_harness_artifact() {
+fn spec_c04_command_accepts_valid_agent_harness_artifact() {
     let root = temp_root("valid");
     let artifact = write_artifact(&root, agent_artifact(&root, false, "devnet-backed"));
     let report = write_report(&root, report_with_agent_claim(&root, Some(&artifact)));
@@ -56,90 +63,16 @@ fn spec_c05_command_accepts_valid_agent_harness_artifact() {
         .expect("valid MCP-agent harness evidence should verify");
 }
 
-fn temp_root(stem: &str) -> PathBuf {
-    let millis = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .expect("clock should be after epoch")
-        .as_millis();
-    std::env::temp_dir().join(format!("kamn-7047-{stem}-{}-{millis}", std::process::id()))
-}
+#[test]
+fn spec_c05_demo_mvp_can_include_agent_harness_evidence() {
+    let root = temp_root("demo-generated");
+    let artifact = write_latest_artifact(&root, agent_latest_artifact(&root));
+    let report = execute_mvp_demo_contract(&demo_config(&root, &artifact))
+        .expect("demo should include harness proof");
 
-fn config(report: &Path) -> VerifyMvpDemoCommandConfig {
-    VerifyMvpDemoCommandConfig {
-        report: report.display().to_string(),
-    }
-}
-
-fn write_report(root: &Path, report: String) -> PathBuf {
-    let path = root.join("proof/report.json");
-    std::fs::create_dir_all(path.parent().expect("report parent should exist")).unwrap();
-    std::fs::write(&path, report).unwrap();
-    path
-}
-
-fn write_artifact(root: &Path, artifact: String) -> PathBuf {
-    let path = root.join("proof/agent-harness-evidence.json");
-    std::fs::create_dir_all(path.parent().expect("artifact parent should exist")).unwrap();
-    std::fs::write(&path, artifact).unwrap();
-    path
-}
-
-fn direct_report(root: &Path) -> String {
-    format!(
-        r#"{{"schema_version":"kamn.mvp.demo.proof-report.v1","run_id":"run-7047","status":"GO","devnet_mode":"optional","artifacts":{},"claim_matrix":[{},{}],"no_go":{{"active":false,"reason":""}}}}"#,
-        artifacts_json(root, None),
-        local_claims(),
-        roadmap_claim()
-    )
-}
-
-fn report_with_agent_claim(root: &Path, artifact: Option<&Path>) -> String {
-    format!(
-        r#"{{"schema_version":"kamn.mvp.demo.proof-report.v1","run_id":"run-7047","status":"GO","devnet_mode":"optional","artifacts":{},"claim_matrix":[{},{},{}],"no_go":{{"active":false,"reason":""}}}}"#,
-        artifacts_json(root, artifact),
-        local_claims(),
-        agent_claim(),
-        roadmap_claim()
-    )
-}
-
-fn artifacts_json(root: &Path, agent_artifact: Option<&Path>) -> String {
-    let base = root.join("proof");
-    let mut fields = format!(
-        r#""report_json":"{}","report_md":"{}","state_dir":"{}","audit_export":"{}","localhost_signed_demo_artifact":"{}","localhost_signed_demo_output":"{}","service_api_vertical_slice_output":"{}","service_api_websocket_output":"{}","devnet_settlement_output":"{}""#,
-        base.join("report.json").display(),
-        base.join("report.md").display(),
-        root.join("state").display(),
-        base.join("audit-export.json").display(),
-        base.join("localhost-signed-demo.json").display(),
-        base.join("localhost-signed-demo-output.txt").display(),
-        base.join("service-api-vertical-slice-output.txt").display(),
-        base.join("service-api-websocket-output.txt").display(),
-        base.join("devnet-settlement-output.txt").display()
-    );
-    if let Some(path) = agent_artifact {
-        fields.push_str(format!(r#","agent_harness_evidence":"{}""#, path.display()).as_str());
-    }
-    format!("{{{fields}}}")
-}
-
-fn local_claims() -> &'static str {
-    r#"{"id":"local_runtime_startup","label":"real","required":true,"status":"PASS","summary":"local runtime"},{"id":"authenticated_agent_identities","label":"local-only","required":true,"status":"PASS","summary":"agent identities"},{"id":"signed_message_or_task_flow","label":"local-only","required":true,"status":"PASS","summary":"message flow"},{"id":"durable_state_written","label":"local-only","required":true,"status":"PASS","summary":"durable state"},{"id":"relay_projection_visible","label":"local-only","required":true,"status":"PASS","summary":"relay projection"},{"id":"websocket_event_visibility","label":"local-only","required":true,"status":"PASS","summary":"websocket events"},{"id":"audit_proof_export","label":"local-only","required":true,"status":"PASS","summary":"audit export"}"#
-}
-
-fn agent_claim() -> &'static str {
-    r#"{"id":"mcp_agent_harness_verification","label":"local-only","required":false,"status":"PASS","summary":"MCP agent harness verified report boundaries","harness":"mcp-agent"}"#
-}
-
-fn roadmap_claim() -> &'static str {
-    r#"{"id":"production_readiness","label":"roadmap","required":false,"status":"NOT_CLAIMED","summary":"production readiness is not claimed"}"#
-}
-
-fn agent_artifact(root: &Path, private_visible: bool, settlement_label: &str) -> String {
-    format!(
-        r#"{{"schema_version":"kamn.mvp.agent-harness-evidence.v1","harness":"mcp-agent","execution_surface":"mcp-tools","report_path":"{}","verifier_status":"PASS","participant_agents":["agent_a","agent_b","agent_c_verifier"],"tool_markers":["register","create_task","fund_escrow","release_escrow","verify_proof"],"claim_boundaries":{{"settlement_claim_label":"{}","dry_run_counted_as_success":false,"placeholder_counted_as_success":false,"verifier_private_view_visible":{}}}}}"#,
-        root.join("proof/report.json").display(),
-        settlement_label,
-        private_visible
-    )
+    assert!(report.contains(r#""agent_harness_evidence":""#));
+    assert!(report.contains(r#""id":"mcp_agent_harness_verification""#));
+    assert!(report.contains(r#""harness":"mcp-agent""#));
+    assert!(!report.contains(r#""id":"devnet_settlement_asset_movement""#));
+    let _ = std::fs::remove_dir_all(&root);
 }

--- a/crates/kamn-e2e-harness/tests/mvp_demo_agent_harness_claim_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_demo_agent_harness_claim_contract.rs
@@ -1,0 +1,145 @@
+use std::path::{Path, PathBuf};
+
+use kamn_e2e_harness::{execute_verify_mvp_demo_contract, VerifyMvpDemoCommandConfig};
+
+#[test]
+fn spec_c01_direct_report_without_agent_harness_still_passes() {
+    let root = temp_root("direct");
+    let report = write_report(&root, direct_report(&root));
+
+    execute_verify_mvp_demo_contract(&config(report.as_path()))
+        .expect("direct MVP report should not require agent harness proof");
+}
+
+#[test]
+fn spec_c02_command_rejects_agent_harness_claim_without_artifact() {
+    let root = temp_root("missing-artifact");
+    let report = write_report(&root, report_with_agent_claim(&root, None));
+
+    let err = execute_verify_mvp_demo_contract(&config(report.as_path()))
+        .expect_err("claimed agent harness proof must name an artifact");
+
+    assert!(err.contains("agent harness evidence"));
+}
+
+#[test]
+fn spec_c03_command_rejects_verifier_private_leak_in_agent_harness_artifact() {
+    let root = temp_root("private-leak");
+    let artifact = write_artifact(&root, agent_artifact(&root, true, "devnet-backed"));
+    let report = write_report(&root, report_with_agent_claim(&root, Some(&artifact)));
+
+    let err = execute_verify_mvp_demo_contract(&config(report.as_path()))
+        .expect_err("agent harness verifier view must stay restricted");
+
+    assert!(err.contains("verifier_private_view_visible"));
+}
+
+#[test]
+fn spec_c04_command_rejects_local_only_settlement_in_agent_harness_artifact() {
+    let root = temp_root("local-settlement");
+    let artifact = write_artifact(&root, agent_artifact(&root, false, "local-only"));
+    let report = write_report(&root, report_with_agent_claim(&root, Some(&artifact)));
+
+    let err = execute_verify_mvp_demo_contract(&config(report.as_path()))
+        .expect_err("agent harness cannot count local-only settlement success");
+
+    assert!(err.contains("settlement_claim_label"));
+}
+
+#[test]
+fn spec_c05_command_accepts_valid_agent_harness_artifact() {
+    let root = temp_root("valid");
+    let artifact = write_artifact(&root, agent_artifact(&root, false, "devnet-backed"));
+    let report = write_report(&root, report_with_agent_claim(&root, Some(&artifact)));
+
+    execute_verify_mvp_demo_contract(&config(report.as_path()))
+        .expect("valid MCP-agent harness evidence should verify");
+}
+
+fn temp_root(stem: &str) -> PathBuf {
+    let millis = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("clock should be after epoch")
+        .as_millis();
+    std::env::temp_dir().join(format!("kamn-7047-{stem}-{}-{millis}", std::process::id()))
+}
+
+fn config(report: &Path) -> VerifyMvpDemoCommandConfig {
+    VerifyMvpDemoCommandConfig {
+        report: report.display().to_string(),
+    }
+}
+
+fn write_report(root: &Path, report: String) -> PathBuf {
+    let path = root.join("proof/report.json");
+    std::fs::create_dir_all(path.parent().expect("report parent should exist")).unwrap();
+    std::fs::write(&path, report).unwrap();
+    path
+}
+
+fn write_artifact(root: &Path, artifact: String) -> PathBuf {
+    let path = root.join("proof/agent-harness-evidence.json");
+    std::fs::create_dir_all(path.parent().expect("artifact parent should exist")).unwrap();
+    std::fs::write(&path, artifact).unwrap();
+    path
+}
+
+fn direct_report(root: &Path) -> String {
+    format!(
+        r#"{{"schema_version":"kamn.mvp.demo.proof-report.v1","run_id":"run-7047","status":"GO","devnet_mode":"optional","artifacts":{},"claim_matrix":[{},{}],"no_go":{{"active":false,"reason":""}}}}"#,
+        artifacts_json(root, None),
+        local_claims(),
+        roadmap_claim()
+    )
+}
+
+fn report_with_agent_claim(root: &Path, artifact: Option<&Path>) -> String {
+    format!(
+        r#"{{"schema_version":"kamn.mvp.demo.proof-report.v1","run_id":"run-7047","status":"GO","devnet_mode":"optional","artifacts":{},"claim_matrix":[{},{},{}],"no_go":{{"active":false,"reason":""}}}}"#,
+        artifacts_json(root, artifact),
+        local_claims(),
+        agent_claim(),
+        roadmap_claim()
+    )
+}
+
+fn artifacts_json(root: &Path, agent_artifact: Option<&Path>) -> String {
+    let base = root.join("proof");
+    let mut fields = format!(
+        r#""report_json":"{}","report_md":"{}","state_dir":"{}","audit_export":"{}","localhost_signed_demo_artifact":"{}","localhost_signed_demo_output":"{}","service_api_vertical_slice_output":"{}","service_api_websocket_output":"{}","devnet_settlement_output":"{}""#,
+        base.join("report.json").display(),
+        base.join("report.md").display(),
+        root.join("state").display(),
+        base.join("audit-export.json").display(),
+        base.join("localhost-signed-demo.json").display(),
+        base.join("localhost-signed-demo-output.txt").display(),
+        base.join("service-api-vertical-slice-output.txt").display(),
+        base.join("service-api-websocket-output.txt").display(),
+        base.join("devnet-settlement-output.txt").display()
+    );
+    if let Some(path) = agent_artifact {
+        fields.push_str(format!(r#","agent_harness_evidence":"{}""#, path.display()).as_str());
+    }
+    format!("{{{fields}}}")
+}
+
+fn local_claims() -> &'static str {
+    r#"{"id":"local_runtime_startup","label":"real","required":true,"status":"PASS","summary":"local runtime"},{"id":"authenticated_agent_identities","label":"local-only","required":true,"status":"PASS","summary":"agent identities"},{"id":"signed_message_or_task_flow","label":"local-only","required":true,"status":"PASS","summary":"message flow"},{"id":"durable_state_written","label":"local-only","required":true,"status":"PASS","summary":"durable state"},{"id":"relay_projection_visible","label":"local-only","required":true,"status":"PASS","summary":"relay projection"},{"id":"websocket_event_visibility","label":"local-only","required":true,"status":"PASS","summary":"websocket events"},{"id":"audit_proof_export","label":"local-only","required":true,"status":"PASS","summary":"audit export"}"#
+}
+
+fn agent_claim() -> &'static str {
+    r#"{"id":"mcp_agent_harness_verification","label":"local-only","required":false,"status":"PASS","summary":"MCP agent harness verified report boundaries","harness":"mcp-agent"}"#
+}
+
+fn roadmap_claim() -> &'static str {
+    r#"{"id":"production_readiness","label":"roadmap","required":false,"status":"NOT_CLAIMED","summary":"production readiness is not claimed"}"#
+}
+
+fn agent_artifact(root: &Path, private_visible: bool, settlement_label: &str) -> String {
+    format!(
+        r#"{{"schema_version":"kamn.mvp.agent-harness-evidence.v1","harness":"mcp-agent","execution_surface":"mcp-tools","report_path":"{}","verifier_status":"PASS","participant_agents":["agent_a","agent_b","agent_c_verifier"],"tool_markers":["register","create_task","fund_escrow","release_escrow","verify_proof"],"claim_boundaries":{{"settlement_claim_label":"{}","dry_run_counted_as_success":false,"placeholder_counted_as_success":false,"verifier_private_view_visible":{}}}}}"#,
+        root.join("proof/report.json").display(),
+        settlement_label,
+        private_visible
+    )
+}

--- a/crates/kamn-e2e-harness/tests/mvp_demo_agent_harness_claim_contract/support.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_demo_agent_harness_claim_contract/support.rs
@@ -1,0 +1,159 @@
+use std::path::{Path, PathBuf};
+
+use kamn_e2e_harness::{MvpDemoCommandConfig, VerifyMvpDemoCommandConfig};
+
+pub(crate) fn temp_root(stem: &str) -> PathBuf {
+    let millis = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("clock should be after epoch")
+        .as_millis();
+    std::env::temp_dir().join(format!("kamn-7047-{stem}-{}-{millis}", std::process::id()))
+}
+
+pub(crate) fn config(report: &Path) -> VerifyMvpDemoCommandConfig {
+    VerifyMvpDemoCommandConfig {
+        report: report.display().to_string(),
+    }
+}
+
+pub(crate) fn write_report(root: &Path, report: String) -> PathBuf {
+    let path = root.join("proof/report.json");
+    write_file(path.as_path(), report);
+    path
+}
+
+pub(crate) fn write_artifact(root: &Path, artifact: String) -> PathBuf {
+    let path = root.join("proof/agent-harness-evidence.json");
+    write_file(path.as_path(), artifact);
+    path
+}
+
+pub(crate) fn write_latest_artifact(root: &Path, artifact: String) -> PathBuf {
+    let path = root.join("agent-harness-evidence.json");
+    write_file(path.as_path(), artifact);
+    path
+}
+
+pub(crate) fn demo_config(root: &Path, artifact: &Path) -> MvpDemoCommandConfig {
+    MvpDemoCommandConfig {
+        output_root: root.display().to_string(),
+        devnet_mode: "optional".to_owned(),
+        solana_rpc_url: None,
+        devnet_settlement_command: None,
+        localhost_signed_demo_command: Some(stub_localhost_command()),
+        service_api_vertical_slice_command: Some(stub_service_command("integration_service_api_endpoint_working_vertical_slice_proves_delivery_dispatch_and_audit_evidence")),
+        service_api_websocket_command: Some(stub_service_command("integration_service_api_endpoint_websocket_upgrade_streams_state_transition_event")),
+        agent_harness_evidence_path: Some(artifact.display().to_string()),
+    }
+}
+
+pub(crate) fn direct_report(root: &Path) -> String {
+    format!(
+        r#"{{"schema_version":"kamn.mvp.demo.proof-report.v1","run_id":"run-7047","status":"GO","devnet_mode":"optional","artifacts":{},"claim_matrix":[{},{}],"no_go":{{"active":false,"reason":""}}}}"#,
+        artifacts_json(root, None),
+        local_claims(),
+        roadmap_claim()
+    )
+}
+
+pub(crate) fn report_with_agent_claim(root: &Path, artifact: Option<&Path>) -> String {
+    format!(
+        r#"{{"schema_version":"kamn.mvp.demo.proof-report.v1","run_id":"run-7047","status":"GO","devnet_mode":"optional","artifacts":{},"claim_matrix":[{},{},{}],"no_go":{{"active":false,"reason":""}}}}"#,
+        artifacts_json(root, artifact),
+        local_claims(),
+        agent_claim(),
+        roadmap_claim()
+    )
+}
+
+pub(crate) fn agent_artifact(root: &Path, private_visible: bool, settlement_label: &str) -> String {
+    agent_artifact_for_report(
+        root.join("proof/report.json")
+            .display()
+            .to_string()
+            .as_str(),
+        private_visible,
+        settlement_label,
+    )
+}
+
+pub(crate) fn agent_latest_artifact(root: &Path) -> String {
+    agent_artifact_for_report(
+        root.join("latest/proof/report.json")
+            .display()
+            .to_string()
+            .as_str(),
+        false,
+        "devnet-backed",
+    )
+}
+
+fn write_file(path: &Path, content: String) {
+    std::fs::create_dir_all(path.parent().expect("parent should exist")).unwrap();
+    std::fs::write(path, content).unwrap();
+}
+
+fn stub_localhost_command() -> Vec<String> {
+    vec![
+        "sh".to_owned(),
+        "-c".to_owned(),
+        r#"cat > "$2" <<'JSON'
+{"schema_version":"kamn.sdk.localhost-signed.demo-receipt-artifact.v1","status": "pass"}
+JSON
+echo "localhost signed message demo completed."
+"#
+        .to_owned(),
+        "kamn-mvp-stub".to_owned(),
+    ]
+}
+
+fn stub_service_command(test_name: &str) -> Vec<String> {
+    vec![
+        "sh".to_owned(),
+        "-c".to_owned(),
+        format!(r#"echo "test {test_name} ... ok""#),
+    ]
+}
+
+fn artifacts_json(root: &Path, agent_artifact: Option<&Path>) -> String {
+    let base = root.join("proof");
+    let mut fields = format!(
+        r#""report_json":"{}","report_md":"{}","state_dir":"{}","audit_export":"{}","localhost_signed_demo_artifact":"{}","localhost_signed_demo_output":"{}","service_api_vertical_slice_output":"{}","service_api_websocket_output":"{}","devnet_settlement_output":"{}""#,
+        base.join("report.json").display(),
+        base.join("report.md").display(),
+        root.join("state").display(),
+        base.join("audit-export.json").display(),
+        base.join("localhost-signed-demo.json").display(),
+        base.join("localhost-signed-demo-output.txt").display(),
+        base.join("service-api-vertical-slice-output.txt").display(),
+        base.join("service-api-websocket-output.txt").display(),
+        base.join("devnet-settlement-output.txt").display()
+    );
+    if let Some(path) = agent_artifact {
+        fields.push_str(format!(r#","agent_harness_evidence":"{}""#, path.display()).as_str());
+    }
+    format!("{{{fields}}}")
+}
+
+fn local_claims() -> &'static str {
+    r#"{"id":"local_runtime_startup","label":"real","required":true,"status":"PASS","summary":"local runtime"},{"id":"authenticated_agent_identities","label":"local-only","required":true,"status":"PASS","summary":"agent identities"},{"id":"signed_message_or_task_flow","label":"local-only","required":true,"status":"PASS","summary":"message flow"},{"id":"durable_state_written","label":"local-only","required":true,"status":"PASS","summary":"durable state"},{"id":"relay_projection_visible","label":"local-only","required":true,"status":"PASS","summary":"relay projection"},{"id":"websocket_event_visibility","label":"local-only","required":true,"status":"PASS","summary":"websocket events"},{"id":"audit_proof_export","label":"local-only","required":true,"status":"PASS","summary":"audit export"}"#
+}
+
+fn agent_claim() -> &'static str {
+    r#"{"id":"mcp_agent_harness_verification","label":"local-only","required":false,"status":"PASS","summary":"MCP agent harness verified report boundaries","harness":"mcp-agent"}"#
+}
+
+fn roadmap_claim() -> &'static str {
+    r#"{"id":"production_readiness","label":"roadmap","required":false,"status":"NOT_CLAIMED","summary":"production readiness is not claimed"}"#
+}
+
+fn agent_artifact_for_report(
+    report_path: &str,
+    private_visible: bool,
+    settlement_label: &str,
+) -> String {
+    format!(
+        r#"{{"schema_version":"kamn.mvp.agent-harness-evidence.v1","harness":"mcp-agent","execution_surface":"mcp-tools","report_path":"{}","verifier_status":"PASS","participant_agents":["agent_a","agent_b","agent_c_verifier"],"tool_markers":["register","create_task","fund_escrow","release_escrow","verify_proof"],"claim_boundaries":{{"settlement_claim_label":"{}","dry_run_counted_as_success":false,"placeholder_counted_as_success":false,"verifier_private_view_visible":{}}}}}"#,
+        report_path, settlement_label, private_visible
+    )
+}

--- a/crates/kamn-e2e-harness/tests/mvp_demo_agent_harness_claim_contract/support.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_demo_agent_harness_claim_contract/support.rs
@@ -89,8 +89,9 @@ pub(crate) fn agent_latest_artifact(root: &Path) -> String {
 }
 
 fn write_file(path: &Path, content: String) {
-    std::fs::create_dir_all(path.parent().expect("parent should exist")).unwrap();
-    std::fs::write(path, content).unwrap();
+    std::fs::create_dir_all(path.parent().expect("parent should exist"))
+        .expect("fixture parent directory should be creatable");
+    std::fs::write(path, content).expect("fixture file should be writable");
 }
 
 fn stub_localhost_command() -> Vec<String> {

--- a/crates/kamn-e2e-harness/tests/mvp_demo_command_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_demo_command_contract.rs
@@ -46,20 +46,7 @@ fn spec_c03_makefile_wires_demo_mvp_to_harness_command() {
 #[test]
 fn spec_c04_demo_mvp_creates_run_directory_and_latest_report_paths() {
     let temp = temp_dir("mvp-demo-command");
-    let config = MvpDemoCommandConfig {
-        output_root: temp.display().to_string(),
-        devnet_mode: "optional".to_owned(),
-        solana_rpc_url: None,
-        devnet_settlement_command: None,
-        localhost_signed_demo_command: Some(stub_localhost_signed_demo_command()),
-        service_api_vertical_slice_command: Some(stub_service_api_command(
-            "integration_service_api_endpoint_working_vertical_slice_proves_delivery_dispatch_and_audit_evidence",
-        )),
-        service_api_websocket_command: Some(stub_service_api_command(
-            "integration_service_api_endpoint_websocket_upgrade_streams_state_transition_event",
-        )),
-        agent_harness_evidence_path: None,
-    };
+    let config = local_demo_config(&temp);
     execute_mvp_demo_contract(&config).expect("demo-mvp should generate local proof artifacts");
     assert!(temp.join("latest/proof/report.json").is_file());
     assert!(temp.join("latest/proof/report.md").is_file());
@@ -73,20 +60,7 @@ fn spec_c04_demo_mvp_creates_run_directory_and_latest_report_paths() {
 #[test]
 fn spec_c05_verify_mvp_demo_command_accepts_generated_report() {
     let temp = temp_dir("mvp-demo-verify");
-    let demo_config = MvpDemoCommandConfig {
-        output_root: temp.display().to_string(),
-        devnet_mode: "optional".to_owned(),
-        solana_rpc_url: None,
-        devnet_settlement_command: None,
-        localhost_signed_demo_command: Some(stub_localhost_signed_demo_command()),
-        service_api_vertical_slice_command: Some(stub_service_api_command(
-            "integration_service_api_endpoint_working_vertical_slice_proves_delivery_dispatch_and_audit_evidence",
-        )),
-        service_api_websocket_command: Some(stub_service_api_command(
-            "integration_service_api_endpoint_websocket_upgrade_streams_state_transition_event",
-        )),
-        agent_harness_evidence_path: None,
-    };
+    let demo_config = local_demo_config(&temp);
     execute_mvp_demo_contract(&demo_config).expect("demo should generate report");
     let verify_config = VerifyMvpDemoCommandConfig {
         report: temp.join("latest/proof/report.json").display().to_string(),
@@ -129,35 +103,6 @@ fn spec_c06_demo_mvp_devnet_required_records_settlement_evidence() {
     let _ = std::fs::remove_dir_all(&temp);
 }
 
-#[test]
-fn spec_c07_demo_mvp_can_include_agent_harness_evidence() {
-    let temp = temp_dir("mvp-demo-agent-harness");
-    let artifact = temp.join("agent-harness-evidence.json");
-    std::fs::create_dir_all(&temp).expect("temp root should be creatable");
-    std::fs::write(&artifact, agent_harness_artifact(&temp)).unwrap();
-    let config = MvpDemoCommandConfig {
-        output_root: temp.display().to_string(),
-        devnet_mode: "optional".to_owned(),
-        solana_rpc_url: None,
-        devnet_settlement_command: None,
-        localhost_signed_demo_command: Some(stub_localhost_signed_demo_command()),
-        service_api_vertical_slice_command: Some(stub_service_api_command(
-            "integration_service_api_endpoint_working_vertical_slice_proves_delivery_dispatch_and_audit_evidence",
-        )),
-        service_api_websocket_command: Some(stub_service_api_command(
-            "integration_service_api_endpoint_websocket_upgrade_streams_state_transition_event",
-        )),
-        agent_harness_evidence_path: Some(artifact.display().to_string()),
-    };
-    let report = execute_mvp_demo_contract(&config).expect("demo should include harness proof");
-
-    assert!(report.contains(r#""agent_harness_evidence":""#));
-    assert!(report.contains(r#""id":"mcp_agent_harness_verification""#));
-    assert!(report.contains(r#""harness":"mcp-agent""#));
-    assert!(!report.contains(r#""id":"devnet_settlement_asset_movement""#));
-    let _ = std::fs::remove_dir_all(&temp);
-}
-
 fn stub_localhost_signed_demo_command() -> Vec<String> {
     vec![
         "sh".to_owned(),
@@ -192,11 +137,21 @@ JSON
     ]
 }
 
-fn agent_harness_artifact(root: &Path) -> String {
-    format!(
-        r#"{{"schema_version":"kamn.mvp.agent-harness-evidence.v1","harness":"mcp-agent","execution_surface":"mcp-tools","report_path":"{}","verifier_status":"PASS","participant_agents":["agent_a","agent_b","agent_c_verifier"],"tool_markers":["register","create_task","fund_escrow","release_escrow","verify_proof"],"claim_boundaries":{{"settlement_claim_label":"devnet-backed","dry_run_counted_as_success":false,"placeholder_counted_as_success":false,"verifier_private_view_visible":false}}}}"#,
-        root.join("latest/proof/report.json").display()
-    )
+fn local_demo_config(temp: &Path) -> MvpDemoCommandConfig {
+    MvpDemoCommandConfig {
+        output_root: temp.display().to_string(),
+        devnet_mode: "optional".to_owned(),
+        solana_rpc_url: None,
+        devnet_settlement_command: None,
+        localhost_signed_demo_command: Some(stub_localhost_signed_demo_command()),
+        service_api_vertical_slice_command: Some(stub_service_api_command(
+            "integration_service_api_endpoint_working_vertical_slice_proves_delivery_dispatch_and_audit_evidence",
+        )),
+        service_api_websocket_command: Some(stub_service_api_command(
+            "integration_service_api_endpoint_websocket_upgrade_streams_state_transition_event",
+        )),
+        agent_harness_evidence_path: None,
+    }
 }
 
 fn make_dry_run(target: &str) -> String {

--- a/crates/kamn-e2e-harness/tests/mvp_demo_command_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_demo_command_contract.rs
@@ -19,6 +19,7 @@ fn spec_c01_parser_accepts_demo_mvp_with_output_root() {
         localhost_signed_demo_command: None,
         service_api_vertical_slice_command: None,
         service_api_websocket_command: None,
+        agent_harness_evidence_path: None,
     });
     assert_eq!(parsed, expected);
 }
@@ -57,6 +58,7 @@ fn spec_c04_demo_mvp_creates_run_directory_and_latest_report_paths() {
         service_api_websocket_command: Some(stub_service_api_command(
             "integration_service_api_endpoint_websocket_upgrade_streams_state_transition_event",
         )),
+        agent_harness_evidence_path: None,
     };
     execute_mvp_demo_contract(&config).expect("demo-mvp should generate local proof artifacts");
     assert!(temp.join("latest/proof/report.json").is_file());
@@ -83,6 +85,7 @@ fn spec_c05_verify_mvp_demo_command_accepts_generated_report() {
         service_api_websocket_command: Some(stub_service_api_command(
             "integration_service_api_endpoint_websocket_upgrade_streams_state_transition_event",
         )),
+        agent_harness_evidence_path: None,
     };
     execute_mvp_demo_contract(&demo_config).expect("demo should generate report");
     let verify_config = VerifyMvpDemoCommandConfig {
@@ -109,6 +112,7 @@ fn spec_c06_demo_mvp_devnet_required_records_settlement_evidence() {
         service_api_websocket_command: Some(stub_service_api_command(
             "integration_service_api_endpoint_websocket_upgrade_streams_state_transition_event",
         )),
+        agent_harness_evidence_path: None,
     };
     let report = execute_mvp_demo_contract(&config)
         .expect("devnet-required demo should accept real settlement evidence");

--- a/crates/kamn-e2e-harness/tests/mvp_demo_command_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_demo_command_contract.rs
@@ -125,6 +125,35 @@ fn spec_c06_demo_mvp_devnet_required_records_settlement_evidence() {
     let _ = std::fs::remove_dir_all(&temp);
 }
 
+#[test]
+fn spec_c07_demo_mvp_can_include_agent_harness_evidence() {
+    let temp = temp_dir("mvp-demo-agent-harness");
+    let artifact = temp.join("agent-harness-evidence.json");
+    std::fs::create_dir_all(&temp).expect("temp root should be creatable");
+    std::fs::write(&artifact, agent_harness_artifact(&temp)).unwrap();
+    let config = MvpDemoCommandConfig {
+        output_root: temp.display().to_string(),
+        devnet_mode: "optional".to_owned(),
+        solana_rpc_url: None,
+        devnet_settlement_command: None,
+        localhost_signed_demo_command: Some(stub_localhost_signed_demo_command()),
+        service_api_vertical_slice_command: Some(stub_service_api_command(
+            "integration_service_api_endpoint_working_vertical_slice_proves_delivery_dispatch_and_audit_evidence",
+        )),
+        service_api_websocket_command: Some(stub_service_api_command(
+            "integration_service_api_endpoint_websocket_upgrade_streams_state_transition_event",
+        )),
+        agent_harness_evidence_path: Some(artifact.display().to_string()),
+    };
+    let report = execute_mvp_demo_contract(&config).expect("demo should include harness proof");
+
+    assert!(report.contains(r#""agent_harness_evidence":""#));
+    assert!(report.contains(r#""id":"mcp_agent_harness_verification""#));
+    assert!(report.contains(r#""harness":"mcp-agent""#));
+    assert!(!report.contains(r#""id":"devnet_settlement_asset_movement""#));
+    let _ = std::fs::remove_dir_all(&temp);
+}
+
 fn stub_localhost_signed_demo_command() -> Vec<String> {
     vec![
         "sh".to_owned(),
@@ -157,6 +186,13 @@ JSON
 "#
         .to_owned(),
     ]
+}
+
+fn agent_harness_artifact(root: &Path) -> String {
+    format!(
+        r#"{{"schema_version":"kamn.mvp.agent-harness-evidence.v1","harness":"mcp-agent","execution_surface":"mcp-tools","report_path":"{}","verifier_status":"PASS","participant_agents":["agent_a","agent_b","agent_c_verifier"],"tool_markers":["register","create_task","fund_escrow","release_escrow","verify_proof"],"claim_boundaries":{{"settlement_claim_label":"devnet-backed","dry_run_counted_as_success":false,"placeholder_counted_as_success":false,"verifier_private_view_visible":false}}}}"#,
+        root.join("latest/proof/report.json").display()
+    )
 }
 
 fn make_dry_run(target: &str) -> String {

--- a/specs/7047-mcp-agent-harness-mvp-proof.md
+++ b/specs/7047-mcp-agent-harness-mvp-proof.md
@@ -1,0 +1,92 @@
+# 7047 MCP Agent Harness Evidence In MVP Demo Proof
+
+## Objective
+Add an optional MVP proof-report bridge for agent-harness evaluation. The bridge
+must let a local agent harness, including Pi when configured, drive or inspect
+the KAMN MCP/demo path and leave durable evidence that the final proof report
+was verified through the same claim boundaries as the direct harness path.
+
+## Inputs/Outputs
+Inputs:
+- MVP demo proof report JSON emitted by `make demo-mvp`.
+- Optional agent-harness evidence JSON emitted by a local MCP-agent evaluator.
+- Existing MCP tool surface and MVP report verifier.
+
+Outputs:
+- Direct `make demo-mvp` remains valid without claiming agent-harness proof.
+- When agent-harness proof is claimed, the report includes an explicit
+  `mcp_agent_harness_verification` claim and an artifact path.
+- `verify-mvp-demo --report ...` reads and validates the artifact when the
+  report claims agent-harness verification.
+- The verifier rejects mismatched, placeholder, or privacy-leaking
+  agent-harness evidence.
+
+## Boundaries/Non-goals
+- Do not replace the existing MVP demo command or MCP live probe driver.
+- Do not require Pi OAuth, OpenAI secrets, or committed credentials for Rust
+  contract tests.
+- Do not turn local MCP-agent evidence into settlement or asset-movement
+  success; settlement remains devnet-backed only.
+- Do not claim production readiness, mainnet settlement, or real economic value.
+
+## Failure modes
+- Report claims `mcp_agent_harness_verification` but omits an artifact path.
+- Artifact path exists in the report but cannot be read by the verifier command.
+- Artifact lacks MCP tool-surface markers for register, task, escrow, and proof
+  verification.
+- Artifact records verifier private view exposure.
+- Artifact records dry-run, placeholder, or local-only settlement success.
+- Artifact report path does not match the report being verified.
+- Agent-harness claim uses an unsupported label or required placeholder/dry-run
+  semantics.
+
+## Acceptance criteria
+- [ ] Direct local optional reports still verify without an agent-harness claim.
+- [ ] Reports with a passing `mcp_agent_harness_verification` claim include an
+  `agent_harness_evidence` artifact path.
+- [ ] `verify-mvp-demo --report ...` rejects a passing agent-harness claim when
+  the artifact path is missing or unreadable.
+- [ ] `verify-mvp-demo --report ...` rejects agent-harness evidence where
+  `verifier_private_view_visible` is true.
+- [ ] `verify-mvp-demo --report ...` rejects agent-harness evidence that counts
+  settlement without `settlement_claim_label=devnet-backed`.
+- [ ] `verify-mvp-demo --report ...` accepts valid local MCP-agent evidence
+  without adding any settlement claim to local-only reports.
+- [ ] Existing claim-contract tests pass.
+
+## Files to touch
+- `crates/kamn-e2e-harness/src/mvp_demo/runner.rs`
+- `crates/kamn-e2e-harness/src/mvp_demo/report.rs`
+- `crates/kamn-e2e-harness/src/mvp_demo/report_artifacts.rs`
+- `crates/kamn-e2e-harness/src/mvp_demo/verify.rs`
+- `crates/kamn-e2e-harness/src/mvp_demo/verify_support.rs`
+- Optional helper modules under `crates/kamn-e2e-harness/src/mvp_demo/`
+- New focused contract test under `crates/kamn-e2e-harness/tests/`
+
+## Error semantics
+- Missing or unreadable claimed agent-harness evidence must hard-fail the
+  `verify-mvp-demo` command.
+- Privacy leaks must fail closed.
+- Settlement claim-label mismatches must fail closed.
+- Direct reports with no agent-harness claim must continue to verify normally.
+
+## Test plan
+Red:
+- Add command-level tests for missing artifact, privacy leak, non-devnet
+  settlement label, and valid MCP-agent evidence.
+- Add pure report verifier coverage that rejects malformed
+  `mcp_agent_harness_verification` claim shape.
+
+Green:
+- Add optional report artifact and claim rendering.
+- Add command-level artifact validation for `verify-mvp-demo`.
+- Keep the direct MVP command path unchanged when no evidence env is provided.
+
+Refactor:
+- Extract small agent-harness validation/rendering helpers so MVP verifier and
+  report modules remain bounded and single-purpose.
+
+Integration:
+- Run targeted MVP claim-contract tests.
+- Run `make demo-mvp`.
+- Run the canonical report verifier against the latest report.

--- a/specs/7047-mcp-agent-harness-mvp-proof.md
+++ b/specs/7047-mcp-agent-harness-mvp-proof.md
@@ -41,18 +41,18 @@ Outputs:
   semantics.
 
 ## Acceptance criteria
-- [ ] Direct local optional reports still verify without an agent-harness claim.
-- [ ] Reports with a passing `mcp_agent_harness_verification` claim include an
+- [x] Direct local optional reports still verify without an agent-harness claim.
+- [x] Reports with a passing `mcp_agent_harness_verification` claim include an
   `agent_harness_evidence` artifact path.
-- [ ] `verify-mvp-demo --report ...` rejects a passing agent-harness claim when
+- [x] `verify-mvp-demo --report ...` rejects a passing agent-harness claim when
   the artifact path is missing or unreadable.
-- [ ] `verify-mvp-demo --report ...` rejects agent-harness evidence where
+- [x] `verify-mvp-demo --report ...` rejects agent-harness evidence where
   `verifier_private_view_visible` is true.
-- [ ] `verify-mvp-demo --report ...` rejects agent-harness evidence that counts
+- [x] `verify-mvp-demo --report ...` rejects agent-harness evidence that counts
   settlement without `settlement_claim_label=devnet-backed`.
-- [ ] `verify-mvp-demo --report ...` accepts valid local MCP-agent evidence
+- [x] `verify-mvp-demo --report ...` accepts valid local MCP-agent evidence
   without adding any settlement claim to local-only reports.
-- [ ] Existing claim-contract tests pass.
+- [x] Existing claim-contract tests pass.
 
 ## Files to touch
 - `crates/kamn-e2e-harness/src/mvp_demo/runner.rs`
@@ -90,3 +90,20 @@ Integration:
 - Run targeted MVP claim-contract tests.
 - Run `make demo-mvp`.
 - Run the canonical report verifier against the latest report.
+
+## Completion evidence
+- `cargo fmt --check`
+- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+- `make check`
+- `cargo test -p kamn-e2e-harness --test mvp_demo_command_contract -- --nocapture`
+- `cargo test -p kamn-e2e-harness --test mvp_demo_claim_contract -- --nocapture`
+- `cargo test -p kamn-e2e-harness --test mvp_demo_three_agent_claim_contract -- --nocapture`
+- `cargo test -p kamn-e2e-harness --test mvp_demo_agent_harness_claim_contract -- --nocapture`
+- `make demo-mvp`
+- `KAMN_MVP_AGENT_HARNESS_EVIDENCE=/tmp/kamn-7047-agent-harness-evidence.json make demo-mvp`
+- `KAMN_MVP_DEVNET_MODE=required KAMN_MVP_SOLANA_RPC_URL=https://api.devnet.solana.com make demo-mvp`
+- `cargo run -p kamn-e2e-harness -- verify-mvp-demo --report .kamn/demo/latest/proof/report.json`
+
+Deviations: live Pi OAuth-driven execution remains outside this issue. This
+issue adds the repo verifier/report bridge that such a Pi run can satisfy
+without requiring local OAuth in deterministic tests.


### PR DESCRIPTION
## Human Summary

- Adds an optional MCP-agent harness evidence path to the MVP proof report without changing the default direct `make demo-mvp` flow.
- When `mcp_agent_harness_verification` is claimed, `verify-mvp-demo` now requires a readable evidence artifact with MCP tool markers, restricted verifier visibility, and devnet-backed settlement boundaries.
- Keeps local agent-harness evidence local-only; it cannot promote settlement or asset movement without devnet settlement proof.
- Splits the new agent-harness test fixtures into a support module to keep the focused test file small.

Closes #7047

## Testing

- `cargo fmt --check`
- `CARGO_TARGET_DIR=target/mvp-demo-proof CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `CARGO_TARGET_DIR=target/mvp-demo-proof CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 make check`
- `CARGO_TARGET_DIR=target/mvp-demo-proof CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 cargo test -p kamn-e2e-harness --test mvp_demo_command_contract -- --nocapture`
- `CARGO_TARGET_DIR=target/mvp-demo-proof CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 cargo test -p kamn-e2e-harness --test mvp_demo_claim_contract -- --nocapture`
- `CARGO_TARGET_DIR=target/mvp-demo-proof CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 cargo test -p kamn-e2e-harness --test mvp_demo_three_agent_claim_contract -- --nocapture`
- `CARGO_TARGET_DIR=target/mvp-demo-proof CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 cargo test -p kamn-e2e-harness --test mvp_demo_agent_harness_claim_contract -- --nocapture`
- `CARGO_TARGET_DIR=target/mvp-demo-proof CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 make demo-mvp`
- `KAMN_MVP_AGENT_HARNESS_EVIDENCE=/tmp/kamn-7047-agent-harness-evidence.json CARGO_TARGET_DIR=target/mvp-demo-proof CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 make demo-mvp`
- `set -a; source .kamn/devnet/mvp-demo-devnet.env; set +a; KAMN_MVP_DEVNET_MODE=required KAMN_MVP_SOLANA_RPC_URL=https://api.devnet.solana.com CARGO_TARGET_DIR=target/mvp-demo-proof CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 make demo-mvp`
- `CARGO_TARGET_DIR=target/mvp-demo-proof CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 cargo run -p kamn-e2e-harness -- verify-mvp-demo --report .kamn/demo/latest/proof/report.json`

## Notes for Reviewers

- Latest devnet-required report status was `GO`; verifier status was `PASS`.
- Latest devnet settlement signature observed in the proof report was `4KNgvVCudhaKJjyUpdGXywdojUy4FsyUNqSYiaC5rAXbmht4jkHLWFezxGg8Ndmq6jmbsbjvARty6J7hk9bBZENF`.
- Live Pi OAuth-driven execution is intentionally not claimed in this PR; this adds the verifier/report bridge that a Pi-driven run can satisfy next.
- No shell/python/workflow/template surface changed in this PR.
