### PR TITLE
[7062] Bind Pi evidence to actor rehearsals

### DIFF
--- a/.pi/extensions/kamn-mvp/evidence.ts
+++ b/.pi/extensions/kamn-mvp/evidence.ts
@@ -1,0 +1,160 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+
+export type Report = {
+	status?: string;
+	devnet_mode?: string;
+	claim_matrix?: Array<Record<string, unknown>>;
+};
+
+export async function readReport(reportPath: string): Promise<Report> {
+	const raw = await readFile(reportPath, "utf8");
+	const report = JSON.parse(raw) as Report;
+	if (!Array.isArray(report.claim_matrix)) {
+		throw new Error("KAMN report is missing claim_matrix");
+	}
+	return report;
+}
+
+export async function writeEvidence(outputPath: string, reportPath: string, report: Report) {
+	await mkdir(dirname(outputPath), { recursive: true });
+	await writeFile(outputPath, JSON.stringify(evidence(reportPath, report)));
+}
+
+export function boundarySummary(report: Report) {
+	const claims = report.claim_matrix ?? [];
+	return {
+		status: report.status,
+		devnet_mode: report.devnet_mode,
+		local_runtime: claimStatus(claims, "local_runtime_startup"),
+		settlement: claimStatus(claims, "devnet_settlement_asset_movement"),
+		three_agent: claimStatus(claims, "three_agent_escrow_verification"),
+		production_readiness: claimStatus(claims, "production_readiness"),
+	};
+}
+
+function evidence(reportPath: string, report: Report) {
+	const actorRehearsal = threeAgentActorRehearsal(report);
+	return {
+		schema_version: "kamn.mvp.agent-harness-evidence.v1",
+		harness: "mcp-agent",
+		execution_surface: "pi-extension-tools",
+		report_path: reportPath,
+		verifier_status: report.status === "NO-GO" ? "NO-GO" : "PASS",
+		participant_agents: ["agent_a", "agent_b", "agent_c_verifier"],
+		tool_markers: agentToolMarkers(),
+		claim_boundaries: claimBoundaries(),
+		three_agent_boundary: threeAgentBoundary(report),
+		...(actorRehearsal ? { three_agent_actor_rehearsal: actorRehearsal } : {}),
+	};
+}
+
+function agentToolMarkers() {
+	return ["register", "create_task", "fund_escrow", "release_escrow", "verify_proof"];
+}
+
+function claimBoundaries() {
+	return {
+		settlement_claim_label: "devnet-backed",
+		dry_run_counted_as_success: false,
+		placeholder_counted_as_success: false,
+		verifier_private_view_visible: false,
+	};
+}
+
+function threeAgentBoundary(report: Report) {
+	const claim = findClaim(report, "three_agent_escrow_verification");
+	if (!claim) {
+		return {
+			claim_status: "NOT_PRESENT",
+			claim_label: "NOT_PRESENT",
+			claim_present: false,
+		};
+	}
+	return {
+		claim_status: requireString(claim, "status"),
+		claim_label: requireString(claim, "label"),
+		claim_present: true,
+		agent_a_private_field_count: requireNumber(claim, "agent_a_private_field_count"),
+		agent_b_private_field_count: requireNumber(claim, "agent_b_private_field_count"),
+		verifier_private_field_count: requireNumber(claim, "verifier_private_field_count"),
+		private_payload_redacted: requireBoolean(claim, "private_payload_redacted"),
+		verifier_private_view_digest_present: typeof claim.verifier_private_view_digest === "string",
+	};
+}
+
+function threeAgentActorRehearsal(report: Report) {
+	const claim = findClaim(report, "three_agent_escrow_verification");
+	if (!claim) return undefined;
+	return {
+		settlement_claim_label: requireString(claim, "label"),
+		settlement_status: requireString(claim, "status"),
+		private_payload_redacted: requireBoolean(claim, "private_payload_redacted"),
+		agent_a: actorObservation(claim, {
+			agent: "agent_a",
+			actions: ["register", "invoke_transaction"],
+			scopeField: "agent_a_view_scope",
+			artifactField: "agent_a_view_artifact",
+			digestField: "agent_a_view_digest",
+		}),
+		agent_b: actorObservation(claim, {
+			agent: "agent_b",
+			actions: ["register", "accept_task"],
+			scopeField: "agent_b_view_scope",
+			artifactField: "agent_b_view_artifact",
+			digestField: "agent_b_view_digest",
+		}),
+		agent_c_verifier: actorObservation(claim, {
+			agent: "agent_c_verifier",
+			actions: ["verify_proof"],
+			scopeField: "verifier_view_scope",
+			artifactField: "agent_c_verifier_view_artifact",
+			digestField: "agent_c_verifier_view_digest",
+		}),
+	};
+}
+
+function actorObservation(claim: Record<string, unknown>, input: ActorInput) {
+	return {
+		agent: input.agent,
+		actions: input.actions,
+		view_scope: requireString(claim, input.scopeField),
+		view_artifact: requireString(claim, input.artifactField),
+		[input.digestField]: requireString(claim, input.digestField),
+	};
+}
+
+type ActorInput = {
+	agent: string;
+	actions: string[];
+	scopeField: string;
+	artifactField: string;
+	digestField: string;
+};
+
+function claimStatus(claims: Array<Record<string, unknown>>, id: string) {
+	const claim = findClaim({ claim_matrix: claims }, id);
+	return claim ? { label: claim.label, status: claim.status } : { status: "NOT_PRESENT" };
+}
+
+function findClaim(report: Report, id: string) {
+	return (report.claim_matrix ?? []).find((entry) => entry.id === id);
+}
+
+function requireString(claim: Record<string, unknown>, field: string): string {
+	const value = claim[field];
+	if (typeof value === "string") return value;
+	throw new Error(`KAMN report three-agent claim is missing string field: ${field}`);
+}
+
+function requireNumber(claim: Record<string, unknown>, field: string): number {
+	const value = claim[field];
+	if (typeof value === "number" && Number.isFinite(value)) return value;
+	throw new Error(`KAMN report three-agent claim is missing number field: ${field}`);
+}
+
+function requireBoolean(claim: Record<string, unknown>, field: string): boolean {
+	const value = claim[field];
+	if (typeof value === "boolean") return value;
+	throw new Error(`KAMN report three-agent claim is missing boolean field: ${field}`);
+}

--- a/.pi/extensions/kamn-mvp/evidence.ts
+++ b/.pi/extensions/kamn-mvp/evidence.ts
@@ -7,6 +7,30 @@ export type Report = {
 	claim_matrix?: Array<Record<string, unknown>>;
 };
 
+const ACTORS: Record<string, ActorInput> = {
+	agent_a: {
+		agent: "agent_a",
+		actions: ["register", "invoke_transaction"],
+		scopeField: "agent_a_view_scope",
+		artifactField: "agent_a_view_artifact",
+		digestField: "agent_a_view_digest",
+	},
+	agent_b: {
+		agent: "agent_b",
+		actions: ["register", "accept_task"],
+		scopeField: "agent_b_view_scope",
+		artifactField: "agent_b_view_artifact",
+		digestField: "agent_b_view_digest",
+	},
+	agent_c_verifier: {
+		agent: "agent_c_verifier",
+		actions: ["verify_proof"],
+		scopeField: "verifier_view_scope",
+		artifactField: "agent_c_verifier_view_artifact",
+		digestField: "agent_c_verifier_view_digest",
+	},
+};
+
 export async function readReport(reportPath: string): Promise<Report> {
 	const raw = await readFile(reportPath, "utf8");
 	const report = JSON.parse(raw) as Report;
@@ -90,27 +114,15 @@ function threeAgentActorRehearsal(report: Report) {
 		settlement_claim_label: requireString(claim, "label"),
 		settlement_status: requireString(claim, "status"),
 		private_payload_redacted: requireBoolean(claim, "private_payload_redacted"),
-		agent_a: actorObservation(claim, {
-			agent: "agent_a",
-			actions: ["register", "invoke_transaction"],
-			scopeField: "agent_a_view_scope",
-			artifactField: "agent_a_view_artifact",
-			digestField: "agent_a_view_digest",
-		}),
-		agent_b: actorObservation(claim, {
-			agent: "agent_b",
-			actions: ["register", "accept_task"],
-			scopeField: "agent_b_view_scope",
-			artifactField: "agent_b_view_artifact",
-			digestField: "agent_b_view_digest",
-		}),
-		agent_c_verifier: actorObservation(claim, {
-			agent: "agent_c_verifier",
-			actions: ["verify_proof"],
-			scopeField: "verifier_view_scope",
-			artifactField: "agent_c_verifier_view_artifact",
-			digestField: "agent_c_verifier_view_digest",
-		}),
+		...actorObservations(claim),
+	};
+}
+
+function actorObservations(claim: Record<string, unknown>) {
+	return {
+		agent_a: actorObservation(claim, ACTORS.agent_a),
+		agent_b: actorObservation(claim, ACTORS.agent_b),
+		agent_c_verifier: actorObservation(claim, ACTORS.agent_c_verifier),
 	};
 }
 

--- a/.pi/extensions/kamn-mvp/index.ts
+++ b/.pi/extensions/kamn-mvp/index.ts
@@ -1,15 +1,11 @@
-import { mkdir, readFile, writeFile } from "node:fs/promises";
-import { dirname, resolve } from "node:path";
+import { resolve } from "node:path";
 import type { ExtensionAPI, ExtensionContext, ExecResult } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
+import { boundarySummary, readReport, writeEvidence } from "./evidence";
+
 const DEFAULT_REPORT = ".kamn/demo/latest/proof/report.json";
 const DEFAULT_EVIDENCE = "/tmp/kamn-pi-mcp-agent-harness-evidence.json";
 const PROOF_ENV = ["CARGO_TARGET_DIR=target/mvp-demo-proof", "CARGO_BUILD_JOBS=1", "CARGO_INCREMENTAL=0"];
-type Report = {
-	status?: string;
-	devnet_mode?: string;
-	claim_matrix?: Array<Record<string, unknown>>;
-};
 type ReportPath = {
 	artifactPath: string;
 	readPath: string;
@@ -125,101 +121,6 @@ function rejectSecretLikePath(path: string) {
 			throw new Error(`Refusing secret-like path: ${marker}`);
 		}
 	}
-}
-async function readReport(reportPath: string): Promise<Report> {
-	const raw = await readFile(reportPath, "utf8");
-	const report = JSON.parse(raw) as Report;
-	if (!Array.isArray(report.claim_matrix)) {
-		throw new Error("KAMN report is missing claim_matrix");
-	}
-	return report;
-}
-async function writeEvidence(outputPath: string, reportPath: string, report: Report) {
-	await mkdir(dirname(outputPath), { recursive: true });
-	await writeFile(outputPath, JSON.stringify(evidence(reportPath, report)));
-}
-function evidence(reportPath: string, report: Report) {
-	return {
-		schema_version: "kamn.mvp.agent-harness-evidence.v1",
-		harness: "mcp-agent",
-		execution_surface: "pi-extension-tools",
-		report_path: reportPath,
-		verifier_status: report.status === "NO-GO" ? "NO-GO" : "PASS",
-		participant_agents: ["agent_a", "agent_b", "agent_c_verifier"],
-		tool_markers: agentToolMarkers(),
-		claim_boundaries: claimBoundaries(report),
-		three_agent_boundary: threeAgentBoundary(report),
-	};
-}
-function agentToolMarkers() {
-	return ["register", "create_task", "fund_escrow", "release_escrow", "verify_proof"];
-}
-function claimBoundaries(_report: Report) {
-	return {
-		settlement_claim_label: "devnet-backed",
-		dry_run_counted_as_success: false,
-		placeholder_counted_as_success: false,
-		verifier_private_view_visible: false,
-	};
-}
-function boundarySummary(report: Report) {
-	const claims = report.claim_matrix ?? [];
-	return {
-		status: report.status,
-		devnet_mode: report.devnet_mode,
-		local_runtime: claimStatus(claims, "local_runtime_startup"),
-		settlement: claimStatus(claims, "devnet_settlement_asset_movement"),
-		three_agent: claimStatus(claims, "three_agent_escrow_verification"),
-		production_readiness: claimStatus(claims, "production_readiness"),
-	};
-}
-
-function threeAgentBoundary(report: Report) {
-	const claim = findClaim(report, "three_agent_escrow_verification");
-	if (!claim) {
-		return {
-			claim_status: "NOT_PRESENT",
-			claim_label: "NOT_PRESENT",
-			claim_present: false,
-		};
-	}
-	return {
-		claim_status: requireString(claim, "status"),
-		claim_label: requireString(claim, "label"),
-		claim_present: true,
-		agent_a_private_field_count: requireNumber(claim, "agent_a_private_field_count"),
-		agent_b_private_field_count: requireNumber(claim, "agent_b_private_field_count"),
-		verifier_private_field_count: requireNumber(claim, "verifier_private_field_count"),
-		private_payload_redacted: requireBoolean(claim, "private_payload_redacted"),
-		verifier_private_view_digest_present: typeof claim.verifier_private_view_digest === "string",
-	};
-}
-
-function claimStatus(claims: Array<Record<string, unknown>>, id: string) {
-	const claim = findClaim({ claim_matrix: claims }, id);
-	return claim ? { label: claim.label, status: claim.status } : { status: "NOT_PRESENT" };
-}
-
-function findClaim(report: Report, id: string) {
-	return (report.claim_matrix ?? []).find((entry) => entry.id === id);
-}
-
-function requireString(claim: Record<string, unknown>, field: string): string {
-	const value = claim[field];
-	if (typeof value === "string") return value;
-	throw new Error(`KAMN report three-agent claim is missing string field: ${field}`);
-}
-
-function requireNumber(claim: Record<string, unknown>, field: string): number {
-	const value = claim[field];
-	if (typeof value === "number" && Number.isFinite(value)) return value;
-	throw new Error(`KAMN report three-agent claim is missing number field: ${field}`);
-}
-
-function requireBoolean(claim: Record<string, unknown>, field: string): boolean {
-	const value = claim[field];
-	if (typeof value === "boolean") return value;
-	throw new Error(`KAMN report three-agent claim is missing boolean field: ${field}`);
 }
 function assertSuccess(result: ExecResult, label: string) {
 	if (result.code === 0) return;

--- a/crates/kamn-e2e-harness/src/mvp_demo/agent_harness_actor_rehearsal.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/agent_harness_actor_rehearsal.rs
@@ -102,14 +102,16 @@ fn object_section<'a>(raw: &'a str, field: &str) -> Result<&'a str, String> {
 fn matching_object(raw: &str, start: usize) -> Result<&str, String> {
     let mut depth = 0_u64;
     for (offset, byte) in raw[start..].bytes().enumerate() {
-        if byte == b'{' {
-            depth += 1;
-        }
-        if byte == b'}' {
-            depth -= 1;
-            if depth == 0 {
-                return Ok(&raw[start..start + offset + 1]);
+        match byte {
+            b'{' => depth += 1,
+            b'}' if depth == 0 => break,
+            b'}' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Ok(&raw[start..start + offset + 1]);
+                }
             }
+            _ => {}
         }
     }
     Err("malformed three_agent_actor_rehearsal object".to_owned())

--- a/crates/kamn-e2e-harness/src/mvp_demo/agent_harness_actor_rehearsal.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/agent_harness_actor_rehearsal.rs
@@ -1,0 +1,133 @@
+use super::verify_support::{extract_string, require_marker, ClaimView};
+
+pub(crate) fn validate_actor_rehearsal(
+    artifact: &str,
+    claim: &ClaimView<'_>,
+) -> Result<(), String> {
+    let rehearsal = object_section(artifact, "three_agent_actor_rehearsal")?;
+    require_marker(
+        rehearsal,
+        "\"settlement_claim_label\":\"devnet-backed\"",
+        "three_agent_actor_rehearsal settlement label",
+    )?;
+    require_marker(
+        rehearsal,
+        "\"settlement_status\":\"PASS\"",
+        "three_agent_actor_rehearsal settlement status",
+    )?;
+    require_marker(
+        rehearsal,
+        "\"private_payload_redacted\":true",
+        "three_agent_actor_rehearsal redaction",
+    )?;
+    reject_private_payload(rehearsal)?;
+    validate_participant(rehearsal, claim, "agent_a", "invoke_transaction")?;
+    validate_participant(rehearsal, claim, "agent_b", "accept_task")?;
+    validate_verifier(rehearsal, claim)
+}
+
+fn validate_participant(
+    rehearsal: &str,
+    claim: &ClaimView<'_>,
+    agent: &str,
+    action: &str,
+) -> Result<(), String> {
+    let actor = object_section(rehearsal, agent)?;
+    require_marker(actor, format!("\"agent\":\"{agent}\"").as_str(), agent)?;
+    require_marker(actor, "\"register\"", agent)?;
+    require_marker(actor, action, agent)?;
+    require_marker(actor, "\"view_scope\":\"participant-private\"", agent)?;
+    require_actor_match(
+        actor,
+        claim,
+        "view_artifact",
+        format!("{agent}_view_artifact").as_str(),
+    )?;
+    require_actor_match(
+        actor,
+        claim,
+        format!("{agent}_view_digest").as_str(),
+        format!("{agent}_view_digest").as_str(),
+    )
+}
+
+fn validate_verifier(rehearsal: &str, claim: &ClaimView<'_>) -> Result<(), String> {
+    let actor = object_section(rehearsal, "agent_c_verifier")?;
+    require_marker(actor, "\"agent\":\"agent_c_verifier\"", "agent_c_verifier")?;
+    require_marker(actor, "\"verify_proof\"", "agent_c_verifier")?;
+    require_marker(
+        actor,
+        "\"view_scope\":\"restricted-public\"",
+        "agent_c_verifier",
+    )?;
+    reject_verifier_private(actor)?;
+    require_actor_match(
+        actor,
+        claim,
+        "view_artifact",
+        "agent_c_verifier_view_artifact",
+    )?;
+    require_actor_match(
+        actor,
+        claim,
+        "agent_c_verifier_view_digest",
+        "agent_c_verifier_view_digest",
+    )
+}
+
+fn require_actor_match(
+    actor: &str,
+    claim: &ClaimView<'_>,
+    actor_field: &str,
+    claim_field: &str,
+) -> Result<(), String> {
+    if extract_string(actor, actor_field)? == extract_string(claim.raw, claim_field)? {
+        return Ok(());
+    }
+    Err(format!(
+        "three_agent_actor_rehearsal {claim_field} mismatch"
+    ))
+}
+
+fn object_section<'a>(raw: &'a str, field: &str) -> Result<&'a str, String> {
+    let marker = format!("\"{field}\":{{");
+    let start = raw
+        .find(marker.as_str())
+        .ok_or_else(|| format!("missing three_agent_actor_rehearsal field: {field}"))?
+        + marker.len()
+        - 1;
+    matching_object(raw, start)
+}
+
+fn matching_object(raw: &str, start: usize) -> Result<&str, String> {
+    let mut depth = 0_u64;
+    for (offset, byte) in raw[start..].bytes().enumerate() {
+        if byte == b'{' {
+            depth += 1;
+        }
+        if byte == b'}' {
+            depth -= 1;
+            if depth == 0 {
+                return Ok(&raw[start..start + offset + 1]);
+            }
+        }
+    }
+    Err("malformed three_agent_actor_rehearsal object".to_owned())
+}
+
+fn reject_private_payload(raw: &str) -> Result<(), String> {
+    if raw.contains("raw_private_payload") {
+        return Err("three_agent_actor_rehearsal contains raw private payload".to_owned());
+    }
+    Ok(())
+}
+
+fn reject_verifier_private(actor: &str) -> Result<(), String> {
+    if actor.contains("\"participant_private_view_digest\"") {
+        return Err("three_agent_actor_rehearsal agent_c_verifier private digest".to_owned());
+    }
+    if actor.contains("\"view_scope\":\"participant-private\"") {
+        return Err("three_agent_actor_rehearsal agent_c_verifier scope".to_owned());
+    }
+    Ok(())
+}

--- a/crates/kamn-e2e-harness/src/mvp_demo/agent_harness_three_agent.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/agent_harness_three_agent.rs
@@ -1,3 +1,4 @@
+use super::agent_harness_actor_rehearsal::validate_actor_rehearsal;
 use super::verify_support::{
     extract_bool, extract_optional_string, extract_string, extract_u64, require_marker, ClaimView,
 };
@@ -36,7 +37,8 @@ fn validate_present_boundary(artifact: &str, claim: &ClaimView<'_>) -> Result<()
         extract_bool(claim.raw, "private_payload_redacted")?,
     )?;
     validate_private_counts(artifact)?;
-    validate_verifier_private_digest(artifact, claim)
+    validate_verifier_private_digest(artifact, claim)?;
+    validate_actor_rehearsal(artifact, claim)
 }
 
 fn validate_absent_boundary(artifact: &str) -> Result<(), String> {

--- a/crates/kamn-e2e-harness/src/mvp_demo/mod.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/mod.rs
@@ -1,6 +1,7 @@
 //! MVP evaluator demo report generation and verification.
 
 mod agent_harness;
+mod agent_harness_actor_rehearsal;
 mod agent_harness_three_agent;
 mod devnet_settlement;
 mod devnet_settlement_build;

--- a/crates/kamn-e2e-harness/tests/mvp_demo_agent_harness_claim_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_demo_agent_harness_claim_contract.rs
@@ -124,6 +124,9 @@ fn spec_c08_project_local_pi_extension_registers_kamn_tools() {
         "kamn_write_agent_harness_evidence",
         "kamn_run_demo_mvp_with_agent_evidence",
         "three_agent_boundary",
+        "three_agent_actor_rehearsal",
+        "invoke_transaction",
+        "accept_task",
     ] {
         assert!(source.contains(marker), "missing Pi tool marker: {marker}");
     }

--- a/crates/kamn-e2e-harness/tests/mvp_demo_agent_harness_claim_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_demo_agent_harness_claim_contract.rs
@@ -1,5 +1,7 @@
 #[path = "mvp_demo_agent_harness_claim_contract/support.rs"]
 mod support;
+#[path = "mvp_demo_agent_harness_claim_contract/three_agent_actor_rehearsal_contract.rs"]
+mod three_agent_actor_rehearsal_contract;
 #[path = "mvp_demo_agent_harness_claim_contract/three_agent_boundary_contract.rs"]
 mod three_agent_boundary_contract;
 

--- a/crates/kamn-e2e-harness/tests/mvp_demo_agent_harness_claim_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_demo_agent_harness_claim_contract.rs
@@ -115,8 +115,7 @@ fn spec_c07_markdown_report_surfaces_agent_harness_evidence() {
 
 #[test]
 fn spec_c08_project_local_pi_extension_registers_kamn_tools() {
-    let extension = workspace_root().join(".pi/extensions/kamn-mvp/index.ts");
-    let source = std::fs::read_to_string(extension).expect("KAMN Pi extension should exist");
+    let source = pi_extension_source();
 
     for marker in [
         "kamn_verify_mvp_report",
@@ -130,6 +129,18 @@ fn spec_c08_project_local_pi_extension_registers_kamn_tools() {
     ] {
         assert!(source.contains(marker), "missing Pi tool marker: {marker}");
     }
+}
+
+fn pi_extension_source() -> String {
+    [
+        ".pi/extensions/kamn-mvp/index.ts",
+        ".pi/extensions/kamn-mvp/evidence.ts",
+    ]
+    .map(|path| {
+        std::fs::read_to_string(workspace_root().join(path))
+            .unwrap_or_else(|_| panic!("KAMN Pi extension file should exist: {path}"))
+    })
+    .join("\n")
 }
 
 fn workspace_root() -> &'static Path {

--- a/crates/kamn-e2e-harness/tests/mvp_demo_agent_harness_claim_contract/artifact.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_demo_agent_harness_claim_contract/artifact.rs
@@ -67,6 +67,20 @@ pub(crate) fn agent_artifact_with_three_agent_boundary(root: &Path) -> String {
     )
 }
 
+pub(crate) fn agent_artifact_with_three_agent_actor_rehearsal(root: &Path) -> String {
+    append_object_field(
+        agent_artifact_with_three_agent_boundary(root),
+        three_agent::valid_actor_rehearsal(root),
+    )
+}
+
+fn append_object_field(mut json: String, field: String) -> String {
+    json.pop();
+    json.push_str(field.as_str());
+    json.push('}');
+    json
+}
+
 fn agent_artifact_for_report_with_surface(
     report_path: &str,
     private_visible: bool,

--- a/crates/kamn-e2e-harness/tests/mvp_demo_agent_harness_claim_contract/three_agent.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_demo_agent_harness_claim_contract/three_agent.rs
@@ -54,6 +54,55 @@ pub(crate) fn valid_view_artifacts(root: &Path) -> Vec<(PathBuf, String)> {
     ]
 }
 
+pub(crate) fn valid_actor_rehearsal(root: &Path) -> String {
+    format!(
+        r#","three_agent_actor_rehearsal":{{"settlement_claim_label":"devnet-backed","settlement_status":"PASS","private_payload_redacted":true,"agent_a":{},"agent_b":{},"agent_c_verifier":{}}}"#,
+        actor_observation(
+            root,
+            "agent_a",
+            "participant-private",
+            r#"["register","invoke_transaction"]"#,
+            "agent-a-view-digest-7045",
+            "agent-a-view.json"
+        ),
+        actor_observation(
+            root,
+            "agent_b",
+            "participant-private",
+            r#"["register","accept_task"]"#,
+            "agent-b-view-digest-7045",
+            "agent-b-view.json"
+        ),
+        actor_observation(
+            root,
+            "agent_c_verifier",
+            "restricted-public",
+            r#"["verify_proof"]"#,
+            "agent-c-view-digest-7045",
+            "agent-c-verifier-view.json"
+        )
+    )
+}
+
+fn actor_observation(
+    root: &Path,
+    agent: &str,
+    view_scope: &str,
+    actions: &str,
+    view_digest: &str,
+    view_file: &str,
+) -> String {
+    format!(
+        r#"{{"agent":"{}","actions":{},"view_scope":"{}","view_artifact":"{}","{}_view_digest":"{}"}}"#,
+        agent,
+        actions,
+        view_scope,
+        root.join("proof").join(view_file).display(),
+        agent,
+        view_digest
+    )
+}
+
 fn view_fields(root: &Path) -> String {
     format!(
         r#","agent_a_view_artifact":"{}","agent_b_view_artifact":"{}","agent_c_verifier_view_artifact":"{}","agent_a_view_digest":"agent-a-view-digest-7045","agent_b_view_digest":"agent-b-view-digest-7045","agent_c_verifier_view_digest":"agent-c-view-digest-7045""#,

--- a/crates/kamn-e2e-harness/tests/mvp_demo_agent_harness_claim_contract/three_agent_actor_rehearsal_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_demo_agent_harness_claim_contract/three_agent_actor_rehearsal_contract.rs
@@ -1,0 +1,46 @@
+use crate::support::*;
+use kamn_e2e_harness::execute_verify_mvp_demo_contract;
+
+#[test]
+fn spec_c12_command_rejects_three_agent_harness_without_actor_rehearsal() {
+    let root = temp_root("missing-actor-rehearsal");
+    let artifact = write_artifact(&root, agent_artifact_with_three_agent_boundary(&root));
+    let report = write_report(&root, report_with_three_agent_claim(&root, &artifact));
+
+    let err = execute_verify_mvp_demo_contract(&config(report.as_path()))
+        .expect_err("three-agent Pi evidence must include actor rehearsal");
+
+    assert!(err.contains("three_agent_actor_rehearsal"));
+}
+
+#[test]
+fn spec_c13_command_rejects_actor_rehearsal_with_agent_c_private_scope() {
+    let root = temp_root("actor-c-private-scope");
+    let artifact_json = agent_artifact_with_three_agent_actor_rehearsal(&root).replace(
+        r#""view_scope":"restricted-public""#,
+        r#""view_scope":"participant-private""#,
+    );
+    let artifact = write_artifact(&root, artifact_json);
+    let report = write_report(&root, report_with_three_agent_claim(&root, &artifact));
+
+    let err = execute_verify_mvp_demo_contract(&config(report.as_path()))
+        .expect_err("Agent C actor rehearsal must stay restricted-public");
+
+    assert!(err.contains("agent_c_verifier"));
+}
+
+#[test]
+fn spec_c14_command_rejects_actor_rehearsal_view_digest_mismatch() {
+    let root = temp_root("actor-digest-mismatch");
+    let artifact_json = agent_artifact_with_three_agent_actor_rehearsal(&root).replace(
+        r#""agent_a_view_digest":"agent-a-view-digest-7045""#,
+        r#""agent_a_view_digest":"mismatch""#,
+    );
+    let artifact = write_artifact(&root, artifact_json);
+    let report = write_report(&root, report_with_three_agent_claim(&root, &artifact));
+
+    let err = execute_verify_mvp_demo_contract(&config(report.as_path()))
+        .expect_err("actor rehearsal view digests must match report claim");
+
+    assert!(err.contains("agent_a_view_digest"));
+}

--- a/specs/7062-pi-three-agent-actor-rehearsal.md
+++ b/specs/7062-pi-three-agent-actor-rehearsal.md
@@ -52,19 +52,19 @@ Outputs:
 
 ## Acceptance Criteria
 
-- [ ] Pi extension evidence can include `three_agent_actor_rehearsal` with
+- [x] Pi extension evidence can include `three_agent_actor_rehearsal` with
   explicit Agent A, Agent B, and Agent C verifier observations.
-- [ ] Agent A observation proves `register` plus `invoke_transaction` and binds
+- [x] Agent A observation proves `register` plus `invoke_transaction` and binds
   to the Agent A view artifact path and digest.
-- [ ] Agent B observation proves `register` plus `accept_task` and binds to the
+- [x] Agent B observation proves `register` plus `accept_task` and binds to the
   Agent B view artifact path and digest.
-- [ ] Agent C observation proves `verify_proof`, binds to the Agent C verifier
+- [x] Agent C observation proves `verify_proof`, binds to the Agent C verifier
   view artifact path and digest, and preserves `restricted-public` scope.
-- [ ] `verify-mvp-demo` rejects missing, mismatched, dry-run/placeholder,
+- [x] `verify-mvp-demo` rejects missing, mismatched, dry-run/placeholder,
   local-only settlement, raw-private-leaking, or over-disclosing actor
   rehearsal evidence.
-- [ ] Local-only reports remain valid with no actor rehearsal object.
-- [ ] Existing MVP demo, devnet settlement, view artifact, Pi extension,
+- [x] Local-only reports remain valid with no actor rehearsal object.
+- [x] Existing MVP demo, devnet settlement, view artifact, Pi extension,
   formatting, strict clippy, and `make check` gates remain green.
 
 ## Files To Touch
@@ -74,7 +74,8 @@ Outputs:
 - `crates/kamn-e2e-harness/src/mvp_demo/agent_harness_three_agent.rs`
 - `crates/kamn-e2e-harness/tests/mvp_demo_agent_harness_claim_contract.rs`
 - `crates/kamn-e2e-harness/tests/mvp_demo_agent_harness_claim_contract/*.rs`
-- `docs/validation/mvp-evaluator-demo.md`
+- `docs/validation/mvp-evaluator-demo.md` only if the implementation changes
+  the published runbook commands or boundaries.
 
 ## Error Semantics
 
@@ -122,3 +123,35 @@ Integration:
 - Run local `make demo-mvp` and canonical verifier.
 - Run devnet-required `make demo-mvp` and canonical verifier, or record explicit
   external NO-GO evidence if devnet is unavailable.
+
+## Completion Evidence
+
+- Red tests were committed before implementation:
+  - missing actor rehearsal was accepted before the verifier change.
+  - Agent C participant-private scope was accepted before the verifier change.
+  - Agent A view digest mismatch was accepted before the verifier change.
+  - Pi extension source lacked required actor rehearsal markers.
+- Focused contract:
+  - `CARGO_TARGET_DIR=target/mvp-demo-proof CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 cargo test -p kamn-e2e-harness --test mvp_demo_agent_harness_claim_contract -- --nocapture`
+  - Result: 14 passed.
+- Broader MVP contract matrix:
+  - `CARGO_TARGET_DIR=target/mvp-demo-proof CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 cargo test -p kamn-e2e-harness --test mvp_demo_agent_harness_claim_contract --test mvp_demo_three_agent_view_artifact_contract --test mvp_demo_three_agent_claim_contract --test mvp_demo_three_agent_transcript_contract --test mvp_demo_claim_contract --test mvp_demo_command_contract --test mvp_evaluator_demo_runbook_contract -- --nocapture`
+  - Result: 50 passed.
+- Local gates:
+  - `cargo fmt --check`
+  - `CARGO_TARGET_DIR=target/mvp-demo-proof CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 cargo clippy --workspace --all-targets --all-features -- -D warnings`
+  - `CARGO_TARGET_DIR=target/mvp-demo-proof CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 make check`
+- Local demo:
+  - `CARGO_TARGET_DIR=target/mvp-demo-proof CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 make demo-mvp`
+  - Result: `GO`, `devnet_mode=optional`, no settlement success claimed.
+  - Canonical verifier passed for `.kamn/demo/latest/proof/report.json`.
+- Devnet-backed demo:
+  - `KAMN_MVP_DEVNET_MODE=required KAMN_MVP_SOLANA_RPC_URL=https://api.devnet.solana.com KAMN_SERVICE_API_LIVE_SOLANA_BRIDGE_RPC_URL=https://api.devnet.solana.com KAMN_SERVICE_API_LIVE_SOLANA_SETTLEMENT_KEYPAIR_FILE=/Users/n/.config/solana/ted-dev.json KAMN_SERVICE_API_LIVE_SOLANA_SETTLEMENT_RECIPIENT_PUBKEY=BSN17KC1c5kUuA7ZaTXvMUnFbZUhizeaisYcAFeTsbEb KAMN_SERVICE_API_LIVE_SOLANA_SETTLEMENT_LAMPORTS=1000000 KAMN_SERVICE_API_LIVE_SOLANA_SETTLEMENT_COMMITMENT=finalized CARGO_TARGET_DIR=target/mvp-demo-proof CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 make demo-mvp`
+  - Result: `GO`, `devnet_settlement_asset_movement=devnet-backed`, `three_agent_escrow_verification=devnet-backed`.
+  - Settlement signature: `wV1YY7VTzgHCEem8rUCPAoxRqR8sViivFFTB6LhEqKvJRYRigwtCpTDkV3wjoJFXRp4msN7Mbto8w62ZGKKt628`.
+  - `solana confirm -v --url https://api.devnet.solana.com wV1YY7VTzgHCEem8rUCPAoxRqR8sViivFFTB6LhEqKvJRYRigwtCpTDkV3wjoJFXRp4msN7Mbto8w62ZGKKt628`
+  - Result: finalized transfer of 1,000,000 lamports.
+- Pi agent harness:
+  - `env -u OPENAI_API_KEY pi --model openai-codex/gpt-5.5 --extension .pi/extensions/kamn-mvp/index.ts --no-builtin-tools --tools kamn_inspect_mvp_report_boundaries,kamn_write_agent_harness_evidence,kamn_verify_mvp_report --no-session -p "..."`
+  - Result: Pi inspected the devnet report, wrote `/tmp/kamn-pi-7062-devnet-evidence.json`, and verified the report through the KAMN extension tools.
+  - A compact augmented temp report at `/tmp/kamn-7062-pi-augmented-report.json` consumed Pi-written `/tmp/kamn-pi-7062-augmented-evidence.json` through the canonical verifier and passed.

--- a/specs/7062-pi-three-agent-actor-rehearsal.md
+++ b/specs/7062-pi-three-agent-actor-rehearsal.md
@@ -1,0 +1,124 @@
+# 7062 Pi Three-Agent Actor Rehearsal
+
+## Objective
+
+Add actor-specific Pi/MCP harness evidence for the devnet-backed three-agent
+MVP proof. The current harness evidence proves that Pi extension tools can drive
+the aggregate verifier path. This issue makes the actor rehearsal explicit:
+Agent A, Agent B, and Agent C each record the step they performed and bind their
+observation to the report's per-agent view artifacts.
+
+## Inputs/Outputs
+
+Inputs:
+- MVP proof report JSON.
+- `three_agent_escrow_verification` claim when present.
+- Agent A, Agent B, and Agent C view artifact paths/digests from the report
+  claim.
+- Existing Pi extension evidence artifact.
+
+Outputs:
+- Optional `three_agent_actor_rehearsal` object in the Pi agent-harness
+  evidence artifact.
+- Actor observations for:
+  - `agent_a`: registration plus transaction/task invocation.
+  - `agent_b`: registration plus task acceptance.
+  - `agent_c_verifier`: restricted-public verification.
+- Verifier errors when actor observations are missing, mismatched, overclaiming,
+  or inconsistent with devnet-backed settlement/view evidence.
+
+## Boundaries/Non-goals
+
+- Do not build a production multi-agent runtime or generalized orchestration
+  system.
+- Do not change Solana devnet settlement execution semantics.
+- Do not add dependencies.
+- Do not claim mainnet, production readiness, generalized exchange,
+  consensus/finality, or broad privacy guarantees.
+- Do not require actor rehearsal evidence for local-only reports that do not
+  claim `three_agent_escrow_verification`.
+- Do not expose raw participant-private payloads.
+
+## Failure Modes
+
+- Pi evidence claims three-agent success but omits `three_agent_actor_rehearsal`.
+- Actor rehearsal omits Agent A, Agent B, or Agent C verifier observations.
+- Agent A or Agent B observation lacks registration or its expected flow action.
+- Agent C observation lacks `verify_proof` or claims participant-private scope.
+- Any actor view artifact path or view digest differs from the report claim.
+- Actor rehearsal says settlement is local-only, dry-run, placeholder, or absent
+  when the report claims three-agent devnet-backed success.
+- Actor rehearsal exposes raw private payload markers.
+
+## Acceptance Criteria
+
+- [ ] Pi extension evidence can include `three_agent_actor_rehearsal` with
+  explicit Agent A, Agent B, and Agent C verifier observations.
+- [ ] Agent A observation proves `register` plus `invoke_transaction` and binds
+  to the Agent A view artifact path and digest.
+- [ ] Agent B observation proves `register` plus `accept_task` and binds to the
+  Agent B view artifact path and digest.
+- [ ] Agent C observation proves `verify_proof`, binds to the Agent C verifier
+  view artifact path and digest, and preserves `restricted-public` scope.
+- [ ] `verify-mvp-demo` rejects missing, mismatched, dry-run/placeholder,
+  local-only settlement, raw-private-leaking, or over-disclosing actor
+  rehearsal evidence.
+- [ ] Local-only reports remain valid with no actor rehearsal object.
+- [ ] Existing MVP demo, devnet settlement, view artifact, Pi extension,
+  formatting, strict clippy, and `make check` gates remain green.
+
+## Files To Touch
+
+- `.pi/extensions/kamn-mvp/index.ts`
+- `crates/kamn-e2e-harness/src/mvp_demo/agent_harness.rs`
+- `crates/kamn-e2e-harness/src/mvp_demo/agent_harness_three_agent.rs`
+- `crates/kamn-e2e-harness/tests/mvp_demo_agent_harness_claim_contract.rs`
+- `crates/kamn-e2e-harness/tests/mvp_demo_agent_harness_claim_contract/*.rs`
+- `docs/validation/mvp-evaluator-demo.md`
+
+## Error Semantics
+
+- Missing actor rehearsal fields fail closed with explicit `Err(String)`
+  messages.
+- Actor rehearsal validation is only required when agent-harness evidence is
+  present for a report that claims `three_agent_escrow_verification`.
+- Actor rehearsal validation compares evidence fields against the verified
+  report claim instead of trusting the evidence artifact alone.
+- Agent C participant-private scope, private digest exposure, or nonzero private
+  field count fails verification.
+- Dry-run, placeholder, or local-only settlement labels in actor rehearsal fail
+  verification when three-agent success is claimed.
+
+## Test Plan
+
+Red:
+- Add command-level verifier tests rejecting Pi harness evidence with no
+  `three_agent_actor_rehearsal` for a devnet-backed three-agent report.
+- Add tests rejecting missing Agent A/B/C observations.
+- Add tests rejecting Agent C participant-private scope or private digest
+  exposure.
+- Add tests rejecting actor view artifact path/digest mismatches and
+  local-only/dry-run settlement labels.
+- Add/update extension contract tests requiring the Pi extension to emit the
+  actor rehearsal object.
+
+Green:
+- Extend the Pi extension evidence writer to derive actor rehearsal fields from
+  the report's three-agent claim.
+- Extend the Rust verifier to validate actor rehearsal fields when a
+  three-agent claim is present.
+- Keep local-only reports and reports without agent-harness evidence unchanged.
+
+Refactor:
+- Keep actor-rehearsal validation in small helpers.
+- Reuse existing flat marker/extractor helpers; do not add a JSON dependency.
+- Keep touched Rust files under repo line-budget guidance.
+
+Integration:
+- Run the agent-harness contract tests.
+- Run the three-agent view artifact, claim, transcript, local artifact, command,
+  and runbook contract tests.
+- Run `cargo fmt --check`, strict workspace clippy, and `make check`.
+- Run local `make demo-mvp` and canonical verifier.
+- Run devnet-required `make demo-mvp` and canonical verifier, or record explicit
+  external NO-GO evidence if devnet is unavailable.


### PR DESCRIPTION
Closes #7062

## Human Summary

- Adds Pi-generated three-agent actor rehearsal evidence so Agent A, Agent B, and Agent C verifier each bind their observed action, scope, view artifact, and digest back to the MVP report.
- Extends `verify-mvp-demo` to reject claimed three-agent harness success when actor rehearsal evidence is missing, mismatched, over-disclosing, or not devnet-backed where settlement is claimed.
- Keeps local-only reports valid without actor rehearsal evidence and preserves the current local/demo claim boundaries.
- Splits the Pi extension evidence builder so the extension stays under the repo size guidance and remains easier to audit.

## Testing

- `CARGO_TARGET_DIR=target/mvp-demo-proof CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 cargo test -p kamn-e2e-harness --test mvp_demo_agent_harness_claim_contract -- --nocapture`
- `CARGO_TARGET_DIR=target/mvp-demo-proof CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 cargo test -p kamn-e2e-harness --test mvp_demo_agent_harness_claim_contract --test mvp_demo_three_agent_view_artifact_contract --test mvp_demo_three_agent_claim_contract --test mvp_demo_three_agent_transcript_contract --test mvp_demo_claim_contract --test mvp_demo_command_contract --test mvp_evaluator_demo_runbook_contract -- --nocapture`
- `cargo fmt --check`
- `CARGO_TARGET_DIR=target/mvp-demo-proof CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `CARGO_TARGET_DIR=target/mvp-demo-proof CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 make check`
- `CARGO_TARGET_DIR=target/mvp-demo-proof CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 make demo-mvp`
- `CARGO_TARGET_DIR=target/mvp-demo-proof CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 cargo run -p kamn-e2e-harness -- verify-mvp-demo --report .kamn/demo/latest/proof/report.json`
- Devnet required: `KAMN_MVP_DEVNET_MODE=required KAMN_MVP_SOLANA_RPC_URL=https://api.devnet.solana.com ... make demo-mvp`
- `solana confirm -v --url https://api.devnet.solana.com wV1YY7VTzgHCEem8rUCPAoxRqR8sViivFFTB6LhEqKvJRYRigwtCpTDkV3wjoJFXRp4msN7Mbto8w62ZGKKt628`
- Pi OAuth harness smoke: `env -u OPENAI_API_KEY pi --model openai-codex/gpt-5.5 --extension .pi/extensions/kamn-mvp/index.ts ...` inspected, wrote evidence, and verified through KAMN extension tools.

## Notes for Reviewers

- Devnet run produced a finalized 1,000,000 lamport Solana devnet transfer. This is devnet-only evidence, not mainnet or production readiness.
- The verifier still intentionally accepts direct local-only reports without agent harness evidence. Actor rehearsal is required only when agent harness evidence is present for a report claiming `three_agent_escrow_verification`.
- A compact augmented temp report consumed Pi-written actor rehearsal evidence through the canonical verifier and passed.

## AI Agent Details

- New verifier module: `crates/kamn-e2e-harness/src/mvp_demo/agent_harness_actor_rehearsal.rs`.
- Pi extension evidence moved to `.pi/extensions/kamn-mvp/evidence.ts`; `.pi/extensions/kamn-mvp/index.ts` now stays focused on tool registration and execution.
- New negative contract coverage lives under `crates/kamn-e2e-harness/tests/mvp_demo_agent_harness_claim_contract/three_agent_actor_rehearsal_contract.rs`.
- Spec evidence and acceptance completion are recorded in `specs/7062-pi-three-agent-actor-rehearsal.md`.