### PR TITLE
[7080] Drive a real two-agent task through Pi

### DIFF
--- a/.pi/extensions/kamn-mvp/live-mcp-tools.ts
+++ b/.pi/extensions/kamn-mvp/live-mcp-tools.ts
@@ -1,33 +1,35 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
-import { McpSession, readLiveMcpConfig } from "./mcp-session.ts";
+import { LiveTaskWorkflow, type AgentRole, type WorkflowResult } from "./live-task-workflow.ts";
 
-type LiveAgentState = { session?: McpSession; did?: string };
+type WorkflowHolder = { workflow?: LiveTaskWorkflow };
 
 export function registerLiveMcpTools(pi: ExtensionAPI) {
-	const state: LiveAgentState = {};
-	registerLiveAgentA(pi, state);
-	registerLiveAgentAQuery(pi, state);
-	pi.on("session_shutdown", async () => state.session?.shutdown());
+	const holder: WorkflowHolder = {};
+	registerAgent(pi, holder, "agent_a", "kamn_live_agent_a_register", "KAMN Live Agent A Register");
+	registerAgent(pi, holder, "agent_b", "kamn_live_agent_b_register", "KAMN Live Agent B Register");
+	registerLiveAgentAQuery(pi, holder);
+	registerTaskTools(pi, holder);
+	pi.on("session_shutdown", async () => holder.workflow?.shutdown());
 }
 
-function registerLiveAgentA(pi: ExtensionAPI, state: LiveAgentState) {
+function registerAgent(pi: ExtensionAPI, holder: WorkflowHolder, role: AgentRole, name: string, label: string) {
+	const agent = role === "agent_a" ? "Agent A" : "Agent B";
 	pi.registerTool({
-		name: "kamn_live_agent_a_register",
-		label: "KAMN Live Agent A Register",
-		description: "Register Agent A through a persistent live local KAMN MCP process.",
-		promptSnippet: "Register Agent A through the live local-only KAMN service path",
+		name,
+		label,
+		description: `Register ${agent} through its persistent live local KAMN MCP process.`,
+		promptSnippet: `Register ${agent} through the live local-only KAMN service path`,
 		parameters: Type.Object({}),
 		executionMode: "sequential",
 		async execute(_id, _params, signal, _onUpdate, ctx) {
-			const result = await session(state, ctx.cwd).call("register", {}, signal);
-			state.did = requiredDid(result);
-			return textResult("Agent A registration persisted through the local KAMN service.", result);
+			const result = await workflow(holder, ctx.cwd).register(role, signal);
+			return identityResult(`${agent} registration persisted through the local KAMN service.`, result);
 		},
 	});
 }
 
-function registerLiveAgentAQuery(pi: ExtensionAPI, state: LiveAgentState) {
+function registerLiveAgentAQuery(pi: ExtensionAPI, holder: WorkflowHolder) {
 	pi.registerTool({
 		name: "kamn_live_agent_a_query_profile",
 		label: "KAMN Live Agent A Query Profile",
@@ -36,26 +38,80 @@ function registerLiveAgentAQuery(pi: ExtensionAPI, state: LiveAgentState) {
 		parameters: Type.Object({}),
 		executionMode: "sequential",
 		async execute(_id, _params, signal, _onUpdate, ctx) {
-			if (!state.did) throw new Error("Register Agent A before querying its live profile");
-			const result = await session(state, ctx.cwd).call("query_agent_profile", { did: state.did }, signal);
-			return textResult("Agent A durable profile query passed through the same local MCP process.", result);
+			const result = await workflow(holder, ctx.cwd).queryProfile("agent_a", signal);
+			return identityResult("Agent A durable profile query passed through the same local MCP process.", result);
 		},
 	});
 }
 
-function session(state: LiveAgentState, cwd: string): McpSession {
-	state.session ??= new McpSession(readLiveMcpConfig(process.env, cwd));
-	return state.session;
+function registerTaskTools(pi: ExtensionAPI, holder: WorkflowHolder) {
+	registerCreateTask(pi, holder);
+	registerAcceptTask(pi, holder);
+	registerQueryTask(pi, holder, "agent_a", "kamn_live_agent_a_query_task", "KAMN Live Agent A Query Task");
+	registerQueryTask(pi, holder, "agent_b", "kamn_live_agent_b_query_task", "KAMN Live Agent B Query Task");
 }
 
-function requiredDid(result: Record<string, unknown>): string {
-	if (typeof result.did !== "string" || !result.did) throw new Error("KAMN live registration omitted Agent A DID");
-	return result.did;
+function registerCreateTask(pi: ExtensionAPI, holder: WorkflowHolder) {
+	pi.registerTool({
+		name: "kamn_live_agent_a_create_task",
+		label: "KAMN Live Agent A Create Task",
+		description: "Create one durable local KAMN task through Agent A's live MCP process.",
+		promptSnippet: "Create a real local-only KAMN task as Agent A",
+		parameters: Type.Object({ title: Type.String({ minLength: 1 }), description: Type.String({ minLength: 1 }) }),
+		executionMode: "sequential",
+		async execute(_id, params, signal, _onUpdate, ctx) {
+			const result = await workflow(holder, ctx.cwd).createTask(params.title, params.description, signal);
+			return taskResult("Agent A created a durable local KAMN task.", result);
+		},
+	});
 }
 
-function textResult(text: string, result: Record<string, unknown>) {
+function registerAcceptTask(pi: ExtensionAPI, holder: WorkflowHolder) {
+	pi.registerTool({
+		name: "kamn_live_agent_b_accept_task",
+		label: "KAMN Live Agent B Accept Task",
+		description: "Accept Agent A's durable task through Agent B's independent live MCP process.",
+		promptSnippet: "Accept the current real local-only KAMN task as Agent B",
+		parameters: Type.Object({}),
+		executionMode: "sequential",
+		async execute(_id, _params, signal, _onUpdate, ctx) {
+			const result = await workflow(holder, ctx.cwd).acceptTask(signal);
+			return taskResult("Agent B accepted Agent A's durable local KAMN task.", result);
+		},
+	});
+}
+
+function registerQueryTask(pi: ExtensionAPI, holder: WorkflowHolder, role: AgentRole, name: string, label: string) {
+	pi.registerTool({
+		name,
+		label,
+		description: "Query the accepted durable task through one participant's independent live MCP process.",
+		promptSnippet: `Query the current accepted KAMN task as ${role === "agent_a" ? "Agent A" : "Agent B"}`,
+		parameters: Type.Object({}),
+		executionMode: "sequential",
+		async execute(_id, _params, signal, _onUpdate, ctx) {
+			const result = await workflow(holder, ctx.cwd).queryTask(role, signal);
+			return taskResult(`${label} observed the accepted durable task.`, result);
+		},
+	});
+}
+
+function workflow(holder: WorkflowHolder, cwd: string): LiveTaskWorkflow {
+	holder.workflow ??= new LiveTaskWorkflow(process.env, cwd);
+	return holder.workflow;
+}
+
+function identityResult(text: string, result: WorkflowResult) {
+	return resultEnvelope(text, "local-only identity durability", result);
+}
+
+function taskResult(text: string, result: WorkflowResult) {
+	return resultEnvelope(text, "real local-only task lifecycle", result);
+}
+
+function resultEnvelope(text: string, claimBoundary: string, result: WorkflowResult) {
 	return {
-		content: [{ type: "text" as const, text: `${text} Claim boundary: local-only identity durability; no settlement or asset movement is claimed.` }],
-		details: { claimBoundary: "local-only identity durability", result },
+		content: [{ type: "text" as const, text: `${text} Claim boundary: ${claimBoundary}; no escrow, settlement, or asset movement is claimed.` }],
+		details: { claimBoundary, result },
 	};
 }

--- a/.pi/extensions/kamn-mvp/live-task-workflow.test.ts
+++ b/.pi/extensions/kamn-mvp/live-task-workflow.test.ts
@@ -47,7 +47,53 @@ test("workflow rejects calls that violate registration and task order", async ()
 	await workflow.shutdown();
 });
 
-async function testSetup() {
+test("workflow rejects duplicate participant DIDs", async () => {
+	const setup = await testSetup({ KAMN_MVP_FAKE_MCP_RESULT_MODE: "same-did" });
+	const workflow = new LiveTaskWorkflow(setup.env, process.cwd());
+	await workflow.register("agent_a");
+
+	await assert.rejects(workflow.register("agent_b"), /must be distinct/);
+	await workflow.shutdown();
+});
+
+for (const [mode, expected] of [
+	["missing-task-id", /omitted task_id/],
+	["wrong-create-state", /expected submitted/],
+] as const) {
+	test(`workflow rejects ${mode} creation result`, async () => {
+		const setup = await testSetup({ KAMN_MVP_FAKE_MCP_RESULT_MODE: mode });
+		const workflow = new LiveTaskWorkflow(setup.env, process.cwd());
+		await workflow.register("agent_a");
+
+		await assert.rejects(workflow.createTask("title", "description"), expected);
+		await workflow.shutdown();
+	});
+}
+
+test("workflow rejects a mismatched acceptance task ID", async () => {
+	const setup = await testSetup({ KAMN_MVP_FAKE_MCP_RESULT_MODE: "wrong-accept-id" });
+	const workflow = new LiveTaskWorkflow(setup.env, process.cwd());
+	await workflow.register("agent_a");
+	await workflow.register("agent_b");
+	await workflow.createTask("title", "description");
+
+	await assert.rejects(workflow.acceptTask(), /different task ID/);
+	await workflow.shutdown();
+});
+
+test("workflow rejects a non-accepted query projection", async () => {
+	const setup = await testSetup({ KAMN_MVP_FAKE_MCP_RESULT_MODE: "wrong-query-state" });
+	const workflow = new LiveTaskWorkflow(setup.env, process.cwd());
+	await workflow.register("agent_a");
+	await workflow.register("agent_b");
+	await workflow.createTask("title", "description");
+	await workflow.acceptTask();
+
+	await assert.rejects(workflow.queryTask("agent_a"), /expected accepted/);
+	await workflow.shutdown();
+});
+
+async function testSetup(extra: Record<string, string> = {}) {
 	const root = await mkdtemp(resolve(tmpdir(), "kamn-live-task-"));
 	const agentAKey = resolve(root, "agent-a.key");
 	const agentBKey = resolve(root, "agent-b.key");
@@ -65,6 +111,7 @@ async function testSetup() {
 			KAMN_MVP_LIVE_MCP_AGENT_B_NAME: "agent-b",
 			KAMN_MVP_LIVE_MCP_AGENT_B_KEY_FILE: agentBKey,
 			KAMN_MVP_FAKE_MCP_STOP_FILE: stopFile,
+			...extra,
 		},
 	};
 }

--- a/.pi/extensions/kamn-mvp/live-task-workflow.test.ts
+++ b/.pi/extensions/kamn-mvp/live-task-workflow.test.ts
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import { chmod, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import test from "node:test";
+import { LiveTaskWorkflow } from "./live-task-workflow.ts";
+
+const fixture = resolve(".pi/extensions/kamn-mvp/test-fixtures/fake-mcp-server.mjs");
+
+test("two agents register and share one accepted task through independent sessions", async () => {
+	const setup = await testSetup();
+	const workflow = new LiveTaskWorkflow(setup.env, process.cwd());
+
+	const agentA = await workflow.register("agent_a");
+	const agentB = await workflow.register("agent_b");
+	const created = await workflow.createTask("Review proof", "Validate the local task lifecycle");
+	const accepted = await workflow.acceptTask();
+	const queryA = await workflow.queryTask("agent_a");
+	const queryB = await workflow.queryTask("agent_b");
+
+	assert.notEqual(agentA.did, agentB.did);
+	assert.notEqual(agentA.pid, agentB.pid);
+	assert.deepEqual([agentA.request_id, created.request_id, queryA.request_id], ["1", "2", "3"]);
+	assert.deepEqual([agentB.request_id, accepted.request_id, queryB.request_id], ["1", "2", "3"]);
+	assert.equal(created.title, "Review proof");
+	assert.equal(created.description, "Validate the local task lifecycle");
+	for (const result of [accepted, queryA, queryB]) {
+		assert.equal(result.task_id, created.task_id);
+		assert.equal(result.state, "accepted");
+	}
+
+	await workflow.shutdown();
+	await workflow.shutdown();
+	assert.equal((await readFile(setup.stopFile, "utf8")).trim().split("\n").length, 2);
+});
+
+test("workflow rejects calls that violate registration and task order", async () => {
+	const setup = await testSetup();
+	const workflow = new LiveTaskWorkflow(setup.env, process.cwd());
+
+	await assert.rejects(workflow.createTask("title", "description"), /Register Agent A/);
+	await assert.rejects(workflow.acceptTask(), /Register Agent B/);
+	await assert.rejects(workflow.queryTask("agent_a"), /Register Agent A/);
+	await workflow.register("agent_a");
+	await assert.rejects(workflow.createTask(" ", "description"), /title/);
+	await assert.rejects(workflow.queryTask("agent_a"), /Create a task/);
+	await workflow.shutdown();
+});
+
+async function testSetup() {
+	const root = await mkdtemp(resolve(tmpdir(), "kamn-live-task-"));
+	const agentAKey = resolve(root, "agent-a.key");
+	const agentBKey = resolve(root, "agent-b.key");
+	const stopFile = resolve(root, "stop");
+	await writeFile(agentAKey, "test-agent-a-key\n");
+	await writeFile(agentBKey, "test-agent-b-key\n");
+	await chmod(fixture, 0o755);
+	return {
+		stopFile,
+		env: {
+			KAMN_MVP_LIVE_MCP_BINARY: fixture,
+			KAMN_MVP_LIVE_MCP_ENDPOINT: "http://127.0.0.1:18278",
+			KAMN_MVP_LIVE_MCP_AGENT_A_NAME: "agent-a",
+			KAMN_MVP_LIVE_MCP_AGENT_A_KEY_FILE: agentAKey,
+			KAMN_MVP_LIVE_MCP_AGENT_B_NAME: "agent-b",
+			KAMN_MVP_LIVE_MCP_AGENT_B_KEY_FILE: agentBKey,
+			KAMN_MVP_FAKE_MCP_STOP_FILE: stopFile,
+		},
+	};
+}

--- a/.pi/extensions/kamn-mvp/live-task-workflow.ts
+++ b/.pi/extensions/kamn-mvp/live-task-workflow.ts
@@ -1,0 +1,94 @@
+import { McpSession, readLiveMcpConfig, type LiveMcpAgent } from "./mcp-session.ts";
+
+export type AgentRole = "agent_a" | "agent_b";
+export type WorkflowResult = Record<string, unknown>;
+type Environment = Record<string, string | undefined>;
+type AgentState = { did?: string; session?: McpSession };
+
+export class LiveTaskWorkflow {
+	private readonly agents: Record<AgentRole, AgentState> = { agent_a: {}, agent_b: {} };
+	private taskId?: string;
+	private readonly env: Environment;
+	private readonly cwd: string;
+	constructor(env: Environment, cwd: string) {
+		this.env = env;
+		this.cwd = cwd;
+	}
+	async register(role: AgentRole, signal?: AbortSignal): Promise<WorkflowResult> {
+		const result = await this.session(role).call("register", {}, signal);
+		const did = requiredString(result, "did", `${agentLabel(role)} registration`);
+		this.assertDistinctDid(role, did);
+		this.agents[role].did = did;
+		return result;
+	}
+	async queryProfile(role: AgentRole, signal?: AbortSignal): Promise<WorkflowResult> {
+		const did = this.registeredDid(role);
+		return this.session(role).call("query_agent_profile", { did }, signal);
+	}
+	async createTask(title: string, description: string, signal?: AbortSignal): Promise<WorkflowResult> {
+		this.registeredDid("agent_a");
+		const payload = JSON.stringify({ title: requiredText(title, "title"), description: requiredText(description, "description") });
+		const result = await this.session("agent_a").call("create_task", { payload }, signal);
+		this.taskId = validateTaskResult(result, undefined, "submitted", "task creation");
+		return result;
+	}
+	async acceptTask(signal?: AbortSignal): Promise<WorkflowResult> {
+		this.registeredDid("agent_b");
+		const taskId = this.createdTaskId();
+		const result = await this.session("agent_b").call("accept_task", { task_id: taskId }, signal);
+		validateTaskResult(result, taskId, "accepted", "task acceptance");
+		return result;
+	}
+	async queryTask(role: AgentRole, signal?: AbortSignal): Promise<WorkflowResult> {
+		this.registeredDid(role);
+		const taskId = this.createdTaskId();
+		const result = await this.session(role).call("query_task", { task_id: taskId }, signal);
+		validateTaskResult(result, taskId, "accepted", `${agentLabel(role)} task query`);
+		return result;
+	}
+	async shutdown(): Promise<void> {
+		await Promise.all(Object.values(this.agents).map((agent) => agent.session?.shutdown()));
+	}
+	private session(role: AgentRole): McpSession {
+		const state = this.agents[role];
+		state.session ??= new McpSession(readLiveMcpConfig(configRole(role), this.env, this.cwd));
+		return state.session;
+	}
+	private registeredDid(role: AgentRole): string {
+		const did = this.agents[role].did;
+		if (!did) throw new Error(`Register ${agentLabel(role)} before continuing`);
+		return did;
+	}
+	private createdTaskId(): string {
+		if (!this.taskId) throw new Error("Create a task before continuing");
+		return this.taskId;
+	}
+	private assertDistinctDid(role: AgentRole, did: string) {
+		const other = role === "agent_a" ? "agent_b" : "agent_a";
+		if (this.agents[other].did === did) throw new Error("Agent A and Agent B registration DIDs must be distinct");
+	}
+}
+
+function validateTaskResult(result: WorkflowResult, expectedId: string | undefined, expectedState: string, step: string): string {
+	const taskId = requiredString(result, "task_id", step);
+	const state = requiredString(result, "state", step);
+	if (expectedId && taskId !== expectedId) throw new Error(`${step} returned a different task ID`);
+	if (state !== expectedState) throw new Error(`${step} returned state ${state}; expected ${expectedState}`);
+	return taskId;
+}
+function requiredString(result: WorkflowResult, field: string, step: string): string {
+	const value = result[field];
+	if (typeof value !== "string" || !value.trim()) throw new Error(`${step} omitted ${field}`);
+	return value;
+}
+function requiredText(value: string, field: string): string {
+	const trimmed = value.trim();
+	if (!trimmed) throw new Error(`Task ${field} must not be blank`);
+	return trimmed;
+}
+function configRole(role: AgentRole): LiveMcpAgent {
+	return role === "agent_a" ? "AGENT_A" : "AGENT_B";
+}
+function agentLabel(role: AgentRole): string {
+	return role === "agent_a" ? "Agent A" : "Agent B";
+}

--- a/.pi/extensions/kamn-mvp/mcp-session.test.ts
+++ b/.pi/extensions/kamn-mvp/mcp-session.test.ts
@@ -25,16 +25,16 @@ test("session starts lazily and reuses one child for ordered calls", async () =>
 });
 
 test("configuration rejects missing values and key files", () => {
-	assert.throws(() => readLiveMcpConfig({}, process.cwd()), /KAMN_MVP_LIVE_MCP_BINARY/);
+	assert.throws(() => readLiveMcpConfig("AGENT_A", {}, process.cwd()), /KAMN_MVP_LIVE_MCP_BINARY/);
 	assert.throws(
-		() => readLiveMcpConfig(configEnv("/missing/key", {}), process.cwd()),
+		() => readLiveMcpConfig("AGENT_A", configEnv("/missing/key", {}), process.cwd()),
 		/key file does not exist/,
 	);
 });
 
 test("configuration does not forward unrelated Pi credentials", async () => {
 	const paths = await testPaths();
-	const config = readLiveMcpConfig(configEnv(paths.keyFile, { OPENAI_API_KEY: "must-not-leak" }), process.cwd());
+	const config = readLiveMcpConfig("AGENT_A", configEnv(paths.keyFile, { OPENAI_API_KEY: "must-not-leak" }), process.cwd());
 
 	assert.equal(config.env.OPENAI_API_KEY, undefined);
 	assert.equal(config.env.KAMN_MVP_LIVE_MCP_AGENT_A_NAME, "agent-a");
@@ -87,7 +87,7 @@ async function testPaths() {
 
 function sessionFor(paths: Awaited<ReturnType<typeof testPaths>>, mode: string, timeoutMs = 1000) {
 	return new McpSession(
-		readLiveMcpConfig(configEnv(paths.keyFile, {
+		readLiveMcpConfig("AGENT_A", configEnv(paths.keyFile, {
 			KAMN_MVP_FAKE_MCP_MODE: mode,
 			KAMN_MVP_FAKE_MCP_START_FILE: paths.startFile,
 			KAMN_MVP_FAKE_MCP_STOP_FILE: paths.stopFile,

--- a/.pi/extensions/kamn-mvp/mcp-session.test.ts
+++ b/.pi/extensions/kamn-mvp/mcp-session.test.ts
@@ -40,6 +40,18 @@ test("configuration does not forward unrelated Pi credentials", async () => {
 	assert.equal(config.env.KAMN_MVP_LIVE_MCP_AGENT_A_NAME, "agent-a");
 });
 
+test("configuration selects independent Agent B identity inputs", async () => {
+	const paths = await testPaths();
+	const env = configEnv(paths.keyFile, {
+		KAMN_MVP_LIVE_MCP_AGENT_B_NAME: "agent-b",
+		KAMN_MVP_LIVE_MCP_AGENT_B_KEY_FILE: paths.keyFile,
+	});
+	const config = readLiveMcpConfig("AGENT_B", env, process.cwd());
+
+	assert.equal(config.agentName, "agent-b");
+	assert.equal(config.keyFile, paths.keyFile);
+});
+
 for (const [mode, expected] of [
 	["error", /backend_error.*forced backend failure/],
 	["malformed", /invalid JSON/],

--- a/.pi/extensions/kamn-mvp/mcp-session.ts
+++ b/.pi/extensions/kamn-mvp/mcp-session.ts
@@ -3,7 +3,12 @@ import { existsSync } from "node:fs";
 import { resolve } from "node:path";
 
 type Environment = Record<string, string | undefined>;
+export type LiveMcpAgent = "AGENT_A" | "AGENT_B";
 const PROCESS_ENV_ALLOWLIST = new Set(["HOME", "PATH", "RUST_LOG", "TMPDIR"]);
+const AGENT_ENV = {
+	AGENT_A: { name: "KAMN_MVP_LIVE_MCP_AGENT_A_NAME", keyFile: "KAMN_MVP_LIVE_MCP_AGENT_A_KEY_FILE" },
+	AGENT_B: { name: "KAMN_MVP_LIVE_MCP_AGENT_B_NAME", keyFile: "KAMN_MVP_LIVE_MCP_AGENT_B_KEY_FILE" },
+} as const;
 type JsonObject = Record<string, unknown>;
 type PendingRequest = {
 	id: string;
@@ -117,16 +122,17 @@ export class McpSession {
 		});
 	}
 }
-export function readLiveMcpConfig(env: Environment = process.env, cwd = process.cwd()): LiveMcpConfig {
+export function readLiveMcpConfig(agent: LiveMcpAgent, env: Environment = process.env, cwd = process.cwd()): LiveMcpConfig {
+	const agentEnv = AGENT_ENV[agent];
 	const binary = absolutePath(requiredEnv(env, "KAMN_MVP_LIVE_MCP_BINARY"), cwd);
-	const keyFile = absolutePath(requiredEnv(env, "KAMN_MVP_LIVE_MCP_AGENT_A_KEY_FILE"), cwd);
+	const keyFile = absolutePath(requiredEnv(env, agentEnv.keyFile), cwd);
 	if (!existsSync(binary)) throw new Error(`KAMN live MCP binary does not exist: ${binary}`);
 	if (!existsSync(keyFile)) throw new Error(`KAMN live MCP key file does not exist: ${keyFile}`);
 	return {
 		binary,
 		keyFile,
 		endpoint: requiredEnv(env, "KAMN_MVP_LIVE_MCP_ENDPOINT"),
-		agentName: requiredEnv(env, "KAMN_MVP_LIVE_MCP_AGENT_A_NAME"),
+		agentName: requiredEnv(env, agentEnv.name),
 		env: childEnvironment(env),
 	};
 }

--- a/.pi/extensions/kamn-mvp/test-fixtures/fake-mcp-server.mjs
+++ b/.pi/extensions/kamn-mvp/test-fixtures/fake-mcp-server.mjs
@@ -1,11 +1,12 @@
 #!/usr/bin/env node
-import { appendFileSync, writeFileSync } from "node:fs";
+import { appendFileSync } from "node:fs";
 import { createInterface } from "node:readline";
 
 const mode = process.env.KAMN_MVP_FAKE_MCP_MODE ?? "success";
 const startFile = process.env.KAMN_MVP_FAKE_MCP_START_FILE;
 const stopFile = process.env.KAMN_MVP_FAKE_MCP_STOP_FILE;
-if (startFile) writeFileSync(startFile, `${process.pid}\n`);
+const agentName = argumentValue("--agent-name") ?? "agent-a";
+if (startFile) appendFileSync(startFile, `${process.pid}\n`);
 
 process.on("SIGTERM", () => {
 	if (stopFile) appendFileSync(stopFile, `${process.pid}\n`);
@@ -22,13 +23,26 @@ createInterface({ input: process.stdin }).on("line", (line) => {
 });
 
 function successResponse(request) {
-	const did = request.did ?? "kamn:did:agent-a";
+	const result = toolResult(request);
 	return {
 		ok: true,
 		id: mode === "mismatch" ? "wrong-id" : request.id,
 		tool: request.tool,
-		result: { did, pid: process.pid, request_id: request.id },
+		result: { ...result, pid: process.pid, request_id: request.id },
 	};
+}
+
+function toolResult(request) {
+	if (request.tool === "register") return { did: `kamn:did:${agentName}` };
+	if (request.tool === "query_agent_profile") return { did: request.did };
+	if (request.tool === "create_task") {
+		const payload = JSON.parse(request.payload);
+		return { task_id: "task-live-1", state: "submitted", ...payload };
+	}
+	if (["accept_task", "query_task"].includes(request.tool)) {
+		return { task_id: request.task_id, state: "accepted" };
+	}
+	return {};
 }
 
 function errorResponse(request) {
@@ -42,4 +56,9 @@ function errorResponse(request) {
 
 function write(response) {
 	process.stdout.write(`${JSON.stringify(response)}\n`);
+}
+
+function argumentValue(flag) {
+	const index = process.argv.indexOf(flag);
+	return index >= 0 ? process.argv[index + 1] : undefined;
 }

--- a/.pi/extensions/kamn-mvp/test-fixtures/fake-mcp-server.mjs
+++ b/.pi/extensions/kamn-mvp/test-fixtures/fake-mcp-server.mjs
@@ -3,6 +3,7 @@ import { appendFileSync } from "node:fs";
 import { createInterface } from "node:readline";
 
 const mode = process.env.KAMN_MVP_FAKE_MCP_MODE ?? "success";
+const resultMode = process.env.KAMN_MVP_FAKE_MCP_RESULT_MODE ?? "success";
 const startFile = process.env.KAMN_MVP_FAKE_MCP_START_FILE;
 const stopFile = process.env.KAMN_MVP_FAKE_MCP_STOP_FILE;
 const agentName = argumentValue("--agent-name") ?? "agent-a";
@@ -33,14 +34,23 @@ function successResponse(request) {
 }
 
 function toolResult(request) {
-	if (request.tool === "register") return { did: `kamn:did:${agentName}` };
+	if (request.tool === "register") {
+		return { did: resultMode === "same-did" ? "kamn:did:shared" : `kamn:did:${agentName}` };
+	}
 	if (request.tool === "query_agent_profile") return { did: request.did };
 	if (request.tool === "create_task") {
 		const payload = JSON.parse(request.payload);
-		return { task_id: "task-live-1", state: "submitted", ...payload };
+		if (resultMode === "missing-task-id") return { state: "submitted", ...payload };
+		const state = resultMode === "wrong-create-state" ? "queued" : "submitted";
+		return { task_id: "task-live-1", state, ...payload };
 	}
-	if (["accept_task", "query_task"].includes(request.tool)) {
-		return { task_id: request.task_id, state: "accepted" };
+	if (request.tool === "accept_task") {
+		const taskId = resultMode === "wrong-accept-id" ? "task-other" : request.task_id;
+		return { task_id: taskId, state: "accepted" };
+	}
+	if (request.tool === "query_task") {
+		const state = resultMode === "wrong-query-state" ? "submitted" : "accepted";
+		return { task_id: request.task_id, state };
 	}
 	return {};
 }

--- a/crates/kamn-e2e-harness/tests/mvp_demo_agent_harness_claim_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_demo_agent_harness_claim_contract.rs
@@ -146,6 +146,14 @@ fn spec_c08_project_local_pi_extension_registers_kamn_tools() {
         "session_shutdown",
         "KAMN_MVP_LIVE_MCP_BINARY",
         "KAMN_MVP_LIVE_MCP_AGENT_A_KEY_FILE",
+        "kamn_live_agent_b_register",
+        "kamn_live_agent_a_create_task",
+        "kamn_live_agent_b_accept_task",
+        "kamn_live_agent_a_query_task",
+        "kamn_live_agent_b_query_task",
+        "KAMN_MVP_LIVE_MCP_AGENT_B_NAME",
+        "KAMN_MVP_LIVE_MCP_AGENT_B_KEY_FILE",
+        "real local-only task lifecycle",
     ] {
         assert!(source.contains(marker), "missing Pi tool marker: {marker}");
     }
@@ -216,6 +224,7 @@ fn pi_extension_source() -> String {
         ".pi/extensions/kamn-mvp/actor-receipts.ts",
         ".pi/extensions/kamn-mvp/live-mcp-tools.ts",
         ".pi/extensions/kamn-mvp/mcp-session.ts",
+        ".pi/extensions/kamn-mvp/live-task-workflow.ts",
     ]
     .map(|path| {
         std::fs::read_to_string(workspace_root().join(path))

--- a/crates/kamn-e2e-harness/tests/mvp_evaluator_demo_runbook_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_evaluator_demo_runbook_contract.rs
@@ -40,6 +40,15 @@ fn spec_c01_mvp_runbook_documents_pi_tool_harness_boundaries() {
         "--api-bind 127.0.0.1:18278",
         "request nonce `1` and status `201`",
         "request nonce `2` and status `200`",
+        "kamn_live_agent_b_register",
+        "kamn_live_agent_a_create_task",
+        "kamn_live_agent_b_accept_task",
+        "kamn_live_agent_a_query_task",
+        "kamn_live_agent_b_query_task",
+        "KAMN_MVP_LIVE_MCP_AGENT_B_NAME",
+        "KAMN_MVP_LIVE_MCP_AGENT_B_KEY_FILE",
+        "real local-only task lifecycle",
+        "does not prove escrow, settlement, asset movement, third-party verification, or restart durability",
     ] {
         assert!(runbook.contains(needle), "{RUNBOOK} missing: {needle}");
     }

--- a/crates/kamn-e2e-harness/tests/mvp_evaluator_demo_runbook_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_evaluator_demo_runbook_contract.rs
@@ -49,6 +49,8 @@ fn spec_c01_mvp_runbook_documents_pi_tool_harness_boundaries() {
         "KAMN_MVP_LIVE_MCP_AGENT_B_KEY_FILE",
         "real local-only task lifecycle",
         "does not prove escrow, settlement, asset movement, third-party verification, or restart durability",
+        "Both registrations and task creation return `201`",
+        "acceptance and both task queries return `200`",
     ] {
         assert!(runbook.contains(needle), "{RUNBOOK} missing: {needle}");
     }

--- a/docs/validation/mvp-evaluator-demo.md
+++ b/docs/validation/mvp-evaluator-demo.md
@@ -185,7 +185,7 @@ env -u OPENAI_API_KEY pi \
   -p "Use only the KAMN tools. Register Agent A and Agent B. As Agent A create a task titled 'Review KAMN proof' with description 'Validate the local two-agent task lifecycle'. As Agent B accept it. Query the accepted task as Agent A and Agent B. Report the claim boundary exactly."
 ```
 
-A passing run returns distinct Agent A and Agent B DIDs, one shared task ID, `submitted` from creation, and `accepted` from acceptance and both queries. Node logs show independent nonce domains: Agent A uses request nonces `1`, `2`, and `3` for register/create/query; Agent B independently uses `1`, `2`, and `3` for register/accept/query.
+A passing run returns distinct Agent A and Agent B DIDs, one shared task ID, `submitted` from creation, and `accepted` from acceptance and both queries. Node logs show independent nonce domains: Agent A uses request nonces `1`, `2`, and `3` for register/create/query; Agent B independently uses `1`, `2`, and `3` for register/accept/query. Both registrations and task creation return `201`; acceptance and both task queries return `200`.
 
 This is a real local-only task lifecycle backed by the service task store. It does not prove escrow, settlement, asset movement, third-party verification, or restart durability. Those claims require their own proof slices, and any eventual value-movement claim must remain devnet-backed.
 

--- a/docs/validation/mvp-evaluator-demo.md
+++ b/docs/validation/mvp-evaluator-demo.md
@@ -161,6 +161,34 @@ A passing node log shows `POST /v1/agents/register` with request nonce `1` and s
 
 This proves local-only identity durability through the live service API. It does not prove task, escrow, settlement, or asset movement, and it does not replace the devnet-required proof for any value-movement claim.
 
+### Live Pi Two-Agent Task Check
+
+The next bounded check uses two independently authenticated MCP children for a real local-only task lifecycle. Keep the node from the identity check running, create a second disposable key, and run Pi with both agent configurations:
+
+```bash
+openssl rand -hex 32 > /tmp/kamn-pi-agent-b.key
+
+KAMN_MVP_LIVE_MCP_BINARY=target/debug/kamn-mcp-server \
+KAMN_MVP_LIVE_MCP_ENDPOINT=http://127.0.0.1:18278 \
+KAMN_MVP_LIVE_MCP_AGENT_A_NAME=pi-agent-a \
+KAMN_MVP_LIVE_MCP_AGENT_A_KEY_FILE=/tmp/kamn-pi-agent-a.key \
+KAMN_MVP_LIVE_MCP_AGENT_B_NAME=pi-agent-b \
+KAMN_MVP_LIVE_MCP_AGENT_B_KEY_FILE=/tmp/kamn-pi-agent-b.key \
+env -u OPENAI_API_KEY pi \
+  --model openai-codex/gpt-5.5 \
+  --thinking medium \
+  --extension .pi/extensions/kamn-mvp/index.ts \
+  --no-builtin-tools \
+  --tools kamn_live_agent_a_register,kamn_live_agent_b_register,kamn_live_agent_a_create_task,kamn_live_agent_b_accept_task,kamn_live_agent_a_query_task,kamn_live_agent_b_query_task \
+  --approve \
+  --no-session \
+  -p "Use only the KAMN tools. Register Agent A and Agent B. As Agent A create a task titled 'Review KAMN proof' with description 'Validate the local two-agent task lifecycle'. As Agent B accept it. Query the accepted task as Agent A and Agent B. Report the claim boundary exactly."
+```
+
+A passing run returns distinct Agent A and Agent B DIDs, one shared task ID, `submitted` from creation, and `accepted` from acceptance and both queries. Node logs show independent nonce domains: Agent A uses request nonces `1`, `2`, and `3` for register/create/query; Agent B independently uses `1`, `2`, and `3` for register/accept/query.
+
+This is a real local-only task lifecycle backed by the service task store. It does not prove escrow, settlement, asset movement, third-party verification, or restart durability. Those claims require their own proof slices, and any eventual value-movement claim must remain devnet-backed.
+
 The evidence also records a `three_agent_boundary` summary derived from the
 verified report: local-only reports are marked `NOT_PRESENT`, while reports with
 `three_agent_escrow_verification` must preserve the report's claim status, label,

--- a/specs/7080-pi-two-agent-live-task.md
+++ b/specs/7080-pi-two-agent-live-task.md
@@ -1,0 +1,102 @@
+# Pi Two-Agent Live Task
+
+## Objective
+
+Let Pi drive one real local-only task lifecycle through two independently authenticated KAMN agents: Agent A and Agent B register through separate persistent `kamn-mcp-server` children, Agent A creates a task, Agent B accepts it, and both query the same accepted task state.
+
+## Inputs/Outputs
+
+Inputs:
+
+- Shared `KAMN_MVP_LIVE_MCP_BINARY` and `KAMN_MVP_LIVE_MCP_ENDPOINT`.
+- Agent A `KAMN_MVP_LIVE_MCP_AGENT_A_NAME` and `KAMN_MVP_LIVE_MCP_AGENT_A_KEY_FILE`.
+- Agent B `KAMN_MVP_LIVE_MCP_AGENT_B_NAME` and `KAMN_MVP_LIVE_MCP_AGENT_B_KEY_FILE`.
+- Non-empty task title and description supplied to `kamn_live_agent_a_create_task`.
+- Ordered Pi calls to register, create, accept, and query tools.
+
+Outputs:
+
+- Two distinct service-persisted agent DIDs.
+- One non-empty service task ID.
+- `submitted` creation state followed by `accepted` acceptance state.
+- Matching accepted task projections from Agent A and Agent B queries.
+- Tool messages and details labelled `real local-only task lifecycle`.
+
+## Boundaries/Non-goals
+
+- Reuse the existing line-protocol `McpSession`; do not add another transport or dependency.
+- Preserve report-derived actor receipt tools unchanged.
+- Preserve existing live Agent A register/profile behavior.
+- Keep one child and request sequence per agent for the Pi session.
+- Never expose key contents or forward Pi/OpenAI credentials.
+- Do not fund/release escrow or claim settlement, exchange, asset movement, Solana devnet, Agent C verification, MCP-child restart durability, or node-restart durability.
+
+## Failure Modes
+
+- Missing Agent B name/key configuration or key file: reject before spawning B.
+- Equal Agent A and Agent B DIDs: reject the second registration result.
+- Create before Agent A registration: reject without MCP dispatch.
+- Accept before Agent B registration or task creation: reject without MCP dispatch.
+- Query before the matching agent registration or task creation: reject without MCP dispatch.
+- Blank task title/description: reject without MCP dispatch.
+- Create result missing task ID or state: reject loudly.
+- Accept/query result task ID differs from stored task ID: reject loudly.
+- Create state is not `submitted`, or accept/final query state is not `accepted`: reject loudly.
+- Either child/process/protocol/auth call fails: surface the existing hard failure with no fallback.
+- Session shutdown: terminate both children idempotently.
+
+## Acceptance Criteria
+
+- [ ] `kamn_live_agent_b_register` uses Agent B configuration and a distinct persistent child.
+- [ ] Agent A and Agent B registration DIDs are non-empty and distinct.
+- [ ] `kamn_live_agent_a_create_task` JSON-encodes validated title/description and dispatches `create_task` through Agent A.
+- [ ] `kamn_live_agent_b_accept_task` dispatches `accept_task` with the stored task ID through Agent B.
+- [ ] `kamn_live_agent_a_query_task` and `kamn_live_agent_b_query_task` dispatch `query_task` through their respective sessions.
+- [ ] Both query tools require and return the same task ID with state `accepted`.
+- [ ] Agent A request IDs progress independently from Agent B request IDs.
+- [ ] Both child processes are cleaned up on Pi shutdown.
+- [ ] Automated tests cover ordered success and every specified prerequisite/result failure.
+- [ ] Rust source/runbook contracts pin the tool names, two-agent configuration, and local-only/non-settlement boundary.
+- [ ] A real Pi run proves two distinct DIDs, A register/create/query nonces `1/2/3`, B register/accept/query nonces `1/2/3`, and matching accepted state.
+- [ ] Formatting, strict clippy, targeted contracts, `make check`, `make demo-mvp`, and the canonical verifier pass.
+
+## Files To Touch
+
+- `.pi/extensions/kamn-mvp/mcp-session.ts`
+- `.pi/extensions/kamn-mvp/mcp-session.test.ts`
+- `.pi/extensions/kamn-mvp/live-mcp-tools.ts`
+- `.pi/extensions/kamn-mvp/live-mcp-tools.test.ts`
+- `.pi/extensions/kamn-mvp/test-fixtures/fake-mcp-server.mjs`
+- `crates/kamn-e2e-harness/tests/mvp_demo_agent_harness_claim_contract.rs`
+- `crates/kamn-e2e-harness/tests/mvp_evaluator_demo_runbook_contract.rs`
+- `docs/validation/mvp-evaluator-demo.md`
+
+## Error Semantics
+
+Pi tool-order and result-validation failures throw `Error` before reporting success. Existing `McpSession` process/protocol errors remain terminal to only the affected agent session. No agent session is replaced automatically, no task ID is synthesized, and no query result is coerced to the expected state.
+
+## Test Plan
+
+RED:
+
+- Extend session tests to require Agent B configuration isolation.
+- Add live-tool tests with the process-boundary fake server for two distinct child PIDs, independent request sequences, exact task payload/ID propagation, ordering failures, and dual shutdown.
+- Extend Rust source and runbook contracts with the new tools and claim boundary.
+
+GREEN:
+
+- Generalize configuration parsing by agent role.
+- Add Agent B registration and Agent A/B task tools with shared task state.
+- Extend the evaluator runbook.
+
+REFACTOR:
+
+- Keep process ownership in `mcp-session.ts` and workflow state/tool registration in focused modules under file/function limits.
+- Remove duplication without generalizing beyond two named MVP agents.
+
+INTEGRATION:
+
+- Build real binaries and start one disposable local node with durable storage.
+- Run Pi with Codex OAuth and only the seven live identity/task tools.
+- Inspect node logs for distinct DIDs and independent nonce sequences.
+- Run Node tests, evaluator contracts, formatting, strict clippy, `make check`, canonical demo, and verifier.

--- a/specs/7080-pi-two-agent-live-task.md
+++ b/specs/7080-pi-two-agent-live-task.md
@@ -97,6 +97,6 @@ REFACTOR:
 INTEGRATION:
 
 - Build real binaries and start one disposable local node with durable storage.
-- Run Pi with Codex OAuth and only the seven live identity/task tools.
+- Run Pi with Codex OAuth and only the six live identity/task tools.
 - Inspect node logs for distinct DIDs and independent nonce sequences.
 - Run Node tests, evaluator contracts, formatting, strict clippy, `make check`, canonical demo, and verifier.


### PR DESCRIPTION
## Human Summary

- Adds a second persistent Pi MCP identity so Agent A and Agent B authenticate through distinct child processes and nonce domains.
- Lets Agent A create one real service-backed task, Agent B accept it, and both participants query the same accepted task state.
- Validates workflow order, distinct DIDs, exact task IDs, and lifecycle states before reporting success.
- Keeps this proof explicitly local-only; escrow, settlement, asset movement, third-party verification, and restart durability are not claimed.

## Testing

- RED: Agent B configuration selection failed against the Agent A-only parser.
- RED: two-agent workflow import failed before `live-task-workflow.ts` existed.
- RED: Pi source contract failed on the missing workflow module.
- RED: runbook contract failed on the missing Agent B tool marker.
- `node --no-warnings --experimental-strip-types --test .pi/extensions/kamn-mvp/mcp-session.test.ts .pi/extensions/kamn-mvp/live-task-workflow.test.ts` (three consecutive passes, 17 tests each)
- `cargo test -p kamn-e2e-harness --test mvp_demo_agent_harness_claim_contract --test mvp_evaluator_demo_runbook_contract` (24 tests)
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `make check`
- `make demo-mvp` (`GO`)
- `cargo run -p kamn-e2e-harness -- verify-mvp-demo --report .kamn/demo/latest/proof/report.json` (`PASS`)
- Real Pi `openai-codex/gpt-5.5` run against local `kamn-node` and two real `kamn-mcp-server` children.
- Live node evidence: distinct Agent A/B DIDs; Agent A nonces `1/2/3` for register/create/query; Agent B nonces `1/2/3` for register/accept/query; shared task `task-local-2fc3aa45365ccb3d`; registration/create `201`; accept/queries `200`.

## Notes for Reviewers

- Review the order and result validation in `.pi/extensions/kamn-mvp/live-task-workflow.ts`.
- Agent B configuration is lazy, so existing Agent A-only identity tools do not require Agent B environment variables.
- Same-DID MCP child restart remains fail-closed under replay protection and is an explicit non-goal.

## AI Agent Details

- Issue: #7080
- Spec: `specs/7080-pi-two-agent-live-task.md`
- The Pi adapter remains under 200 lines and delegates state validation to a dependency-free workflow module.
- Negative tests cover duplicate DIDs, malformed creation results, task-ID substitution, stale query state, ordering errors, protocol failures, cancellation, and cleanup.

Closes #7080

shell_loc_delta_actual: 0
rust_loc_delta_actual: 20
shell_to_rust_ratio_delta_actual: 0.0
shell_surface_ratio_target_status: neutral
