### PR TITLE
feat: make MCP agent registration service-backed

### DIFF
--- a/crates/kamn-agent-lib/src/client.rs
+++ b/crates/kamn-agent-lib/src/client.rs
@@ -1,10 +1,11 @@
 use crate::errors::AgentLibError;
 use kamn_sdk::{
     service_public_key_for_private_key, service_signature_for_state_hash_with_private_key,
-    AgentDid, ServiceAgentProfile, ServiceApiClient, ServiceBridgeStatus, ServiceBridgeSubmission,
-    ServiceChannelMessages, ServiceChannelReceipt, ServiceContentRegistration,
-    ServiceContentStatus, ServiceEscrowStatus, ServiceHealthStatus, ServiceMessageReceipt,
-    ServiceMessageStatus, ServiceRequestAuth, ServiceTaskReceipt, ServiceTaskStatus,
+    AgentDid, AgentMetadata, ServiceAgentProfile, ServiceApiClient, ServiceBridgeStatus,
+    ServiceBridgeSubmission, ServiceChannelMessages, ServiceChannelReceipt,
+    ServiceContentRegistration, ServiceContentStatus, ServiceEscrowStatus, ServiceHealthStatus,
+    ServiceMessageReceipt, ServiceMessageStatus, ServiceRequestAuth, ServiceTaskReceipt,
+    ServiceTaskStatus,
 };
 use std::env;
 
@@ -248,6 +249,15 @@ impl ServiceApiHttpClient {
         auth: &ServiceRequestAuth,
     ) -> Result<ServiceAgentProfile, AgentLibError> {
         Ok(self.inner.get_agent_profile(did, auth)?)
+    }
+
+    /// Registers the authenticated sender through `POST /v1/agents/register`.
+    pub fn register_agent(
+        &self,
+        metadata: &AgentMetadata,
+        auth: &ServiceRequestAuth,
+    ) -> Result<ServiceAgentProfile, AgentLibError> {
+        Ok(self.inner.register_agent(metadata, auth)?)
     }
 
     /// Queries service health via `GET /healthz`.

--- a/crates/kamn-agent-lib/src/lib.rs
+++ b/crates/kamn-agent-lib/src/lib.rs
@@ -6,6 +6,7 @@ use std::sync::Mutex;
 use auth::KamnAuthHeaders;
 use client::ServiceApiHttpClient;
 use envelope::{build_and_sign_envelope, CanonicalMessageEnvelope};
+use kamn_sdk::{service_agent_registration_payload, AgentMetadata};
 use kolme::KolmeClient;
 use nonce::{NonceTracker, NonceTrackerError};
 
@@ -179,6 +180,30 @@ impl KamnAgentHandle {
             Some("agents:read"),
         )?;
         self.service_client.get_agent_profile(did, &auth)
+    }
+
+    /// Registers this authenticated identity through the service API.
+    pub fn register_agent(
+        &self,
+        metadata: &AgentMetadata,
+    ) -> Result<ServiceAgentProfile, AgentLibError> {
+        let payload = service_agent_registration_payload(metadata)?;
+        let nonce = self.next_nonce()?;
+        let auth = self.service_client.build_auth(
+            self.identity.did(),
+            self.identity.signing_key(),
+            nonce,
+            payload.as_str(),
+            Some("agents:write"),
+        )?;
+        let profile = self.service_client.register_agent(metadata, &auth)?;
+        if profile.did != self.identity.did().as_str() {
+            return Err(AgentLibError::InvalidInput {
+                field: "service_agent_profile.did",
+                reason: "must match authenticated identity".to_owned(),
+            });
+        }
+        Ok(profile)
     }
 
     /// Queries service health.

--- a/crates/kamn-mcp-server/src/dispatch.rs
+++ b/crates/kamn-mcp-server/src/dispatch.rs
@@ -1,4 +1,5 @@
 use crate::json_helpers::{escape_json, json_optional_string_field, json_required_string_field};
+use crate::registration::register_mcp_agent;
 use kamn_agent_lib::{AgentLibError, KamnAgentHandle, KolmeProofReceipt};
 
 /// Backend abstraction used by MCP tool dispatch.
@@ -55,10 +56,7 @@ pub trait McpToolBackend {
 
 impl McpToolBackend for KamnAgentHandle {
     fn register(&self) -> Result<String, AgentLibError> {
-        Ok(format!(
-            r#"{{"did":"{}"}}"#,
-            escape_json(self.identity().did().as_str())
-        ))
+        register_mcp_agent(self)
     }
 
     fn send_message(&self, payload: &str) -> Result<String, AgentLibError> {

--- a/crates/kamn-mcp-server/src/dispatch.rs
+++ b/crates/kamn-mcp-server/src/dispatch.rs
@@ -1,5 +1,5 @@
 use crate::json_helpers::{escape_json, json_optional_string_field, json_required_string_field};
-use crate::registration::register_mcp_agent;
+use crate::registration::register_service_backed_mcp_agent;
 use kamn_agent_lib::{AgentLibError, KamnAgentHandle, KolmeProofReceipt};
 
 /// Backend abstraction used by MCP tool dispatch.
@@ -56,7 +56,7 @@ pub trait McpToolBackend {
 
 impl McpToolBackend for KamnAgentHandle {
     fn register(&self) -> Result<String, AgentLibError> {
-        register_mcp_agent(self)
+        register_service_backed_mcp_agent(self)
     }
 
     fn send_message(&self, payload: &str) -> Result<String, AgentLibError> {

--- a/crates/kamn-mcp-server/src/lib.rs
+++ b/crates/kamn-mcp-server/src/lib.rs
@@ -8,6 +8,7 @@ pub mod dispatch;
 mod json_helpers;
 /// MCP stdio framing + JSON-RPC protocol handling.
 pub mod protocol;
+mod registration;
 /// MCP tool registry scaffold.
 pub mod tools;
 

--- a/crates/kamn-mcp-server/src/registration.rs
+++ b/crates/kamn-mcp-server/src/registration.rs
@@ -1,7 +1,9 @@
 use kamn_agent_lib::{AgentLibError, KamnAgentHandle};
 use kamn_sdk::AgentMetadata;
 
-pub(crate) fn register_mcp_agent(handle: &KamnAgentHandle) -> Result<String, AgentLibError> {
+pub(crate) fn register_service_backed_mcp_agent(
+    handle: &KamnAgentHandle,
+) -> Result<String, AgentLibError> {
     let profile = handle.register_agent(&mcp_agent_metadata())?;
     Ok(serde_json::json!({
         "did": profile.did,

--- a/crates/kamn-mcp-server/src/registration.rs
+++ b/crates/kamn-mcp-server/src/registration.rs
@@ -1,0 +1,22 @@
+use kamn_agent_lib::{AgentLibError, KamnAgentHandle};
+use kamn_sdk::AgentMetadata;
+
+pub(crate) fn register_mcp_agent(handle: &KamnAgentHandle) -> Result<String, AgentLibError> {
+    let profile = handle.register_agent(&mcp_agent_metadata())?;
+    Ok(serde_json::json!({
+        "did": profile.did,
+        "reputation_score": profile.reputation_score,
+        "agent_type": profile.agent_type,
+        "model_family": profile.model_family,
+        "capabilities": profile.capabilities,
+    })
+    .to_string())
+}
+
+fn mcp_agent_metadata() -> AgentMetadata {
+    AgentMetadata {
+        agent_type: "autonomous".to_owned(),
+        model_family: "mcp-agent".to_owned(),
+        capabilities: vec!["mcp".to_owned()],
+    }
+}

--- a/crates/kamn-mcp-server/tests/real_backend_integration_contract.rs
+++ b/crates/kamn-mcp-server/tests/real_backend_integration_contract.rs
@@ -8,6 +8,7 @@ use std::time::{Duration, Instant};
 const SERVICE_AUTH_PRIVATE_KEY_ENV: &str = "KAMN_SERVICE_API_AUTH_PRIVATE_KEY_HEX";
 const TEST_SERVICE_AUTH_PRIVATE_KEY_HEX: &str =
     "1111111111111111111111111111111111111111111111111111111111111111";
+const TEST_MCP_AGENT_DID: &str = "kamn:did:agent:pkh-038394c7f7ffdc1bfd761be5740fd3aeb46fdea8a79c1b9384d79c03c50fc44248--keyh-67726c2c9ade28652475e1b8fa00855e";
 
 fn bind_loopback_listener() -> TcpListener {
     let listener = TcpListener::bind("127.0.0.1:0").expect("listener should bind");
@@ -17,7 +18,7 @@ fn bind_loopback_listener() -> TcpListener {
     listener
 }
 
-fn parse_http_request(stream: &mut TcpStream) -> Result<(String, String), String> {
+fn parse_http_request(stream: &mut TcpStream) -> Result<(String, String, String), String> {
     let mut request = Vec::new();
     let mut chunk = [0_u8; 1024];
     stream
@@ -46,7 +47,7 @@ fn parse_http_request(stream: &mut TcpStream) -> Result<(String, String), String
 
     let request_text =
         String::from_utf8(request).map_err(|_| "request was not valid utf-8".to_owned())?;
-    let Some((request_head, _)) = request_text.split_once("\r\n\r\n") else {
+    let Some((request_head, request_body)) = request_text.split_once("\r\n\r\n") else {
         return Err("request header terminator missing".to_owned());
     };
     let request_line = request_head
@@ -62,7 +63,7 @@ fn parse_http_request(stream: &mut TcpStream) -> Result<(String, String), String
         .next()
         .ok_or_else(|| "request path missing".to_owned())?
         .to_owned();
-    Ok((method, path))
+    Ok((method, path, request_body.to_owned()))
 }
 
 fn write_http_response(stream: &mut TcpStream, status: u16, body: &str) -> Result<(), String> {
@@ -70,6 +71,7 @@ fn write_http_response(stream: &mut TcpStream, status: u16, body: &str) -> Resul
         200 => "200 OK",
         201 => "201 Created",
         202 => "202 Accepted",
+        400 => "400 Bad Request",
         404 => "404 Not Found",
         _ => "500 Internal Server Error",
     };
@@ -116,8 +118,8 @@ fn accept_real_backend_request(listener: &TcpListener) -> Result<usize, String> 
 }
 
 fn serve_real_backend_connection(stream: &mut TcpStream) -> Result<(), String> {
-    let (method, path) = parse_http_request(stream)?;
-    if write_public_or_task_response(stream, &method, &path)? {
+    let (method, path, body) = parse_http_request(stream)?;
+    if write_public_or_task_response(stream, &method, &path, &body)? {
         return Ok(());
     }
     if write_content_response(stream, &method, &path)? {
@@ -137,6 +139,7 @@ fn write_public_or_task_response(
     stream: &mut TcpStream,
     method: &str,
     path: &str,
+    body: &str,
 ) -> Result<bool, String> {
     let response = match (method, path) {
         ("GET", "/healthz") => Some((
@@ -154,9 +157,21 @@ fn write_public_or_task_response(
             200,
             r#"{"did":"kamn:did:agent:alice","reputation_score":42,"agent_type":"service-agent","model_family":"service-api","capabilities":["profile:read"]}"#,
         )),
+        ("POST", "/v1/agents/register") if body == mcp_registration_payload() => Some((
+            201,
+            r#"{"did":"kamn:did:agent:pkh-038394c7f7ffdc1bfd761be5740fd3aeb46fdea8a79c1b9384d79c03c50fc44248--keyh-67726c2c9ade28652475e1b8fa00855e","reputation_score":0,"agent_type":"autonomous","model_family":"mcp-agent","capabilities":["mcp"]}"#,
+        )),
+        ("POST", "/v1/agents/register") => Some((
+            400,
+            r#"{"error":"bad-request","reason_code":"registration_payload_mismatch"}"#,
+        )),
         _ => None,
     };
     write_optional_response(stream, response)
+}
+
+fn mcp_registration_payload() -> &'static str {
+    r#"{"agent_type":"autonomous","capabilities":["mcp"],"model_family":"mcp-agent"}"#
 }
 
 fn write_content_response(
@@ -486,5 +501,34 @@ fn spec_c09_real_backend_dispatch_bridge_lifecycle_contract() {
     assert!(
         server_result.is_ok(),
         "service fixture should satisfy request budget"
+    );
+}
+
+#[test]
+fn spec_c10_real_backend_register_persists_mcp_agent_profile() {
+    let (bind_addr, server) = spawn_real_backend_service_server(1);
+    let backend = real_backend(bind_addr.as_str());
+
+    let response = dispatch_tool_request_json(&backend, r#"{"id":"req-10","tool":"register"}"#)
+        .expect("register dispatch should use the service backend");
+
+    for marker in [
+        r#""ok":true"#,
+        r#""agent_type":"autonomous""#,
+        r#""model_family":"mcp-agent""#,
+        r#""capabilities":["mcp"]"#,
+        r#""reputation_score":0"#,
+    ] {
+        assert!(
+            response.contains(marker),
+            "missing marker {marker}: {response}"
+        );
+    }
+    assert!(response.contains(TEST_MCP_AGENT_DID));
+
+    let server_result = server.join().expect("server thread should join");
+    assert!(
+        server_result.is_ok(),
+        "register must consume the HTTP request"
     );
 }

--- a/crates/kamn-sdk/src/lib.rs
+++ b/crates/kamn-sdk/src/lib.rs
@@ -5,6 +5,7 @@ mod bridge;
 mod channel_create;
 mod events;
 mod observability;
+mod service_agent_registration;
 
 /// Agent-facing traits and transport mode primitives.
 pub mod agent;
@@ -45,6 +46,8 @@ pub use service::{
     ServiceHealthStatus, ServiceMessageReceipt, ServiceMessageStatus, ServiceRequestAuth,
     ServiceRouteEvent, ServiceTaskReceipt, ServiceTaskStatus,
 };
+/// Re-exported canonical service-backed agent registration payload helper.
+pub use service_agent_registration::service_agent_registration_payload;
 /// Re-exported TCP relay adapter and envelope helpers.
 pub use tcp::{
     signature_for_fields, TcpReceivedEnvelope, TcpSignedEnvelope, TcpTransportAdapter,

--- a/crates/kamn-sdk/src/live/routes.rs
+++ b/crates/kamn-sdk/src/live/routes.rs
@@ -2,8 +2,8 @@ use super::task_escrow::escape_json;
 use crate::channel_create::payload as channel_create_json_payload;
 use crate::service::ServiceMessageDelivery;
 use crate::{
-    AgentDid, AgentMetadata, AgentReputation, AgentSummary, DidDocument, Message, MessageId,
-    MessageRecord, SdkError, ServiceAgentProfile,
+    service_agent_registration_payload, AgentDid, AgentMetadata, AgentReputation, AgentSummary,
+    DidDocument, Message, MessageId, MessageRecord, SdkError, ServiceAgentProfile,
 };
 
 pub(crate) fn service_message_payload(message: &Message) -> String {
@@ -24,13 +24,7 @@ pub(crate) fn service_message_payload(message: &Message) -> String {
 }
 
 pub(crate) fn agent_registration_payload(metadata: &AgentMetadata) -> Result<String, SdkError> {
-    validate_agent_metadata(metadata)?;
-    Ok(serde_json::json!({
-        "agent_type": metadata.agent_type,
-        "model_family": metadata.model_family,
-        "capabilities": metadata.capabilities,
-    })
-    .to_string())
+    service_agent_registration_payload(metadata)
 }
 
 pub(crate) fn channel_create_payload(name: &str) -> Result<String, SdkError> {
@@ -114,36 +108,4 @@ pub(crate) fn agent_profile_to_summary(
 
 fn parse_service_agent_did(raw: &str, error_message: &'static str) -> Result<AgentDid, SdkError> {
     AgentDid::parse(raw).map_err(|_| SdkError::TransportFailure(error_message))
-}
-
-fn validate_agent_metadata(metadata: &AgentMetadata) -> Result<(), SdkError> {
-    if metadata.agent_type.trim().is_empty() {
-        return Err(SdkError::InvalidInput {
-            field: "agent_type",
-            reason: "must not be empty",
-        });
-    }
-    if metadata.model_family.trim().is_empty() {
-        return Err(SdkError::InvalidInput {
-            field: "model_family",
-            reason: "must not be empty",
-        });
-    }
-    if metadata.capabilities.is_empty() {
-        return Err(SdkError::InvalidInput {
-            field: "capabilities",
-            reason: "must include at least one capability",
-        });
-    }
-    if metadata
-        .capabilities
-        .iter()
-        .any(|value| value.trim().is_empty())
-    {
-        return Err(SdkError::InvalidInput {
-            field: "capabilities",
-            reason: "must not include empty capability entries",
-        });
-    }
-    Ok(())
 }

--- a/crates/kamn-sdk/src/service_agent_registration.rs
+++ b/crates/kamn-sdk/src/service_agent_registration.rs
@@ -1,0 +1,45 @@
+use crate::{AgentMetadata, SdkError};
+
+/// Builds the canonical JSON body for service-backed agent registration.
+pub fn service_agent_registration_payload(metadata: &AgentMetadata) -> Result<String, SdkError> {
+    validate_agent_metadata(metadata)?;
+    Ok(serde_json::json!({
+        "agent_type": metadata.agent_type,
+        "model_family": metadata.model_family,
+        "capabilities": metadata.capabilities,
+    })
+    .to_string())
+}
+
+fn validate_agent_metadata(metadata: &AgentMetadata) -> Result<(), SdkError> {
+    validate_non_empty("agent_type", metadata.agent_type.as_str())?;
+    validate_non_empty("model_family", metadata.model_family.as_str())?;
+    if metadata.capabilities.is_empty() {
+        return Err(invalid(
+            "capabilities",
+            "must include at least one capability",
+        ));
+    }
+    if metadata
+        .capabilities
+        .iter()
+        .any(|value| value.trim().is_empty())
+    {
+        return Err(invalid(
+            "capabilities",
+            "must not include empty capability entries",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_non_empty(field: &'static str, value: &str) -> Result<(), SdkError> {
+    if value.trim().is_empty() {
+        return Err(invalid(field, "must not be empty"));
+    }
+    Ok(())
+}
+
+fn invalid(field: &'static str, reason: &'static str) -> SdkError {
+    SdkError::InvalidInput { field, reason }
+}

--- a/crates/kamn-sdk/src/service_client_bridge_misc_routes.rs
+++ b/crates/kamn-sdk/src/service_client_bridge_misc_routes.rs
@@ -4,7 +4,7 @@ use super::super::{
     ServiceBridgeStatus, ServiceBridgeSubmission, ServiceHealthStatus, ServiceRequestAuth,
 };
 use super::ServiceApiClient;
-use crate::{AgentDid, AgentMetadata, AgentQuery};
+use crate::{service_agent_registration_payload, AgentDid, AgentMetadata, AgentQuery};
 
 impl ServiceApiClient {
     /// Submits one bridge message via `POST /v1/bridge/submit`.
@@ -78,12 +78,7 @@ impl ServiceApiClient {
         metadata: &AgentMetadata,
         auth: &ServiceRequestAuth,
     ) -> Result<ServiceAgentProfile, SdkError> {
-        let payload = serde_json::json!({
-            "agent_type": metadata.agent_type,
-            "model_family": metadata.model_family,
-            "capabilities": metadata.capabilities,
-        })
-        .to_string();
+        let payload = service_agent_registration_payload(metadata)?;
         let response = self.request("POST", "/v1/agents/register", payload.as_str(), Some(auth))?;
         expect_status(response.status, 201)?;
         parse_agent_profile_response(response.body.as_str())

--- a/docs/validation/mvp-evaluator-demo.md
+++ b/docs/validation/mvp-evaluator-demo.md
@@ -114,6 +114,13 @@ When `--agent-harness-evidence` is supplied directly to `verify-mvp-demo`, the
 same checks run without adding `mcp_agent_harness_verification` to the report.
 The verifier result names the separately validated evidence artifact instead.
 
+The underlying `kamn-mcp-server` `register` tool is service-backed: it signs an
+`agents:write` request, calls `POST /v1/agents/register`, and returns the
+persisted profile. The similarly named project-local Pi actor receipt tool
+still records report-bound evaluator evidence; it is not yet wired to invoke
+the live MCP registration process. Keep those two surfaces distinct when
+describing the current demo.
+
 The evidence also records a `three_agent_boundary` summary derived from the
 verified report: local-only reports are marked `NOT_PRESENT`, while reports with
 `three_agent_escrow_verification` must preserve the report's claim status, label,

--- a/specs/7076-mcp-service-backed-registration.md
+++ b/specs/7076-mcp-service-backed-registration.md
@@ -89,8 +89,41 @@ instead of returning an identity-only synthetic response.
 
 ## Deviations
 
-- None at specification time.
+- Live validation exposed an existing nonce-continuity boundary: launching a
+  fresh MCP process for the same DID resets its local nonce tracker and the
+  service correctly rejects nonce `1` as replay. Registration plus follow-up
+  operations must use one persistent MCP session or a persisted nonce source.
+- No fallback was added; the replay failure remains hard and observable.
 
 ## Completion Evidence
 
-- Pending implementation and verification.
+- Red evidence: the focused real-backend contract failed because `register`
+  returned only a DID and omitted persisted profile metadata without consuming
+  the fixture HTTP request.
+- Green evidence: the real-backend contract passed after `register` called the
+  canonical service route and returned the persisted profile.
+- `cargo test -p kamn-sdk` passed.
+- `cargo test -p kamn-agent-lib` passed.
+- `cargo test -p kamn-mcp-server` passed, including real backend, persistent
+  stdio, protocol, dispatch, inventory, and duplicate-helper contracts.
+- `cargo fmt --check` passed.
+- `CARGO_TARGET_DIR=target/mvp-demo-proof CARGO_BUILD_JOBS=1
+  CARGO_INCREMENTAL=0 cargo clippy --workspace --all-targets --all-features --
+  -D warnings` passed.
+- `CARGO_TARGET_DIR=target/mvp-demo-proof CARGO_BUILD_JOBS=1
+  CARGO_INCREMENTAL=0 make check` passed.
+- Live loopback proof built and started `kamn-node` on `127.0.0.1:18276`, then
+  invoked the real `kamn-mcp-server` binary with a disposable deterministic
+  test identity.
+- Agent A registration returned `ok=true`, `agent_type=autonomous`,
+  `model_family=mcp-agent`, `capabilities=[mcp]`, and a persisted
+  self-certifying DID.
+- One persistent Agent B MCP process registered and then queried its profile;
+  both calls returned `ok=true`, and node logs recorded HTTP `201` then `200`
+  with nonce progression from `1` to `2`.
+- One persistent Agent C MCP process repeated identical registration; both
+  calls returned the same DID/profile and node logs recorded two HTTP `201`
+  outcomes, proving idempotent retry behavior.
+- A deliberately fresh process for the already-used Agent A DID was rejected
+  with `service_api_auth_replay_nonce_detected`, proving the replay guard and
+  persistent-session requirement remain active.

--- a/specs/7076-mcp-service-backed-registration.md
+++ b/specs/7076-mcp-service-backed-registration.md
@@ -1,0 +1,96 @@
+# Issue 7076: MCP Service-Backed Agent Registration
+
+## Objective
+
+Make the existing MCP `register` tool perform authenticated, durable agent
+registration through KAMN's real `POST /v1/agents/register` service route
+instead of returning an identity-only synthetic response.
+
+## Inputs/Outputs
+
+- Input: the existing empty MCP `register` arguments object.
+- Input: the MCP process identity and signing key configured at startup.
+- Input: deterministic MVP metadata: `agent_type=autonomous`,
+  `model_family=mcp-agent`, and `capabilities=[mcp]`.
+- Output: a successful MCP envelope containing the persisted DID, agent type,
+  model family, capabilities, and reputation score returned by the service.
+- Side effect: the authenticated sender profile is persisted by the existing
+  service registration route.
+
+## Boundaries/Non-goals
+
+- Do not add or rename an MCP tool.
+- Do not change the empty `register` input schema.
+- Do not add configurable metadata or dependencies in this slice.
+- Do not add Pi orchestration or claim a complete actor-driven workflow yet.
+- Do not change task, escrow, settlement, Solana, or proof semantics.
+- Do not fall back to identity-only success when the service route fails.
+
+## Failure Modes
+
+- Registration endpoint is unavailable.
+- Service authentication or `agents:write` authorization fails.
+- Service rejects invalid or conflicting metadata.
+- Service returns malformed profile JSON.
+- Returned DID does not match the authenticated MCP identity.
+- Canonical registration payload used for signing differs from the HTTP body.
+
+## Acceptance Criteria
+
+- [ ] Real-backend MCP `register` invokes `POST /v1/agents/register`.
+- [ ] The request is signed with `agents:write` and uses the canonical SDK
+      registration payload.
+- [ ] The persisted profile uses the deterministic MCP metadata contract.
+- [ ] The MCP response exposes the persisted profile fields.
+- [ ] Service failures and malformed responses fail hard with no fallback.
+- [ ] Repeating identical registration remains compatible with the service's
+      existing idempotent registration semantics.
+- [ ] The `register` tool name and empty input schema do not change.
+- [ ] Fake backends and existing task/escrow/proof tools remain compatible.
+
+## Files To Touch
+
+- `specs/7076-mcp-service-backed-registration.md`
+- `crates/kamn-sdk/src/lib.rs`
+- `crates/kamn-sdk/src/service_agent_registration.rs`
+- `crates/kamn-sdk/src/service_client_bridge_misc_routes.rs`
+- `crates/kamn-sdk/src/live/routes.rs`
+- `crates/kamn-agent-lib/src/client.rs`
+- `crates/kamn-agent-lib/src/lib.rs`
+- `crates/kamn-mcp-server/src/lib.rs`
+- `crates/kamn-mcp-server/src/registration.rs`
+- `crates/kamn-mcp-server/src/dispatch.rs`
+- `crates/kamn-mcp-server/tests/real_backend_integration_contract.rs`
+- Existing SDK, agent-lib, and MCP regression tests as required.
+
+## Error Semantics
+
+- SDK metadata validation returns existing typed `SdkError::InvalidInput`.
+- Agent-lib preserves SDK errors through `AgentLibError`; it does not log or
+  substitute a local DID.
+- MCP dispatch translates the propagated error into its existing structured
+  failure envelope.
+- A service-returned DID mismatch fails before MCP success is rendered.
+- Network, authentication, conflict, and malformed-response failures remain
+  distinguishable through existing SDK/agent-lib error mappings.
+
+## Test Plan
+
+- Red: real-backend MCP registration test requiring one observed service HTTP
+  request and persisted profile metadata in the MCP response.
+- Red: SDK canonical payload contract used by both auth signing and HTTP body.
+- Green: extract the existing SDK registration payload builder, add agent-lib
+  service registration, and wire MCP registration through it.
+- Refactor: keep registration rendering in a dedicated MCP module and remove
+  duplicate SDK metadata validation/payload code.
+- Integration: run SDK registration tests, agent-lib contracts, MCP real
+  backend/dispatch/protocol/inventory suites, formatter, strict workspace
+  clippy, `make check`, and a live local MCP registration against KAMN runtime.
+
+## Deviations
+
+- None at specification time.
+
+## Completion Evidence
+
+- Pending implementation and verification.


### PR DESCRIPTION
## Human Summary

- Changes the existing MCP `register` tool from an identity echo into authenticated, durable service-backed registration.
- Persists deterministic MVP metadata through `POST /v1/agents/register` and returns the profile supplied by KAMN runtime.
- Preserves the existing tool name and empty input schema.
- Fails closed on service, authentication, conflict, malformed-response, DID-mismatch, and replay errors.
- Documents that live MCP registration is now real while the project-local Pi actor receipt tool remains report-derived pending the next wiring issue.

Closes #7076

Spec: `specs/7076-mcp-service-backed-registration.md`

## Testing

- RED: focused real-backend contract failed because `register` returned only a DID and did not consume an HTTP request.
- `cargo test -p kamn-sdk`
- `cargo test -p kamn-agent-lib`
- `cargo test -p kamn-mcp-server`
- `cargo fmt --check`
- `CARGO_TARGET_DIR=target/mvp-demo-proof CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `CARGO_TARGET_DIR=target/mvp-demo-proof CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 make check`
- `cargo test -p kamn-e2e-harness --test mvp_evaluator_demo_runbook_contract -- --nocapture`
- Live loopback: built and started `kamn-node` on `127.0.0.1:18276`, then used the real `kamn-mcp-server` binary with disposable deterministic test identities.
- Live Agent B: registration returned HTTP 201 and profile query returned HTTP 200 in one persistent MCP session with nonce progression 1 to 2.
- Live Agent C: identical registration repeated successfully with the same DID/profile and two HTTP 201 outcomes.
- Negative live check: a fresh process for an already-used DID was rejected with `service_api_auth_replay_nonce_detected` rather than bypassing replay protection.

## Notes for Reviewers

The review focus is the payload/provenance boundary. The SDK now owns one canonical registration payload helper used for both request signing and the HTTP body. Agent-lib propagates failures and verifies the returned DID matches the authenticated identity. The MCP renderer only reports the returned persisted profile.

This PR does not wire Pi's report-bound actor receipt tools to the live MCP process. That is the next dependent slice.

shell_loc_delta_actual: 0
rust_loc_delta_actual: 107
shell_to_rust_ratio_delta_actual: 0.0
shell_surface_ratio_target_status: neutral

## AI Agent Details

- Added `service_agent_registration_payload` to remove duplicate SDK payload validation.
- Added `KamnAgentHandle::register_agent` with `agents:write` authentication and DID consistency validation.
- Added a dedicated MCP registration renderer with deterministic MVP metadata.
- Kept fake backend injection and all existing MCP inventory/protocol contracts unchanged.
