### PR TITLE
[7078] Give Pi a persistent live MCP agent session

### DIFF
--- a/.pi/extensions/kamn-mvp/index.ts
+++ b/.pi/extensions/kamn-mvp/index.ts
@@ -3,6 +3,7 @@ import type { ExtensionAPI, ExtensionContext, ExecResult } from "@earendil-works
 import { Type } from "typebox";
 import { actorToolSpecs, recordActorReceipt } from "./actor-receipts";
 import { boundarySummary, readReport, writeEvidence } from "./evidence";
+import { registerLiveMcpTools } from "./live-mcp-tools.ts";
 
 const DEFAULT_REPORT = ".kamn/demo/latest/proof/report.json";
 const DEFAULT_EVIDENCE = "/tmp/kamn-pi-mcp-agent-harness-evidence.json";
@@ -17,6 +18,7 @@ export default function kamnMvpExtension(pi: ExtensionAPI) {
 	registerActorReceiptTools(pi);
 	registerEvidenceTool(pi);
 	registerDemoTool(pi);
+	registerLiveMcpTools(pi);
 }
 function registerVerifyTool(pi: ExtensionAPI) {
 	pi.registerTool({

--- a/.pi/extensions/kamn-mvp/live-mcp-tools.ts
+++ b/.pi/extensions/kamn-mvp/live-mcp-tools.ts
@@ -6,6 +6,12 @@ type LiveAgentState = { session?: McpSession; did?: string };
 
 export function registerLiveMcpTools(pi: ExtensionAPI) {
 	const state: LiveAgentState = {};
+	registerLiveAgentA(pi, state);
+	registerLiveAgentAQuery(pi, state);
+	pi.on("session_shutdown", async () => state.session?.shutdown());
+}
+
+function registerLiveAgentA(pi: ExtensionAPI, state: LiveAgentState) {
 	pi.registerTool({
 		name: "kamn_live_agent_a_register",
 		label: "KAMN Live Agent A Register",
@@ -19,6 +25,9 @@ export function registerLiveMcpTools(pi: ExtensionAPI) {
 			return textResult("Agent A registration persisted through the local KAMN service.", result);
 		},
 	});
+}
+
+function registerLiveAgentAQuery(pi: ExtensionAPI, state: LiveAgentState) {
 	pi.registerTool({
 		name: "kamn_live_agent_a_query_profile",
 		label: "KAMN Live Agent A Query Profile",
@@ -32,7 +41,6 @@ export function registerLiveMcpTools(pi: ExtensionAPI) {
 			return textResult("Agent A durable profile query passed through the same local MCP process.", result);
 		},
 	});
-	pi.on("session_shutdown", async () => state.session?.shutdown());
 }
 
 function session(state: LiveAgentState, cwd: string): McpSession {

--- a/.pi/extensions/kamn-mvp/live-mcp-tools.ts
+++ b/.pi/extensions/kamn-mvp/live-mcp-tools.ts
@@ -1,0 +1,53 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { Type } from "typebox";
+import { McpSession, readLiveMcpConfig } from "./mcp-session.ts";
+
+type LiveAgentState = { session?: McpSession; did?: string };
+
+export function registerLiveMcpTools(pi: ExtensionAPI) {
+	const state: LiveAgentState = {};
+	pi.registerTool({
+		name: "kamn_live_agent_a_register",
+		label: "KAMN Live Agent A Register",
+		description: "Register Agent A through a persistent live local KAMN MCP process.",
+		promptSnippet: "Register Agent A through the live local-only KAMN service path",
+		parameters: Type.Object({}),
+		executionMode: "sequential",
+		async execute(_id, _params, signal, _onUpdate, ctx) {
+			const result = await session(state, ctx.cwd).call("register", {}, signal);
+			state.did = requiredDid(result);
+			return textResult("Agent A registration persisted through the local KAMN service.", result);
+		},
+	});
+	pi.registerTool({
+		name: "kamn_live_agent_a_query_profile",
+		label: "KAMN Live Agent A Query Profile",
+		description: "Query Agent A's durable profile through the same live local KAMN MCP process.",
+		promptSnippet: "Query the registered Agent A profile through the live local-only KAMN service path",
+		parameters: Type.Object({}),
+		executionMode: "sequential",
+		async execute(_id, _params, signal, _onUpdate, ctx) {
+			if (!state.did) throw new Error("Register Agent A before querying its live profile");
+			const result = await session(state, ctx.cwd).call("query_agent_profile", { did: state.did }, signal);
+			return textResult("Agent A durable profile query passed through the same local MCP process.", result);
+		},
+	});
+	pi.on("session_shutdown", async () => state.session?.shutdown());
+}
+
+function session(state: LiveAgentState, cwd: string): McpSession {
+	state.session ??= new McpSession(readLiveMcpConfig(process.env, cwd));
+	return state.session;
+}
+
+function requiredDid(result: Record<string, unknown>): string {
+	if (typeof result.did !== "string" || !result.did) throw new Error("KAMN live registration omitted Agent A DID");
+	return result.did;
+}
+
+function textResult(text: string, result: Record<string, unknown>) {
+	return {
+		content: [{ type: "text" as const, text: `${text} Claim boundary: local-only identity durability; no settlement or asset movement is claimed.` }],
+		details: { claimBoundary: "local-only identity durability", result },
+	};
+}

--- a/.pi/extensions/kamn-mvp/mcp-session.test.ts
+++ b/.pi/extensions/kamn-mvp/mcp-session.test.ts
@@ -35,6 +35,7 @@ test("configuration rejects missing values and key files", () => {
 for (const [mode, expected] of [
 	["error", /backend_error.*forced backend failure/],
 	["malformed", /invalid JSON/],
+	["mismatch", /response ID mismatch/],
 	["exit", /exited.*7/],
 	["hang", /timed out/],
 ] as const) {
@@ -45,6 +46,16 @@ for (const [mode, expected] of [
 		await session.shutdown();
 	});
 }
+
+test("an already aborted call rejects without starting the child", async () => {
+	const paths = await testPaths();
+	const session = sessionFor(paths, "success");
+	const controller = new AbortController();
+	controller.abort();
+
+	await assert.rejects(session.call("register", {}, controller.signal), /aborted/);
+	await assert.rejects(readFile(paths.startFile), { code: "ENOENT" });
+});
 
 async function testPaths() {
 	const root = await mkdtemp(resolve(tmpdir(), "kamn-mcp-session-"));

--- a/.pi/extensions/kamn-mvp/mcp-session.test.ts
+++ b/.pi/extensions/kamn-mvp/mcp-session.test.ts
@@ -41,7 +41,7 @@ for (const [mode, expected] of [
 ] as const) {
 	test(`session fails loudly for ${mode} child behavior`, async () => {
 		const paths = await testPaths();
-		const session = sessionFor(paths, mode, 50);
+		const session = sessionFor(paths, mode, mode === "hang" ? 50 : 1000);
 		await assert.rejects(session.call("register"), expected);
 		await session.shutdown();
 	});

--- a/.pi/extensions/kamn-mvp/mcp-session.test.ts
+++ b/.pi/extensions/kamn-mvp/mcp-session.test.ts
@@ -32,6 +32,14 @@ test("configuration rejects missing values and key files", () => {
 	);
 });
 
+test("configuration does not forward unrelated Pi credentials", async () => {
+	const paths = await testPaths();
+	const config = readLiveMcpConfig(configEnv(paths.keyFile, { OPENAI_API_KEY: "must-not-leak" }), process.cwd());
+
+	assert.equal(config.env.OPENAI_API_KEY, undefined);
+	assert.equal(config.env.KAMN_MVP_LIVE_MCP_AGENT_A_NAME, "agent-a");
+});
+
 for (const [mode, expected] of [
 	["error", /backend_error.*forced backend failure/],
 	["malformed", /invalid JSON/],

--- a/.pi/extensions/kamn-mvp/mcp-session.test.ts
+++ b/.pi/extensions/kamn-mvp/mcp-session.test.ts
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import { chmod, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import test from "node:test";
+import { McpSession, readLiveMcpConfig } from "./mcp-session.ts";
+
+const fixture = resolve(".pi/extensions/kamn-mvp/test-fixtures/fake-mcp-server.mjs");
+
+test("session starts lazily and reuses one child for ordered calls", async () => {
+	const paths = await testPaths();
+	const session = sessionFor(paths, "success");
+	await assert.rejects(readFile(paths.startFile), { code: "ENOENT" });
+
+	const registered = await session.call("register");
+	const queried = await session.call("query_agent_profile", { did: registered.did });
+
+	assert.equal(registered.pid, queried.pid);
+	assert.equal(registered.request_id, "1");
+	assert.equal(queried.request_id, "2");
+	assert.equal(queried.did, registered.did);
+	await session.shutdown();
+	await session.shutdown();
+	assert.equal((await readFile(paths.stopFile, "utf8")).trim(), String(registered.pid));
+});
+
+test("configuration rejects missing values and key files", () => {
+	assert.throws(() => readLiveMcpConfig({}, process.cwd()), /KAMN_MVP_LIVE_MCP_BINARY/);
+	assert.throws(
+		() => readLiveMcpConfig(configEnv("/missing/key", {}), process.cwd()),
+		/key file does not exist/,
+	);
+});
+
+for (const [mode, expected] of [
+	["error", /backend_error.*forced backend failure/],
+	["malformed", /invalid JSON/],
+	["exit", /exited.*7/],
+	["hang", /timed out/],
+] as const) {
+	test(`session fails loudly for ${mode} child behavior`, async () => {
+		const paths = await testPaths();
+		const session = sessionFor(paths, mode, 50);
+		await assert.rejects(session.call("register"), expected);
+		await session.shutdown();
+	});
+}
+
+async function testPaths() {
+	const root = await mkdtemp(resolve(tmpdir(), "kamn-mcp-session-"));
+	const keyFile = resolve(root, "agent.key");
+	await writeFile(keyFile, "test-only-key\n");
+	await chmod(fixture, 0o755);
+	return { keyFile, startFile: resolve(root, "start"), stopFile: resolve(root, "stop") };
+}
+
+function sessionFor(paths: Awaited<ReturnType<typeof testPaths>>, mode: string, timeoutMs = 1000) {
+	return new McpSession(
+		readLiveMcpConfig(configEnv(paths.keyFile, {
+			KAMN_MVP_FAKE_MCP_MODE: mode,
+			KAMN_MVP_FAKE_MCP_START_FILE: paths.startFile,
+			KAMN_MVP_FAKE_MCP_STOP_FILE: paths.stopFile,
+		}), process.cwd()),
+		{ timeoutMs },
+	);
+}
+
+function configEnv(keyFile: string, extra: Record<string, string>) {
+	return {
+		KAMN_MVP_LIVE_MCP_BINARY: fixture,
+		KAMN_MVP_LIVE_MCP_ENDPOINT: "http://127.0.0.1:18278",
+		KAMN_MVP_LIVE_MCP_AGENT_A_NAME: "agent-a",
+		KAMN_MVP_LIVE_MCP_AGENT_A_KEY_FILE: keyFile,
+		...extra,
+	};
+}

--- a/.pi/extensions/kamn-mvp/mcp-session.ts
+++ b/.pi/extensions/kamn-mvp/mcp-session.ts
@@ -3,6 +3,7 @@ import { existsSync } from "node:fs";
 import { resolve } from "node:path";
 
 type Environment = Record<string, string | undefined>;
+const PROCESS_ENV_ALLOWLIST = new Set(["HOME", "PATH", "RUST_LOG", "TMPDIR"]);
 type JsonObject = Record<string, unknown>;
 type PendingRequest = {
 	id: string;
@@ -126,8 +127,15 @@ export function readLiveMcpConfig(env: Environment = process.env, cwd = process.
 		keyFile,
 		endpoint: requiredEnv(env, "KAMN_MVP_LIVE_MCP_ENDPOINT"),
 		agentName: requiredEnv(env, "KAMN_MVP_LIVE_MCP_AGENT_A_NAME"),
-		env: { ...process.env, ...env },
+		env: childEnvironment(env),
 	};
+}
+function childEnvironment(env: Environment): NodeJS.ProcessEnv {
+	return Object.fromEntries(
+		Object.entries({ ...process.env, ...env }).filter(
+			([name, value]) => value !== undefined && (name.startsWith("KAMN_") || PROCESS_ENV_ALLOWLIST.has(name)),
+		),
+	);
 }
 function requiredEnv(env: Environment, name: string): string {
 	const value = env[name]?.trim();

--- a/.pi/extensions/kamn-mvp/mcp-session.ts
+++ b/.pi/extensions/kamn-mvp/mcp-session.ts
@@ -32,6 +32,7 @@ export class McpSession {
 		this.options = options;
 	}
 	async call(tool: string, fields: JsonObject = {}, signal?: AbortSignal): Promise<JsonObject> {
+		if (signal?.aborted) throw new Error("KAMN live MCP request aborted before start");
 		if (this.terminalError) throw this.terminalError;
 		if (this.pending) throw new Error("KAMN live MCP session already has an active request");
 		const child = this.start();
@@ -63,7 +64,6 @@ export class McpSession {
 		const timer = setTimeout(() => this.failSession(new Error(`KAMN live MCP request ${id} timed out`)), this.options.timeoutMs);
 		const abort = () => this.failSession(new Error(`KAMN live MCP request ${id} aborted`));
 		signal?.addEventListener("abort", abort, { once: true });
-		if (signal?.aborted) abort();
 		return { id, resolve: resolveRequest, reject, timer, removeAbort: () => signal?.removeEventListener("abort", abort) };
 	}
 	private consumeStdout(chunk: string) {
@@ -90,13 +90,14 @@ export class McpSession {
 	}
 	private handleExit(code: number | null, signal: NodeJS.Signals | null) {
 		if (this.shutdownPromise) return;
+		if (this.terminalError) return;
 		this.failSession(new Error(`KAMN live MCP exited with code ${code ?? "none"} signal ${signal ?? "none"}`), false);
 	}
 	private failSession(error: Error, kill = true) {
-		this.terminalError = error;
+		this.terminalError ??= error;
 		const pending = this.pending;
 		this.clearPending();
-		pending?.reject(error);
+		pending?.reject(this.terminalError);
 		if (kill) this.child?.kill("SIGTERM");
 	}
 	private clearPending() {

--- a/.pi/extensions/kamn-mvp/mcp-session.ts
+++ b/.pi/extensions/kamn-mvp/mcp-session.ts
@@ -1,0 +1,145 @@
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+
+type Environment = Record<string, string | undefined>;
+type JsonObject = Record<string, unknown>;
+type PendingRequest = {
+	id: string;
+	resolve: (result: JsonObject) => void;
+	reject: (error: Error) => void;
+	timer: NodeJS.Timeout;
+	removeAbort: () => void;
+};
+export type LiveMcpConfig = {
+	binary: string;
+	endpoint: string;
+	agentName: string;
+	keyFile: string;
+	env: NodeJS.ProcessEnv;
+};
+export class McpSession {
+	private child?: ChildProcessWithoutNullStreams;
+	private pending?: PendingRequest;
+	private terminalError?: Error;
+	private sequence = 0;
+	private stdoutBuffer = "";
+	private shutdownPromise?: Promise<void>;
+	private readonly config: LiveMcpConfig;
+	private readonly options: { timeoutMs: number };
+	constructor(config: LiveMcpConfig, options = { timeoutMs: 10000 }) {
+		this.config = config;
+		this.options = options;
+	}
+	async call(tool: string, fields: JsonObject = {}, signal?: AbortSignal): Promise<JsonObject> {
+		if (this.terminalError) throw this.terminalError;
+		if (this.pending) throw new Error("KAMN live MCP session already has an active request");
+		const child = this.start();
+		const id = String(++this.sequence);
+		return new Promise((resolveRequest, rejectRequest) => {
+			this.pending = this.pendingRequest(id, resolveRequest, rejectRequest, signal);
+			child.stdin.write(`${JSON.stringify({ id, tool, ...fields })}\n`, (error) => {
+				if (error) this.failSession(new Error(`KAMN live MCP write failed: ${error.message}`));
+			});
+		});
+	}
+	async shutdown(): Promise<void> {
+		if (this.shutdownPromise) return this.shutdownPromise;
+		this.shutdownPromise = this.stopChild();
+		return this.shutdownPromise;
+	}
+	private start(): ChildProcessWithoutNullStreams {
+		if (this.child) return this.child;
+		const args = ["--endpoint", this.config.endpoint, "--agent-name", this.config.agentName, "--key-file", this.config.keyFile];
+		const child = spawn(this.config.binary, args, { env: this.config.env, stdio: ["pipe", "pipe", "pipe"] });
+		this.child = child;
+		child.stdout.setEncoding("utf8");
+		child.stdout.on("data", (chunk: string) => this.consumeStdout(chunk));
+		child.once("error", (error) => this.failSession(new Error(`KAMN live MCP spawn failed: ${error.message}`)));
+		child.once("exit", (code, signal) => this.handleExit(code, signal));
+		return child;
+	}
+	private pendingRequest(id: string, resolveRequest: PendingRequest["resolve"], reject: PendingRequest["reject"], signal?: AbortSignal): PendingRequest {
+		const timer = setTimeout(() => this.failSession(new Error(`KAMN live MCP request ${id} timed out`)), this.options.timeoutMs);
+		const abort = () => this.failSession(new Error(`KAMN live MCP request ${id} aborted`));
+		signal?.addEventListener("abort", abort, { once: true });
+		if (signal?.aborted) abort();
+		return { id, resolve: resolveRequest, reject, timer, removeAbort: () => signal?.removeEventListener("abort", abort) };
+	}
+	private consumeStdout(chunk: string) {
+		this.stdoutBuffer += chunk;
+		for (let newline = this.stdoutBuffer.indexOf("\n"); newline >= 0; newline = this.stdoutBuffer.indexOf("\n")) {
+			const line = this.stdoutBuffer.slice(0, newline).trim();
+			this.stdoutBuffer = this.stdoutBuffer.slice(newline + 1);
+			if (line) this.resolveLine(line);
+		}
+	}
+	private resolveLine(line: string) {
+		let response: JsonObject;
+		try {
+			response = JSON.parse(line) as JsonObject;
+		} catch {
+			return this.failSession(new Error("KAMN live MCP returned invalid JSON"));
+		}
+		const pending = this.pending;
+		if (!pending || response.id !== pending.id) return this.failSession(new Error("KAMN live MCP response ID mismatch"));
+		this.clearPending();
+		if (response.ok !== true) return pending.reject(toolError(response));
+		if (!isObject(response.result)) return pending.reject(new Error("KAMN live MCP success response omitted result"));
+		pending.resolve(response.result);
+	}
+	private handleExit(code: number | null, signal: NodeJS.Signals | null) {
+		if (this.shutdownPromise) return;
+		this.failSession(new Error(`KAMN live MCP exited with code ${code ?? "none"} signal ${signal ?? "none"}`), false);
+	}
+	private failSession(error: Error, kill = true) {
+		this.terminalError = error;
+		const pending = this.pending;
+		this.clearPending();
+		pending?.reject(error);
+		if (kill) this.child?.kill("SIGTERM");
+	}
+	private clearPending() {
+		if (!this.pending) return;
+		clearTimeout(this.pending.timer);
+		this.pending.removeAbort();
+		this.pending = undefined;
+	}
+	private async stopChild(): Promise<void> {
+		this.failSession(new Error("KAMN live MCP session shut down"), false);
+		const child = this.child;
+		if (!child || child.exitCode !== null || child.signalCode !== null) return;
+		await new Promise<void>((resolveExit) => {
+			child.once("exit", () => resolveExit());
+			child.kill("SIGTERM");
+		});
+	}
+}
+export function readLiveMcpConfig(env: Environment = process.env, cwd = process.cwd()): LiveMcpConfig {
+	const binary = absolutePath(requiredEnv(env, "KAMN_MVP_LIVE_MCP_BINARY"), cwd);
+	const keyFile = absolutePath(requiredEnv(env, "KAMN_MVP_LIVE_MCP_AGENT_A_KEY_FILE"), cwd);
+	if (!existsSync(binary)) throw new Error(`KAMN live MCP binary does not exist: ${binary}`);
+	if (!existsSync(keyFile)) throw new Error(`KAMN live MCP key file does not exist: ${keyFile}`);
+	return {
+		binary,
+		keyFile,
+		endpoint: requiredEnv(env, "KAMN_MVP_LIVE_MCP_ENDPOINT"),
+		agentName: requiredEnv(env, "KAMN_MVP_LIVE_MCP_AGENT_A_NAME"),
+		env: { ...process.env, ...env },
+	};
+}
+function requiredEnv(env: Environment, name: string): string {
+	const value = env[name]?.trim();
+	if (!value) throw new Error(`Missing required environment variable: ${name}`);
+	return value;
+}
+function absolutePath(path: string, cwd: string): string {
+	return path.startsWith("/") ? path : resolve(cwd, path);
+}
+function isObject(value: unknown): value is JsonObject {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+function toolError(response: JsonObject): Error {
+	const error = isObject(response.error) ? response.error : {};
+	return new Error(`${String(error.kind ?? "unknown_error")}: ${String(error.message ?? "KAMN live MCP tool failed")}`);
+}

--- a/.pi/extensions/kamn-mvp/test-fixtures/fake-mcp-server.mjs
+++ b/.pi/extensions/kamn-mvp/test-fixtures/fake-mcp-server.mjs
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+import { appendFileSync, writeFileSync } from "node:fs";
+import { createInterface } from "node:readline";
+
+const mode = process.env.KAMN_MVP_FAKE_MCP_MODE ?? "success";
+const startFile = process.env.KAMN_MVP_FAKE_MCP_START_FILE;
+const stopFile = process.env.KAMN_MVP_FAKE_MCP_STOP_FILE;
+if (startFile) writeFileSync(startFile, `${process.pid}\n`);
+
+process.on("SIGTERM", () => {
+	if (stopFile) appendFileSync(stopFile, `${process.pid}\n`);
+	process.exit(0);
+});
+
+createInterface({ input: process.stdin }).on("line", (line) => {
+	if (mode === "exit") process.exit(7);
+	if (mode === "hang") return;
+	if (mode === "malformed") return process.stdout.write("not-json\n");
+	const request = JSON.parse(line);
+	if (mode === "error") return write(errorResponse(request));
+	write(successResponse(request));
+});
+
+function successResponse(request) {
+	const did = request.did ?? "kamn:did:agent-a";
+	return {
+		ok: true,
+		id: request.id,
+		tool: request.tool,
+		result: { did, pid: process.pid, request_id: request.id },
+	};
+}
+
+function errorResponse(request) {
+	return {
+		ok: false,
+		id: request.id,
+		tool: request.tool,
+		error: { kind: "backend_error", message: "forced backend failure" },
+	};
+}
+
+function write(response) {
+	process.stdout.write(`${JSON.stringify(response)}\n`);
+}

--- a/.pi/extensions/kamn-mvp/test-fixtures/fake-mcp-server.mjs
+++ b/.pi/extensions/kamn-mvp/test-fixtures/fake-mcp-server.mjs
@@ -25,7 +25,7 @@ function successResponse(request) {
 	const did = request.did ?? "kamn:did:agent-a";
 	return {
 		ok: true,
-		id: request.id,
+		id: mode === "mismatch" ? "wrong-id" : request.id,
 		tool: request.tool,
 		result: { did, pid: process.pid, request_id: request.id },
 	};

--- a/crates/kamn-e2e-harness/tests/mvp_demo_agent_harness_claim_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_demo_agent_harness_claim_contract.rs
@@ -140,6 +140,12 @@ fn spec_c08_project_local_pi_extension_registers_kamn_tools() {
         "kamn_agent_c_verify_three_agent_proof",
         "invoke_transaction",
         "accept_task",
+        "kamn_live_agent_a_register",
+        "kamn_live_agent_a_query_profile",
+        "query_agent_profile",
+        "session_shutdown",
+        "KAMN_MVP_LIVE_MCP_BINARY",
+        "KAMN_MVP_LIVE_MCP_AGENT_A_KEY_FILE",
     ] {
         assert!(source.contains(marker), "missing Pi tool marker: {marker}");
     }
@@ -208,6 +214,8 @@ fn pi_extension_source() -> String {
         ".pi/extensions/kamn-mvp/index.ts",
         ".pi/extensions/kamn-mvp/evidence.ts",
         ".pi/extensions/kamn-mvp/actor-receipts.ts",
+        ".pi/extensions/kamn-mvp/live-mcp-tools.ts",
+        ".pi/extensions/kamn-mvp/mcp-session.ts",
     ]
     .map(|path| {
         std::fs::read_to_string(workspace_root().join(path))

--- a/crates/kamn-e2e-harness/tests/mvp_evaluator_demo_runbook_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_evaluator_demo_runbook_contract.rs
@@ -26,6 +26,15 @@ fn spec_c01_mvp_runbook_documents_pi_tool_harness_boundaries() {
         "three-agent-transcript.json",
         "raw participant-private payloads stay redacted",
         "does not prove generic Pi MCP protocol support",
+        "kamn_live_agent_a_register",
+        "kamn_live_agent_a_query_profile",
+        "KAMN_MVP_LIVE_MCP_BINARY",
+        "KAMN_MVP_LIVE_MCP_ENDPOINT",
+        "KAMN_MVP_LIVE_MCP_AGENT_A_NAME",
+        "KAMN_MVP_LIVE_MCP_AGENT_A_KEY_FILE",
+        "persistent live MCP process",
+        "local-only identity durability",
+        "does not prove task, escrow, settlement, or asset movement",
     ] {
         assert!(runbook.contains(needle), "{RUNBOOK} missing: {needle}");
     }

--- a/crates/kamn-e2e-harness/tests/mvp_evaluator_demo_runbook_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_evaluator_demo_runbook_contract.rs
@@ -35,6 +35,11 @@ fn spec_c01_mvp_runbook_documents_pi_tool_harness_boundaries() {
         "persistent live MCP process",
         "local-only identity durability",
         "does not prove task, escrow, settlement, or asset movement",
+        "openssl rand -hex 32 > /tmp/kamn-pi-agent-a.key",
+        "--runtime-mode api",
+        "--api-bind 127.0.0.1:18278",
+        "request nonce `1` and status `201`",
+        "request nonce `2` and status `200`",
     ] {
         assert!(runbook.contains(needle), "{RUNBOOK} missing: {needle}");
     }

--- a/docs/validation/mvp-evaluator-demo.md
+++ b/docs/validation/mvp-evaluator-demo.md
@@ -121,6 +121,32 @@ still records report-bound evaluator evidence; it is not yet wired to invoke
 the live MCP registration process. Keep those two surfaces distinct when
 describing the current demo.
 
+### Live Pi Identity Check
+
+Pi can also prove local-only identity durability through a persistent live MCP process. Build the binaries, start the local KAMN service separately, and provide an existing disposable Agent A key file:
+
+```bash
+cargo build -p kamn-mcp-server -p kamn-node
+
+KAMN_MVP_LIVE_MCP_BINARY=target/debug/kamn-mcp-server \
+KAMN_MVP_LIVE_MCP_ENDPOINT=http://127.0.0.1:18278 \
+KAMN_MVP_LIVE_MCP_AGENT_A_NAME=pi-agent-a \
+KAMN_MVP_LIVE_MCP_AGENT_A_KEY_FILE=/absolute/path/to/disposable-agent-a.key \
+env -u OPENAI_API_KEY pi \
+  --model openai-codex/gpt-5.5 \
+  --thinking medium \
+  --extension .pi/extensions/kamn-mvp/index.ts \
+  --no-builtin-tools \
+  --tools kamn_live_agent_a_register,kamn_live_agent_a_query_profile \
+  --approve \
+  --no-session \
+  -p "Use only the KAMN tools. Register Agent A, then query the same durable Agent A profile. Report the claim boundary exactly."
+```
+
+`kamn_live_agent_a_register` starts `kamn-mcp-server` lazily. `kamn_live_agent_a_query_profile` reuses that process, preserving its authenticated request nonce and querying the DID returned by registration. The extension passes the key-file path to the child process but does not read or return key contents; Pi session shutdown terminates the child.
+
+This proves local-only identity durability through the live service API. It does not prove task, escrow, settlement, or asset movement, and it does not replace the devnet-required proof for any value-movement claim.
+
 The evidence also records a `three_agent_boundary` summary derived from the
 verified report: local-only reports are marked `NOT_PRESENT`, while reports with
 `three_agent_escrow_verification` must preserve the report's claim status, label,

--- a/docs/validation/mvp-evaluator-demo.md
+++ b/docs/validation/mvp-evaluator-demo.md
@@ -155,7 +155,7 @@ env -u OPENAI_API_KEY pi \
   -p "Use only the KAMN tools. Register Agent A, then query the same durable Agent A profile. Report the claim boundary exactly."
 ```
 
-`kamn_live_agent_a_register` starts `kamn-mcp-server` lazily. `kamn_live_agent_a_query_profile` reuses that process, preserving its authenticated request nonce and querying the DID returned by registration. The extension passes the key-file path to the child process but does not read or return key contents; Pi session shutdown terminates the child.
+`kamn_live_agent_a_register` starts `kamn-mcp-server` lazily. `kamn_live_agent_a_query_profile` reuses that process, preserving its authenticated request nonce and querying the DID returned by registration. The extension passes the key-file path to the child process but does not read or return key contents; Pi session shutdown terminates the child. Only KAMN-prefixed configuration and basic process variables are forwarded to the child; Pi and OpenAI credentials are not forwarded.
 
 A passing node log shows `POST /v1/agents/register` with request nonce `1` and status `201`, followed by `GET /v1/agents/<same-did>` with request nonce `2` and status `200`.
 

--- a/docs/validation/mvp-evaluator-demo.md
+++ b/docs/validation/mvp-evaluator-demo.md
@@ -123,15 +123,27 @@ describing the current demo.
 
 ### Live Pi Identity Check
 
-Pi can also prove local-only identity durability through a persistent live MCP process. Build the binaries, start the local KAMN service separately, and provide an existing disposable Agent A key file:
+Pi can also prove local-only identity durability through a persistent live MCP process. In one terminal, build the binaries, create a disposable Agent A key, and start the local KAMN service:
 
 ```bash
 cargo build -p kamn-mcp-server -p kamn-node
+openssl rand -hex 32 > /tmp/kamn-pi-agent-a.key
+KAMN_SERVICE_API_TLS_MODE=disabled target/debug/kamn-node \
+  --runtime-mode api \
+  --role processor \
+  --api-bind 127.0.0.1:18278 \
+  --api-max-requests 1000 \
+  --api-idle-timeout-ms 600000 \
+  --storage-dir /tmp/kamn-node-pi-live
+```
 
+In a second terminal, run the two live Pi tools:
+
+```bash
 KAMN_MVP_LIVE_MCP_BINARY=target/debug/kamn-mcp-server \
 KAMN_MVP_LIVE_MCP_ENDPOINT=http://127.0.0.1:18278 \
 KAMN_MVP_LIVE_MCP_AGENT_A_NAME=pi-agent-a \
-KAMN_MVP_LIVE_MCP_AGENT_A_KEY_FILE=/absolute/path/to/disposable-agent-a.key \
+KAMN_MVP_LIVE_MCP_AGENT_A_KEY_FILE=/tmp/kamn-pi-agent-a.key \
 env -u OPENAI_API_KEY pi \
   --model openai-codex/gpt-5.5 \
   --thinking medium \
@@ -144,6 +156,8 @@ env -u OPENAI_API_KEY pi \
 ```
 
 `kamn_live_agent_a_register` starts `kamn-mcp-server` lazily. `kamn_live_agent_a_query_profile` reuses that process, preserving its authenticated request nonce and querying the DID returned by registration. The extension passes the key-file path to the child process but does not read or return key contents; Pi session shutdown terminates the child.
+
+A passing node log shows `POST /v1/agents/register` with request nonce `1` and status `201`, followed by `GET /v1/agents/<same-did>` with request nonce `2` and status `200`.
 
 This proves local-only identity durability through the live service API. It does not prove task, escrow, settlement, or asset movement, and it does not replace the devnet-required proof for any value-movement claim.
 

--- a/specs/7078-pi-persistent-live-mcp-session.md
+++ b/specs/7078-pi-persistent-live-mcp-session.md
@@ -1,0 +1,99 @@
+# Pi Persistent Live MCP Session
+
+## Objective
+
+Give the project-local Pi evaluator a persistent, live `kamn-mcp-server` session for Agent A so Pi can register the agent through `POST /v1/agents/register` and then query the durable profile through the same authenticated process.
+
+## Inputs/Outputs
+
+Inputs:
+
+- `KAMN_MVP_LIVE_MCP_BINARY`: absolute or repository-relative `kamn-mcp-server` binary path.
+- `KAMN_MVP_LIVE_MCP_ENDPOINT`: live local KAMN service endpoint.
+- `KAMN_MVP_LIVE_MCP_AGENT_A_NAME`: logical Agent A name.
+- `KAMN_MVP_LIVE_MCP_AGENT_A_KEY_FILE`: existing private key file passed to the child process without reading it.
+- Pi calls to `kamn_live_agent_a_register` and `kamn_live_agent_a_query_profile`.
+
+Outputs:
+
+- Registration tool result containing the service-persisted Agent A profile.
+- Query tool result containing the same durable Agent A profile.
+- Human-readable Pi tool messages that label the result `local-only` and make no settlement claim.
+
+## Boundaries/Non-goals
+
+- Preserve the existing report-derived `kamn_agent_a_register` receipt tool unchanged.
+- Start `kamn-mcp-server` lazily on the first live tool call, not when the extension module loads.
+- Share one child process and monotonically increasing request IDs for the Pi session.
+- Pi starts neither `kamn-node` nor any devnet process.
+- Never read, print, return, or persist private-key contents.
+- Do not implement task invocation, Agent B, Agent C, escrow, settlement, exchange, or asset movement here.
+- Do not claim generic Pi MCP-host compatibility; this is a project-local stdio bridge to KAMN's line protocol.
+- Add no dependency.
+
+## Failure Modes
+
+- Missing or blank required environment variable: reject before spawning.
+- Missing key file: reject before spawning without reading its contents.
+- Child spawn failure or premature exit: reject the active call and make later calls fail rather than silently replacing identity state.
+- Request timeout or abort: reject and terminate the session.
+- Malformed stdout JSON: reject and terminate the session.
+- Mismatched response ID: reject and terminate the session.
+- MCP envelope with `ok:false`: surface the tool error and do not report success.
+- Profile query before successful registration: reject without calling the server.
+- Repeated shutdown: succeed without duplicate side effects.
+
+## Acceptance Criteria
+
+- [ ] The Pi extension registers `kamn_live_agent_a_register` and `kamn_live_agent_a_query_profile`.
+- [ ] Both tools share one lazily spawned child and ordered request IDs.
+- [ ] Registration dispatches `register`; query dispatches `agent_profile_query` with the registered DID.
+- [ ] Required configuration and key-file existence are validated before spawn.
+- [ ] The key path is passed as a child argument, while key contents remain inaccessible to tool output.
+- [ ] All specified protocol, process, timeout, abort, and ordering failures are loud.
+- [ ] `session_shutdown` cleanup is idempotent.
+- [ ] Node contract tests prove persistence, request ordering, failures, and cleanup.
+- [ ] Rust source/runbook contracts pin the live tool names and honest claim boundary.
+- [ ] A real Pi run against local `kamn-node` proves register then query through the persistent process.
+- [ ] Formatting, strict workspace clippy, targeted tests, and `make check` pass.
+
+## Files To Touch
+
+- `.pi/extensions/kamn-mvp/index.ts`
+- `.pi/extensions/kamn-mvp/mcp-session.ts`
+- `.pi/extensions/kamn-mvp/live-mcp-tools.ts`
+- `.pi/extensions/kamn-mvp/mcp-session.test.ts`
+- `.pi/extensions/kamn-mvp/test-fixtures/fake-mcp-server.mjs`
+- `crates/kamn-e2e-harness/tests/mvp_demo_agent_harness_claim_contract.rs`
+- `crates/kamn-e2e-harness/tests/mvp_evaluator_demo_runbook_contract.rs`
+- `docs/validation/mvp-evaluator-demo.md`
+
+## Error Semantics
+
+All configuration and process failures throw `Error` at the Pi tool boundary. The session rejects exactly one active request, kills the child after protocol-integrity failures, and never synthesizes a fallback result. Tool-level KAMN errors retain the server's error kind and message. Error text may include binary path, endpoint, request ID, and child exit status, but never key contents.
+
+## Test Plan
+
+RED:
+
+- Add Node tests that require lazy startup, same-PID reuse, request IDs `1` then `2`, DID propagation, failure handling, and idempotent shutdown.
+- Extend the Rust Pi source contract to require the new tool and lifecycle markers.
+- Extend the runbook contract to require configuration, local-only labeling, and the non-settlement boundary.
+
+GREEN:
+
+- Implement the minimum persistent line-protocol session and two Pi tools.
+- Document the exact evaluator commands.
+
+REFACTOR:
+
+- Separate process/protocol ownership from Pi tool registration.
+- Verify functions remain single-purpose and files remain within repository size limits.
+
+INTEGRATION:
+
+- Build real `kamn-node` and `kamn-mcp-server` binaries.
+- Start a disposable loopback node and key file.
+- Run Pi with Codex auth and only the two live tools.
+- Prove the node receives registration nonce 1 and profile query nonce 2 for the same DID.
+- Run targeted contracts, `cargo fmt --check`, strict clippy, and `make check`.

--- a/specs/7078-pi-persistent-live-mcp-session.md
+++ b/specs/7078-pi-persistent-live-mcp-session.md
@@ -47,7 +47,7 @@ Outputs:
 
 - [ ] The Pi extension registers `kamn_live_agent_a_register` and `kamn_live_agent_a_query_profile`.
 - [ ] Both tools share one lazily spawned child and ordered request IDs.
-- [ ] Registration dispatches `register`; query dispatches `agent_profile_query` with the registered DID.
+- [ ] Registration dispatches `register`; query dispatches `query_agent_profile` with the registered DID.
 - [ ] Required configuration and key-file existence are validated before spawn.
 - [ ] The key path is passed as a child argument, while key contents remain inaccessible to tool output.
 - [ ] All specified protocol, process, timeout, abort, and ordering failures are loud.


### PR DESCRIPTION
## Human Summary

- Adds two project-local Pi tools that register Agent A through the live KAMN service and query the same durable profile through one persistent MCP child process.
- Preserves authentication nonce state across calls and fails loudly on configuration, process, timeout, abort, protocol, and backend errors.
- Keeps the existing report-derived receipt tools unchanged and labels the new proof as local-only identity durability, never settlement or asset movement.
- Prevents Pi and OpenAI credentials from being forwarded to the MCP child and documents a reproducible two-terminal evaluator run.

## Testing

- RED: Node test failed with `ERR_MODULE_NOT_FOUND` before `mcp-session.ts` existed.
- RED: Pi source contract failed on missing `live-mcp-tools.ts`.
- RED: runbook contract failed on missing `kamn_live_agent_a_register`.
- `node --no-warnings --experimental-strip-types --test .pi/extensions/kamn-mvp/mcp-session.test.ts` (three consecutive passes, 9 tests each)
- `cargo test -p kamn-e2e-harness --test mvp_demo_agent_harness_claim_contract --test mvp_evaluator_demo_runbook_contract` (24 tests)
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `make check`
- `make demo-mvp` (`GO`)
- `cargo run -p kamn-e2e-harness -- verify-mvp-demo --report .kamn/demo/latest/proof/report.json`
- Real Pi `openai-codex/gpt-5.5` run against local `kamn-node` and real `kamn-mcp-server`: registration nonce `1` returned `201`; same-DID profile query nonce `2` returned `200`.
- Negative live check: restarting the same DID at nonce `1` returned `409 replay`.

## Notes for Reviewers

- Review the process lifecycle and first-failure behavior in `.pi/extensions/kamn-mvp/mcp-session.ts`.
- This PR proves only local identity registration and durable lookup. Task flow, escrow, settlement, and asset movement remain outside this slice.
- No new dependency, CI workflow, shell script, public Rust API, or schema change is introduced.

## AI Agent Details

- Issue: #7078
- Spec: `specs/7078-pi-persistent-live-mcp-session.md`
- The Pi extension starts the child lazily, serializes one request at a time, correlates response IDs, and terminates on protocol-integrity failures.
- Child environment forwarding is restricted to `KAMN_*` plus `HOME`, `PATH`, `RUST_LOG`, and `TMPDIR`.
- Existing `kamn_agent_a_register` remains report-derived; the live tool is explicitly named `kamn_live_agent_a_register`.

Closes #7078

shell_loc_delta_actual: 0
rust_loc_delta_actual: 22
shell_to_rust_ratio_delta_actual: 0.0
shell_surface_ratio_target_status: neutral
