### PR TITLE
[7068] feat: bind three-agent proof digests to artifact hashes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2168,6 +2168,7 @@ dependencies = [
  "kamn-agent-lib",
  "kamn-cli",
  "kamn-mcp-server",
+ "sha2",
 ]
 
 [[package]]

--- a/crates/kamn-e2e-harness/Cargo.toml
+++ b/crates/kamn-e2e-harness/Cargo.toml
@@ -8,6 +8,7 @@ license = "Apache-2.0"
 kamn-agent-lib = { path = "../kamn-agent-lib" }
 kamn-cli = { path = "../kamn-cli" }
 kamn-mcp-server = { path = "../kamn-mcp-server" }
+sha2.workspace = true
 
 [lints]
 workspace = true

--- a/crates/kamn-e2e-harness/src/mvp_demo/artifact_digest.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/artifact_digest.rs
@@ -1,0 +1,109 @@
+use sha2::{Digest, Sha256};
+
+pub(crate) struct ArtifactJson {
+    pub(crate) json: String,
+    pub(crate) digest: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ThreeAgentViewDigests {
+    pub(crate) agent_a: String,
+    pub(crate) agent_b: String,
+    pub(crate) agent_c_verifier: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ThreeAgentArtifactDigests {
+    pub(crate) transcript: String,
+    pub(crate) views: ThreeAgentViewDigests,
+}
+
+pub(crate) fn attach_json_digest(raw: String, field: &str) -> Result<ArtifactJson, String> {
+    let digest = digest_json_without_field(raw.as_str(), field)?;
+    let placeholder = format!("\"{field}\":\"\"");
+    let replacement = format!("\"{field}\":\"{digest}\"");
+    if !raw.contains(placeholder.as_str()) {
+        return Err(format!("missing digest placeholder field: {field}"));
+    }
+    Ok(ArtifactJson {
+        json: raw.replace(placeholder.as_str(), replacement.as_str()),
+        digest,
+    })
+}
+
+pub(crate) fn validate_json_digest(
+    raw: &str,
+    field: &str,
+    expected: &str,
+    context: &str,
+) -> Result<(), String> {
+    let actual = digest_json_without_field(raw, field)?;
+    if actual == expected {
+        return Ok(());
+    }
+    Err(format!("{context} digest mismatch"))
+}
+
+pub(crate) fn digest_json_without_field(raw: &str, field: &str) -> Result<String, String> {
+    Ok(tagged_sha256(
+        json_without_string_field(raw, field)?.as_str(),
+    ))
+}
+
+fn tagged_sha256(value: &str) -> String {
+    format!("sha256:{}", sha256_hex(value))
+}
+
+fn sha256_hex(value: &str) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let digest = Sha256::digest(value.as_bytes());
+    let mut output = String::with_capacity(64);
+    for byte in digest {
+        output.push(HEX[(byte >> 4) as usize] as char);
+        output.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    output
+}
+
+fn json_without_string_field(raw: &str, field: &str) -> Result<String, String> {
+    let (field_start, pair_end) = string_field_span(raw, field)?;
+    let (remove_start, remove_end) = removal_span(raw, field_start, pair_end)?;
+    let mut output = String::with_capacity(raw.len().saturating_sub(remove_end - remove_start));
+    output.push_str(&raw[..remove_start]);
+    output.push_str(&raw[remove_end..]);
+    Ok(output)
+}
+
+fn string_field_span(raw: &str, field: &str) -> Result<(usize, usize), String> {
+    let marker = format!("\"{field}\":\"");
+    let field_start = raw
+        .find(marker.as_str())
+        .ok_or_else(|| format!("missing digest field: {field}"))?;
+    let value_start = field_start + marker.len();
+    let value_end = closing_quote(raw, value_start)?;
+    Ok((field_start, value_end + 1))
+}
+
+fn closing_quote(raw: &str, start: usize) -> Result<usize, String> {
+    let mut escaped = false;
+    for (offset, character) in raw[start..].char_indices() {
+        if escaped {
+            escaped = false;
+        } else if character == '\\' {
+            escaped = true;
+        } else if character == '"' {
+            return Ok(start + offset);
+        }
+    }
+    Err("unterminated digest string field".to_owned())
+}
+
+fn removal_span(raw: &str, field_start: usize, pair_end: usize) -> Result<(usize, usize), String> {
+    if raw[pair_end..].starts_with(',') {
+        return Ok((field_start, pair_end + 1));
+    }
+    if field_start > 0 && raw.as_bytes()[field_start - 1] == b',' {
+        return Ok((field_start - 1, pair_end));
+    }
+    Err("digest field must be in a JSON object with a sibling field".to_owned())
+}

--- a/crates/kamn-e2e-harness/src/mvp_demo/command_config.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/command_config.rs
@@ -1,0 +1,27 @@
+/// Parsed `demo-mvp` command configuration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MvpDemoCommandConfig {
+    /// Demo output root directory.
+    pub output_root: String,
+    /// Devnet execution mode (`optional` or `required`).
+    pub devnet_mode: String,
+    /// Optional Solana RPC URL for devnet-backed proof attempts.
+    pub solana_rpc_url: Option<String>,
+    /// Optional devnet settlement command override for tests.
+    pub devnet_settlement_command: Option<Vec<String>>,
+    /// Optional localhost signed demo command override for tests.
+    pub localhost_signed_demo_command: Option<Vec<String>>,
+    /// Optional service API vertical slice command override for tests.
+    pub service_api_vertical_slice_command: Option<Vec<String>>,
+    /// Optional service API websocket command override for tests.
+    pub service_api_websocket_command: Option<Vec<String>>,
+    /// Optional MCP-agent harness evidence artifact path.
+    pub agent_harness_evidence_path: Option<String>,
+}
+
+/// Parsed `verify-mvp-demo` command configuration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VerifyMvpDemoCommandConfig {
+    /// Proof report JSON path.
+    pub report: String,
+}

--- a/crates/kamn-e2e-harness/src/mvp_demo/mod.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/mod.rs
@@ -5,6 +5,7 @@ mod agent_harness_actor_receipts;
 mod agent_harness_actor_rehearsal;
 mod agent_harness_json;
 mod agent_harness_three_agent;
+mod artifact_digest;
 mod devnet_settlement;
 mod devnet_settlement_build;
 mod devnet_settlement_json;

--- a/crates/kamn-e2e-harness/src/mvp_demo/mod.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/mod.rs
@@ -6,6 +6,7 @@ mod agent_harness_actor_rehearsal;
 mod agent_harness_json;
 mod agent_harness_three_agent;
 mod artifact_digest;
+mod command_config;
 mod devnet_settlement;
 mod devnet_settlement_build;
 mod devnet_settlement_json;
@@ -34,14 +35,12 @@ mod three_agent_views;
 mod verify;
 mod verify_support;
 
+pub use command_config::{MvpDemoCommandConfig, VerifyMvpDemoCommandConfig};
 pub use report::{
     CLAIM_LABEL_DEVNET_BACKED, CLAIM_LABEL_DRY_RUN, CLAIM_LABEL_LOCAL_ONLY,
     CLAIM_LABEL_PLACEHOLDER, CLAIM_LABEL_REAL, CLAIM_LABEL_ROADMAP, MVP_DEMO_REPORT_SCHEMA_VERSION,
 };
-pub use runner::{
-    execute_mvp_demo_contract, execute_verify_mvp_demo_contract, MvpDemoCommandConfig,
-    VerifyMvpDemoCommandConfig,
-};
+pub use runner::{execute_mvp_demo_contract, execute_verify_mvp_demo_contract};
 pub use verify::verify_mvp_demo_report_json;
 
 pub(crate) const DEFAULT_MVP_DEMO_OUTPUT_ROOT: &str = ".kamn/demo";

--- a/crates/kamn-e2e-harness/src/mvp_demo/report.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/report.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 
 use super::agent_harness::agent_harness_claim_json;
+use super::artifact_digest::ThreeAgentArtifactDigests;
 use super::devnet_settlement::{
     devnet_no_go_reason, devnet_settlement_claim_json, DevnetSettlementEvidence,
 };
@@ -32,20 +33,21 @@ pub(crate) struct DemoReportInput<'a> {
     pub(crate) devnet_settlement: Option<&'a DevnetSettlementEvidence>,
     pub(crate) devnet_no_go_reason: Option<&'a str>,
     pub(crate) agent_harness_evidence_path: Option<&'a str>,
+    pub(crate) three_agent_artifact_digests: Option<&'a ThreeAgentArtifactDigests>,
 }
 
-pub(crate) fn render_report_json(input: &DemoReportInput<'_>) -> String {
+pub(crate) fn render_report_json(input: &DemoReportInput<'_>) -> Result<String, String> {
     let status = report_status(input);
-    format!(
+    Ok(format!(
         "{{\"schema_version\":\"{}\",\"run_id\":\"{}\",\"status\":\"{}\",\"devnet_mode\":\"{}\",\"artifacts\":{},\"claim_matrix\":[{}],\"no_go\":{}}}",
         MVP_DEMO_REPORT_SCHEMA_VERSION,
         escape_json(input.run_id),
         status,
         escape_json(input.devnet_mode),
         artifacts_json(input),
-        claim_matrix_json(input),
+        claim_matrix_json(input)?,
         no_go_json(input)
-    )
+    ))
 }
 
 pub(crate) fn report_status(input: &DemoReportInput<'_>) -> &'static str {
@@ -56,16 +58,16 @@ pub(crate) fn report_status(input: &DemoReportInput<'_>) -> &'static str {
     }
 }
 
-fn claim_matrix_json(input: &DemoReportInput<'_>) -> String {
+fn claim_matrix_json(input: &DemoReportInput<'_>) -> Result<String, String> {
     let mut claims = local_claims();
     if input.agent_harness_evidence_path.is_some() {
         claims.push(agent_harness_claim_json());
     }
     if input.devnet_mode == "required" {
-        claims.extend(devnet_required_claims(input));
+        claims.extend(devnet_required_claims(input)?);
     }
     claims.push(roadmap_claim());
-    claims.join(",")
+    Ok(claims.join(","))
 }
 
 fn local_claims() -> Vec<String> {
@@ -137,30 +139,34 @@ fn roadmap_claim() -> String {
     )
 }
 
-fn devnet_required_claims(input: &DemoReportInput<'_>) -> Vec<String> {
+fn devnet_required_claims(input: &DemoReportInput<'_>) -> Result<Vec<String>, String> {
     match input.devnet_settlement {
         Some(evidence) => devnet_success_claims(input, evidence),
-        None => vec![devnet_no_go_claim_with_reason(input)],
+        None => Ok(vec![devnet_no_go_claim_with_reason(input)]),
     }
 }
 
 fn devnet_success_claims(
     input: &DemoReportInput<'_>,
     evidence: &DevnetSettlementEvidence,
-) -> Vec<String> {
+) -> Result<Vec<String>, String> {
+    let digests = input
+        .three_agent_artifact_digests
+        .ok_or_else(|| "missing three-agent artifact digests".to_owned())?;
     let transcript = three_agent_transcript_path(input);
     let agent_a = agent_a_view_path(input);
     let agent_b = agent_b_view_path(input);
     let agent_c = agent_c_verifier_view_path(input);
-    vec![
+    Ok(vec![
         devnet_settlement_claim_json(evidence),
         three_agent_escrow_claim_json(
             input.run_id,
             evidence,
             transcript.as_str(),
             [agent_a.as_str(), agent_b.as_str(), agent_c.as_str()],
+            digests,
         ),
-    ]
+    ])
 }
 
 fn no_go_json(input: &DemoReportInput<'_>) -> String {

--- a/crates/kamn-e2e-harness/src/mvp_demo/report.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/report.rs
@@ -10,19 +10,19 @@ use super::three_agent_claim::three_agent_escrow_claim_json;
 use super::three_agent_transcript::three_agent_transcript_path;
 use super::three_agent_views::{agent_a_view_path, agent_b_view_path, agent_c_verifier_view_path};
 
-/// MVP demo proof report schema marker.
+#[doc = "MVP demo proof report schema marker."]
 pub const MVP_DEMO_REPORT_SCHEMA_VERSION: &str = "kamn.mvp.demo.proof-report.v1";
-/// Claim label for actual local KAMN execution.
+#[doc = "Claim label for actual local KAMN execution."]
 pub const CLAIM_LABEL_REAL: &str = "real";
-/// Claim label for Solana devnet-backed execution or evidence.
+#[doc = "Claim label for Solana devnet-backed execution or evidence."]
 pub const CLAIM_LABEL_DEVNET_BACKED: &str = "devnet-backed";
-/// Claim label for local-only KAMN execution.
+#[doc = "Claim label for local-only KAMN execution."]
 pub const CLAIM_LABEL_LOCAL_ONLY: &str = "local-only";
-/// Claim label for dry-run-only behavior.
+#[doc = "Claim label for dry-run-only behavior."]
 pub const CLAIM_LABEL_DRY_RUN: &str = "dry-run";
-/// Claim label for placeholder behavior.
+#[doc = "Claim label for placeholder behavior."]
 pub const CLAIM_LABEL_PLACEHOLDER: &str = "placeholder";
-/// Claim label for explicit non-MVP roadmap behavior.
+#[doc = "Claim label for explicit non-MVP roadmap behavior."]
 pub const CLAIM_LABEL_ROADMAP: &str = "roadmap";
 
 pub(crate) struct DemoReportInput<'a> {
@@ -52,10 +52,9 @@ pub(crate) fn render_report_json(input: &DemoReportInput<'_>) -> Result<String, 
 
 pub(crate) fn report_status(input: &DemoReportInput<'_>) -> &'static str {
     if input.devnet_mode == "required" && input.devnet_settlement.is_none() {
-        "NO-GO"
-    } else {
-        "GO"
+        return "NO-GO";
     }
+    "GO"
 }
 
 fn claim_matrix_json(input: &DemoReportInput<'_>) -> Result<String, String> {
@@ -170,10 +169,7 @@ fn devnet_success_claims(
 }
 
 fn no_go_json(input: &DemoReportInput<'_>) -> String {
-    if input.devnet_mode != "required" {
-        return "{\"active\":false,\"reason\":\"\"}".to_owned();
-    }
-    if input.devnet_settlement.is_some() {
+    if input.devnet_mode != "required" || input.devnet_settlement.is_some() {
         return "{\"active\":false,\"reason\":\"\"}".to_owned();
     }
     format!(

--- a/crates/kamn-e2e-harness/src/mvp_demo/runner.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/runner.rs
@@ -3,6 +3,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use super::agent_harness::validate_agent_harness_evidence_file;
 use super::artifact_digest::ThreeAgentArtifactDigests;
+use super::command_config::{MvpDemoCommandConfig, VerifyMvpDemoCommandConfig};
 use super::devnet_settlement::{
     collect_devnet_settlement_evidence, DevnetSettlementAttempt, DevnetSettlementInput,
 };
@@ -17,34 +18,6 @@ use super::three_agent_transcript::{
 };
 use super::three_agent_views::write_three_agent_views;
 use super::verify::verify_mvp_demo_report_json;
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-/// Parsed `demo-mvp` command configuration.
-pub struct MvpDemoCommandConfig {
-    /// Demo output root directory.
-    pub output_root: String,
-    /// Devnet execution mode (`optional` or `required`).
-    pub devnet_mode: String,
-    /// Optional Solana RPC URL for devnet-backed proof attempts.
-    pub solana_rpc_url: Option<String>,
-    /// Optional command override for tests; production uses the service API live Solana lane.
-    pub devnet_settlement_command: Option<Vec<String>>,
-    /// Optional command override for tests; production uses the SDK localhost signed demo.
-    pub localhost_signed_demo_command: Option<Vec<String>>,
-    /// Optional command override for tests; production uses the service API vertical slice test.
-    pub service_api_vertical_slice_command: Option<Vec<String>>,
-    /// Optional command override for tests; production uses the service API websocket test.
-    pub service_api_websocket_command: Option<Vec<String>>,
-    /// Optional MCP-agent harness evidence artifact path.
-    pub agent_harness_evidence_path: Option<String>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-/// Parsed `verify-mvp-demo` command configuration.
-pub struct VerifyMvpDemoCommandConfig {
-    /// Proof report JSON path.
-    pub report: String,
-}
 
 /// Executes the MVP demo command and writes proof artifacts.
 pub fn execute_mvp_demo_contract(config: &MvpDemoCommandConfig) -> Result<String, String> {
@@ -66,11 +39,7 @@ pub fn execute_mvp_demo_contract(config: &MvpDemoCommandConfig) -> Result<String
         three_agent_artifact_digests.as_ref(),
     );
     let report_json = render_report_json(&input)?;
-    verify_mvp_demo_report_json(report_json.as_str())?;
-    validate_local_artifact_files(report_json.as_str())?;
-    let latest_report = latest_report_path(output_root);
-    validate_agent_harness_evidence_file(report_json.as_str(), latest_report.as_str())?;
-    validate_three_agent_transcript_file(report_json.as_str())?;
+    validate_generated_report(report_json.as_str(), output_root)?;
     write_reports(output_root, run_id.as_str(), report_json.as_str(), &input)?;
     Ok(report_json)
 }
@@ -102,6 +71,13 @@ fn create_three_agent_transcript(
     let views = write_three_agent_views(run_id, evidence, run_dir)?;
     let transcript = write_three_agent_transcript(run_id, evidence, run_dir, &views)?;
     Ok(Some(ThreeAgentArtifactDigests { transcript, views }))
+}
+
+fn validate_generated_report(report_json: &str, output_root: &Path) -> Result<(), String> {
+    verify_mvp_demo_report_json(report_json)?;
+    validate_local_artifact_files(report_json)?;
+    validate_agent_harness_evidence_file(report_json, latest_report_path(output_root).as_str())?;
+    validate_three_agent_transcript_file(report_json)
 }
 
 fn validate_devnet_mode(devnet_mode: &str) -> Result<(), String> {

--- a/crates/kamn-e2e-harness/src/mvp_demo/runner.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/runner.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use super::agent_harness::validate_agent_harness_evidence_file;
+use super::artifact_digest::ThreeAgentArtifactDigests;
 use super::devnet_settlement::{
     collect_devnet_settlement_evidence, DevnetSettlementAttempt, DevnetSettlementInput,
 };
@@ -55,9 +56,16 @@ pub fn execute_mvp_demo_contract(config: &MvpDemoCommandConfig) -> Result<String
     create_localhost_signed_artifact(config, &run_dir)?;
     create_service_api_artifacts(config, &run_dir)?;
     let devnet_settlement = create_devnet_settlement_artifact(config, &run_dir)?;
-    create_three_agent_transcript(run_id.as_str(), &devnet_settlement, &run_dir)?;
-    let input = report_input(config, output_root, run_id.as_str(), &devnet_settlement);
-    let report_json = render_report_json(&input);
+    let three_agent_artifact_digests =
+        create_three_agent_transcript(run_id.as_str(), &devnet_settlement, &run_dir)?;
+    let input = report_input(
+        config,
+        output_root,
+        run_id.as_str(),
+        &devnet_settlement,
+        three_agent_artifact_digests.as_ref(),
+    );
+    let report_json = render_report_json(&input)?;
     verify_mvp_demo_report_json(report_json.as_str())?;
     validate_local_artifact_files(report_json.as_str())?;
     let latest_report = latest_report_path(output_root);
@@ -87,12 +95,13 @@ fn create_three_agent_transcript(
     run_id: &str,
     settlement: &DevnetSettlementAttempt,
     run_dir: &Path,
-) -> Result<(), String> {
+) -> Result<Option<ThreeAgentArtifactDigests>, String> {
     let Some(evidence) = settlement.evidence.as_ref() else {
-        return Ok(());
+        return Ok(None);
     };
-    write_three_agent_views(run_id, evidence, run_dir)?;
-    write_three_agent_transcript(run_id, evidence, run_dir)
+    let views = write_three_agent_views(run_id, evidence, run_dir)?;
+    let transcript = write_three_agent_transcript(run_id, evidence, run_dir, &views)?;
+    Ok(Some(ThreeAgentArtifactDigests { transcript, views }))
 }
 
 fn validate_devnet_mode(devnet_mode: &str) -> Result<(), String> {
@@ -118,6 +127,7 @@ fn report_input<'a>(
     output_root: &'a Path,
     run_id: &'a str,
     settlement: &'a DevnetSettlementAttempt,
+    three_agent_artifact_digests: Option<&'a ThreeAgentArtifactDigests>,
 ) -> DemoReportInput<'a> {
     DemoReportInput {
         run_id,
@@ -127,6 +137,7 @@ fn report_input<'a>(
         devnet_settlement: settlement.evidence.as_ref(),
         devnet_no_go_reason: settlement.no_go_reason.as_deref(),
         agent_harness_evidence_path: config.agent_harness_evidence_path.as_deref(),
+        three_agent_artifact_digests,
     }
 }
 

--- a/crates/kamn-e2e-harness/src/mvp_demo/three_agent_claim.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/three_agent_claim.rs
@@ -1,8 +1,8 @@
+use super::artifact_digest::ThreeAgentArtifactDigests;
 use super::devnet_settlement::DevnetSettlementEvidence;
 use super::report::{escape_json, CLAIM_LABEL_DEVNET_BACKED};
 use super::three_agent_views::{
-    agent_a_private_view_digest, agent_a_view_digest, agent_b_private_view_digest,
-    agent_b_view_digest, agent_c_verifier_view_digest, public_view_digest,
+    agent_a_private_view_digest, agent_b_private_view_digest, public_view_digest,
 };
 
 pub(crate) fn three_agent_escrow_claim_json(
@@ -10,6 +10,7 @@ pub(crate) fn three_agent_escrow_claim_json(
     evidence: &DevnetSettlementEvidence,
     transcript_path: &str,
     view_paths: [&str; 3],
+    artifact_digests: &ThreeAgentArtifactDigests,
 ) -> String {
     let transaction_id = format!("mvp-three-agent-{run_id}");
     let terms_digest = format!("terms-digest-{run_id}");
@@ -17,8 +18,8 @@ pub(crate) fn three_agent_escrow_claim_json(
     format!(
         "{{{},{},{},{},{},{},{},{}}}",
         claim_header(),
-        transcript_fields(run_id, transcript_path),
-        view_artifact_fields(run_id, view_paths),
+        transcript_fields(transcript_path, artifact_digests),
+        view_artifact_fields(view_paths, artifact_digests),
         digest_fields(transaction_id.as_str(), terms_digest.as_str()),
         escrow_fields(escrow_id.as_str()),
         settlement_fields(evidence),
@@ -27,23 +28,23 @@ pub(crate) fn three_agent_escrow_claim_json(
     )
 }
 
-fn transcript_fields(run_id: &str, path: &str) -> String {
+fn transcript_fields(path: &str, artifact_digests: &ThreeAgentArtifactDigests) -> String {
     format!(
         "\"three_agent_transcript_artifact\":\"{}\",\"three_agent_transcript_digest\":\"{}\"",
         escape_json(path),
-        escape_json(format!("three-agent-transcript-digest-{run_id}").as_str())
+        escape_json(artifact_digests.transcript.as_str())
     )
 }
 
-fn view_artifact_fields(run_id: &str, paths: [&str; 3]) -> String {
+fn view_artifact_fields(paths: [&str; 3], artifact_digests: &ThreeAgentArtifactDigests) -> String {
     format!(
         "\"agent_a_view_artifact\":\"{}\",\"agent_b_view_artifact\":\"{}\",\"agent_c_verifier_view_artifact\":\"{}\",\"agent_a_view_digest\":\"{}\",\"agent_b_view_digest\":\"{}\",\"agent_c_verifier_view_digest\":\"{}\"",
         escape_json(paths[0]),
         escape_json(paths[1]),
         escape_json(paths[2]),
-        escape_json(agent_a_view_digest(run_id).as_str()),
-        escape_json(agent_b_view_digest(run_id).as_str()),
-        escape_json(agent_c_verifier_view_digest(run_id).as_str())
+        escape_json(artifact_digests.views.agent_a.as_str()),
+        escape_json(artifact_digests.views.agent_b.as_str()),
+        escape_json(artifact_digests.views.agent_c_verifier.as_str())
     )
 }
 

--- a/crates/kamn-e2e-harness/src/mvp_demo/three_agent_transcript.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/three_agent_transcript.rs
@@ -1,5 +1,6 @@
 use std::path::Path;
 
+use super::artifact_digest::{validate_json_digest, ThreeAgentViewDigests};
 use super::devnet_settlement::DevnetSettlementEvidence;
 use super::report::DemoReportInput;
 use super::three_agent_transcript_build::transcript_json;
@@ -24,15 +25,17 @@ pub(crate) fn write_three_agent_transcript(
     run_id: &str,
     evidence: &DevnetSettlementEvidence,
     run_dir: &Path,
-) -> Result<(), String> {
+    view_digests: &ThreeAgentViewDigests,
+) -> Result<String, String> {
     let path = run_dir.join("proof").join(TRANSCRIPT_FILE);
-    let json = transcript_json(run_id, evidence, run_dir);
-    std::fs::write(path.as_path(), json).map_err(|error| {
+    let artifact = transcript_json(run_id, evidence, run_dir, view_digests)?;
+    std::fs::write(path.as_path(), artifact.json.as_str()).map_err(|error| {
         format!(
             "failed to write three-agent transcript artifact {}: {error}",
             path.display()
         )
-    })
+    })?;
+    Ok(artifact.digest)
 }
 
 pub(crate) fn validate_three_agent_transcript_file(report_json: &str) -> Result<(), String> {
@@ -129,10 +132,15 @@ fn validate_transcript_fields(raw: &str, claim: &ClaimView<'_>) -> Result<(), St
 fn validate_digest(raw: &str, claim: &ClaimView<'_>) -> Result<(), String> {
     let artifact_digest = extract_string(raw, "transcript_digest")?;
     let claim_digest = extract_string(claim.raw, "three_agent_transcript_digest")?;
-    if artifact_digest == claim_digest {
-        return Ok(());
+    if artifact_digest != claim_digest {
+        return Err("three-agent transcript digest mismatch".to_owned());
     }
-    Err("three-agent transcript digest mismatch".to_owned())
+    validate_json_digest(
+        raw,
+        "transcript_digest",
+        claim_digest.as_str(),
+        "three-agent transcript",
+    )
 }
 
 fn require_matching_string(raw: &str, claim: &ClaimView<'_>, field: &str) -> Result<(), String> {

--- a/crates/kamn-e2e-harness/src/mvp_demo/three_agent_transcript_build.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/three_agent_transcript_build.rs
@@ -1,25 +1,26 @@
 use std::path::Path;
 
+use super::artifact_digest::{attach_json_digest, ArtifactJson, ThreeAgentViewDigests};
 use super::devnet_settlement::DevnetSettlementEvidence;
 use super::report::escape_json;
-use super::three_agent_views::{
-    agent_a_view_digest, agent_b_view_digest, agent_c_verifier_view_digest,
-};
 
 pub(crate) fn transcript_json(
     run_id: &str,
     evidence: &DevnetSettlementEvidence,
     run_dir: &Path,
-) -> String {
-    format!(
-        "{{\"schema_version\":\"kamn.mvp.three-agent-transcript.v1\",\"proof_label\":\"local-only\",\"devnet_settlement_linked\":true,\"transaction_id\":\"mvp-three-agent-{}\",\"escrow_id\":\"escrow-three-agent-{}\",{},\"views\":{},\"agent_a_private_field_count\":3,\"agent_b_private_field_count\":3,\"verifier_private_field_count\":0,\"private_payload_redacted\":true,{},\"transcript_digest\":\"{}\",{}}}",
-        escape_json(run_id),
-        escape_json(run_id),
-        steps_json(),
-        views_json(),
-        settlement_json(evidence),
-        escape_json(format!("three-agent-transcript-digest-{run_id}").as_str()),
-        transcript_view_fields(run_id, run_dir)
+    view_digests: &ThreeAgentViewDigests,
+) -> Result<ArtifactJson, String> {
+    attach_json_digest(
+        format!(
+            "{{\"schema_version\":\"kamn.mvp.three-agent-transcript.v1\",\"proof_label\":\"local-only\",\"devnet_settlement_linked\":true,\"transaction_id\":\"mvp-three-agent-{}\",\"escrow_id\":\"escrow-three-agent-{}\",{},\"views\":{},\"agent_a_private_field_count\":3,\"agent_b_private_field_count\":3,\"verifier_private_field_count\":0,\"private_payload_redacted\":true,{},\"transcript_digest\":\"\",{}}}",
+            escape_json(run_id),
+            escape_json(run_id),
+            steps_json(),
+            views_json(),
+            settlement_json(evidence),
+            transcript_view_fields(run_dir, view_digests)
+        ),
+        "transcript_digest",
     )
 }
 
@@ -42,15 +43,15 @@ fn settlement_json(evidence: &DevnetSettlementEvidence) -> String {
     )
 }
 
-fn transcript_view_fields(run_id: &str, run_dir: &Path) -> String {
+fn transcript_view_fields(run_dir: &Path, view_digests: &ThreeAgentViewDigests) -> String {
     format!(
         "\"agent_a_view_artifact\":\"{}\",\"agent_b_view_artifact\":\"{}\",\"agent_c_verifier_view_artifact\":\"{}\",\"agent_a_view_digest\":\"{}\",\"agent_b_view_digest\":\"{}\",\"agent_c_verifier_view_digest\":\"{}\"",
         proof_artifact_path(run_dir, "agent-a-view.json"),
         proof_artifact_path(run_dir, "agent-b-view.json"),
         proof_artifact_path(run_dir, "agent-c-verifier-view.json"),
-        escape_json(agent_a_view_digest(run_id).as_str()),
-        escape_json(agent_b_view_digest(run_id).as_str()),
-        escape_json(agent_c_verifier_view_digest(run_id).as_str())
+        escape_json(view_digests.agent_a.as_str()),
+        escape_json(view_digests.agent_b.as_str()),
+        escape_json(view_digests.agent_c_verifier.as_str())
     )
 }
 

--- a/crates/kamn-e2e-harness/src/mvp_demo/three_agent_view_artifacts.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/three_agent_view_artifacts.rs
@@ -1,3 +1,4 @@
+use super::artifact_digest::validate_json_digest;
 use super::verify_support::{
     extract_bool, extract_optional_string, extract_string, extract_u64, require_marker,
     validate_json_delimiters, ClaimView,
@@ -150,7 +151,13 @@ fn reject_private_payload(raw: &str) -> Result<(), String> {
 }
 
 fn validate_view_digest(raw: &str, claim: &ClaimView<'_>, claim_field: &str) -> Result<(), String> {
-    validate_artifact_digest(raw, claim, "view_digest", claim_field)
+    validate_artifact_digest(raw, claim, "view_digest", claim_field)?;
+    validate_json_digest(
+        raw,
+        "view_digest",
+        extract_string(claim.raw, claim_field)?.as_str(),
+        format!("three-agent view {claim_field}").as_str(),
+    )
 }
 
 fn validate_artifact_digest(

--- a/crates/kamn-e2e-harness/src/mvp_demo/three_agent_views.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/three_agent_views.rs
@@ -1,5 +1,6 @@
 use std::path::Path;
 
+use super::artifact_digest::{attach_json_digest, ArtifactJson, ThreeAgentViewDigests};
 use super::devnet_settlement::DevnetSettlementEvidence;
 use super::report::{escape_json, DemoReportInput};
 
@@ -19,18 +20,6 @@ pub(crate) fn agent_c_verifier_view_path(input: &DemoReportInput<'_>) -> String 
     view_path(input, AGENT_C_VIEW_FILE)
 }
 
-pub(crate) fn agent_a_view_digest(run_id: &str) -> String {
-    format!("agent-a-view-digest-{run_id}")
-}
-
-pub(crate) fn agent_b_view_digest(run_id: &str) -> String {
-    format!("agent-b-view-digest-{run_id}")
-}
-
-pub(crate) fn agent_c_verifier_view_digest(run_id: &str) -> String {
-    format!("agent-c-view-digest-{run_id}")
-}
-
 pub(crate) fn public_view_digest(run_id: &str) -> String {
     format!("public-view-digest-{run_id}")
 }
@@ -47,32 +36,28 @@ pub(crate) fn write_three_agent_views(
     run_id: &str,
     evidence: &DevnetSettlementEvidence,
     run_dir: &Path,
-) -> Result<(), String> {
-    write_view(
-        run_dir,
-        AGENT_A_VIEW_FILE,
-        participant_view_json(
-            run_id,
-            evidence,
-            "agent_a",
-            agent_a_private_view_digest(run_id),
-        ),
+) -> Result<ThreeAgentViewDigests, String> {
+    let agent_a = participant_view_json(
+        run_id,
+        evidence,
+        "agent_a",
+        agent_a_private_view_digest(run_id),
     )?;
-    write_view(
-        run_dir,
-        AGENT_B_VIEW_FILE,
-        participant_view_json(
-            run_id,
-            evidence,
-            "agent_b",
-            agent_b_private_view_digest(run_id),
-        ),
+    let agent_b = participant_view_json(
+        run_id,
+        evidence,
+        "agent_b",
+        agent_b_private_view_digest(run_id),
     )?;
-    write_view(
-        run_dir,
-        AGENT_C_VIEW_FILE,
-        verifier_view_json(run_id, evidence),
-    )
+    let agent_c = verifier_view_json(run_id, evidence)?;
+    write_view(run_dir, AGENT_A_VIEW_FILE, agent_a.json.as_str())?;
+    write_view(run_dir, AGENT_B_VIEW_FILE, agent_b.json.as_str())?;
+    write_view(run_dir, AGENT_C_VIEW_FILE, agent_c.json.as_str())?;
+    Ok(ThreeAgentViewDigests {
+        agent_a: agent_a.digest,
+        agent_b: agent_b.digest,
+        agent_c_verifier: agent_c.digest,
+    })
 }
 
 fn view_path(input: &DemoReportInput<'_>, file_name: &str) -> String {
@@ -83,7 +68,7 @@ fn view_path(input: &DemoReportInput<'_>, file_name: &str) -> String {
         .to_string()
 }
 
-fn write_view(run_dir: &Path, file_name: &str, json: String) -> Result<(), String> {
+fn write_view(run_dir: &Path, file_name: &str, json: &str) -> Result<(), String> {
     let path = run_dir.join("proof").join(file_name);
     std::fs::write(path.as_path(), json).map_err(|error| {
         format!(
@@ -98,27 +83,30 @@ fn participant_view_json(
     evidence: &DevnetSettlementEvidence,
     agent: &str,
     private_digest: String,
-) -> String {
-    let view_digest = match agent {
-        "agent_a" => agent_a_view_digest(run_id),
-        _ => agent_b_view_digest(run_id),
-    };
-    format!(
-        "{{\"schema_version\":\"kamn.mvp.three-agent-view.v1\",\"agent\":\"{}\",\"view_scope\":\"participant-private\",{},\"private_field_count\":3,\"participant_private_view_digest\":\"{}\",\"public_view_digest\":\"{}\",\"private_payload_redacted\":true,\"view_digest\":\"{}\"}}",
-        escape_json(agent),
-        shared_view_fields(run_id, evidence),
-        escape_json(private_digest.as_str()),
-        escape_json(public_view_digest(run_id).as_str()),
-        escape_json(view_digest.as_str())
+) -> Result<ArtifactJson, String> {
+    attach_json_digest(
+        format!(
+            "{{\"schema_version\":\"kamn.mvp.three-agent-view.v1\",\"agent\":\"{}\",\"view_scope\":\"participant-private\",{},\"private_field_count\":3,\"participant_private_view_digest\":\"{}\",\"public_view_digest\":\"{}\",\"private_payload_redacted\":true,\"view_digest\":\"\"}}",
+            escape_json(agent),
+            shared_view_fields(run_id, evidence),
+            escape_json(private_digest.as_str()),
+            escape_json(public_view_digest(run_id).as_str()),
+        ),
+        "view_digest",
     )
 }
 
-fn verifier_view_json(run_id: &str, evidence: &DevnetSettlementEvidence) -> String {
-    format!(
-        "{{\"schema_version\":\"kamn.mvp.three-agent-view.v1\",\"agent\":\"agent_c_verifier\",\"view_scope\":\"restricted-public\",{},\"private_field_count\":0,\"public_view_digest\":\"{}\",\"private_payload_redacted\":true,\"view_digest\":\"{}\"}}",
-        shared_view_fields(run_id, evidence),
-        escape_json(public_view_digest(run_id).as_str()),
-        escape_json(agent_c_verifier_view_digest(run_id).as_str())
+fn verifier_view_json(
+    run_id: &str,
+    evidence: &DevnetSettlementEvidence,
+) -> Result<ArtifactJson, String> {
+    attach_json_digest(
+        format!(
+            "{{\"schema_version\":\"kamn.mvp.three-agent-view.v1\",\"agent\":\"agent_c_verifier\",\"view_scope\":\"restricted-public\",{},\"private_field_count\":0,\"public_view_digest\":\"{}\",\"private_payload_redacted\":true,\"view_digest\":\"\"}}",
+            shared_view_fields(run_id, evidence),
+            escape_json(public_view_digest(run_id).as_str()),
+        ),
+        "view_digest",
     )
 }
 

--- a/crates/kamn-e2e-harness/tests/mvp_demo_agent_harness_claim_contract/actor_receipts.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_demo_agent_harness_claim_contract/actor_receipts.rs
@@ -1,5 +1,7 @@
 use std::path::Path;
 
+use super::three_agent;
+
 pub(crate) fn valid_actor_receipts(root: &Path) -> String {
     format!(
         r#","three_agent_actor_tool_receipts":[{},{},{},{},{}]"#,
@@ -46,8 +48,16 @@ fn receipt(root: &Path, sequence: u64, tool: &str, agent: &str, action: &str) ->
 
 fn view_for(root: &Path, agent: &str) -> View {
     match agent {
-        "agent_a" => View::participant(root, "agent-a-view.json", "agent-a-view-digest-7045"),
-        "agent_b" => View::participant(root, "agent-b-view.json", "agent-b-view-digest-7045"),
+        "agent_a" => View::participant(
+            root,
+            "agent-a-view.json",
+            three_agent::view_digest_for(agent),
+        ),
+        "agent_b" => View::participant(
+            root,
+            "agent-b-view.json",
+            three_agent::view_digest_for(agent),
+        ),
         _ => View::verifier(root),
     }
 }
@@ -55,11 +65,11 @@ fn view_for(root: &Path, agent: &str) -> View {
 struct View {
     scope: &'static str,
     artifact: std::path::PathBuf,
-    digest: &'static str,
+    digest: String,
 }
 
 impl View {
-    fn participant(root: &Path, file: &str, digest: &'static str) -> Self {
+    fn participant(root: &Path, file: &str, digest: String) -> Self {
         Self {
             scope: "participant-private",
             artifact: root.join("proof").join(file),
@@ -71,7 +81,7 @@ impl View {
         Self {
             scope: "restricted-public",
             artifact: root.join("proof/agent-c-verifier-view.json"),
-            digest: "agent-c-view-digest-7045",
+            digest: three_agent::view_digest_for("agent_c_verifier"),
         }
     }
 }

--- a/crates/kamn-e2e-harness/tests/mvp_demo_agent_harness_claim_contract/support.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_demo_agent_harness_claim_contract/support.rs
@@ -9,6 +9,7 @@ mod mvp_local_artifacts;
 mod three_agent;
 
 pub(crate) use artifact::*;
+pub(crate) use three_agent::view_digest_for;
 
 pub(crate) fn temp_root(stem: &str) -> PathBuf {
     let millis = std::time::SystemTime::now()

--- a/crates/kamn-e2e-harness/tests/mvp_demo_agent_harness_claim_contract/three_agent.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_demo_agent_harness_claim_contract/three_agent.rs
@@ -1,5 +1,11 @@
 use std::path::{Path, PathBuf};
 
+#[allow(dead_code)]
+#[path = "../support/artifact_digest.rs"]
+mod artifact_digest;
+
+use artifact_digest::{digest_field, with_digest};
+
 pub(crate) const NO_THREE_AGENT_BOUNDARY: &str = "";
 
 pub(crate) fn absent_boundary() -> &'static str {
@@ -16,16 +22,20 @@ pub(crate) fn devnet_settlement_claim() -> &'static str {
 
 pub(crate) fn three_agent_claim(root: &Path, transcript: &Path) -> String {
     format!(
-        r#"{{"id":"three_agent_escrow_verification","label":"devnet-backed","required":true,"status":"PASS","summary":"Agent C verifies escrow settlement from restricted proof view","three_agent_transcript_artifact":"{}","three_agent_transcript_digest":"three-agent-transcript-digest-7045","transaction_id":"tx-three-agent-7045","terms_digest":"terms-digest-7045","agent_a_terms_digest":"terms-digest-7045","agent_b_terms_digest":"terms-digest-7045","verifier_terms_digest":"terms-digest-7045","escrow_id":"escrow-three-agent-7045","agent_a_escrow_id":"escrow-three-agent-7045","agent_b_escrow_id":"escrow-three-agent-7045","verifier_escrow_id":"escrow-three-agent-7045","network":"solana:devnet","rpc_url":"https://api.devnet.solana.com","payer_pubkey":"payer111111111111111111111111111111111111111","recipient_pubkey":"recipient11111111111111111111111111111111111","lamports":1,"settlement_tx_signature":"5nSgnDevnetSignature111111111111111111111111111","agent_a_settlement_tx_signature":"5nSgnDevnetSignature111111111111111111111111111","agent_b_settlement_tx_signature":"5nSgnDevnetSignature111111111111111111111111111","verifier_settlement_tx_signature":"5nSgnDevnetSignature111111111111111111111111111","settlement_commitment":"finalized","agent_a_settlement_commitment":"finalized","agent_b_settlement_commitment":"finalized","verifier_settlement_commitment":"finalized","payer_balance_before":20,"payer_balance_after":19,"recipient_balance_before":10,"recipient_balance_after":11,"persisted_settlement_tx_signature":"5nSgnDevnetSignature111111111111111111111111111","amount_lamports":1,"agent_a_amount_lamports":1,"agent_b_amount_lamports":1,"verifier_amount_lamports":1,"agent_a_private_view_visible":true,"agent_b_private_view_visible":true,"verifier_private_view_visible":false,"agent_a_view_scope":"participant-private","agent_b_view_scope":"participant-private","verifier_view_scope":"restricted-public","agent_a_private_field_count":3,"agent_b_private_field_count":3,"verifier_private_field_count":0,"agent_a_private_view_digest":"agent-a-private-digest-7045","agent_b_private_view_digest":"agent-b-private-digest-7045","agent_a_public_view_digest":"public-view-digest-7045","agent_b_public_view_digest":"public-view-digest-7045","verifier_public_view_digest":"public-view-digest-7045","private_payload_redacted":true{}}}"#,
+        r#"{{"id":"three_agent_escrow_verification","label":"devnet-backed","required":true,"status":"PASS","summary":"Agent C verifies escrow settlement from restricted proof view","three_agent_transcript_artifact":"{}","three_agent_transcript_digest":"{}","transaction_id":"tx-three-agent-7045","terms_digest":"terms-digest-7045","agent_a_terms_digest":"terms-digest-7045","agent_b_terms_digest":"terms-digest-7045","verifier_terms_digest":"terms-digest-7045","escrow_id":"escrow-three-agent-7045","agent_a_escrow_id":"escrow-three-agent-7045","agent_b_escrow_id":"escrow-three-agent-7045","verifier_escrow_id":"escrow-three-agent-7045","network":"solana:devnet","rpc_url":"https://api.devnet.solana.com","payer_pubkey":"payer111111111111111111111111111111111111111","recipient_pubkey":"recipient11111111111111111111111111111111111","lamports":1,"settlement_tx_signature":"5nSgnDevnetSignature111111111111111111111111111","agent_a_settlement_tx_signature":"5nSgnDevnetSignature111111111111111111111111111","agent_b_settlement_tx_signature":"5nSgnDevnetSignature111111111111111111111111111","verifier_settlement_tx_signature":"5nSgnDevnetSignature111111111111111111111111111","settlement_commitment":"finalized","agent_a_settlement_commitment":"finalized","agent_b_settlement_commitment":"finalized","verifier_settlement_commitment":"finalized","payer_balance_before":20,"payer_balance_after":19,"recipient_balance_before":10,"recipient_balance_after":11,"persisted_settlement_tx_signature":"5nSgnDevnetSignature111111111111111111111111111","amount_lamports":1,"agent_a_amount_lamports":1,"agent_b_amount_lamports":1,"verifier_amount_lamports":1,"agent_a_private_view_visible":true,"agent_b_private_view_visible":true,"verifier_private_view_visible":false,"agent_a_view_scope":"participant-private","agent_b_view_scope":"participant-private","verifier_view_scope":"restricted-public","agent_a_private_field_count":3,"agent_b_private_field_count":3,"verifier_private_field_count":0,"agent_a_private_view_digest":"agent-a-private-digest-7045","agent_b_private_view_digest":"agent-b-private-digest-7045","agent_a_public_view_digest":"public-view-digest-7045","agent_b_public_view_digest":"public-view-digest-7045","verifier_public_view_digest":"public-view-digest-7045","private_payload_redacted":true{}}}"#,
         transcript.display(),
+        transcript_digest(root),
         view_fields(root)
     )
 }
 
 pub(crate) fn valid_transcript(root: &Path) -> String {
-    format!(
-        r#"{{"schema_version":"kamn.mvp.three-agent-transcript.v1","proof_label":"local-only","devnet_settlement_linked":true,"transaction_id":"tx-three-agent-7045","escrow_id":"escrow-three-agent-7045","steps":["agent_a_registered","agent_b_registered","agent_a_invoked_transaction","agent_b_accepted_task","escrow_funded","escrow_released","agent_c_verifier_verified"],"views":{{"agent_a":"participant-private","agent_b":"participant-private","agent_c_verifier":"restricted-public"}},"agent_a_private_field_count":3,"agent_b_private_field_count":3,"verifier_private_field_count":0,"private_payload_redacted":true,"settlement_tx_signature":"5nSgnDevnetSignature111111111111111111111111111","amount_lamports":1,"payer_pubkey":"payer111111111111111111111111111111111111111","recipient_pubkey":"recipient11111111111111111111111111111111111","settlement_commitment":"finalized","transcript_digest":"three-agent-transcript-digest-7045"{} }}"#,
-        view_fields(root)
+    with_digest(
+        format!(
+            r#"{{"schema_version":"kamn.mvp.three-agent-transcript.v1","proof_label":"local-only","devnet_settlement_linked":true,"transaction_id":"tx-three-agent-7045","escrow_id":"escrow-three-agent-7045","steps":["agent_a_registered","agent_b_registered","agent_a_invoked_transaction","agent_b_accepted_task","escrow_funded","escrow_released","agent_c_verifier_verified"],"views":{{"agent_a":"participant-private","agent_b":"participant-private","agent_c_verifier":"restricted-public"}},"agent_a_private_field_count":3,"agent_b_private_field_count":3,"verifier_private_field_count":0,"private_payload_redacted":true,"settlement_tx_signature":"5nSgnDevnetSignature111111111111111111111111111","amount_lamports":1,"payer_pubkey":"payer111111111111111111111111111111111111111","recipient_pubkey":"recipient11111111111111111111111111111111111","settlement_commitment":"finalized","transcript_digest":""{} }}"#,
+            view_fields(root)
+        ),
+        "transcript_digest",
     )
 }
 
@@ -33,19 +43,11 @@ pub(crate) fn valid_view_artifacts(root: &Path) -> Vec<(PathBuf, String)> {
     vec![
         (
             root.join("proof/agent-a-view.json"),
-            participant_view(
-                "agent_a",
-                "agent-a-private-digest-7045",
-                "agent-a-view-digest-7045",
-            ),
+            participant_view("agent_a", "agent-a-private-digest-7045"),
         ),
         (
             root.join("proof/agent-b-view.json"),
-            participant_view(
-                "agent_b",
-                "agent-b-private-digest-7045",
-                "agent-b-view-digest-7045",
-            ),
+            participant_view("agent_b", "agent-b-private-digest-7045"),
         ),
         (
             root.join("proof/agent-c-verifier-view.json"),
@@ -62,7 +64,7 @@ pub(crate) fn valid_actor_rehearsal(root: &Path) -> String {
             "agent_a",
             "participant-private",
             r#"["register","invoke_transaction"]"#,
-            "agent-a-view-digest-7045",
+            view_digest_for("agent_a").as_str(),
             "agent-a-view.json"
         ),
         actor_observation(
@@ -70,7 +72,7 @@ pub(crate) fn valid_actor_rehearsal(root: &Path) -> String {
             "agent_b",
             "participant-private",
             r#"["register","accept_task"]"#,
-            "agent-b-view-digest-7045",
+            view_digest_for("agent_b").as_str(),
             "agent-b-view.json"
         ),
         actor_observation(
@@ -78,7 +80,7 @@ pub(crate) fn valid_actor_rehearsal(root: &Path) -> String {
             "agent_c_verifier",
             "restricted-public",
             r#"["verify_proof"]"#,
-            "agent-c-view-digest-7045",
+            view_digest_for("agent_c_verifier").as_str(),
             "agent-c-verifier-view.json"
         )
     )
@@ -105,20 +107,42 @@ fn actor_observation(
 
 fn view_fields(root: &Path) -> String {
     format!(
-        r#","agent_a_view_artifact":"{}","agent_b_view_artifact":"{}","agent_c_verifier_view_artifact":"{}","agent_a_view_digest":"agent-a-view-digest-7045","agent_b_view_digest":"agent-b-view-digest-7045","agent_c_verifier_view_digest":"agent-c-view-digest-7045""#,
+        r#","agent_a_view_artifact":"{}","agent_b_view_artifact":"{}","agent_c_verifier_view_artifact":"{}","agent_a_view_digest":"{}","agent_b_view_digest":"{}","agent_c_verifier_view_digest":"{}""#,
         root.join("proof/agent-a-view.json").display(),
         root.join("proof/agent-b-view.json").display(),
-        root.join("proof/agent-c-verifier-view.json").display()
+        root.join("proof/agent-c-verifier-view.json").display(),
+        view_digest_for("agent_a"),
+        view_digest_for("agent_b"),
+        view_digest_for("agent_c_verifier"),
     )
 }
 
-fn participant_view(agent: &str, private_digest: &str, view_digest: &str) -> String {
-    format!(
-        r#"{{"schema_version":"kamn.mvp.three-agent-view.v1","agent":"{}","view_scope":"participant-private","transaction_id":"tx-three-agent-7045","escrow_id":"escrow-three-agent-7045","settlement_tx_signature":"5nSgnDevnetSignature111111111111111111111111111","amount_lamports":1,"payer_pubkey":"payer111111111111111111111111111111111111111","recipient_pubkey":"recipient11111111111111111111111111111111111","settlement_commitment":"finalized","private_field_count":3,"participant_private_view_digest":"{}","public_view_digest":"public-view-digest-7045","private_payload_redacted":true,"view_digest":"{}"}}"#,
-        agent, private_digest, view_digest
+pub(crate) fn view_digest_for(agent: &str) -> String {
+    let view = match agent {
+        "agent_a" => participant_view("agent_a", "agent-a-private-digest-7045"),
+        "agent_b" => participant_view("agent_b", "agent-b-private-digest-7045"),
+        _ => verifier_view(),
+    };
+    digest_field(view.as_str(), "view_digest")
+}
+
+fn participant_view(agent: &str, private_digest: &str) -> String {
+    with_digest(
+        format!(
+            r#"{{"schema_version":"kamn.mvp.three-agent-view.v1","agent":"{}","view_scope":"participant-private","transaction_id":"tx-three-agent-7045","escrow_id":"escrow-three-agent-7045","settlement_tx_signature":"5nSgnDevnetSignature111111111111111111111111111","amount_lamports":1,"payer_pubkey":"payer111111111111111111111111111111111111111","recipient_pubkey":"recipient11111111111111111111111111111111111","settlement_commitment":"finalized","private_field_count":3,"participant_private_view_digest":"{}","public_view_digest":"public-view-digest-7045","private_payload_redacted":true,"view_digest":""}}"#,
+            agent, private_digest
+        ),
+        "view_digest",
     )
 }
 
 fn verifier_view() -> String {
-    r#"{"schema_version":"kamn.mvp.three-agent-view.v1","agent":"agent_c_verifier","view_scope":"restricted-public","transaction_id":"tx-three-agent-7045","escrow_id":"escrow-three-agent-7045","settlement_tx_signature":"5nSgnDevnetSignature111111111111111111111111111","amount_lamports":1,"payer_pubkey":"payer111111111111111111111111111111111111111","recipient_pubkey":"recipient11111111111111111111111111111111111","settlement_commitment":"finalized","private_field_count":0,"public_view_digest":"public-view-digest-7045","private_payload_redacted":true,"view_digest":"agent-c-view-digest-7045"}"#.to_owned()
+    with_digest(
+        r#"{"schema_version":"kamn.mvp.three-agent-view.v1","agent":"agent_c_verifier","view_scope":"restricted-public","transaction_id":"tx-three-agent-7045","escrow_id":"escrow-three-agent-7045","settlement_tx_signature":"5nSgnDevnetSignature111111111111111111111111111","amount_lamports":1,"payer_pubkey":"payer111111111111111111111111111111111111111","recipient_pubkey":"recipient11111111111111111111111111111111111","settlement_commitment":"finalized","private_field_count":0,"public_view_digest":"public-view-digest-7045","private_payload_redacted":true,"view_digest":""}"#.to_owned(),
+        "view_digest",
+    )
+}
+
+fn transcript_digest(root: &Path) -> String {
+    digest_field(valid_transcript(root).as_str(), "transcript_digest")
 }

--- a/crates/kamn-e2e-harness/tests/mvp_demo_agent_harness_claim_contract/three_agent_actor_receipts_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_demo_agent_harness_claim_contract/three_agent_actor_receipts_contract.rs
@@ -20,7 +20,7 @@ fn spec_c15_command_rejects_three_agent_harness_without_actor_tool_receipts() {
 fn spec_c16_command_rejects_actor_tool_receipt_view_digest_mismatch() {
     let root = temp_root("receipt-digest-mismatch");
     let artifact_json = agent_artifact_with_three_agent_actor_receipts(&root).replace(
-        r#""view_digest":"agent-a-view-digest-7045""#,
+        format!(r#""view_digest":"{}""#, view_digest_for("agent_a")).as_str(),
         r#""view_digest":"mismatch""#,
     );
     let artifact = write_artifact(&root, artifact_json);

--- a/crates/kamn-e2e-harness/tests/mvp_demo_agent_harness_claim_contract/three_agent_actor_rehearsal_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_demo_agent_harness_claim_contract/three_agent_actor_rehearsal_contract.rs
@@ -33,7 +33,7 @@ fn spec_c13_command_rejects_actor_rehearsal_with_agent_c_private_scope() {
 fn spec_c14_command_rejects_actor_rehearsal_view_digest_mismatch() {
     let root = temp_root("actor-digest-mismatch");
     let artifact_json = agent_artifact_with_three_agent_actor_rehearsal(&root).replace(
-        r#""agent_a_view_digest":"agent-a-view-digest-7045""#,
+        format!(r#""agent_a_view_digest":"{}""#, view_digest_for("agent_a")).as_str(),
         r#""agent_a_view_digest":"mismatch""#,
     );
     let artifact = write_artifact(&root, artifact_json);

--- a/crates/kamn-e2e-harness/tests/mvp_demo_command_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_demo_command_contract.rs
@@ -100,6 +100,10 @@ fn spec_c06_demo_mvp_devnet_required_records_settlement_evidence() {
     assert!(report.contains(r#""payer_balance_after":2498995000"#));
     assert!(report.contains(r#""recipient_balance_before":2500000000"#));
     assert!(report.contains(r#""recipient_balance_after":2501000000"#));
+    assert!(report.contains(r#""three_agent_transcript_digest":"sha256:"#));
+    assert!(report.contains(r#""agent_a_view_digest":"sha256:"#));
+    assert!(report.contains(r#""agent_b_view_digest":"sha256:"#));
+    assert!(report.contains(r#""agent_c_verifier_view_digest":"sha256:"#));
     let _ = std::fs::remove_dir_all(&temp);
 }
 

--- a/crates/kamn-e2e-harness/tests/mvp_demo_command_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_demo_command_contract.rs
@@ -7,6 +7,9 @@ use kamn_e2e_harness::{
     HarnessCommand, MvpDemoCommandConfig, VerifyMvpDemoCommandConfig,
 };
 
+#[path = "support/mvp_demo_command.rs"]
+mod mvp_demo_command;
+
 #[test]
 fn spec_c01_parser_accepts_demo_mvp_with_output_root() {
     let parsed = parse_command_args(["demo-mvp", "--output-root", "/tmp/kamn-demo"])
@@ -46,7 +49,7 @@ fn spec_c03_makefile_wires_demo_mvp_to_harness_command() {
 #[test]
 fn spec_c04_demo_mvp_creates_run_directory_and_latest_report_paths() {
     let temp = temp_dir("mvp-demo-command");
-    let config = local_demo_config(&temp);
+    let config = mvp_demo_command::local_demo_config(&temp);
     execute_mvp_demo_contract(&config).expect("demo-mvp should generate local proof artifacts");
     assert!(temp.join("latest/proof/report.json").is_file());
     assert!(temp.join("latest/proof/report.md").is_file());
@@ -60,7 +63,7 @@ fn spec_c04_demo_mvp_creates_run_directory_and_latest_report_paths() {
 #[test]
 fn spec_c05_verify_mvp_demo_command_accepts_generated_report() {
     let temp = temp_dir("mvp-demo-verify");
-    let demo_config = local_demo_config(&temp);
+    let demo_config = mvp_demo_command::local_demo_config(&temp);
     execute_mvp_demo_contract(&demo_config).expect("demo should generate report");
     let verify_config = VerifyMvpDemoCommandConfig {
         report: temp.join("latest/proof/report.json").display().to_string(),
@@ -74,89 +77,40 @@ fn spec_c05_verify_mvp_demo_command_accepts_generated_report() {
 #[test]
 fn spec_c06_demo_mvp_devnet_required_records_settlement_evidence() {
     let temp = temp_dir("mvp-demo-devnet-settlement");
-    let config = MvpDemoCommandConfig {
-        output_root: temp.display().to_string(),
-        devnet_mode: "required".to_owned(),
-        solana_rpc_url: Some("https://api.devnet.solana.com".to_owned()),
-        devnet_settlement_command: Some(stub_devnet_settlement_command()),
-        localhost_signed_demo_command: Some(stub_localhost_signed_demo_command()),
-        service_api_vertical_slice_command: Some(stub_service_api_command(
-            "integration_service_api_endpoint_working_vertical_slice_proves_delivery_dispatch_and_audit_evidence",
-        )),
-        service_api_websocket_command: Some(stub_service_api_command(
-            "integration_service_api_endpoint_websocket_upgrade_streams_state_transition_event",
-        )),
-        agent_harness_evidence_path: None,
-    };
+    let config = mvp_demo_command::devnet_required_demo_config(&temp);
     let report = execute_mvp_demo_contract(&config)
         .expect("devnet-required demo should accept real settlement evidence");
 
     assert!(report.contains(r#""status":"GO""#));
     assert!(report.contains(r#""id":"devnet_settlement_asset_movement""#));
     assert!(report.contains(r#""label":"devnet-backed""#));
-    assert!(report.contains(r#""settlement_tx_signature":"devnet-signature-111""#));
-    assert!(report.contains(r#""persisted_settlement_tx_signature":"devnet-signature-111""#));
-    assert!(report.contains(r#""payer_balance_before":2500000000"#));
-    assert!(report.contains(r#""payer_balance_after":2498995000"#));
-    assert!(report.contains(r#""recipient_balance_before":2500000000"#));
-    assert!(report.contains(r#""recipient_balance_after":2501000000"#));
-    assert!(report.contains(r#""three_agent_transcript_digest":"sha256:"#));
-    assert!(report.contains(r#""agent_a_view_digest":"sha256:"#));
-    assert!(report.contains(r#""agent_b_view_digest":"sha256:"#));
-    assert!(report.contains(r#""agent_c_verifier_view_digest":"sha256:"#));
+    for marker in devnet_settlement_markers() {
+        assert!(report.contains(marker), "missing report marker: {marker}");
+    }
+    for marker in three_agent_digest_markers() {
+        assert!(report.contains(marker), "missing report marker: {marker}");
+    }
     let _ = std::fs::remove_dir_all(&temp);
 }
 
-fn stub_localhost_signed_demo_command() -> Vec<String> {
-    vec![
-        "sh".to_owned(),
-        "-c".to_owned(),
-        r#"cat > "$2" <<'JSON'
-{"schema_version":"kamn.sdk.localhost-signed.demo-receipt-artifact.v1","status": "pass","signed_exchange":{"from":"kamn:did:agent:alice","to":"kamn:did:agent:bob","verified": true},"signed_flow":"task"}
-JSON
-echo "receipt_reconciliation=GO"
-echo "localhost signed message demo completed."
-"#
-        .to_owned(),
-        "kamn-mvp-stub".to_owned(),
+fn devnet_settlement_markers() -> [&'static str; 6] {
+    [
+        r#""settlement_tx_signature":"devnet-signature-111""#,
+        r#""persisted_settlement_tx_signature":"devnet-signature-111""#,
+        r#""payer_balance_before":2500000000"#,
+        r#""payer_balance_after":2498995000"#,
+        r#""recipient_balance_before":2500000000"#,
+        r#""recipient_balance_after":2501000000"#,
     ]
 }
 
-fn stub_service_api_command(test_name: &str) -> Vec<String> {
-    vec![
-        "sh".to_owned(),
-        "-c".to_owned(),
-        format!(r#"echo "test {test_name} ... ok"; echo "test result: ok""#),
+fn three_agent_digest_markers() -> [&'static str; 4] {
+    [
+        r#""three_agent_transcript_digest":"sha256:"#,
+        r#""agent_a_view_digest":"sha256:"#,
+        r#""agent_b_view_digest":"sha256:"#,
+        r#""agent_c_verifier_view_digest":"sha256:"#,
     ]
-}
-
-fn stub_devnet_settlement_command() -> Vec<String> {
-    vec![
-        "sh".to_owned(),
-        "-c".to_owned(),
-        r#"cat <<'JSON'
-{"network":"solana:devnet","rpc_url":"https://api.devnet.solana.com","payer_pubkey":"2FjUiacAXtokhA8YzGiyfVEdu5D9LxKFhjptJLrz4V9T","recipient_pubkey":"FV5LvudLjZQGCrPwXUY2JaVr26sQE15K25BGvsKWvyFe","lamports":1000000,"settlement_tx_signature":"devnet-signature-111","settlement_commitment":"finalized","payer_balance_before":2500000000,"payer_balance_after":2498995000,"recipient_balance_before":2500000000,"recipient_balance_after":2501000000,"persisted_settlement_tx_signature":"devnet-signature-111"}
-JSON
-"#
-        .to_owned(),
-    ]
-}
-
-fn local_demo_config(temp: &Path) -> MvpDemoCommandConfig {
-    MvpDemoCommandConfig {
-        output_root: temp.display().to_string(),
-        devnet_mode: "optional".to_owned(),
-        solana_rpc_url: None,
-        devnet_settlement_command: None,
-        localhost_signed_demo_command: Some(stub_localhost_signed_demo_command()),
-        service_api_vertical_slice_command: Some(stub_service_api_command(
-            "integration_service_api_endpoint_working_vertical_slice_proves_delivery_dispatch_and_audit_evidence",
-        )),
-        service_api_websocket_command: Some(stub_service_api_command(
-            "integration_service_api_endpoint_websocket_upgrade_streams_state_transition_event",
-        )),
-        agent_harness_evidence_path: None,
-    }
 }
 
 fn make_dry_run(target: &str) -> String {

--- a/crates/kamn-e2e-harness/tests/mvp_demo_three_agent_transcript_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_demo_three_agent_transcript_contract.rs
@@ -5,6 +5,10 @@ use std::path::{Path, PathBuf};
 #[path = "support/mvp_local_artifacts.rs"]
 mod mvp_local_artifacts;
 
+#[allow(dead_code)]
+#[path = "support/three_agent_view_artifacts.rs"]
+mod three_agent_view_artifacts;
+
 #[test]
 fn spec_c01_report_rejects_missing_transcript_fields() {
     let root = Path::new("/tmp/kamn-7056-unused");
@@ -71,6 +75,27 @@ fn spec_c04_command_rejects_raw_private_payload_transcript() {
         .expect_err("raw private payload transcript must fail");
 
     assert!(err.contains("raw private payload"));
+}
+
+#[test]
+fn spec_c05_command_rejects_stale_transcript_digest_after_content_tamper() {
+    let root = three_agent_view_artifacts::temp_root("stale-transcript-digest");
+    mvp_local_artifacts::write_valid_local_artifacts(&root);
+    three_agent_view_artifacts::write_view_artifacts(&root, None);
+    let tampered = append_json_marker(
+        three_agent_view_artifacts::transcript(Some(&root)),
+        "transcript-tampered",
+    );
+    three_agent_view_artifacts::write_transcript(&root, tampered);
+    let report = three_agent_view_artifacts::write_report(
+        &root,
+        three_agent_view_artifacts::report_json(&root, Some(&root)),
+    );
+
+    let err = execute_verify_mvp_demo_contract(&config(report.as_path()))
+        .expect_err("stale transcript digest must fail");
+
+    assert!(err.contains("three-agent transcript digest"));
 }
 
 fn temp_root(stem: &str) -> PathBuf {
@@ -165,4 +190,11 @@ fn valid_transcript() -> String {
 
 fn roadmap_claim() -> &'static str {
     r#"{"id":"production_readiness","label":"roadmap","required":false,"status":"NOT_CLAIMED","summary":"production readiness is not claimed"}"#
+}
+
+fn append_json_marker(raw: String, marker: &str) -> String {
+    raw.strip_suffix(" }")
+        .or_else(|| raw.strip_suffix('}'))
+        .map(|prefix| format!("{prefix},\"tamper_marker\":\"{marker}\"}}"))
+        .expect("transcript fixture should be a JSON object")
 }

--- a/crates/kamn-e2e-harness/tests/mvp_demo_three_agent_view_artifact_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_demo_three_agent_view_artifact_contract.rs
@@ -143,8 +143,83 @@ fn spec_c06_command_rejects_agent_c_short_identity() {
     assert!(err.contains("agent_c_verifier_view"));
 }
 
+#[test]
+fn spec_c07_command_rejects_stale_agent_a_view_digest_after_content_tamper() {
+    let root = three_agent_view_artifacts::temp_root("agent-a-stale-view-digest");
+    mvp_local_artifacts::write_valid_local_artifacts(&root);
+    three_agent_view_artifacts::write_view_artifacts(&root, None);
+    append_json_marker(&root.join("proof/agent-a-view.json"), "agent-a-tampered");
+    three_agent_view_artifacts::write_transcript(
+        &root,
+        three_agent_view_artifacts::transcript(Some(&root)),
+    );
+    let report = three_agent_view_artifacts::write_report(
+        &root,
+        three_agent_view_artifacts::report_json(&root, Some(&root)),
+    );
+
+    let err = execute_verify_mvp_demo_contract(&config(report.as_path()))
+        .expect_err("stale Agent A view digest must fail");
+
+    assert!(err.contains("agent_a_view_digest"));
+}
+
+#[test]
+fn spec_c08_command_rejects_stale_agent_b_view_digest_after_content_tamper() {
+    let root = three_agent_view_artifacts::temp_root("agent-b-stale-view-digest");
+    mvp_local_artifacts::write_valid_local_artifacts(&root);
+    three_agent_view_artifacts::write_view_artifacts(&root, None);
+    append_json_marker(&root.join("proof/agent-b-view.json"), "agent-b-tampered");
+    three_agent_view_artifacts::write_transcript(
+        &root,
+        three_agent_view_artifacts::transcript(Some(&root)),
+    );
+    let report = three_agent_view_artifacts::write_report(
+        &root,
+        three_agent_view_artifacts::report_json(&root, Some(&root)),
+    );
+
+    let err = execute_verify_mvp_demo_contract(&config(report.as_path()))
+        .expect_err("stale Agent B view digest must fail");
+
+    assert!(err.contains("agent_b_view_digest"));
+}
+
+#[test]
+fn spec_c09_command_rejects_stale_agent_c_view_digest_after_content_tamper() {
+    let root = three_agent_view_artifacts::temp_root("agent-c-stale-view-digest");
+    mvp_local_artifacts::write_valid_local_artifacts(&root);
+    three_agent_view_artifacts::write_view_artifacts(&root, None);
+    append_json_marker(
+        &root.join("proof/agent-c-verifier-view.json"),
+        "agent-c-tampered",
+    );
+    three_agent_view_artifacts::write_transcript(
+        &root,
+        three_agent_view_artifacts::transcript(Some(&root)),
+    );
+    let report = three_agent_view_artifacts::write_report(
+        &root,
+        three_agent_view_artifacts::report_json(&root, Some(&root)),
+    );
+
+    let err = execute_verify_mvp_demo_contract(&config(report.as_path()))
+        .expect_err("stale Agent C verifier view digest must fail");
+
+    assert!(err.contains("agent_c_verifier_view_digest"));
+}
+
 fn config(report: &Path) -> VerifyMvpDemoCommandConfig {
     VerifyMvpDemoCommandConfig {
         report: report.display().to_string(),
     }
+}
+
+fn append_json_marker(path: &Path, marker: &str) {
+    let raw = std::fs::read_to_string(path).expect("view fixture should be readable");
+    let tampered = raw
+        .strip_suffix('}')
+        .map(|prefix| format!("{prefix},\"tamper_marker\":\"{marker}\"}}"))
+        .expect("view fixture should be a JSON object");
+    std::fs::write(path, tampered).expect("tampered view fixture should be written");
 }

--- a/crates/kamn-e2e-harness/tests/mvp_demo_three_agent_view_artifact_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_demo_three_agent_view_artifact_contract.rs
@@ -143,83 +143,8 @@ fn spec_c06_command_rejects_agent_c_short_identity() {
     assert!(err.contains("agent_c_verifier_view"));
 }
 
-#[test]
-fn spec_c07_command_rejects_stale_agent_a_view_digest_after_content_tamper() {
-    let root = three_agent_view_artifacts::temp_root("agent-a-stale-view-digest");
-    mvp_local_artifacts::write_valid_local_artifacts(&root);
-    three_agent_view_artifacts::write_view_artifacts(&root, None);
-    append_json_marker(&root.join("proof/agent-a-view.json"), "agent-a-tampered");
-    three_agent_view_artifacts::write_transcript(
-        &root,
-        three_agent_view_artifacts::transcript(Some(&root)),
-    );
-    let report = three_agent_view_artifacts::write_report(
-        &root,
-        three_agent_view_artifacts::report_json(&root, Some(&root)),
-    );
-
-    let err = execute_verify_mvp_demo_contract(&config(report.as_path()))
-        .expect_err("stale Agent A view digest must fail");
-
-    assert!(err.contains("agent_a_view_digest"));
-}
-
-#[test]
-fn spec_c08_command_rejects_stale_agent_b_view_digest_after_content_tamper() {
-    let root = three_agent_view_artifacts::temp_root("agent-b-stale-view-digest");
-    mvp_local_artifacts::write_valid_local_artifacts(&root);
-    three_agent_view_artifacts::write_view_artifacts(&root, None);
-    append_json_marker(&root.join("proof/agent-b-view.json"), "agent-b-tampered");
-    three_agent_view_artifacts::write_transcript(
-        &root,
-        three_agent_view_artifacts::transcript(Some(&root)),
-    );
-    let report = three_agent_view_artifacts::write_report(
-        &root,
-        three_agent_view_artifacts::report_json(&root, Some(&root)),
-    );
-
-    let err = execute_verify_mvp_demo_contract(&config(report.as_path()))
-        .expect_err("stale Agent B view digest must fail");
-
-    assert!(err.contains("agent_b_view_digest"));
-}
-
-#[test]
-fn spec_c09_command_rejects_stale_agent_c_view_digest_after_content_tamper() {
-    let root = three_agent_view_artifacts::temp_root("agent-c-stale-view-digest");
-    mvp_local_artifacts::write_valid_local_artifacts(&root);
-    three_agent_view_artifacts::write_view_artifacts(&root, None);
-    append_json_marker(
-        &root.join("proof/agent-c-verifier-view.json"),
-        "agent-c-tampered",
-    );
-    three_agent_view_artifacts::write_transcript(
-        &root,
-        three_agent_view_artifacts::transcript(Some(&root)),
-    );
-    let report = three_agent_view_artifacts::write_report(
-        &root,
-        three_agent_view_artifacts::report_json(&root, Some(&root)),
-    );
-
-    let err = execute_verify_mvp_demo_contract(&config(report.as_path()))
-        .expect_err("stale Agent C verifier view digest must fail");
-
-    assert!(err.contains("agent_c_verifier_view_digest"));
-}
-
 fn config(report: &Path) -> VerifyMvpDemoCommandConfig {
     VerifyMvpDemoCommandConfig {
         report: report.display().to_string(),
     }
-}
-
-fn append_json_marker(path: &Path, marker: &str) {
-    let raw = std::fs::read_to_string(path).expect("view fixture should be readable");
-    let tampered = raw
-        .strip_suffix('}')
-        .map(|prefix| format!("{prefix},\"tamper_marker\":\"{marker}\"}}"))
-        .expect("view fixture should be a JSON object");
-    std::fs::write(path, tampered).expect("tampered view fixture should be written");
 }

--- a/crates/kamn-e2e-harness/tests/mvp_demo_three_agent_view_digest_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_demo_three_agent_view_digest_contract.rs
@@ -1,0 +1,77 @@
+use kamn_e2e_harness::{execute_verify_mvp_demo_contract, VerifyMvpDemoCommandConfig};
+use std::path::Path;
+
+#[path = "support/mvp_local_artifacts.rs"]
+mod mvp_local_artifacts;
+
+#[allow(dead_code)]
+#[path = "support/three_agent_view_artifacts.rs"]
+mod three_agent_view_artifacts;
+
+#[test]
+fn spec_c01_command_rejects_stale_agent_a_view_digest_after_content_tamper() {
+    assert_stale_view_digest_rejected(
+        "agent-a-stale-view-digest",
+        "agent-a-view.json",
+        "agent-a-tampered",
+        "agent_a_view_digest",
+    );
+}
+
+#[test]
+fn spec_c02_command_rejects_stale_agent_b_view_digest_after_content_tamper() {
+    assert_stale_view_digest_rejected(
+        "agent-b-stale-view-digest",
+        "agent-b-view.json",
+        "agent-b-tampered",
+        "agent_b_view_digest",
+    );
+}
+
+#[test]
+fn spec_c03_command_rejects_stale_agent_c_view_digest_after_content_tamper() {
+    assert_stale_view_digest_rejected(
+        "agent-c-stale-view-digest",
+        "agent-c-verifier-view.json",
+        "agent-c-tampered",
+        "agent_c_verifier_view_digest",
+    );
+}
+
+fn assert_stale_view_digest_rejected(
+    stem: &str,
+    file_name: &str,
+    marker: &str,
+    expected_error: &str,
+) {
+    let root = three_agent_view_artifacts::temp_root(stem);
+    mvp_local_artifacts::write_valid_local_artifacts(&root);
+    three_agent_view_artifacts::write_view_artifacts(&root, None);
+    append_json_marker(&root.join("proof").join(file_name), marker);
+    three_agent_view_artifacts::write_transcript(
+        &root,
+        three_agent_view_artifacts::transcript(Some(&root)),
+    );
+    let report = three_agent_view_artifacts::write_report(
+        &root,
+        three_agent_view_artifacts::report_json(&root, Some(&root)),
+    );
+    let err = execute_verify_mvp_demo_contract(&config(report.as_path()))
+        .expect_err("stale view digest must fail");
+    assert!(err.contains(expected_error));
+}
+
+fn append_json_marker(path: &Path, marker: &str) {
+    let raw = std::fs::read_to_string(path).expect("view fixture should be readable");
+    let tampered = raw
+        .strip_suffix('}')
+        .map(|prefix| format!("{prefix},\"tamper_marker\":\"{marker}\"}}"))
+        .expect("view fixture should be a JSON object");
+    std::fs::write(path, tampered).expect("tampered view fixture should be written");
+}
+
+fn config(report: &Path) -> VerifyMvpDemoCommandConfig {
+    VerifyMvpDemoCommandConfig {
+        report: report.display().to_string(),
+    }
+}

--- a/crates/kamn-e2e-harness/tests/support/artifact_digest.rs
+++ b/crates/kamn-e2e-harness/tests/support/artifact_digest.rs
@@ -1,0 +1,67 @@
+use sha2::{Digest, Sha256};
+
+pub(crate) fn digest_field(raw: &str, field: &str) -> String {
+    let marker = format!("\"{field}\":\"");
+    let start = raw
+        .find(marker.as_str())
+        .expect("digest field should exist")
+        + marker.len();
+    let end = raw[start..].find('"').expect("digest field should end");
+    raw[start..start + end].to_owned()
+}
+
+pub(crate) fn refresh_digest(raw: String) -> String {
+    let digest = tagged_sha256(without_string_field(raw.as_str(), "view_digest").as_str());
+    replace_string_field(raw.as_str(), "view_digest", digest.as_str())
+}
+
+pub(crate) fn with_digest(raw: String, field: &str) -> String {
+    let digest = tagged_sha256(without_string_field(raw.as_str(), field).as_str());
+    replace_string_field(raw.as_str(), field, digest.as_str())
+}
+
+fn replace_string_field(raw: &str, field: &str, value: &str) -> String {
+    let marker = format!("\"{field}\":\"");
+    let start = raw
+        .find(marker.as_str())
+        .expect("digest field should exist")
+        + marker.len();
+    let end = raw[start..].find('"').expect("digest field should end");
+    format!("{}{}{}", &raw[..start], value, &raw[start + end..])
+}
+
+fn without_string_field(raw: &str, field: &str) -> String {
+    let marker = format!("\"{field}\":\"");
+    let start = raw
+        .find(marker.as_str())
+        .expect("digest field should exist");
+    let value_start = start + marker.len();
+    let end = value_start
+        + raw[value_start..]
+            .find('"')
+            .expect("digest field should end")
+        + 1;
+    remove_pair(raw, start, end)
+}
+
+fn remove_pair(raw: &str, start: usize, end: usize) -> String {
+    if raw[end..].starts_with(',') {
+        return format!("{}{}", &raw[..start], &raw[end + 1..]);
+    }
+    format!("{}{}", &raw[..start - 1], &raw[end..])
+}
+
+fn tagged_sha256(value: &str) -> String {
+    format!("sha256:{}", sha256_hex(value))
+}
+
+fn sha256_hex(value: &str) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let digest = Sha256::digest(value.as_bytes());
+    let mut output = String::with_capacity(64);
+    for byte in digest {
+        output.push(HEX[(byte >> 4) as usize] as char);
+        output.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    output
+}

--- a/crates/kamn-e2e-harness/tests/support/mvp_demo_command.rs
+++ b/crates/kamn-e2e-harness/tests/support/mvp_demo_command.rs
@@ -1,0 +1,63 @@
+use std::path::Path;
+
+use kamn_e2e_harness::MvpDemoCommandConfig;
+
+pub(crate) fn local_demo_config(temp: &Path) -> MvpDemoCommandConfig {
+    MvpDemoCommandConfig {
+        output_root: temp.display().to_string(),
+        devnet_mode: "optional".to_owned(),
+        solana_rpc_url: None,
+        devnet_settlement_command: None,
+        localhost_signed_demo_command: Some(stub_localhost_signed_demo_command()),
+        service_api_vertical_slice_command: Some(stub_service_api_command(
+            "integration_service_api_endpoint_working_vertical_slice_proves_delivery_dispatch_and_audit_evidence",
+        )),
+        service_api_websocket_command: Some(stub_service_api_command(
+            "integration_service_api_endpoint_websocket_upgrade_streams_state_transition_event",
+        )),
+        agent_harness_evidence_path: None,
+    }
+}
+
+pub(crate) fn devnet_required_demo_config(temp: &Path) -> MvpDemoCommandConfig {
+    let mut config = local_demo_config(temp);
+    config.devnet_mode = "required".to_owned();
+    config.solana_rpc_url = Some("https://api.devnet.solana.com".to_owned());
+    config.devnet_settlement_command = Some(stub_devnet_settlement_command());
+    config
+}
+
+fn stub_localhost_signed_demo_command() -> Vec<String> {
+    vec![
+        "sh".to_owned(),
+        "-c".to_owned(),
+        r#"cat > "$2" <<'JSON'
+{"schema_version":"kamn.sdk.localhost-signed.demo-receipt-artifact.v1","status": "pass","signed_exchange":{"from":"kamn:did:agent:alice","to":"kamn:did:agent:bob","verified": true},"signed_flow":"task"}
+JSON
+echo "receipt_reconciliation=GO"
+echo "localhost signed message demo completed."
+"#
+        .to_owned(),
+        "kamn-mvp-stub".to_owned(),
+    ]
+}
+
+fn stub_service_api_command(test_name: &str) -> Vec<String> {
+    vec![
+        "sh".to_owned(),
+        "-c".to_owned(),
+        format!(r#"echo "test {test_name} ... ok"; echo "test result: ok""#),
+    ]
+}
+
+fn stub_devnet_settlement_command() -> Vec<String> {
+    vec![
+        "sh".to_owned(),
+        "-c".to_owned(),
+        r#"cat <<'JSON'
+{"network":"solana:devnet","rpc_url":"https://api.devnet.solana.com","payer_pubkey":"2FjUiacAXtokhA8YzGiyfVEdu5D9LxKFhjptJLrz4V9T","recipient_pubkey":"FV5LvudLjZQGCrPwXUY2JaVr26sQE15K25BGvsKWvyFe","lamports":1000000,"settlement_tx_signature":"devnet-signature-111","settlement_commitment":"finalized","payer_balance_before":2500000000,"payer_balance_after":2498995000,"recipient_balance_before":2500000000,"recipient_balance_after":2501000000,"persisted_settlement_tx_signature":"devnet-signature-111"}
+JSON
+"#
+        .to_owned(),
+    ]
+}

--- a/crates/kamn-e2e-harness/tests/support/three_agent_view_artifacts.rs
+++ b/crates/kamn-e2e-harness/tests/support/three_agent_view_artifacts.rs
@@ -1,7 +1,10 @@
 use std::path::{Path, PathBuf};
 
+#[path = "artifact_digest.rs"]
+mod artifact_digest;
+
 use crate::mvp_local_artifacts;
-use sha2::{Digest, Sha256};
+use artifact_digest::{digest_field, refresh_digest, with_digest};
 
 const SIGNATURE: &str = "5nSgnDevnetSignature111111111111111111111111111";
 
@@ -29,21 +32,11 @@ pub(crate) fn write_transcript(root: &Path, transcript: String) {
 pub(crate) fn write_view_artifacts(root: &Path, agent_c: Option<String>) {
     mvp_local_artifacts::write_file(
         root.join("proof/agent-a-view.json").as_path(),
-        participant_view(
-            "agent_a",
-            "agent-a-private-digest-7060",
-            "agent-a-view-digest-7060",
-        )
-        .as_str(),
+        participant_view("agent_a", "agent-a-private-digest-7060").as_str(),
     );
     mvp_local_artifacts::write_file(
         root.join("proof/agent-b-view.json").as_path(),
-        participant_view(
-            "agent_b",
-            "agent-b-private-digest-7060",
-            "agent-b-view-digest-7060",
-        )
-        .as_str(),
+        participant_view("agent_b", "agent-b-private-digest-7060").as_str(),
     );
     mvp_local_artifacts::write_file(
         root.join("proof/agent-c-verifier-view.json").as_path(),
@@ -104,19 +97,11 @@ pub(crate) fn agent_c_short_identity_view() -> String {
 }
 
 pub(crate) fn agent_a_mismatched_identity_view() -> String {
-    participant_view(
-        "agent_b",
-        "agent-a-private-digest-7060",
-        "agent-a-view-digest-7060",
-    )
+    participant_view("agent_b", "agent-a-private-digest-7060")
 }
 
 pub(crate) fn agent_b_mismatched_identity_view() -> String {
-    participant_view(
-        "agent_a",
-        "agent-b-private-digest-7060",
-        "agent-b-view-digest-7060",
-    )
+    participant_view("agent_a", "agent-b-private-digest-7060")
 }
 
 fn artifacts_json(root: &Path, views_root: Option<&Path>) -> String {
@@ -151,16 +136,8 @@ fn three_agent_claim(root: &Path, views_root: Option<&Path>) -> String {
 }
 
 fn shared_view_fields(root: &Path) -> String {
-    let agent_a = participant_view(
-        "agent_a",
-        "agent-a-private-digest-7060",
-        "agent-a-view-digest-7060",
-    );
-    let agent_b = participant_view(
-        "agent_b",
-        "agent-b-private-digest-7060",
-        "agent-b-view-digest-7060",
-    );
+    let agent_a = participant_view("agent_a", "agent-a-private-digest-7060");
+    let agent_b = participant_view("agent_b", "agent-b-private-digest-7060");
     let agent_c = agent_c_public_view();
     format!(
         r#","agent_a_view_artifact":"{}","agent_b_view_artifact":"{}","agent_c_verifier_view_artifact":"{}","agent_a_view_digest":"{}","agent_b_view_digest":"{}","agent_c_verifier_view_digest":"{}""#,
@@ -173,7 +150,7 @@ fn shared_view_fields(root: &Path) -> String {
     )
 }
 
-fn participant_view(agent: &str, private_digest: &str, _view_digest: &str) -> String {
+fn participant_view(agent: &str, private_digest: &str) -> String {
     with_digest(
         format!(
             r#"{{"schema_version":"kamn.mvp.three-agent-view.v1","agent":"{}","view_scope":"participant-private","transaction_id":"tx-three-agent-7060","escrow_id":"escrow-three-agent-7060","settlement_tx_signature":"{}","amount_lamports":1,"payer_pubkey":"payer111111111111111111111111111111111111111","recipient_pubkey":"recipient11111111111111111111111111111111111","settlement_commitment":"finalized","private_field_count":3,"participant_private_view_digest":"{}","public_view_digest":"public-view-digest-7060","private_payload_redacted":true,"view_digest":""}}"#,
@@ -203,71 +180,4 @@ fn roadmap_claim() -> &'static str {
 
 fn transcript_digest(views_root: Option<&Path>) -> String {
     digest_field(transcript(views_root).as_str(), "transcript_digest")
-}
-
-fn refresh_digest(raw: String) -> String {
-    let without_digest = without_string_field(raw.as_str(), "view_digest");
-    let digest = tagged_sha256(without_digest.as_str());
-    replace_string_field(raw.as_str(), "view_digest", digest.as_str())
-}
-
-fn with_digest(raw: String, field: &str) -> String {
-    let digest = tagged_sha256(without_string_field(raw.as_str(), field).as_str());
-    replace_string_field(raw.as_str(), field, digest.as_str())
-}
-
-fn digest_field(raw: &str, field: &str) -> String {
-    let marker = format!("\"{field}\":\"");
-    let start = raw
-        .find(marker.as_str())
-        .expect("digest field should exist")
-        + marker.len();
-    let end = raw[start..].find('"').expect("digest field should end");
-    raw[start..start + end].to_owned()
-}
-
-fn replace_string_field(raw: &str, field: &str, value: &str) -> String {
-    let marker = format!("\"{field}\":\"");
-    let start = raw
-        .find(marker.as_str())
-        .expect("digest field should exist")
-        + marker.len();
-    let end = raw[start..].find('"').expect("digest field should end");
-    format!("{}{}{}", &raw[..start], value, &raw[start + end..])
-}
-
-fn without_string_field(raw: &str, field: &str) -> String {
-    let marker = format!("\"{field}\":\"");
-    let start = raw
-        .find(marker.as_str())
-        .expect("digest field should exist");
-    let value_start = start + marker.len();
-    let end = value_start
-        + raw[value_start..]
-            .find('"')
-            .expect("digest field should end")
-        + 1;
-    remove_pair(raw, start, end)
-}
-
-fn remove_pair(raw: &str, start: usize, end: usize) -> String {
-    if raw[end..].starts_with(',') {
-        return format!("{}{}", &raw[..start], &raw[end + 1..]);
-    }
-    format!("{}{}", &raw[..start - 1], &raw[end..])
-}
-
-fn tagged_sha256(value: &str) -> String {
-    format!("sha256:{}", sha256_hex(value))
-}
-
-fn sha256_hex(value: &str) -> String {
-    const HEX: &[u8; 16] = b"0123456789abcdef";
-    let digest = Sha256::digest(value.as_bytes());
-    let mut output = String::with_capacity(64);
-    for byte in digest {
-        output.push(HEX[(byte >> 4) as usize] as char);
-        output.push(HEX[(byte & 0x0f) as usize] as char);
-    }
-    output
 }

--- a/crates/kamn-e2e-harness/tests/support/three_agent_view_artifacts.rs
+++ b/crates/kamn-e2e-harness/tests/support/three_agent_view_artifacts.rs
@@ -1,6 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use crate::mvp_local_artifacts;
+use sha2::{Digest, Sha256};
 
 const SIGNATURE: &str = "5nSgnDevnetSignature111111111111111111111111111";
 
@@ -76,25 +77,30 @@ pub(crate) fn report_json(root: &Path, views_root: Option<&Path>) -> String {
 }
 
 pub(crate) fn transcript(views_root: Option<&Path>) -> String {
-    format!(
-        r#"{{"schema_version":"kamn.mvp.three-agent-transcript.v1","proof_label":"local-only","devnet_settlement_linked":true,"transaction_id":"tx-three-agent-7060","escrow_id":"escrow-three-agent-7060","steps":["agent_a_registered","agent_b_registered","agent_a_invoked_transaction","agent_b_accepted_task","escrow_funded","escrow_released","agent_c_verifier_verified"],"views":{{"agent_a":"participant-private","agent_b":"participant-private","agent_c_verifier":"restricted-public"}},"agent_a_private_field_count":3,"agent_b_private_field_count":3,"verifier_private_field_count":0,"private_payload_redacted":true,"settlement_tx_signature":"5nSgnDevnetSignature111111111111111111111111111","amount_lamports":1,"payer_pubkey":"payer111111111111111111111111111111111111111","recipient_pubkey":"recipient11111111111111111111111111111111111","settlement_commitment":"finalized","transcript_digest":"three-agent-transcript-digest-7060"{} }}"#,
-        views_root.map(shared_view_fields).unwrap_or_default()
+    with_digest(
+        format!(
+            r#"{{"schema_version":"kamn.mvp.three-agent-transcript.v1","proof_label":"local-only","devnet_settlement_linked":true,"transaction_id":"tx-three-agent-7060","escrow_id":"escrow-three-agent-7060","steps":["agent_a_registered","agent_b_registered","agent_a_invoked_transaction","agent_b_accepted_task","escrow_funded","escrow_released","agent_c_verifier_verified"],"views":{{"agent_a":"participant-private","agent_b":"participant-private","agent_c_verifier":"restricted-public"}},"agent_a_private_field_count":3,"agent_b_private_field_count":3,"verifier_private_field_count":0,"private_payload_redacted":true,"settlement_tx_signature":"5nSgnDevnetSignature111111111111111111111111111","amount_lamports":1,"payer_pubkey":"payer111111111111111111111111111111111111111","recipient_pubkey":"recipient11111111111111111111111111111111111","settlement_commitment":"finalized","transcript_digest":""{} }}"#,
+            views_root.map(shared_view_fields).unwrap_or_default()
+        ),
+        "transcript_digest",
     )
 }
 
 pub(crate) fn agent_c_private_view() -> String {
-    agent_c_public_view().replace(
+    refresh_digest(agent_c_public_view().replace(
         r#""view_scope":"restricted-public""#,
         r#""view_scope":"participant-private","participant_private_view_digest":"leaked""#,
-    )
+    ))
 }
 
 pub(crate) fn agent_c_mismatched_signature_view() -> String {
-    agent_c_public_view().replace(SIGNATURE, "mismatch")
+    refresh_digest(agent_c_public_view().replace(SIGNATURE, "mismatch"))
 }
 
 pub(crate) fn agent_c_short_identity_view() -> String {
-    agent_c_public_view().replace(r#""agent":"agent_c_verifier""#, r#""agent":"agent_c""#)
+    refresh_digest(
+        agent_c_public_view().replace(r#""agent":"agent_c_verifier""#, r#""agent":"agent_c""#),
+    )
 }
 
 pub(crate) fn agent_a_mismatched_identity_view() -> String {
@@ -137,32 +143,53 @@ fn devnet_settlement_claim() -> &'static str {
 
 fn three_agent_claim(root: &Path, views_root: Option<&Path>) -> String {
     format!(
-        r#"{{"id":"three_agent_escrow_verification","label":"devnet-backed","required":true,"status":"PASS","summary":"Agent C verifies escrow settlement from restricted proof view","three_agent_transcript_artifact":"{}","three_agent_transcript_digest":"three-agent-transcript-digest-7060","transaction_id":"tx-three-agent-7060","terms_digest":"terms-digest-7060","agent_a_terms_digest":"terms-digest-7060","agent_b_terms_digest":"terms-digest-7060","verifier_terms_digest":"terms-digest-7060","escrow_id":"escrow-three-agent-7060","agent_a_escrow_id":"escrow-three-agent-7060","agent_b_escrow_id":"escrow-three-agent-7060","verifier_escrow_id":"escrow-three-agent-7060","network":"solana:devnet","rpc_url":"https://api.devnet.solana.com","payer_pubkey":"payer111111111111111111111111111111111111111","recipient_pubkey":"recipient11111111111111111111111111111111111","lamports":1,"settlement_tx_signature":"5nSgnDevnetSignature111111111111111111111111111","agent_a_settlement_tx_signature":"5nSgnDevnetSignature111111111111111111111111111","agent_b_settlement_tx_signature":"5nSgnDevnetSignature111111111111111111111111111","verifier_settlement_tx_signature":"5nSgnDevnetSignature111111111111111111111111111","settlement_commitment":"finalized","agent_a_settlement_commitment":"finalized","agent_b_settlement_commitment":"finalized","verifier_settlement_commitment":"finalized","payer_balance_before":20,"payer_balance_after":19,"recipient_balance_before":10,"recipient_balance_after":11,"persisted_settlement_tx_signature":"5nSgnDevnetSignature111111111111111111111111111","amount_lamports":1,"agent_a_amount_lamports":1,"agent_b_amount_lamports":1,"verifier_amount_lamports":1,"agent_a_private_view_visible":true,"agent_b_private_view_visible":true,"verifier_private_view_visible":false,"agent_a_view_scope":"participant-private","agent_b_view_scope":"participant-private","verifier_view_scope":"restricted-public","agent_a_private_field_count":3,"agent_b_private_field_count":3,"verifier_private_field_count":0,"agent_a_private_view_digest":"agent-a-private-digest-7060","agent_b_private_view_digest":"agent-b-private-digest-7060","agent_a_public_view_digest":"public-view-digest-7060","agent_b_public_view_digest":"public-view-digest-7060","verifier_public_view_digest":"public-view-digest-7060","private_payload_redacted":true{}}}"#,
+        r#"{{"id":"three_agent_escrow_verification","label":"devnet-backed","required":true,"status":"PASS","summary":"Agent C verifies escrow settlement from restricted proof view","three_agent_transcript_artifact":"{}","three_agent_transcript_digest":"{}","transaction_id":"tx-three-agent-7060","terms_digest":"terms-digest-7060","agent_a_terms_digest":"terms-digest-7060","agent_b_terms_digest":"terms-digest-7060","verifier_terms_digest":"terms-digest-7060","escrow_id":"escrow-three-agent-7060","agent_a_escrow_id":"escrow-three-agent-7060","agent_b_escrow_id":"escrow-three-agent-7060","verifier_escrow_id":"escrow-three-agent-7060","network":"solana:devnet","rpc_url":"https://api.devnet.solana.com","payer_pubkey":"payer111111111111111111111111111111111111111","recipient_pubkey":"recipient11111111111111111111111111111111111","lamports":1,"settlement_tx_signature":"5nSgnDevnetSignature111111111111111111111111111","agent_a_settlement_tx_signature":"5nSgnDevnetSignature111111111111111111111111111","agent_b_settlement_tx_signature":"5nSgnDevnetSignature111111111111111111111111111","verifier_settlement_tx_signature":"5nSgnDevnetSignature111111111111111111111111111","settlement_commitment":"finalized","agent_a_settlement_commitment":"finalized","agent_b_settlement_commitment":"finalized","verifier_settlement_commitment":"finalized","payer_balance_before":20,"payer_balance_after":19,"recipient_balance_before":10,"recipient_balance_after":11,"persisted_settlement_tx_signature":"5nSgnDevnetSignature111111111111111111111111111","amount_lamports":1,"agent_a_amount_lamports":1,"agent_b_amount_lamports":1,"verifier_amount_lamports":1,"agent_a_private_view_visible":true,"agent_b_private_view_visible":true,"verifier_private_view_visible":false,"agent_a_view_scope":"participant-private","agent_b_view_scope":"participant-private","verifier_view_scope":"restricted-public","agent_a_private_field_count":3,"agent_b_private_field_count":3,"verifier_private_field_count":0,"agent_a_private_view_digest":"agent-a-private-digest-7060","agent_b_private_view_digest":"agent-b-private-digest-7060","agent_a_public_view_digest":"public-view-digest-7060","agent_b_public_view_digest":"public-view-digest-7060","verifier_public_view_digest":"public-view-digest-7060","private_payload_redacted":true{}}}"#,
         root.join("proof/three-agent-transcript.json").display(),
+        transcript_digest(views_root),
         views_root.map(shared_view_fields).unwrap_or_default()
     )
 }
 
 fn shared_view_fields(root: &Path) -> String {
+    let agent_a = participant_view(
+        "agent_a",
+        "agent-a-private-digest-7060",
+        "agent-a-view-digest-7060",
+    );
+    let agent_b = participant_view(
+        "agent_b",
+        "agent-b-private-digest-7060",
+        "agent-b-view-digest-7060",
+    );
+    let agent_c = agent_c_public_view();
     format!(
-        r#","agent_a_view_artifact":"{}","agent_b_view_artifact":"{}","agent_c_verifier_view_artifact":"{}","agent_a_view_digest":"agent-a-view-digest-7060","agent_b_view_digest":"agent-b-view-digest-7060","agent_c_verifier_view_digest":"agent-c-view-digest-7060""#,
+        r#","agent_a_view_artifact":"{}","agent_b_view_artifact":"{}","agent_c_verifier_view_artifact":"{}","agent_a_view_digest":"{}","agent_b_view_digest":"{}","agent_c_verifier_view_digest":"{}""#,
         root.join("proof/agent-a-view.json").display(),
         root.join("proof/agent-b-view.json").display(),
-        root.join("proof/agent-c-verifier-view.json").display()
+        root.join("proof/agent-c-verifier-view.json").display(),
+        digest_field(agent_a.as_str(), "view_digest"),
+        digest_field(agent_b.as_str(), "view_digest"),
+        digest_field(agent_c.as_str(), "view_digest"),
     )
 }
 
-fn participant_view(agent: &str, private_digest: &str, view_digest: &str) -> String {
-    format!(
-        r#"{{"schema_version":"kamn.mvp.three-agent-view.v1","agent":"{}","view_scope":"participant-private","transaction_id":"tx-three-agent-7060","escrow_id":"escrow-three-agent-7060","settlement_tx_signature":"{}","amount_lamports":1,"payer_pubkey":"payer111111111111111111111111111111111111111","recipient_pubkey":"recipient11111111111111111111111111111111111","settlement_commitment":"finalized","private_field_count":3,"participant_private_view_digest":"{}","public_view_digest":"public-view-digest-7060","private_payload_redacted":true,"view_digest":"{}"}}"#,
-        agent, SIGNATURE, private_digest, view_digest
+fn participant_view(agent: &str, private_digest: &str, _view_digest: &str) -> String {
+    with_digest(
+        format!(
+            r#"{{"schema_version":"kamn.mvp.three-agent-view.v1","agent":"{}","view_scope":"participant-private","transaction_id":"tx-three-agent-7060","escrow_id":"escrow-three-agent-7060","settlement_tx_signature":"{}","amount_lamports":1,"payer_pubkey":"payer111111111111111111111111111111111111111","recipient_pubkey":"recipient11111111111111111111111111111111111","settlement_commitment":"finalized","private_field_count":3,"participant_private_view_digest":"{}","public_view_digest":"public-view-digest-7060","private_payload_redacted":true,"view_digest":""}}"#,
+            agent, SIGNATURE, private_digest
+        ),
+        "view_digest",
     )
 }
 
 fn agent_c_public_view() -> String {
-    format!(
-        r#"{{"schema_version":"kamn.mvp.three-agent-view.v1","agent":"agent_c_verifier","view_scope":"restricted-public","transaction_id":"tx-three-agent-7060","escrow_id":"escrow-three-agent-7060","settlement_tx_signature":"{}","amount_lamports":1,"payer_pubkey":"payer111111111111111111111111111111111111111","recipient_pubkey":"recipient11111111111111111111111111111111111","settlement_commitment":"finalized","private_field_count":0,"public_view_digest":"public-view-digest-7060","private_payload_redacted":true,"view_digest":"agent-c-view-digest-7060"}}"#,
-        SIGNATURE
+    with_digest(
+        format!(
+            r#"{{"schema_version":"kamn.mvp.three-agent-view.v1","agent":"agent_c_verifier","view_scope":"restricted-public","transaction_id":"tx-three-agent-7060","escrow_id":"escrow-three-agent-7060","settlement_tx_signature":"{}","amount_lamports":1,"payer_pubkey":"payer111111111111111111111111111111111111111","recipient_pubkey":"recipient11111111111111111111111111111111111","settlement_commitment":"finalized","private_field_count":0,"public_view_digest":"public-view-digest-7060","private_payload_redacted":true,"view_digest":""}}"#,
+            SIGNATURE
+        ),
+        "view_digest",
     )
 }
 
@@ -172,4 +199,75 @@ fn local_claims() -> &'static str {
 
 fn roadmap_claim() -> &'static str {
     r#"{"id":"production_readiness","label":"roadmap","required":false,"status":"NOT_CLAIMED","summary":"production readiness is not claimed"}"#
+}
+
+fn transcript_digest(views_root: Option<&Path>) -> String {
+    digest_field(transcript(views_root).as_str(), "transcript_digest")
+}
+
+fn refresh_digest(raw: String) -> String {
+    let without_digest = without_string_field(raw.as_str(), "view_digest");
+    let digest = tagged_sha256(without_digest.as_str());
+    replace_string_field(raw.as_str(), "view_digest", digest.as_str())
+}
+
+fn with_digest(raw: String, field: &str) -> String {
+    let digest = tagged_sha256(without_string_field(raw.as_str(), field).as_str());
+    replace_string_field(raw.as_str(), field, digest.as_str())
+}
+
+fn digest_field(raw: &str, field: &str) -> String {
+    let marker = format!("\"{field}\":\"");
+    let start = raw
+        .find(marker.as_str())
+        .expect("digest field should exist")
+        + marker.len();
+    let end = raw[start..].find('"').expect("digest field should end");
+    raw[start..start + end].to_owned()
+}
+
+fn replace_string_field(raw: &str, field: &str, value: &str) -> String {
+    let marker = format!("\"{field}\":\"");
+    let start = raw
+        .find(marker.as_str())
+        .expect("digest field should exist")
+        + marker.len();
+    let end = raw[start..].find('"').expect("digest field should end");
+    format!("{}{}{}", &raw[..start], value, &raw[start + end..])
+}
+
+fn without_string_field(raw: &str, field: &str) -> String {
+    let marker = format!("\"{field}\":\"");
+    let start = raw
+        .find(marker.as_str())
+        .expect("digest field should exist");
+    let value_start = start + marker.len();
+    let end = value_start
+        + raw[value_start..]
+            .find('"')
+            .expect("digest field should end")
+        + 1;
+    remove_pair(raw, start, end)
+}
+
+fn remove_pair(raw: &str, start: usize, end: usize) -> String {
+    if raw[end..].starts_with(',') {
+        return format!("{}{}", &raw[..start], &raw[end + 1..]);
+    }
+    format!("{}{}", &raw[..start - 1], &raw[end..])
+}
+
+fn tagged_sha256(value: &str) -> String {
+    format!("sha256:{}", sha256_hex(value))
+}
+
+fn sha256_hex(value: &str) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let digest = Sha256::digest(value.as_bytes());
+    let mut output = String::with_capacity(64);
+    for byte in digest {
+        output.push(HEX[(byte >> 4) as usize] as char);
+        output.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    output
 }

--- a/specs/7068-bind-three-agent-artifact-digests.md
+++ b/specs/7068-bind-three-agent-artifact-digests.md
@@ -49,19 +49,19 @@ Outputs:
 
 ## Acceptance Criteria
 
-- [ ] `verify-mvp-demo` rejects transcript content tampering when the report's
+- [x] `verify-mvp-demo` rejects transcript content tampering when the report's
   `three_agent_transcript_digest` remains stale.
-- [ ] `verify-mvp-demo` rejects Agent A view content tampering when
+- [x] `verify-mvp-demo` rejects Agent A view content tampering when
   `agent_a_view_digest` remains stale.
-- [ ] `verify-mvp-demo` rejects Agent B view content tampering when
+- [x] `verify-mvp-demo` rejects Agent B view content tampering when
   `agent_b_view_digest` remains stale.
-- [ ] `verify-mvp-demo` rejects Agent C verifier view content tampering when
+- [x] `verify-mvp-demo` rejects Agent C verifier view content tampering when
   `agent_c_verifier_view_digest` remains stale.
-- [ ] Generated MVP reports write `sha256:<hex>` values for transcript and
+- [x] Generated MVP reports write `sha256:<hex>` values for transcript and
   per-agent view digest claims.
-- [ ] Embedded transcript/view digest fields match the same recomputed digest
+- [x] Embedded transcript/view digest fields match the same recomputed digest
   values expected by the report claim.
-- [ ] Existing three-agent disclosure boundaries, devnet settlement evidence,
+- [x] Existing three-agent disclosure boundaries, devnet settlement evidence,
   Pi actor receipt evidence, local artifact binding, formatting, strict clippy,
   and `make check` remain green.
 
@@ -133,3 +133,82 @@ Integration:
 - Run local `make demo-mvp` and canonical `verify-mvp-demo`.
 - Run the devnet-required demo and canonical verifier, or record explicit
   external NO-GO evidence if Solana devnet is unavailable.
+
+## Completion Evidence
+
+- Spec checkpoint:
+  - Issue: #7068.
+  - Spec: `specs/7068-bind-three-agent-artifact-digests.md`.
+- Red tests:
+  - `mvp_demo_command_contract::spec_c06_demo_mvp_devnet_required_records_settlement_evidence`
+    failed because generated digest claims were not `sha256:` values.
+  - `mvp_demo_three_agent_view_artifact_contract` failed stale digest tests for
+    Agent A, Agent B, and Agent C verifier views because tampered artifacts
+    still verified.
+  - `mvp_demo_three_agent_transcript_contract::spec_c05_command_rejects_stale_transcript_digest_after_content_tamper`
+    failed because a tampered transcript still verified.
+- Green/refactor focused tests:
+  - `CARGO_TARGET_DIR=target/mvp-demo-proof CARGO_BUILD_JOBS=1
+    CARGO_INCREMENTAL=0 cargo test -p kamn-e2e-harness --test
+    mvp_demo_three_agent_view_artifact_contract --test
+    mvp_demo_three_agent_view_digest_contract --test
+    mvp_demo_three_agent_transcript_contract --test
+    mvp_demo_command_contract -- --nocapture`
+  - Result: 20 passed.
+- Broader MVP proof matrix:
+  - `CARGO_TARGET_DIR=target/mvp-demo-proof CARGO_BUILD_JOBS=1
+    CARGO_INCREMENTAL=0 cargo test -p kamn-e2e-harness --test
+    mvp_demo_three_agent_view_artifact_contract --test
+    mvp_demo_three_agent_view_digest_contract --test
+    mvp_demo_three_agent_claim_contract --test
+    mvp_demo_three_agent_transcript_contract --test
+    mvp_demo_agent_harness_claim_contract --test
+    mvp_demo_local_artifact_contract --test mvp_demo_claim_contract --test
+    mvp_demo_command_contract --test mvp_evaluator_demo_runbook_contract --
+    --nocapture`
+  - Result: 64 passed.
+- Local quality gates:
+  - `cargo fmt --check`
+  - `CARGO_TARGET_DIR=target/mvp-demo-proof CARGO_BUILD_JOBS=1
+    CARGO_INCREMENTAL=0 cargo clippy --workspace --all-targets
+    --all-features -- -D warnings`
+  - `CARGO_TARGET_DIR=target/mvp-demo-proof CARGO_BUILD_JOBS=1
+    CARGO_INCREMENTAL=0 make check`
+- Local optional demo:
+  - `CARGO_TARGET_DIR=target/mvp-demo-proof CARGO_BUILD_JOBS=1
+    CARGO_INCREMENTAL=0 make demo-mvp`
+  - Result: `GO`, `devnet_mode=optional`, local-only MVP claims passed, and
+    no devnet settlement or three-agent settlement claim was made.
+  - Canonical verifier passed for `.kamn/demo/latest/proof/report.json`.
+- Devnet-backed demo:
+  - `KAMN_MVP_DEVNET_MODE=required
+    KAMN_MVP_SOLANA_RPC_URL=https://api.devnet.solana.com
+    KAMN_SERVICE_API_LIVE_SOLANA_BRIDGE_RPC_URL=https://api.devnet.solana.com
+    KAMN_SERVICE_API_LIVE_SOLANA_SETTLEMENT_KEYPAIR_FILE=/Users/n/.config/solana/ted-dev.json
+    KAMN_SERVICE_API_LIVE_SOLANA_SETTLEMENT_RECIPIENT_PUBKEY=BSN17KC1c5kUuA7ZaTXvMUnFbZUhizeaisYcAFeTsbEb
+    KAMN_SERVICE_API_LIVE_SOLANA_SETTLEMENT_LAMPORTS=1000000
+    KAMN_SERVICE_API_LIVE_SOLANA_SETTLEMENT_COMMITMENT=finalized
+    CARGO_TARGET_DIR=target/mvp-demo-proof CARGO_BUILD_JOBS=1
+    CARGO_INCREMENTAL=0 make demo-mvp`
+  - Result: `GO`, `devnet_settlement_asset_movement=devnet-backed`, and
+    `three_agent_escrow_verification=devnet-backed`.
+  - Settlement signature:
+    `2NrcVDZpuSSjveRdqbwnGj6SWCEUkzS8hZhNikSq5LNty882ydoK4Sa2ZWC99CYDfeTaXxXVGQjX24zWt9etnLsr`.
+  - `solana confirm -v --url https://api.devnet.solana.com
+    2NrcVDZpuSSjveRdqbwnGj6SWCEUkzS8hZhNikSq5LNty882ydoK4Sa2ZWC99CYDfeTaXxXVGQjX24zWt9etnLsr`
+  - Result: finalized transfer of 1,000,000 lamports from
+    `Ew2NpaFAK2TbUkbUMV54JN1gURSKkLWEypk5v9kJR7XU` to
+    `BSN17KC1c5kUuA7ZaTXvMUnFbZUhizeaisYcAFeTsbEb`.
+  - Canonical verifier passed for `.kamn/demo/latest/proof/report.json`.
+  - Generated transcript and Agent A/B/C verifier view digest claims were
+    `sha256:<hex>` values.
+  - Generated Agent C verifier view reported `agent=agent_c_verifier`,
+    `view_scope=restricted-public`, `private_field_count=0`, and no
+    `participant_private_view_digest`.
+
+## Deviations
+
+- The spec focused on report, transcript, and view artifacts. During
+  integration, the Pi/agent-harness actor rehearsal and actor receipt fixtures
+  also had to move from marker digests to computed artifact digests so the
+  broader MVP proof matrix stayed wired to the same verifier semantics.

--- a/specs/7068-bind-three-agent-artifact-digests.md
+++ b/specs/7068-bind-three-agent-artifact-digests.md
@@ -1,0 +1,135 @@
+# 7068 Bind Three-Agent Artifact Digests
+
+## Objective
+
+Make the MVP three-agent proof bind transcript and per-agent view digest claims
+to verifier-computed SHA-256 hashes over the generated artifact content. The
+demo should continue to prove the same local/devnet story, but digest fields
+must become tamper-evident instead of run-id marker strings.
+
+## Inputs/Outputs
+
+Inputs:
+- MVP proof report JSON.
+- `three_agent_escrow_verification` claim when present.
+- Three-agent transcript artifact.
+- Agent A, Agent B, and Agent C verifier view artifact files.
+
+Outputs:
+- Generated `sha256:<hex>` digests for `three_agent_transcript_digest`,
+  `agent_a_view_digest`, `agent_b_view_digest`, and
+  `agent_c_verifier_view_digest`.
+- Verifier failures when transcript or view artifact content changes without a
+  matching report claim update.
+- Verifier failures when embedded digest fields do not match the
+  self-reference-safe digest over their artifact payload.
+
+## Boundaries/Non-goals
+
+- Do not build new escrow, settlement, exchange, or runtime architecture.
+- Do not change Solana devnet settlement execution or keypair handling.
+- Do not broaden production readiness, mainnet, or asset-movement claims.
+- Do not expose participant-private material to the Agent C verifier view.
+- Do not weaken local-only/devnet-backed/dry-run/placeholder claim labels.
+- Do not add a new third-party crate; reuse existing workspace hashing surface
+  or existing workspace dependencies only.
+
+## Failure Modes
+
+- A generated report still uses marker strings such as
+  `agent-a-view-digest-<run_id>`.
+- `verify-mvp-demo` accepts a transcript artifact with changed content while
+  `three_agent_transcript_digest` remains stale.
+- `verify-mvp-demo` accepts an Agent A, Agent B, or Agent C verifier view
+  artifact with changed content while its report digest remains stale.
+- Hash computation includes the digest field value itself and becomes
+  impossible to reproduce without self-reference ambiguity.
+- View hash enforcement accidentally requires Agent C to expose participant
+  private digests.
+
+## Acceptance Criteria
+
+- [ ] `verify-mvp-demo` rejects transcript content tampering when the report's
+  `three_agent_transcript_digest` remains stale.
+- [ ] `verify-mvp-demo` rejects Agent A view content tampering when
+  `agent_a_view_digest` remains stale.
+- [ ] `verify-mvp-demo` rejects Agent B view content tampering when
+  `agent_b_view_digest` remains stale.
+- [ ] `verify-mvp-demo` rejects Agent C verifier view content tampering when
+  `agent_c_verifier_view_digest` remains stale.
+- [ ] Generated MVP reports write `sha256:<hex>` values for transcript and
+  per-agent view digest claims.
+- [ ] Embedded transcript/view digest fields match the same recomputed digest
+  values expected by the report claim.
+- [ ] Existing three-agent disclosure boundaries, devnet settlement evidence,
+  Pi actor receipt evidence, local artifact binding, formatting, strict clippy,
+  and `make check` remain green.
+
+## Files To Touch
+
+- `crates/kamn-e2e-harness/Cargo.toml`
+- `crates/kamn-e2e-harness/src/mvp_demo/mod.rs`
+- `crates/kamn-e2e-harness/src/mvp_demo/artifact_digest.rs`
+- `crates/kamn-e2e-harness/src/mvp_demo/report.rs`
+- `crates/kamn-e2e-harness/src/mvp_demo/runner.rs`
+- `crates/kamn-e2e-harness/src/mvp_demo/three_agent_claim.rs`
+- `crates/kamn-e2e-harness/src/mvp_demo/three_agent_transcript.rs`
+- `crates/kamn-e2e-harness/src/mvp_demo/three_agent_transcript_build.rs`
+- `crates/kamn-e2e-harness/src/mvp_demo/three_agent_view_artifacts.rs`
+- `crates/kamn-e2e-harness/src/mvp_demo/three_agent_views.rs`
+- `crates/kamn-e2e-harness/tests/mvp_demo_three_agent_transcript_contract.rs`
+- `crates/kamn-e2e-harness/tests/mvp_demo_three_agent_view_artifact_contract.rs`
+- `crates/kamn-e2e-harness/tests/support/three_agent_view_artifacts.rs`
+- `specs/7068-bind-three-agent-artifact-digests.md`
+
+## Error Semantics
+
+- Missing or malformed digest fields fail closed with explicit `Err(String)`
+  messages.
+- Digest comparison must use recomputed artifact digests, not only report and
+  artifact string equality.
+- The digest canonical payload excludes the embedded digest field being checked
+  (`transcript_digest` for the transcript and `view_digest` for a view) so the
+  verifier can recompute the value deterministically.
+- Any hash helper failure is a verifier failure. No fallback may convert an
+  invalid digest artifact into a passing proof.
+
+## Test Plan
+
+Red:
+- Add a transcript contract test that writes a valid report/transcript, appends
+  an otherwise ignored field to the transcript, keeps the original report
+  digest, and expects `verify-mvp-demo` to reject it.
+- Add Agent A, Agent B, and Agent C verifier view contract tests that mutate
+  otherwise ignored view content while keeping report digest claims stale and
+  expect `verify-mvp-demo` to reject each artifact.
+- Add generation contract coverage that requires the report digest claims to
+  start with `sha256:`.
+
+Green:
+- Add a small artifact digest helper for SHA-256 tagged digesting over artifact
+  JSON with one embedded digest field removed.
+- Generate view artifacts with `view_digest` equal to the canonical view
+  payload digest.
+- Generate the transcript after view artifacts exist and set
+  `transcript_digest` to the canonical transcript payload digest.
+- Pass the computed digest values into the report claim instead of deriving
+  marker strings from `run_id`.
+- Recompute and compare transcript/view digests during verifier validation.
+
+Refactor:
+- Keep digest helpers isolated from field-specific verifier logic.
+- Keep existing claim boundary checks and actor identity checks intact.
+- Split validation helpers if touched files exceed repo line-budget guidance.
+
+Integration:
+- Run `mvp_demo_three_agent_transcript_contract`.
+- Run `mvp_demo_three_agent_view_artifact_contract`.
+- Run the broader MVP proof contract matrix covering claims, transcript, local
+  artifacts, agent harness, command behavior, and evaluator runbook behavior.
+- Run `cargo fmt --check`.
+- Run strict workspace clippy.
+- Run `make check`.
+- Run local `make demo-mvp` and canonical `verify-mvp-demo`.
+- Run the devnet-required demo and canonical verifier, or record explicit
+  external NO-GO evidence if Solana devnet is unavailable.


### PR DESCRIPTION
## Human Summary

- Binds the MVP three-agent transcript and Agent A/B/C view digest claims to recomputed `sha256:<hex>` artifact content instead of run-id marker strings.
- Adds stale-digest verifier regressions for transcript tampering and all three per-agent view artifacts.
- Keeps Agent C verifier visibility restricted-public while preserving Agent A/B participant-private views.
- Updates Pi/agent-harness actor rehearsal and receipt fixtures to use the same digest semantics.

Closes #7068
Spec: specs/7068-bind-three-agent-artifact-digests.md

## Testing

- `cargo fmt --check`
- `CARGO_TARGET_DIR=target/mvp-demo-proof CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `CARGO_TARGET_DIR=target/mvp-demo-proof CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 make check`
- `CARGO_TARGET_DIR=target/mvp-demo-proof CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 cargo test -p kamn-e2e-harness --test mvp_demo_three_agent_view_artifact_contract --test mvp_demo_three_agent_view_digest_contract --test mvp_demo_three_agent_claim_contract --test mvp_demo_three_agent_transcript_contract --test mvp_demo_agent_harness_claim_contract --test mvp_demo_local_artifact_contract --test mvp_demo_claim_contract --test mvp_demo_command_contract --test mvp_evaluator_demo_runbook_contract -- --nocapture`
- `CARGO_TARGET_DIR=target/mvp-demo-proof CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 make demo-mvp`
- `CARGO_TARGET_DIR=target/mvp-demo-proof CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 cargo run -p kamn-e2e-harness -- verify-mvp-demo --report .kamn/demo/latest/proof/report.json`
- `KAMN_MVP_DEVNET_MODE=required KAMN_MVP_SOLANA_RPC_URL=https://api.devnet.solana.com KAMN_SERVICE_API_LIVE_SOLANA_BRIDGE_RPC_URL=https://api.devnet.solana.com KAMN_SERVICE_API_LIVE_SOLANA_SETTLEMENT_KEYPAIR_FILE=/Users/n/.config/solana/ted-dev.json KAMN_SERVICE_API_LIVE_SOLANA_SETTLEMENT_RECIPIENT_PUBKEY=BSN17KC1c5kUuA7ZaTXvMUnFbZUhizeaisYcAFeTsbEb KAMN_SERVICE_API_LIVE_SOLANA_SETTLEMENT_LAMPORTS=1000000 KAMN_SERVICE_API_LIVE_SOLANA_SETTLEMENT_COMMITMENT=finalized CARGO_TARGET_DIR=target/mvp-demo-proof CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 make demo-mvp`
- `solana confirm -v --url https://api.devnet.solana.com 2NrcVDZpuSSjveRdqbwnGj6SWCEUkzS8hZhNikSq5LNty882ydoK4Sa2ZWC99CYDfeTaXxXVGQjX24zWt9etnLsr`

## Notes for Reviewers

- The digest canonical payload excludes the embedded digest field itself (`transcript_digest` or `view_digest`) to avoid self-reference ambiguity.
- Devnet confirmation showed a finalized 1,000,000 lamport transfer from `Ew2NpaFAK2TbUkbUMV54JN1gURSKkLWEypk5v9kJR7XU` to `BSN17KC1c5kUuA7ZaTXvMUnFbZUhizeaisYcAFeTsbEb`.
- Agent C verifier view remains `restricted-public`, has `private_field_count=0`, and contains no `participant_private_view_digest`.

## AI Agent Details

- Added `mvp_demo/artifact_digest.rs` to compute tagged SHA-256 digests over JSON with one embedded digest field omitted.
- Added `mvp_demo/command_config.rs` to keep public command config docs and runner file size clean.
- Report generation now receives computed three-agent artifact digests instead of deriving digest labels from `run_id`.
- `verify-mvp-demo` now compares embedded digest fields to report claims and recomputes transcript/view artifact digests from artifact content.
- Static test fixtures for three-agent views, transcript, actor rehearsal, and actor receipts now compute digest values from fixture payloads.
