### PR TITLE
feat: verify Pi evidence against one canonical report

### DIFF
--- a/.pi/extensions/kamn-mvp/index.ts
+++ b/.pi/extensions/kamn-mvp/index.ts
@@ -23,13 +23,19 @@ function registerVerifyTool(pi: ExtensionAPI) {
 		name: "kamn_verify_mvp_report",
 		label: "KAMN Verify MVP",
 		description: "Run KAMN verify-mvp-demo against a local proof report.",
-		promptSnippet: "Verify a KAMN MVP proof report with the repo verifier",
-		parameters: Type.Object({ reportPath: Type.Optional(Type.String()) }),
+		promptSnippet: "Verify a KAMN MVP proof report and optional Pi evidence with the repo verifier",
+		parameters: Type.Object({
+			reportPath: Type.Optional(Type.String()),
+			agentHarnessEvidencePath: Type.Optional(Type.String()),
+		}),
 		async execute(_id, params, signal, _onUpdate, ctx) {
 			const reportPath = safeReportPath(ctx, params.reportPath).artifactPath;
-			const result = await proofExec(pi, ctx, verifyArgs(reportPath), signal);
+			const evidencePath = params.agentHarnessEvidencePath
+				? safeOutputPath(ctx, params.agentHarnessEvidencePath)
+				: undefined;
+			const result = await proofExec(pi, ctx, verifyArgs(reportPath, evidencePath), signal);
 			assertSuccess(result, "verify-mvp-demo");
-			return textResult("KAMN MVP report verifier passed.", { reportPath });
+			return textResult("KAMN MVP report verifier passed.", { reportPath, evidencePath });
 		},
 	});
 }
@@ -107,8 +113,9 @@ function registerDemoTool(pi: ExtensionAPI) {
 		},
 	});
 }
-function verifyArgs(reportPath: string): string[] {
-	return ["cargo", "run", "-p", "kamn-e2e-harness", "--", "verify-mvp-demo", "--report", reportPath];
+function verifyArgs(reportPath: string, evidencePath?: string): string[] {
+	const args = ["cargo", "run", "-p", "kamn-e2e-harness", "--", "verify-mvp-demo", "--report", reportPath];
+	return evidencePath ? [...args, "--agent-harness-evidence", evidencePath] : args;
 }
 function demoArgs(evidencePath: string): string[] {
 	return [`KAMN_MVP_AGENT_HARNESS_EVIDENCE=${evidencePath}`, "make", "demo-mvp"];

--- a/crates/kamn-e2e-harness/src/lib.rs
+++ b/crates/kamn-e2e-harness/src/lib.rs
@@ -460,6 +460,7 @@ fn parse_demo_mvp_command(args: &[String]) -> Result<HarnessCommand, String> {
 
 fn parse_verify_mvp_demo_command(args: &[String]) -> Result<HarnessCommand, String> {
     let mut report = None;
+    let mut agent_harness_evidence_path = None;
     let mut index = 1;
     while index < args.len() {
         let (parsed_report, advanced) = parse_flag_value(args, index, "--report")?;
@@ -468,11 +469,19 @@ fn parse_verify_mvp_demo_command(args: &[String]) -> Result<HarnessCommand, Stri
             index = advanced + 1;
             continue;
         }
+        let (parsed_evidence, advanced) =
+            parse_flag_value(args, index, "--agent-harness-evidence")?;
+        if let Some(value) = parsed_evidence {
+            agent_harness_evidence_path = Some(value);
+            index = advanced + 1;
+            continue;
+        }
         return Err(format!("unknown verify-mvp-demo flag: {}", args[index]));
     }
     let report = report.ok_or_else(|| "missing required flag --report".to_owned())?;
     Ok(HarnessCommand::VerifyMvpDemo(VerifyMvpDemoCommandConfig {
         report,
+        agent_harness_evidence_path,
     }))
 }
 

--- a/crates/kamn-e2e-harness/src/mvp_demo/agent_harness.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/agent_harness.rs
@@ -31,7 +31,15 @@ pub(crate) fn validate_agent_harness_evidence_file(
     }
     let artifact_path = extract_optional_string(report_json, AGENT_HARNESS_ARTIFACT_FIELD)
         .ok_or_else(|| "missing agent harness evidence artifact path".to_owned())?;
-    let artifact = std::fs::read_to_string(artifact_path.as_str()).map_err(|error| {
+    validate_agent_harness_evidence_path(report_json, report_path, artifact_path.as_str())
+}
+
+pub(crate) fn validate_agent_harness_evidence_path(
+    report_json: &str,
+    report_path: &str,
+    artifact_path: &str,
+) -> Result<(), String> {
+    let artifact = std::fs::read_to_string(artifact_path).map_err(|error| {
         format!(
             "failed to read agent harness evidence {}: {error}",
             artifact_path

--- a/crates/kamn-e2e-harness/src/mvp_demo/agent_harness.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/agent_harness.rs
@@ -22,7 +22,7 @@ pub(crate) fn validate_agent_harness_claim_shape(claims: &[ClaimView<'_>]) -> Re
     Ok(())
 }
 
-pub(crate) fn validate_agent_harness_evidence_file(
+pub(crate) fn validate_embedded_agent_harness_evidence(
     report_json: &str,
     report_path: &str,
 ) -> Result<(), String> {

--- a/crates/kamn-e2e-harness/src/mvp_demo/command_config.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/command_config.rs
@@ -24,4 +24,6 @@ pub struct MvpDemoCommandConfig {
 pub struct VerifyMvpDemoCommandConfig {
     /// Proof report JSON path.
     pub report: String,
+    /// Optional agent-harness evidence validated directly against the report.
+    pub agent_harness_evidence_path: Option<String>,
 }

--- a/crates/kamn-e2e-harness/src/mvp_demo/runner.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/runner.rs
@@ -1,7 +1,9 @@
 use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use super::agent_harness::validate_agent_harness_evidence_file;
+use super::agent_harness::{
+    validate_agent_harness_evidence_file, validate_agent_harness_evidence_path,
+};
 use super::artifact_digest::ThreeAgentArtifactDigests;
 use super::command_config::{MvpDemoCommandConfig, VerifyMvpDemoCommandConfig};
 use super::devnet_settlement::{
@@ -54,10 +56,15 @@ pub fn execute_verify_mvp_demo_contract(
     verify_mvp_demo_report_json(report.as_str())?;
     validate_local_artifact_files(report.as_str())?;
     validate_agent_harness_evidence_file(report.as_str(), config.report.as_str())?;
+    if let Some(path) = config.agent_harness_evidence_path.as_deref() {
+        validate_agent_harness_evidence_path(report.as_str(), config.report.as_str(), path)?;
+    }
     validate_three_agent_transcript_file(report.as_str())?;
+    let evidence_path = config.agent_harness_evidence_path.as_deref().unwrap_or("");
     Ok(format!(
-        "{{\"status\":\"PASS\",\"report\":\"{}\"}}",
-        escape_json(config.report.as_str())
+        "{{\"status\":\"PASS\",\"report\":\"{}\",\"agent_harness_evidence\":\"{}\"}}",
+        escape_json(config.report.as_str()),
+        escape_json(evidence_path)
     ))
 }
 

--- a/crates/kamn-e2e-harness/src/mvp_demo/runner.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/runner.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use super::agent_harness::{
-    validate_agent_harness_evidence_file, validate_agent_harness_evidence_path,
+    validate_agent_harness_evidence_path, validate_embedded_agent_harness_evidence,
 };
 use super::artifact_digest::ThreeAgentArtifactDigests;
 use super::command_config::{MvpDemoCommandConfig, VerifyMvpDemoCommandConfig};
@@ -55,7 +55,7 @@ pub fn execute_verify_mvp_demo_contract(
         .map_err(|error| format!("failed to read MVP demo report {}: {error}", config.report))?;
     verify_mvp_demo_report_json(report.as_str())?;
     validate_local_artifact_files(report.as_str())?;
-    validate_agent_harness_evidence_file(report.as_str(), config.report.as_str())?;
+    validate_embedded_agent_harness_evidence(report.as_str(), config.report.as_str())?;
     if let Some(path) = config.agent_harness_evidence_path.as_deref() {
         validate_agent_harness_evidence_path(report.as_str(), config.report.as_str(), path)?;
     }
@@ -89,7 +89,10 @@ fn create_three_agent_transcript(
 fn validate_generated_report(report_json: &str, output_root: &Path) -> Result<(), String> {
     verify_mvp_demo_report_json(report_json)?;
     validate_local_artifact_files(report_json)?;
-    validate_agent_harness_evidence_file(report_json, latest_report_path(output_root).as_str())?;
+    validate_embedded_agent_harness_evidence(
+        report_json,
+        latest_report_path(output_root).as_str(),
+    )?;
     validate_three_agent_transcript_file(report_json)
 }
 

--- a/crates/kamn-e2e-harness/tests/mvp_demo_agent_harness_claim_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_demo_agent_harness_claim_contract.rs
@@ -11,6 +11,7 @@ mod three_agent_boundary_contract;
 
 use kamn_e2e_harness::{execute_mvp_demo_contract, execute_verify_mvp_demo_contract};
 use std::path::Path;
+use std::process::Command;
 use support::*;
 
 #[test]
@@ -123,6 +124,8 @@ fn spec_c08_project_local_pi_extension_registers_kamn_tools() {
 
     for marker in [
         "kamn_verify_mvp_report",
+        "agentHarnessEvidencePath",
+        "--agent-harness-evidence",
         "kamn_inspect_mvp_report_boundaries",
         "kamn_write_agent_harness_evidence",
         "kamn_run_demo_mvp_with_agent_evidence",
@@ -140,6 +143,64 @@ fn spec_c08_project_local_pi_extension_registers_kamn_tools() {
     ] {
         assert!(source.contains(marker), "missing Pi tool marker: {marker}");
     }
+}
+
+#[test]
+fn spec_c22_cli_verifies_direct_pi_evidence_without_mutating_report() {
+    let root = temp_root("direct-pi-evidence");
+    let report = write_report(&root, direct_report_with_three_agent_claim(&root));
+    let artifact = write_artifact(
+        &root,
+        agent_artifact_with_canonical_observation_receipts(&root),
+    );
+    let before = std::fs::read(&report).expect("report should be readable");
+
+    let output = verify_with_direct_evidence(report.as_path(), artifact.as_path());
+
+    assert!(output.status.success(), "{}", command_output(&output));
+    assert!(String::from_utf8_lossy(&output.stdout).contains("\"status\":\"PASS\""));
+    assert_eq!(
+        before,
+        std::fs::read(&report).expect("report should remain readable")
+    );
+}
+
+#[test]
+fn spec_c23_cli_rejects_direct_pi_evidence_for_a_different_report() {
+    let root = temp_root("direct-pi-evidence-report-mismatch");
+    let report = write_report(&root, direct_report_with_three_agent_claim(&root));
+    let artifact_json = agent_artifact_with_canonical_observation_receipts(&root)
+        .replace("proof/report.json", "proof/other-report.json");
+    let artifact = write_artifact(&root, artifact_json);
+
+    let output = verify_with_direct_evidence(report.as_path(), artifact.as_path());
+
+    assert!(
+        !output.status.success(),
+        "mismatched report evidence must fail"
+    );
+    assert!(command_output(&output).contains("report_path does not match"));
+}
+
+fn verify_with_direct_evidence(report: &Path, artifact: &Path) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_kamn-e2e-harness"))
+        .args([
+            "verify-mvp-demo",
+            "--report",
+            report.to_str().expect("report path should be UTF-8"),
+            "--agent-harness-evidence",
+            artifact.to_str().expect("artifact path should be UTF-8"),
+        ])
+        .output()
+        .expect("verifier binary should execute")
+}
+
+fn command_output(output: &std::process::Output) -> String {
+    format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
 }
 
 fn pi_extension_source() -> String {

--- a/crates/kamn-e2e-harness/tests/mvp_demo_agent_harness_claim_contract/support.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_demo_agent_harness_claim_contract/support.rs
@@ -97,6 +97,25 @@ pub(crate) fn report_with_three_agent_claim(root: &Path, artifact: &Path) -> Str
     )
 }
 
+pub(crate) fn direct_report_with_three_agent_claim(root: &Path) -> String {
+    let transcript = root.join("proof/three-agent-transcript.json");
+    write_file(transcript.as_path(), three_agent::valid_transcript(root));
+    for (path, content) in three_agent::valid_view_artifacts(root) {
+        write_file(path.as_path(), content);
+    }
+    for (path, content) in canonical_receipts::valid_receipt_artifacts(root) {
+        write_file(path.as_path(), content);
+    }
+    format!(
+        r#"{{"schema_version":"kamn.mvp.demo.proof-report.v1","run_id":"run-7074","status":"GO","devnet_mode":"required","artifacts":{},"claim_matrix":[{},{},{},{}],"no_go":{{"active":false,"reason":""}}}}"#,
+        artifacts_json_with_three_agent(root, None, transcript.as_path()),
+        local_claims(),
+        three_agent::devnet_settlement_claim(),
+        three_agent::three_agent_claim(root, transcript.as_path()),
+        roadmap_claim()
+    )
+}
+
 fn write_file(path: &Path, content: String) {
     std::fs::create_dir_all(path.parent().expect("parent should exist"))
         .expect("fixture parent directory should be creatable");

--- a/crates/kamn-e2e-harness/tests/mvp_demo_agent_harness_claim_contract/support.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_demo_agent_harness_claim_contract/support.rs
@@ -23,6 +23,7 @@ pub(crate) fn temp_root(stem: &str) -> PathBuf {
 pub(crate) fn config(report: &Path) -> VerifyMvpDemoCommandConfig {
     VerifyMvpDemoCommandConfig {
         report: report.display().to_string(),
+        agent_harness_evidence_path: None,
     }
 }
 

--- a/crates/kamn-e2e-harness/tests/mvp_demo_command_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_demo_command_contract.rs
@@ -38,6 +38,22 @@ fn spec_c02_parser_accepts_verify_mvp_demo_with_report() {
 }
 
 #[test]
+fn spec_c07_parser_accepts_verify_mvp_demo_with_agent_harness_evidence() {
+    let parsed = parse_command_args([
+        "verify-mvp-demo",
+        "--agent-harness-evidence",
+        "/tmp/pi-evidence.json",
+        "--report",
+        "/tmp/report.json",
+    ])
+    .expect("verify-mvp-demo should accept direct Pi evidence");
+
+    let debug = format!("{parsed:?}");
+    assert!(debug.contains("/tmp/report.json"));
+    assert!(debug.contains("/tmp/pi-evidence.json"));
+}
+
+#[test]
 fn spec_c03_makefile_wires_demo_mvp_to_harness_command() {
     let output = make_dry_run("demo-mvp");
     assert!(

--- a/crates/kamn-e2e-harness/tests/mvp_demo_command_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_demo_command_contract.rs
@@ -33,6 +33,7 @@ fn spec_c02_parser_accepts_verify_mvp_demo_with_report() {
         .expect("verify-mvp-demo command should parse");
     let expected = HarnessCommand::VerifyMvpDemo(VerifyMvpDemoCommandConfig {
         report: "/tmp/report.json".to_owned(),
+        agent_harness_evidence_path: None,
     });
     assert_eq!(parsed, expected);
 }
@@ -83,6 +84,7 @@ fn spec_c05_verify_mvp_demo_command_accepts_generated_report() {
     execute_mvp_demo_contract(&demo_config).expect("demo should generate report");
     let verify_config = VerifyMvpDemoCommandConfig {
         report: temp.join("latest/proof/report.json").display().to_string(),
+        agent_harness_evidence_path: None,
     };
     let output = execute_verify_mvp_demo_contract(&verify_config)
         .expect("verify-mvp-demo should accept generated report");

--- a/crates/kamn-e2e-harness/tests/mvp_demo_local_artifact_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_demo_local_artifact_contract.rs
@@ -55,6 +55,7 @@ fn temp_root(stem: &str) -> PathBuf {
 fn config(report: &Path) -> VerifyMvpDemoCommandConfig {
     VerifyMvpDemoCommandConfig {
         report: report.display().to_string(),
+        agent_harness_evidence_path: None,
     }
 }
 

--- a/crates/kamn-e2e-harness/tests/mvp_demo_three_agent_receipt_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_demo_three_agent_receipt_contract.rs
@@ -109,6 +109,7 @@ fn spec_c05_demo_mvp_devnet_required_writes_observation_receipt_digests() {
 fn config(report: &Path) -> VerifyMvpDemoCommandConfig {
     VerifyMvpDemoCommandConfig {
         report: report.display().to_string(),
+        agent_harness_evidence_path: None,
     }
 }
 

--- a/crates/kamn-e2e-harness/tests/mvp_demo_three_agent_transcript_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_demo_three_agent_transcript_contract.rs
@@ -109,6 +109,7 @@ fn temp_root(stem: &str) -> PathBuf {
 fn config(report: &Path) -> VerifyMvpDemoCommandConfig {
     VerifyMvpDemoCommandConfig {
         report: report.display().to_string(),
+        agent_harness_evidence_path: None,
     }
 }
 

--- a/crates/kamn-e2e-harness/tests/mvp_demo_three_agent_view_artifact_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_demo_three_agent_view_artifact_contract.rs
@@ -146,5 +146,6 @@ fn spec_c06_command_rejects_agent_c_short_identity() {
 fn config(report: &Path) -> VerifyMvpDemoCommandConfig {
     VerifyMvpDemoCommandConfig {
         report: report.display().to_string(),
+        agent_harness_evidence_path: None,
     }
 }

--- a/crates/kamn-e2e-harness/tests/mvp_demo_three_agent_view_digest_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_demo_three_agent_view_digest_contract.rs
@@ -73,5 +73,6 @@ fn append_json_marker(path: &Path, marker: &str) {
 fn config(report: &Path) -> VerifyMvpDemoCommandConfig {
     VerifyMvpDemoCommandConfig {
         report: report.display().to_string(),
+        agent_harness_evidence_path: None,
     }
 }

--- a/crates/kamn-e2e-harness/tests/mvp_evaluator_demo_runbook_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_evaluator_demo_runbook_contract.rs
@@ -10,6 +10,8 @@ fn spec_c01_mvp_runbook_documents_pi_tool_harness_boundaries() {
         "## Optional Pi Agent Harness",
         ".pi/extensions/kamn-mvp/index.ts",
         "kamn_write_agent_harness_evidence",
+        "--agent-harness-evidence /tmp/kamn-pi-mcp-agent-harness-evidence.json",
+        "one canonical report remains unchanged",
         "kamn_run_demo_mvp_with_agent_evidence",
         "kamn_agent_a_register",
         "kamn_agent_a_invoke_transaction",

--- a/docs/validation/mvp-evaluator-demo.md
+++ b/docs/validation/mvp-evaluator-demo.md
@@ -110,6 +110,10 @@ canonical `agent_a_observation_receipt_digest`,
 report. Agent C's verifier receipt evidence remains restricted-public and must
 not expose participant-private digest or raw private payload markers.
 
+When `--agent-harness-evidence` is supplied directly to `verify-mvp-demo`, the
+same checks run without adding `mcp_agent_harness_verification` to the report.
+The verifier result names the separately validated evidence artifact instead.
+
 The evidence also records a `three_agent_boundary` summary derived from the
 verified report: local-only reports are marked `NOT_PRESENT`, while reports with
 `three_agent_escrow_verification` must preserve the report's claim status, label,

--- a/docs/validation/mvp-evaluator-demo.md
+++ b/docs/validation/mvp-evaluator-demo.md
@@ -79,8 +79,21 @@ env -u OPENAI_API_KEY pi \
   --tools kamn_verify_mvp_report,kamn_inspect_mvp_report_boundaries,kamn_agent_a_register,kamn_agent_a_invoke_transaction,kamn_agent_b_register,kamn_agent_b_accept_task,kamn_agent_c_verify_three_agent_proof,kamn_write_agent_harness_evidence,kamn_run_demo_mvp_with_agent_evidence \
   --approve \
   --no-session \
-  -p "Use only the KAMN tools. Verify the current report, inspect claim boundaries, call the Agent A register tool, Agent A invoke transaction tool, Agent B register tool, Agent B accept task tool, and Agent C verify proof tool against the current report, then write /tmp/kamn-pi-mcp-agent-harness-evidence.json and verify the report again."
+  -p "Use only the KAMN tools. Verify the current report, inspect claim boundaries, call the Agent A register tool, Agent A invoke transaction tool, Agent B register tool, Agent B accept task tool, and Agent C verify proof tool against the current report, then write /tmp/kamn-pi-mcp-agent-harness-evidence.json and verify the same report with agentHarnessEvidencePath set to that evidence path."
 ```
+
+The final Pi verifier tool call executes the equivalent canonical command:
+
+```bash
+cargo run -p kamn-e2e-harness -- verify-mvp-demo \
+  --report .kamn/demo/latest/proof/report.json \
+  --agent-harness-evidence /tmp/kamn-pi-mcp-agent-harness-evidence.json
+```
+
+In this flow one canonical report remains unchanged. The verifier reads the Pi
+artifact separately and fails if its report path, claim boundaries, actor tool
+receipts, or canonical observation receipt artifacts/digests disagree with that
+report. This does not rerun settlement or submit another devnet transaction.
 
 When the Pi tool path writes evidence, the proof artifact records
 `execution_surface:"pi-extension-tools"` and the final report may include

--- a/specs/7074-verify-pi-evidence-against-canonical-report.md
+++ b/specs/7074-verify-pi-evidence-against-canonical-report.md
@@ -1,0 +1,101 @@
+# Issue 7074: Verify Pi Evidence Against One Canonical Report
+
+## Objective
+
+Make the evaluator's Pi workflow reproducible by allowing the canonical MVP
+verifier to validate a Pi agent-harness evidence artifact directly against the
+exact canonical report that produced its actor and observation receipts.
+
+## Inputs/Outputs
+
+- Input: `verify-mvp-demo --report <path>` for the immutable canonical report.
+- Input: optional `--agent-harness-evidence <path>` for Pi extension evidence.
+- Input: canonical three-agent claim, view, actor receipt, and observation
+  receipt fields already present in a devnet-backed report.
+- Output: `PASS` only when the report verifies and the supplied Pi artifact
+  agrees with the report path, claim boundaries, actor tool receipts, and
+  canonical observation receipt artifact/digest references.
+- Output: the verifier result identifies the validated evidence path when the
+  optional artifact is supplied.
+
+## Boundaries/Non-goals
+
+- Do not mutate, patch, or relabel the canonical report.
+- Do not rerun settlement or submit a second devnet transaction.
+- Do not claim Pi performs settlement or asset movement.
+- Keep Pi agent-harness verification `local-only`; value movement remains
+  `devnet-backed` only through the canonical report evidence.
+- Do not add dependencies, agent runtimes, wallet formats, or settlement paths.
+- Do not generalize this MVP handshake into production attestation or mainnet.
+
+## Failure Modes
+
+- The supplied evidence names a different report path.
+- The supplied evidence omits an actor tool receipt required for the report.
+- The supplied evidence omits a canonical observation receipt.
+- A supplied observation receipt artifact or digest differs from the report.
+- Evidence counts dry-run or placeholder behavior as success.
+- Agent C evidence exposes participant-private fields.
+- The evidence path is unreadable or malformed.
+
+## Acceptance Criteria
+
+- [ ] `verify-mvp-demo` accepts optional `--agent-harness-evidence` after or
+      before `--report`.
+- [ ] Supplying valid Pi evidence verifies against a direct canonical report
+      without adding an agent-harness claim to that report.
+- [ ] Report path, actor tool receipt, canonical observation receipt, boundary,
+      privacy, unreadable-file, and malformed-artifact failures remain hard
+      failures with specific context.
+- [ ] Verification leaves the report bytes unchanged.
+- [ ] The Pi report verifier tool accepts an optional evidence path and passes
+      both paths to the canonical Rust verifier.
+- [ ] The evaluator runbook documents one report, one Pi evidence artifact,
+      and one combined canonical verification step.
+- [ ] Existing embedded agent-harness evidence and report-only verification
+      remain backward compatible.
+
+## Files To Touch
+
+- `specs/7074-verify-pi-evidence-against-canonical-report.md`
+- `crates/kamn-e2e-harness/src/mvp_demo/command_config.rs`
+- `crates/kamn-e2e-harness/src/mvp_demo/agent_harness.rs`
+- `crates/kamn-e2e-harness/src/mvp_demo/runner.rs`
+- `crates/kamn-e2e-harness/src/lib.rs`
+- `crates/kamn-e2e-harness/tests/mvp_demo_command_contract.rs`
+- `crates/kamn-e2e-harness/tests/mvp_demo_agent_harness_claim_contract.rs`
+- `crates/kamn-e2e-harness/tests/mvp_demo_agent_harness_claim_contract/*`
+- `crates/kamn-e2e-harness/tests/mvp_evaluator_demo_runbook_contract.rs`
+- `.pi/extensions/kamn-mvp/index.ts`
+- `docs/validation/mvp-evaluator-demo.md`
+
+## Error Semantics
+
+- Missing flags and unknown flags return parser errors and exit non-zero.
+- Unreadable evidence returns an error naming the evidence path.
+- Evidence/report disagreement returns the existing specific harness boundary,
+  actor receipt, observation receipt, or privacy error.
+- Report-only verification keeps its current behavior.
+- No failure silently falls back to report-only verification.
+
+## Test Plan
+
+- Red: parser contract for optional evidence and direct evidence verification.
+- Red: negative direct-verification cases for report mismatch and canonical
+  observation receipt mismatch.
+- Red: Pi source and runbook markers for the combined verifier command.
+- Green: add the optional config field, reuse existing evidence validation,
+  and pass both paths through the Pi verifier tool.
+- Refactor: centralize path-based evidence loading and keep modified functions
+  within the repository size limits where the surrounding file permits.
+- Integration: run focused command/harness/runbook tests, the broader MVP proof
+  matrix, formatter, strict clippy, `make check`, local and devnet-required MVP
+  demos, canonical combined verification, and a Pi agent rehearsal.
+
+## Deviations
+
+- None at specification time.
+
+## Completion Evidence
+
+- Pending implementation and verification.

--- a/specs/7074-verify-pi-evidence-against-canonical-report.md
+++ b/specs/7074-verify-pi-evidence-against-canonical-report.md
@@ -94,8 +94,41 @@ exact canonical report that produced its actor and observation receipts.
 
 ## Deviations
 
-- None at specification time.
+- The existing report-only verifier result now includes an empty
+  `agent_harness_evidence` field. This is an additive JSON field; report-only
+  validation behavior and exit semantics are unchanged.
 
 ## Completion Evidence
 
-- Pending implementation and verification.
+- Red command/harness/runbook contracts failed as expected because
+  `--agent-harness-evidence`, the Pi parameter, and the immutable-report
+  runbook flow did not exist.
+- Focused green contracts passed: 23 agent-harness tests, 7 command tests, and
+  1 evaluator runbook test.
+- The broader MVP proof matrix passed 75 tests across claim, command, local
+  artifact, three-agent transcript/view/receipt, agent-harness, and runbook
+  contracts.
+- `cargo fmt --check` passed.
+- `CARGO_TARGET_DIR=target/mvp-demo-proof CARGO_BUILD_JOBS=1
+  CARGO_INCREMENTAL=0 cargo clippy --workspace --all-targets --all-features --
+  -D warnings` passed.
+- `CARGO_TARGET_DIR=target/mvp-demo-proof CARGO_BUILD_JOBS=1
+  CARGO_INCREMENTAL=0 make check` passed.
+- Optional `make demo-mvp` returned `GO`; report-only `verify-mvp-demo`
+  returned `PASS`.
+- Devnet-required `make demo-mvp` returned `GO` for run
+  `run-44951-1783642279986` and recorded finalized Solana signature
+  `2j5TsXkw51sFs8CjhCorKC38om3YnDkmqruL7rjEsjwqSpx6pTLJVbPZBiyqqo9K8os4QhLyz3PsSgAt4bYXofQ8`.
+- `solana confirm -v` independently showed the 1,000,000 lamport transfer
+  finalized in slot `475171619` from
+  `Ew2NpaFAK2TbUkbUMV54JN1gURSKkLWEypk5v9kJR7XU` to
+  `BSN17KC1c5kUuA7ZaTXvMUnFbZUhizeaisYcAFeTsbEb`.
+- Pi with `openai-codex/gpt-5.5` invoked Agent A register/invoke, Agent B
+  register/accept, and Agent C verify tools, then wrote
+  `/tmp/kamn-pi-7074-evidence.json` with five actor tool receipts and canonical
+  observation receipts for all three agents.
+- Combined verification with `--report .kamn/demo/latest/proof/report.json
+  --agent-harness-evidence /tmp/kamn-pi-7074-evidence.json` returned `PASS`.
+- The report SHA-256 remained
+  `33590f1770c0fb5a501bd0956c26d12c354624d47f4db7962f1e2261685a775c`
+  before and after combined verification.


### PR DESCRIPTION
## Human Summary

- Adds a first-class `--agent-harness-evidence` input to the canonical MVP verifier.
- Lets Pi's Agent A, Agent B, and Agent C evidence be checked against the exact immutable devnet report that produced the canonical receipts.
- Rejects mismatched report provenance, actor receipts, observation receipt artifacts/digests, privacy leakage, dry-run success, and placeholder success through the existing strict evidence contract.
- Keeps Pi evidence `local-only`; settlement and value movement remain `devnet-backed` only through the canonical report.
- Removes the evaluator's previous need to patch report JSON or rerun settlement.

Closes #7074

Spec: `specs/7074-verify-pi-evidence-against-canonical-report.md`

## Testing

- RED: focused command, harness, Pi source, and runbook contracts failed on the missing combined-verifier path.
- `CARGO_TARGET_DIR=target/mvp-demo-proof CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 cargo test -p kamn-e2e-harness --test mvp_demo_three_agent_receipt_contract --test mvp_demo_three_agent_view_artifact_contract --test mvp_demo_three_agent_view_digest_contract --test mvp_demo_three_agent_claim_contract --test mvp_demo_three_agent_transcript_contract --test mvp_demo_agent_harness_claim_contract --test mvp_demo_local_artifact_contract --test mvp_demo_claim_contract --test mvp_demo_command_contract --test mvp_evaluator_demo_runbook_contract -- --nocapture` (75 passed)
- `cargo fmt --check`
- `CARGO_TARGET_DIR=target/mvp-demo-proof CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `CARGO_TARGET_DIR=target/mvp-demo-proof CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 make check`
- `CARGO_TARGET_DIR=target/mvp-demo-proof CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 make demo-mvp` (`GO`, local optional mode)
- `cargo run -p kamn-e2e-harness -- verify-mvp-demo --report .kamn/demo/latest/proof/report.json` (`PASS`)
- Devnet-required `make demo-mvp` (`GO`)
- Solana devnet transaction `2j5TsXkw51sFs8CjhCorKC38om3YnDkmqruL7rjEsjwqSpx6pTLJVbPZBiyqqo9K8os4QhLyz3PsSgAt4bYXofQ8` finalized in slot `475171619` for 1,000,000 lamports.
- Pi 0.80.3 with `openai-codex/gpt-5.5` recorded five actor tool receipts and all three canonical observation receipts.
- Combined verifier passed with `/tmp/kamn-pi-7074-evidence.json`; report SHA-256 remained `33590f1770c0fb5a501bd0956c26d12c354624d47f4db7962f1e2261685a775c` before and after.

## Notes for Reviewers

The key review boundary is provenance: direct Pi evidence is an optional verifier input, not a mutation of the canonical report and not a new devnet-backed claim. Existing report-only and embedded-evidence verification remain supported.

shell_loc_delta_actual: 0
rust_loc_delta_actual: 135
shell_to_rust_ratio_delta_actual: 0.0
shell_surface_ratio_target_status: neutral

## AI Agent Details

- `VerifyMvpDemoCommandConfig` carries the optional direct evidence path.
- `validate_embedded_agent_harness_evidence` and `validate_agent_harness_evidence_path` make provenance explicit while sharing the same strict artifact validator.
- The project-local Pi extension forwards `agentHarnessEvidencePath` to the Rust verifier.
- The canonical report is read-only throughout combined verification.
