### PR TITLE
[7082] Prove the live task with independent Pi actors

### DIFF
--- a/.pi/extensions/kamn-mvp/live-mcp-tools.ts
+++ b/.pi/extensions/kamn-mvp/live-mcp-tools.ts
@@ -1,6 +1,7 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
 import { LiveTaskWorkflow, type AgentRole, type WorkflowResult } from "./live-task-workflow.ts";
+import { registerLiveTaskCoordinationTools } from "./live-task-coordination-tools.ts";
 
 type WorkflowHolder = { workflow?: LiveTaskWorkflow };
 
@@ -10,6 +11,7 @@ export function registerLiveMcpTools(pi: ExtensionAPI) {
 	registerAgent(pi, holder, "agent_b", "kamn_live_agent_b_register", "KAMN Live Agent B Register");
 	registerLiveAgentAQuery(pi, holder);
 	registerTaskTools(pi, holder);
+	registerLiveTaskCoordinationTools(pi, (cwd) => workflow(holder, cwd));
 	pi.on("session_shutdown", async () => holder.workflow?.shutdown());
 }
 

--- a/.pi/extensions/kamn-mvp/live-task-coordination-tools.ts
+++ b/.pi/extensions/kamn-mvp/live-task-coordination-tools.ts
@@ -1,0 +1,119 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { Type } from "typebox";
+import {
+	COORDINATION_TOOL_NAMES,
+	coordinationConfig,
+	verifyIndependentActorReceipts,
+	waitForTaskHandoff,
+	writeActorReceipt,
+	writeTaskHandoff,
+} from "./live-task-coordination.ts";
+import type { LiveTaskWorkflow, WorkflowResult } from "./live-task-workflow.ts";
+
+type WorkflowResolver = (cwd: string) => LiveTaskWorkflow;
+
+export function registerLiveTaskCoordinationTools(pi: ExtensionAPI, resolveWorkflow: WorkflowResolver) {
+	registerPublishTool(pi, resolveWorkflow);
+	registerReceiveTool(pi, resolveWorkflow);
+	registerAgentAWaitTool(pi, resolveWorkflow);
+	registerAgentBReceiptTool(pi, resolveWorkflow);
+	registerVerifierTool(pi);
+}
+
+function registerPublishTool(pi: ExtensionAPI, resolveWorkflow: WorkflowResolver) {
+	pi.registerTool({
+		name: COORDINATION_TOOL_NAMES[0],
+		label: "KAMN Agent A Publish Task Handoff",
+		description: "Publish the current non-secret task ID for an independent Agent B Pi process.",
+		parameters: Type.Object({}),
+		executionMode: "sequential",
+		async execute(_id, _params, _signal, _onUpdate, ctx) {
+			const config = coordinationConfig(process.env, ctx.cwd);
+			const taskId = resolveWorkflow(ctx.cwd).currentTaskId();
+			await writeTaskHandoff(config.handoffPath, taskId);
+			return coordinationResult("Agent A published the task handoff.", { task_id: taskId });
+		},
+	});
+}
+
+function registerReceiveTool(pi: ExtensionAPI, resolveWorkflow: WorkflowResolver) {
+	pi.registerTool({
+		name: COORDINATION_TOOL_NAMES[1],
+		label: "KAMN Agent B Receive Task Handoff",
+		description: "Wait for and validate Agent A's task handoff in an independent Pi process.",
+		parameters: Type.Object({}),
+		executionMode: "sequential",
+		async execute(_id, _params, signal, _onUpdate, ctx) {
+			const config = coordinationConfig(process.env, ctx.cwd);
+			const taskId = await waitForTaskHandoff(config.handoffPath, config.options, signal);
+			resolveWorkflow(ctx.cwd).importTask(taskId);
+			return coordinationResult("Agent B received the task handoff.", { task_id: taskId });
+		},
+	});
+}
+
+function registerAgentAWaitTool(pi: ExtensionAPI, resolveWorkflow: WorkflowResolver) {
+	pi.registerTool({
+		name: COORDINATION_TOOL_NAMES[2],
+		label: "KAMN Agent A Wait For Task Acceptance",
+		description: "Poll through Agent A's persistent MCP session and record accepted state.",
+		parameters: Type.Object({}),
+		executionMode: "sequential",
+		async execute(_id, _params, signal, _onUpdate, ctx) {
+			const config = coordinationConfig(process.env, ctx.cwd);
+			const result = await resolveWorkflow(ctx.cwd).waitForAccepted("agent_a", config.options, signal);
+			await writeObservation(config.agentAReceiptPath, "agent_a", result);
+			return coordinationResult("Agent A independently observed accepted state.", result);
+		},
+	});
+}
+
+function registerAgentBReceiptTool(pi: ExtensionAPI, resolveWorkflow: WorkflowResolver) {
+	pi.registerTool({
+		name: COORDINATION_TOOL_NAMES[3],
+		label: "KAMN Agent B Write Task Receipt",
+		description: "Write Agent B's accepted-state receipt from its independent Pi process.",
+		parameters: Type.Object({}),
+		executionMode: "sequential",
+		async execute(_id, _params, _signal, _onUpdate, ctx) {
+			const config = coordinationConfig(process.env, ctx.cwd);
+			const result = resolveWorkflow(ctx.cwd).acceptedObservation("agent_b");
+			await writeObservation(config.agentBReceiptPath, "agent_b", result);
+			return coordinationResult("Agent B wrote its independent accepted-state receipt.", result);
+		},
+	});
+}
+
+function registerVerifierTool(pi: ExtensionAPI) {
+	pi.registerTool({
+		name: COORDINATION_TOOL_NAMES[4],
+		label: "KAMN Verify Independent Actor Receipts",
+		description: "Verify Agent A and Agent B receipts came from distinct Pi processes and agree.",
+		parameters: Type.Object({}),
+		executionMode: "sequential",
+		async execute(_id, _params, _signal, _onUpdate, ctx) {
+			const config = coordinationConfig(process.env, ctx.cwd);
+			const result = await verifyIndependentActorReceipts(config.handoffPath, config.agentAReceiptPath, config.agentBReceiptPath);
+			return coordinationResult("Independent Pi actor receipts verified.", result);
+		},
+	});
+}
+
+async function writeObservation(path: string, actor: "agent_a" | "agent_b", result: WorkflowResult) {
+	const taskId = requiredString(result, "task_id");
+	const state = requiredString(result, "state");
+	await writeActorReceipt(path, actor, taskId, state, process.pid);
+}
+
+function requiredString(result: WorkflowResult, field: string): string {
+	const value = result[field];
+	if (typeof value !== "string" || !value) throw new Error(`KAMN live task observation omitted ${field}`);
+	return value;
+}
+
+function coordinationResult(text: string, result: Record<string, unknown>) {
+	return {
+		content: [{ type: "text" as const, text: `${text} Claim boundary: real local-only independent Pi actors.` }],
+		details: { claimBoundary: "real local-only independent Pi actors", result },
+	};
+}

--- a/.pi/extensions/kamn-mvp/live-task-coordination.test.ts
+++ b/.pi/extensions/kamn-mvp/live-task-coordination.test.ts
@@ -5,6 +5,7 @@ import { resolve } from "node:path";
 import test from "node:test";
 import {
 	verifyIndependentActorReceipts,
+	coordinationConfig,
 	waitForTaskHandoff,
 	writeActorReceipt,
 	writeTaskHandoff,
@@ -41,6 +42,17 @@ test("handoff rejects tampering, stale state, timeout, abort, and secret-like pa
 	await assert.rejects(writeTaskHandoff("/tmp/kamn-keypair-handoff.json", "task-1"), /secret-like/);
 });
 
+test("coordination rejects missing config and unknown artifact fields", async () => {
+	assert.throws(() => coordinationConfig({}, process.cwd()), /KAMN_MVP_LIVE_TASK_HANDOFF_FILE/);
+	const paths = await pathsForTest();
+	await writeTaskHandoff(paths.handoff, "task-live-1");
+	const artifact = JSON.parse(await readFile(paths.handoff, "utf8"));
+	artifact.unexpected = "field";
+	await writeFile(paths.handoff, JSON.stringify(artifact));
+
+	await assert.rejects(waitForTaskHandoff(paths.handoff, options()), /field mismatch/);
+});
+
 test("actor receipts verify agreement and distinct Pi processes", async () => {
 	const paths = await pathsForTest();
 	await writeTaskHandoff(paths.handoff, "task-live-1");
@@ -65,6 +77,9 @@ test("actor receipts verify agreement and distinct Pi processes", async () => {
 	]);
 	await writeActorReceipt(paths.agentA, "agent_a", "task-live-1", "accepted", 101);
 	await assert.rejects(writeActorReceipt(paths.agentA, "agent_a", "task-live-1", "accepted", 303), /conflicts/);
+	const tampered = (await readFile(paths.agentB, "utf8")).replace("task-live-1", "task-tampered");
+	await writeFile(paths.agentB, tampered);
+	await assert.rejects(verifyIndependentActorReceipts(paths.handoff, paths.agentA, paths.agentB), /digest mismatch/);
 });
 
 test("receipt verifier rejects same process and task mismatch", async () => {

--- a/.pi/extensions/kamn-mvp/live-task-coordination.test.ts
+++ b/.pi/extensions/kamn-mvp/live-task-coordination.test.ts
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, utimes, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import test from "node:test";
+import {
+	verifyIndependentActorReceipts,
+	waitForTaskHandoff,
+	writeActorReceipt,
+	writeTaskHandoff,
+} from "./live-task-coordination.ts";
+
+test("handoff is minimal, valid, and idempotent", async () => {
+	const paths = await pathsForTest();
+	await writeTaskHandoff(paths.handoff, "task-live-1");
+	await writeTaskHandoff(paths.handoff, "task-live-1");
+
+	assert.equal(await waitForTaskHandoff(paths.handoff, options()), "task-live-1");
+	assert.deepEqual(Object.keys(JSON.parse(await readFile(paths.handoff, "utf8"))).sort(), [
+		"artifact_digest",
+		"schema_version",
+		"task_id",
+	]);
+	await assert.rejects(writeTaskHandoff(paths.handoff, "task-other"), /conflicts/);
+});
+
+test("handoff rejects tampering, stale state, timeout, abort, and secret-like paths", async () => {
+	const paths = await pathsForTest();
+	await writeTaskHandoff(paths.handoff, "task-live-1");
+	const tampered = (await readFile(paths.handoff, "utf8")).replace("task-live-1", "task-tampered");
+	await writeFile(paths.handoff, tampered);
+	await assert.rejects(waitForTaskHandoff(paths.handoff, options()), /digest mismatch/);
+
+	await writeTaskHandoff(paths.stale, "task-stale");
+	await utimes(paths.stale, new Date(0), new Date(0));
+	await assert.rejects(waitForTaskHandoff(paths.stale, options({ maxAgeMs: 1 })), /stale/);
+	await assert.rejects(waitForTaskHandoff(paths.missing, options({ timeoutMs: 20 })), /timed out/);
+	const controller = new AbortController();
+	controller.abort();
+	await assert.rejects(waitForTaskHandoff(paths.missing, options(), controller.signal), /aborted/);
+	await assert.rejects(writeTaskHandoff("/tmp/kamn-keypair-handoff.json", "task-1"), /secret-like/);
+});
+
+test("actor receipts verify agreement and distinct Pi processes", async () => {
+	const paths = await pathsForTest();
+	await writeTaskHandoff(paths.handoff, "task-live-1");
+	await writeActorReceipt(paths.agentA, "agent_a", "task-live-1", "accepted", 101);
+	await writeActorReceipt(paths.agentB, "agent_b", "task-live-1", "accepted", 202);
+
+	const result = await verifyIndependentActorReceipts(paths.handoff, paths.agentA, paths.agentB);
+	assert.deepEqual(result, {
+		claim_boundary: "real local-only independent Pi actors",
+		task_id: "task-live-1",
+		state: "accepted",
+		agent_a_pi_process_id: 101,
+		agent_b_pi_process_id: 202,
+	});
+	assert.deepEqual(Object.keys(JSON.parse(await readFile(paths.agentA, "utf8"))).sort(), [
+		"actor",
+		"artifact_digest",
+		"pi_process_id",
+		"schema_version",
+		"state",
+		"task_id",
+	]);
+	await writeActorReceipt(paths.agentA, "agent_a", "task-live-1", "accepted", 101);
+	await assert.rejects(writeActorReceipt(paths.agentA, "agent_a", "task-live-1", "accepted", 303), /conflicts/);
+});
+
+test("receipt verifier rejects same process and task mismatch", async () => {
+	const paths = await pathsForTest();
+	await writeTaskHandoff(paths.handoff, "task-live-1");
+	await writeActorReceipt(paths.agentA, "agent_a", "task-live-1", "accepted", 101);
+	await writeActorReceipt(paths.agentB, "agent_b", "task-live-1", "accepted", 101);
+	await assert.rejects(verifyIndependentActorReceipts(paths.handoff, paths.agentA, paths.agentB), /distinct Pi processes/);
+
+	const other = await pathsForTest();
+	await writeTaskHandoff(other.handoff, "task-live-1");
+	await writeActorReceipt(other.agentA, "agent_a", "task-live-1", "accepted", 101);
+	await writeActorReceipt(other.agentB, "agent_b", "task-other", "accepted", 202);
+	await assert.rejects(verifyIndependentActorReceipts(other.handoff, other.agentA, other.agentB), /task ID mismatch/);
+});
+
+function options(overrides: Partial<{ timeoutMs: number; pollMs: number; maxAgeMs: number }> = {}) {
+	return { timeoutMs: 100, pollMs: 5, maxAgeMs: 60000, ...overrides };
+}
+
+async function pathsForTest() {
+	const root = await mkdtemp(resolve(tmpdir(), "kamn-task-coordination-"));
+	return {
+		handoff: resolve(root, "handoff.json"),
+		stale: resolve(root, "stale.json"),
+		missing: resolve(root, "missing.json"),
+		agentA: resolve(root, "agent-a.json"),
+		agentB: resolve(root, "agent-b.json"),
+	};
+}

--- a/.pi/extensions/kamn-mvp/live-task-coordination.ts
+++ b/.pi/extensions/kamn-mvp/live-task-coordination.ts
@@ -89,7 +89,9 @@ async function readHandoffIfPresent(path: string, maxAgeMs: number): Promise<Han
 
 async function readHandoff(path: string): Promise<Handoff> {
 	assertSafePath(path);
-	return parseArtifact(await readFile(path, "utf8"), HANDOFF_SCHEMA, ["artifact_digest", "schema_version", "task_id"]) as Handoff;
+	const handoff = parseArtifact(await readFile(path, "utf8"), HANDOFF_SCHEMA, ["artifact_digest", "schema_version", "task_id"]) as Handoff;
+	validTaskId(handoff.task_id);
+	return handoff;
 }
 
 async function readReceipt(path: string, actor: Actor): Promise<Receipt> {
@@ -162,8 +164,13 @@ function optionalPositiveInteger(raw: string | undefined, fallback: number): num
 
 function delay(milliseconds: number, signal?: AbortSignal): Promise<void> {
 	return new Promise((resolveDelay, reject) => {
-		const timer = setTimeout(resolveDelay, milliseconds);
-		const abort = () => { clearTimeout(timer); reject(new Error("KAMN live task handoff wait aborted")); };
+		const finish = () => { signal?.removeEventListener("abort", abort); resolveDelay(); };
+		const timer = setTimeout(finish, milliseconds);
+		const abort = () => {
+			clearTimeout(timer);
+			signal?.removeEventListener("abort", abort);
+			reject(new Error("KAMN live task handoff wait aborted"));
+		};
 		signal?.addEventListener("abort", abort, { once: true });
 	});
 }

--- a/.pi/extensions/kamn-mvp/live-task-coordination.ts
+++ b/.pi/extensions/kamn-mvp/live-task-coordination.ts
@@ -1,0 +1,173 @@
+import { createHash } from "node:crypto";
+import { readFile, stat, writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+
+const HANDOFF_SCHEMA = "kamn.mvp.live-task-handoff.v1";
+const RECEIPT_SCHEMA = "kamn.mvp.live-task-actor-receipt.v1";
+const SECRET_MARKERS = [".kamn/devnet", "auth.json", ".env", "keypair", "id_rsa", "oauth"];
+export const COORDINATION_TOOL_NAMES = [
+	"kamn_live_agent_a_publish_task_handoff",
+	"kamn_live_agent_b_receive_task_handoff",
+	"kamn_live_agent_a_wait_for_task_acceptance",
+	"kamn_live_agent_b_write_task_receipt",
+	"kamn_live_verify_independent_actor_receipts",
+] as const;
+export type CoordinationOptions = { timeoutMs: number; pollMs: number; maxAgeMs: number };
+type Environment = Record<string, string | undefined>;
+type Actor = "agent_a" | "agent_b";
+type Handoff = { schema_version: string; task_id: string; artifact_digest: string };
+type Receipt = Handoff & { actor: Actor; state: string; pi_process_id: number };
+
+export async function writeTaskHandoff(path: string, taskId: string): Promise<void> {
+	assertSafePath(path);
+	const artifact = withDigest({ schema_version: HANDOFF_SCHEMA, task_id: validTaskId(taskId) });
+	await writeIdempotent(path, artifact, "task handoff");
+}
+
+export async function waitForTaskHandoff(path: string, options: CoordinationOptions, signal?: AbortSignal): Promise<string> {
+	assertSafePath(path);
+	validateOptions(options);
+	const deadline = Date.now() + options.timeoutMs;
+	while (Date.now() <= deadline) {
+		if (signal?.aborted) throw new Error("KAMN live task handoff wait aborted");
+		const handoff = await readHandoffIfPresent(path, options.maxAgeMs);
+		if (handoff) return handoff.task_id;
+		await delay(options.pollMs, signal);
+	}
+	throw new Error(`KAMN live task handoff timed out: ${path}`);
+}
+
+export async function writeActorReceipt(path: string, actor: Actor, taskId: string, state: string, piProcessId: number): Promise<void> {
+	assertSafePath(path);
+	if (state !== "accepted") throw new Error("KAMN live task actor receipt state must be accepted");
+	if (!Number.isInteger(piProcessId) || piProcessId <= 0) throw new Error("KAMN live task actor receipt Pi process ID must be positive");
+	const artifact = withDigest({
+		schema_version: RECEIPT_SCHEMA,
+		actor,
+		task_id: validTaskId(taskId),
+		state,
+		pi_process_id: piProcessId,
+	});
+	await writeIdempotent(path, artifact, `${actor} receipt`);
+}
+
+export async function verifyIndependentActorReceipts(handoffPath: string, agentAPath: string, agentBPath: string) {
+	const handoff = await readHandoff(handoffPath);
+	const agentA = await readReceipt(agentAPath, "agent_a");
+	const agentB = await readReceipt(agentBPath, "agent_b");
+	if (agentA.task_id !== handoff.task_id || agentB.task_id !== handoff.task_id) throw new Error("KAMN live actor receipt task ID mismatch");
+	if (agentA.pi_process_id === agentB.pi_process_id) throw new Error("KAMN live actor receipts must come from distinct Pi processes");
+	return {
+		claim_boundary: "real local-only independent Pi actors",
+		task_id: handoff.task_id,
+		state: "accepted",
+		agent_a_pi_process_id: agentA.pi_process_id,
+		agent_b_pi_process_id: agentB.pi_process_id,
+	};
+}
+
+export function coordinationConfig(env: Environment, cwd: string) {
+	const timeoutMs = optionalPositiveInteger(env.KAMN_MVP_LIVE_TASK_COORDINATION_TIMEOUT_MS, 30000);
+	return {
+		handoffPath: configuredPath(env, "KAMN_MVP_LIVE_TASK_HANDOFF_FILE", cwd),
+		agentAReceiptPath: configuredPath(env, "KAMN_MVP_LIVE_TASK_AGENT_A_RECEIPT_FILE", cwd),
+		agentBReceiptPath: configuredPath(env, "KAMN_MVP_LIVE_TASK_AGENT_B_RECEIPT_FILE", cwd),
+		options: { timeoutMs, pollMs: 100, maxAgeMs: 300000 },
+	};
+}
+
+async function readHandoffIfPresent(path: string, maxAgeMs: number): Promise<Handoff | undefined> {
+	try {
+		const metadata = await stat(path);
+		if (Date.now() - metadata.mtimeMs > maxAgeMs) throw new Error(`KAMN live task handoff is stale: ${path}`);
+		return readHandoff(path);
+	} catch (error) {
+		if (isNodeError(error, "ENOENT")) return undefined;
+		throw error;
+	}
+}
+
+async function readHandoff(path: string): Promise<Handoff> {
+	assertSafePath(path);
+	return parseArtifact(await readFile(path, "utf8"), HANDOFF_SCHEMA, ["artifact_digest", "schema_version", "task_id"]) as Handoff;
+}
+
+async function readReceipt(path: string, actor: Actor): Promise<Receipt> {
+	assertSafePath(path);
+	const artifact = parseArtifact(await readFile(path, "utf8"), RECEIPT_SCHEMA, ["actor", "artifact_digest", "pi_process_id", "schema_version", "state", "task_id"]) as Receipt;
+	if (artifact.actor !== actor) throw new Error(`KAMN live task actor receipt expected ${actor}`);
+	if (artifact.state !== "accepted") throw new Error("KAMN live task actor receipt state mismatch");
+	if (!Number.isInteger(artifact.pi_process_id) || artifact.pi_process_id <= 0) throw new Error("KAMN live task actor receipt Pi process ID is invalid");
+	validTaskId(artifact.task_id);
+	return artifact;
+}
+
+function parseArtifact(raw: string, schema: string, keys: string[]): Record<string, unknown> {
+	let artifact: Record<string, unknown>;
+	try { artifact = JSON.parse(raw) as Record<string, unknown>; } catch { throw new Error("KAMN live task coordination artifact is malformed JSON"); }
+	if (!artifact || Array.isArray(artifact) || artifact.schema_version !== schema) throw new Error("KAMN live task coordination artifact schema mismatch");
+	if (Object.keys(artifact).sort().join(",") !== keys.join(",")) throw new Error("KAMN live task coordination artifact field mismatch");
+	const digest = artifact.artifact_digest;
+	const unsigned = Object.fromEntries(Object.entries(artifact).filter(([key]) => key !== "artifact_digest"));
+	if (digest !== artifactDigest(unsigned)) throw new Error("KAMN live task coordination artifact digest mismatch");
+	return artifact;
+}
+
+function withDigest<T extends Record<string, unknown>>(artifact: T): T & { artifact_digest: string } {
+	return { ...artifact, artifact_digest: artifactDigest(artifact) };
+}
+
+function artifactDigest(artifact: Record<string, unknown>): string {
+	return createHash("sha256").update(JSON.stringify(artifact)).digest("hex");
+}
+
+async function writeIdempotent(path: string, artifact: Record<string, unknown>, label: string) {
+	const json = `${JSON.stringify(artifact)}\n`;
+	try { await writeFile(path, json, { flag: "wx", mode: 0o600 }); } catch (error) {
+		if (!isNodeError(error, "EEXIST")) throw error;
+		if (await readFile(path, "utf8") !== json) throw new Error(`KAMN live ${label} conflicts with existing artifact`);
+	}
+}
+
+function validTaskId(taskId: string): string {
+	if (!/^[A-Za-z0-9._:-]{1,200}$/.test(taskId)) throw new Error("KAMN live task ID is invalid");
+	return taskId;
+}
+
+function configuredPath(env: Environment, name: string, cwd: string): string {
+	const value = env[name]?.trim();
+	if (!value) throw new Error(`Missing required environment variable: ${name}`);
+	const path = value.startsWith("/") ? value : resolve(cwd, value);
+	assertSafePath(path);
+	return path;
+}
+
+function assertSafePath(path: string) {
+	const lower = path.toLowerCase();
+	if (SECRET_MARKERS.some((marker) => lower.includes(marker))) throw new Error("Refusing secret-like KAMN live task coordination path");
+}
+
+function validateOptions(options: CoordinationOptions) {
+	for (const [name, value] of Object.entries(options)) {
+		if (!Number.isInteger(value) || value <= 0) throw new Error(`KAMN live task coordination ${name} must be positive`);
+	}
+}
+
+function optionalPositiveInteger(raw: string | undefined, fallback: number): number {
+	if (raw === undefined) return fallback;
+	const value = Number(raw);
+	if (!Number.isInteger(value) || value <= 0) throw new Error("KAMN live task coordination timeout must be positive");
+	return value;
+}
+
+function delay(milliseconds: number, signal?: AbortSignal): Promise<void> {
+	return new Promise((resolveDelay, reject) => {
+		const timer = setTimeout(resolveDelay, milliseconds);
+		const abort = () => { clearTimeout(timer); reject(new Error("KAMN live task handoff wait aborted")); };
+		signal?.addEventListener("abort", abort, { once: true });
+	});
+}
+
+function isNodeError(error: unknown, code: string): boolean {
+	return error instanceof Error && "code" in error && error.code === code;
+}

--- a/.pi/extensions/kamn-mvp/live-task-workflow.test.ts
+++ b/.pi/extensions/kamn-mvp/live-task-workflow.test.ts
@@ -93,6 +93,25 @@ test("workflow rejects a non-accepted query projection", async () => {
 	await workflow.shutdown();
 });
 
+test("Agent B imports an external task while Agent A polls accepted state", async () => {
+	const setupA = await testSetup();
+	const setupB = await testSetup();
+	const agentA = new LiveTaskWorkflow(setupA.env, process.cwd());
+	const agentB = new LiveTaskWorkflow(setupB.env, process.cwd());
+	await agentA.register("agent_a");
+	await agentB.register("agent_b");
+	const created = await agentA.createTask("title", "description");
+	agentB.importTask(String(created.task_id));
+
+	await agentB.acceptTask();
+	await agentB.queryTask("agent_b");
+	const observed = await agentA.waitForAccepted("agent_a", { timeoutMs: 100, pollMs: 5 });
+	assert.deepEqual(agentA.acceptedObservation("agent_a"), observed);
+	assert.equal(agentB.acceptedObservation("agent_b").task_id, created.task_id);
+	await agentA.shutdown();
+	await agentB.shutdown();
+});
+
 async function testSetup(extra: Record<string, string> = {}) {
 	const root = await mkdtemp(resolve(tmpdir(), "kamn-live-task-"));
 	const agentAKey = resolve(root, "agent-a.key");

--- a/.pi/extensions/kamn-mvp/live-task-workflow.test.ts
+++ b/.pi/extensions/kamn-mvp/live-task-workflow.test.ts
@@ -112,6 +112,21 @@ test("Agent B imports an external task while Agent A polls accepted state", asyn
 	await agentB.shutdown();
 });
 
+test("external task import and acceptance polling fail closed", async () => {
+	const setup = await testSetup({ KAMN_MVP_FAKE_MCP_RESULT_MODE: "wrong-query-state" });
+	const workflow = new LiveTaskWorkflow(setup.env, process.cwd());
+	assert.throws(() => workflow.importTask("bad task id"), /invalid/);
+	workflow.importTask("task-live-1");
+	assert.throws(() => workflow.importTask("task-other"), /conflicts/);
+	await workflow.register("agent_a");
+
+	await assert.rejects(workflow.waitForAccepted("agent_a", { timeoutMs: 20, pollMs: 5 }), /timed out/);
+	const controller = new AbortController();
+	controller.abort();
+	await assert.rejects(workflow.waitForAccepted("agent_a", { timeoutMs: 20, pollMs: 5 }, controller.signal), /aborted/);
+	await workflow.shutdown();
+});
+
 async function testSetup(extra: Record<string, string> = {}) {
 	const root = await mkdtemp(resolve(tmpdir(), "kamn-live-task-"));
 	const agentAKey = resolve(root, "agent-a.key");

--- a/.pi/extensions/kamn-mvp/live-task-workflow.ts
+++ b/.pi/extensions/kamn-mvp/live-task-workflow.ts
@@ -63,6 +63,7 @@ export class LiveTaskWorkflow {
 		return observation;
 	}
 	async waitForAccepted(role: AgentRole, options: WaitOptions, signal?: AbortSignal): Promise<WorkflowResult> {
+		validateWaitOptions(options);
 		this.registeredDid(role);
 		const taskId = this.createdTaskId();
 		const deadline = Date.now() + options.timeoutMs;
@@ -135,8 +136,17 @@ function validImportedTaskId(taskId: string): string {
 }
 function delay(milliseconds: number, signal?: AbortSignal): Promise<void> {
 	return new Promise((resolveDelay, reject) => {
-		const timer = setTimeout(resolveDelay, milliseconds);
-		const abort = () => { clearTimeout(timer); reject(new Error("Task acceptance wait aborted")); };
+		const finish = () => { signal?.removeEventListener("abort", abort); resolveDelay(); };
+		const timer = setTimeout(finish, milliseconds);
+		const abort = () => {
+			clearTimeout(timer);
+			signal?.removeEventListener("abort", abort);
+			reject(new Error("Task acceptance wait aborted"));
+		};
 		signal?.addEventListener("abort", abort, { once: true });
 	});
+}
+function validateWaitOptions(options: WaitOptions) {
+	if (!Number.isInteger(options.timeoutMs) || options.timeoutMs <= 0) throw new Error("Task acceptance timeout must be positive");
+	if (!Number.isInteger(options.pollMs) || options.pollMs <= 0) throw new Error("Task acceptance poll interval must be positive");
 }

--- a/.pi/extensions/kamn-mvp/live-task-workflow.ts
+++ b/.pi/extensions/kamn-mvp/live-task-workflow.ts
@@ -4,9 +4,11 @@ export type AgentRole = "agent_a" | "agent_b";
 export type WorkflowResult = Record<string, unknown>;
 type Environment = Record<string, string | undefined>;
 type AgentState = { did?: string; session?: McpSession };
+type WaitOptions = { timeoutMs: number; pollMs: number };
 
 export class LiveTaskWorkflow {
 	private readonly agents: Record<AgentRole, AgentState> = { agent_a: {}, agent_b: {} };
+	private readonly observations: Partial<Record<AgentRole, WorkflowResult>> = {};
 	private taskId?: string;
 	private readonly env: Environment;
 	private readonly cwd: string;
@@ -44,7 +46,38 @@ export class LiveTaskWorkflow {
 		const taskId = this.createdTaskId();
 		const result = await this.session(role).call("query_task", { task_id: taskId }, signal);
 		validateTaskResult(result, taskId, "accepted", `${agentLabel(role)} task query`);
+		this.observations[role] = result;
 		return result;
+	}
+	importTask(taskId: string) {
+		const imported = validImportedTaskId(taskId);
+		if (this.taskId && this.taskId !== imported) throw new Error("Imported task ID conflicts with current task");
+		this.taskId = imported;
+	}
+	currentTaskId(): string {
+		return this.createdTaskId();
+	}
+	acceptedObservation(role: AgentRole): WorkflowResult {
+		const observation = this.observations[role];
+		if (!observation) throw new Error(`${agentLabel(role)} has not observed accepted task state`);
+		return observation;
+	}
+	async waitForAccepted(role: AgentRole, options: WaitOptions, signal?: AbortSignal): Promise<WorkflowResult> {
+		this.registeredDid(role);
+		const taskId = this.createdTaskId();
+		const deadline = Date.now() + options.timeoutMs;
+		while (Date.now() <= deadline) {
+			if (signal?.aborted) throw new Error(`${agentLabel(role)} task acceptance wait aborted`);
+			const result = await this.session(role).call("query_task", { task_id: taskId }, signal);
+			const state = validateTaskProjection(result, taskId, `${agentLabel(role)} task acceptance wait`);
+			if (state === "accepted") {
+				this.observations[role] = result;
+				return result;
+			}
+			if (state !== "submitted") throw new Error(`${agentLabel(role)} task acceptance wait returned unexpected state ${state}`);
+			await delay(options.pollMs, signal);
+		}
+		throw new Error(`${agentLabel(role)} task acceptance wait timed out`);
 	}
 	async shutdown(): Promise<void> {
 		await Promise.all(Object.values(this.agents).map((agent) => agent.session?.shutdown()));
@@ -71,10 +104,14 @@ export class LiveTaskWorkflow {
 
 function validateTaskResult(result: WorkflowResult, expectedId: string | undefined, expectedState: string, step: string): string {
 	const taskId = requiredString(result, "task_id", step);
-	const state = requiredString(result, "state", step);
-	if (expectedId && taskId !== expectedId) throw new Error(`${step} returned a different task ID`);
+	const state = validateTaskProjection(result, expectedId, step);
 	if (state !== expectedState) throw new Error(`${step} returned state ${state}; expected ${expectedState}`);
 	return taskId;
+}
+function validateTaskProjection(result: WorkflowResult, expectedId: string | undefined, step: string): string {
+	const taskId = requiredString(result, "task_id", step);
+	if (expectedId && taskId !== expectedId) throw new Error(`${step} returned a different task ID`);
+	return requiredString(result, "state", step);
 }
 function requiredString(result: WorkflowResult, field: string, step: string): string {
 	const value = result[field];
@@ -91,4 +128,15 @@ function configRole(role: AgentRole): LiveMcpAgent {
 }
 function agentLabel(role: AgentRole): string {
 	return role === "agent_a" ? "Agent A" : "Agent B";
+}
+function validImportedTaskId(taskId: string): string {
+	if (!/^[A-Za-z0-9._:-]{1,200}$/.test(taskId)) throw new Error("Imported task ID is invalid");
+	return taskId;
+}
+function delay(milliseconds: number, signal?: AbortSignal): Promise<void> {
+	return new Promise((resolveDelay, reject) => {
+		const timer = setTimeout(resolveDelay, milliseconds);
+		const abort = () => { clearTimeout(timer); reject(new Error("Task acceptance wait aborted")); };
+		signal?.addEventListener("abort", abort, { once: true });
+	});
 }

--- a/crates/kamn-e2e-harness/tests/mvp_demo_agent_harness_claim_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_demo_agent_harness_claim_contract.rs
@@ -154,6 +154,15 @@ fn spec_c08_project_local_pi_extension_registers_kamn_tools() {
         "KAMN_MVP_LIVE_MCP_AGENT_B_NAME",
         "KAMN_MVP_LIVE_MCP_AGENT_B_KEY_FILE",
         "real local-only task lifecycle",
+        "kamn_live_agent_a_publish_task_handoff",
+        "kamn_live_agent_b_receive_task_handoff",
+        "kamn_live_agent_a_wait_for_task_acceptance",
+        "kamn_live_agent_b_write_task_receipt",
+        "kamn_live_verify_independent_actor_receipts",
+        "KAMN_MVP_LIVE_TASK_HANDOFF_FILE",
+        "KAMN_MVP_LIVE_TASK_AGENT_A_RECEIPT_FILE",
+        "KAMN_MVP_LIVE_TASK_AGENT_B_RECEIPT_FILE",
+        "real local-only independent Pi actors",
     ] {
         assert!(source.contains(marker), "missing Pi tool marker: {marker}");
     }
@@ -225,6 +234,7 @@ fn pi_extension_source() -> String {
         ".pi/extensions/kamn-mvp/live-mcp-tools.ts",
         ".pi/extensions/kamn-mvp/mcp-session.ts",
         ".pi/extensions/kamn-mvp/live-task-workflow.ts",
+        ".pi/extensions/kamn-mvp/live-task-coordination.ts",
     ]
     .map(|path| {
         std::fs::read_to_string(workspace_root().join(path))

--- a/crates/kamn-e2e-harness/tests/mvp_evaluator_demo_runbook_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_evaluator_demo_runbook_contract.rs
@@ -51,6 +51,16 @@ fn spec_c01_mvp_runbook_documents_pi_tool_harness_boundaries() {
         "does not prove escrow, settlement, asset movement, third-party verification, or restart durability",
         "Both registrations and task creation return `201`",
         "acceptance and both task queries return `200`",
+        "kamn_live_agent_a_publish_task_handoff",
+        "kamn_live_agent_b_receive_task_handoff",
+        "kamn_live_agent_a_wait_for_task_acceptance",
+        "kamn_live_agent_b_write_task_receipt",
+        "kamn_live_verify_independent_actor_receipts",
+        "KAMN_MVP_LIVE_TASK_HANDOFF_FILE",
+        "KAMN_MVP_LIVE_TASK_AGENT_A_RECEIPT_FILE",
+        "KAMN_MVP_LIVE_TASK_AGENT_B_RECEIPT_FILE",
+        "real local-only independent Pi actors",
+        "separate Pi processes",
     ] {
         assert!(runbook.contains(needle), "{RUNBOOK} missing: {needle}");
     }

--- a/crates/kamn-e2e-harness/tests/mvp_evaluator_demo_runbook_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_evaluator_demo_runbook_contract.rs
@@ -62,6 +62,8 @@ fn spec_c01_mvp_runbook_documents_pi_tool_harness_boundaries() {
         "real local-only independent Pi actors",
         "separate Pi processes",
         "Run this export block in each actor and verifier terminal",
+        "Agent A and Agent B Pi process IDs must differ",
+        "one or more `submitted` polls before its final `accepted` query",
     ] {
         assert!(runbook.contains(needle), "{RUNBOOK} missing: {needle}");
     }

--- a/crates/kamn-e2e-harness/tests/mvp_evaluator_demo_runbook_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_evaluator_demo_runbook_contract.rs
@@ -61,6 +61,7 @@ fn spec_c01_mvp_runbook_documents_pi_tool_harness_boundaries() {
         "KAMN_MVP_LIVE_TASK_AGENT_B_RECEIPT_FILE",
         "real local-only independent Pi actors",
         "separate Pi processes",
+        "Run this export block in each actor and verifier terminal",
     ] {
         assert!(runbook.contains(needle), "{RUNBOOK} missing: {needle}");
     }

--- a/docs/validation/mvp-evaluator-demo.md
+++ b/docs/validation/mvp-evaluator-demo.md
@@ -248,7 +248,7 @@ env -u OPENAI_API_KEY pi \
   -p "Use only the KAMN tool. Verify the independent actor receipts and report the claim boundary exactly."
 ```
 
-The verifier requires matching accepted task IDs and distinct positive Pi process IDs. Handoff and receipt artifacts are integrity-protected and contain no DIDs, task payload, keys, auth headers, signatures, nonces, or credentials. This proves real local-only independent Pi actors. It does not prove Agent C, disclosure asymmetry, escrow, settlement, asset movement, devnet execution, or restart durability.
+The verifier requires matching accepted task IDs and distinct positive Pi process IDs; the Agent A and Agent B Pi process IDs must differ. Node logs show separate DIDs and nonce streams. Agent B uses register/accept/query requests, while Agent A may record one or more `submitted` polls before its final `accepted` query. Handoff and receipt artifacts are integrity-protected and contain no DIDs, task payload, keys, auth headers, signatures, nonces, or credentials. This proves real local-only independent Pi actors. It does not prove Agent C, disclosure asymmetry, escrow, settlement, asset movement, devnet execution, or restart durability.
 
 The evidence also records a `three_agent_boundary` summary derived from the
 verified report: local-only reports are marked `NOT_PRESENT`, while reports with

--- a/docs/validation/mvp-evaluator-demo.md
+++ b/docs/validation/mvp-evaluator-demo.md
@@ -191,12 +191,13 @@ This is a real local-only task lifecycle backed by the service task store. It do
 
 ### Independent Pi Actor Check
 
-The two-agent task check above uses separate KAMN identities inside one Pi process. To prove independent AI actors, run Agent A and Agent B as separate Pi processes with a minimal task handoff. Use fresh artifact paths for each rehearsal:
+The two-agent task check above uses separate KAMN identities inside one Pi process. To prove independent AI actors, run Agent A and Agent B as separate Pi processes with a minimal task handoff. Run this export block in each actor and verifier terminal with the same newly chosen run ID; use a fresh run ID for every rehearsal:
 
 ```bash
-export KAMN_MVP_LIVE_TASK_HANDOFF_FILE=/tmp/kamn-independent-task-handoff.json
-export KAMN_MVP_LIVE_TASK_AGENT_A_RECEIPT_FILE=/tmp/kamn-independent-agent-a.json
-export KAMN_MVP_LIVE_TASK_AGENT_B_RECEIPT_FILE=/tmp/kamn-independent-agent-b.json
+export KAMN_MVP_LIVE_TASK_RUN_ID=run-7082-001
+export KAMN_MVP_LIVE_TASK_HANDOFF_FILE=/tmp/kamn-independent-${KAMN_MVP_LIVE_TASK_RUN_ID}-handoff.json
+export KAMN_MVP_LIVE_TASK_AGENT_A_RECEIPT_FILE=/tmp/kamn-independent-${KAMN_MVP_LIVE_TASK_RUN_ID}-agent-a.json
+export KAMN_MVP_LIVE_TASK_AGENT_B_RECEIPT_FILE=/tmp/kamn-independent-${KAMN_MVP_LIVE_TASK_RUN_ID}-agent-b.json
 export KAMN_MVP_LIVE_TASK_COORDINATION_TIMEOUT_MS=60000
 ```
 

--- a/docs/validation/mvp-evaluator-demo.md
+++ b/docs/validation/mvp-evaluator-demo.md
@@ -189,6 +189,66 @@ A passing run returns distinct Agent A and Agent B DIDs, one shared task ID, `su
 
 This is a real local-only task lifecycle backed by the service task store. It does not prove escrow, settlement, asset movement, third-party verification, or restart durability. Those claims require their own proof slices, and any eventual value-movement claim must remain devnet-backed.
 
+### Independent Pi Actor Check
+
+The two-agent task check above uses separate KAMN identities inside one Pi process. To prove independent AI actors, run Agent A and Agent B as separate Pi processes with a minimal task handoff. Use fresh artifact paths for each rehearsal:
+
+```bash
+export KAMN_MVP_LIVE_TASK_HANDOFF_FILE=/tmp/kamn-independent-task-handoff.json
+export KAMN_MVP_LIVE_TASK_AGENT_A_RECEIPT_FILE=/tmp/kamn-independent-agent-a.json
+export KAMN_MVP_LIVE_TASK_AGENT_B_RECEIPT_FILE=/tmp/kamn-independent-agent-b.json
+export KAMN_MVP_LIVE_TASK_COORDINATION_TIMEOUT_MS=60000
+```
+
+Start Agent B first. It registers through its own MCP child, then waits for Agent A's task handoff:
+
+```bash
+KAMN_MVP_LIVE_MCP_BINARY=target/debug/kamn-mcp-server \
+KAMN_MVP_LIVE_MCP_ENDPOINT=http://127.0.0.1:18278 \
+KAMN_MVP_LIVE_MCP_AGENT_B_NAME=pi-independent-agent-b \
+KAMN_MVP_LIVE_MCP_AGENT_B_KEY_FILE=/tmp/kamn-pi-agent-b.key \
+env -u OPENAI_API_KEY pi \
+  --model openai-codex/gpt-5.5 \
+  --thinking medium \
+  --extension .pi/extensions/kamn-mvp/index.ts \
+  --no-builtin-tools \
+  --tools kamn_live_agent_b_register,kamn_live_agent_b_receive_task_handoff,kamn_live_agent_b_accept_task,kamn_live_agent_b_query_task,kamn_live_agent_b_write_task_receipt \
+  --approve --no-session \
+  -p "Use only the KAMN tools. Register Agent B, receive Agent A's task handoff, accept the task, query accepted state, and write Agent B's task receipt. Report the claim boundary exactly."
+```
+
+While Agent B is waiting, start Agent A in another terminal. Agent A's Pi process stays alive while its persistent MCP child polls for Agent B's acceptance:
+
+```bash
+KAMN_MVP_LIVE_MCP_BINARY=target/debug/kamn-mcp-server \
+KAMN_MVP_LIVE_MCP_ENDPOINT=http://127.0.0.1:18278 \
+KAMN_MVP_LIVE_MCP_AGENT_A_NAME=pi-independent-agent-a \
+KAMN_MVP_LIVE_MCP_AGENT_A_KEY_FILE=/tmp/kamn-pi-agent-a.key \
+env -u OPENAI_API_KEY pi \
+  --model openai-codex/gpt-5.5 \
+  --thinking medium \
+  --extension .pi/extensions/kamn-mvp/index.ts \
+  --no-builtin-tools \
+  --tools kamn_live_agent_a_register,kamn_live_agent_a_create_task,kamn_live_agent_a_publish_task_handoff,kamn_live_agent_a_wait_for_task_acceptance \
+  --approve --no-session \
+  -p "Use only the KAMN tools. Register Agent A, create a task titled 'Independent actor proof' with description 'Prove separate Pi processes coordinate one KAMN task', publish the task handoff, and wait until Agent B accepts it. Report the claim boundary exactly."
+```
+
+After both actor processes exit successfully, run a verifier-only Pi process. It requires coordination artifact paths but no KAMN key or identity configuration:
+
+```bash
+env -u OPENAI_API_KEY pi \
+  --model openai-codex/gpt-5.5 \
+  --thinking medium \
+  --extension .pi/extensions/kamn-mvp/index.ts \
+  --no-builtin-tools \
+  --tools kamn_live_verify_independent_actor_receipts \
+  --approve --no-session \
+  -p "Use only the KAMN tool. Verify the independent actor receipts and report the claim boundary exactly."
+```
+
+The verifier requires matching accepted task IDs and distinct positive Pi process IDs. Handoff and receipt artifacts are integrity-protected and contain no DIDs, task payload, keys, auth headers, signatures, nonces, or credentials. This proves real local-only independent Pi actors. It does not prove Agent C, disclosure asymmetry, escrow, settlement, asset movement, devnet execution, or restart durability.
+
 The evidence also records a `three_agent_boundary` summary derived from the
 verified report: local-only reports are marked `NOT_PRESENT`, while reports with
 `three_agent_escrow_verification` must preserve the report's claim status, label,

--- a/specs/7082-independent-pi-task-actors.md
+++ b/specs/7082-independent-pi-task-actors.md
@@ -1,0 +1,104 @@
+# Independent Pi Task Actors
+
+## Objective
+
+Prove Agent A and Agent B are driven by separate Pi processes, not one Pi process invoking two KAMN identities, while they coordinate one real local service-backed task through independent persistent MCP children.
+
+## Inputs/Outputs
+
+Inputs:
+
+- Existing Agent A/B live MCP binary, endpoint, name, and key-file configuration.
+- `KAMN_MVP_LIVE_TASK_HANDOFF_FILE`: shared non-secret handoff path.
+- `KAMN_MVP_LIVE_TASK_AGENT_A_RECEIPT_FILE`: Agent A observation receipt path.
+- `KAMN_MVP_LIVE_TASK_AGENT_B_RECEIPT_FILE`: Agent B observation receipt path.
+- Optional positive integer `KAMN_MVP_LIVE_TASK_COORDINATION_TIMEOUT_MS`.
+- Two concurrently running Pi processes with disjoint tool allowlists.
+
+Outputs:
+
+- Handoff artifact `kamn.mvp.live-task-handoff.v1` containing only schema version, task ID, and SHA-256 digest.
+- Agent receipts `kamn.mvp.live-task-actor-receipt.v1` containing only schema version, actor, task ID, accepted state, Pi process ID, and SHA-256 digest.
+- Verifier result requiring matching task IDs/states, valid digests, expected actor labels, and distinct positive Pi process IDs.
+- Human output labelled `real local-only independent Pi actors`.
+
+## Boundaries/Non-goals
+
+- Reuse `LiveTaskWorkflow`, `McpSession`, and existing create/accept/query tools.
+- Agent A process may access only Agent A live/coordination tools; Agent B process may access only Agent B live/coordination tools.
+- Use the filesystem only as a bounded handoff/evidence boundary, not as a broker, queue, database, or auth mechanism.
+- Handoff and receipt paths must reject secret-like markers and resolve explicitly from the evaluator working directory.
+- Never put DIDs, title, description, task payload, key paths/contents, headers, signatures, auth nonces, or credentials in coordination artifacts.
+- Do not claim Agent C, disclosure asymmetry, service-side redaction, escrow, settlement, asset movement, devnet execution, or restart durability.
+
+## Failure Modes
+
+- Missing/blank path or timeout environment: reject before coordination work.
+- Secret-like coordination path: reject before filesystem access.
+- Existing handoff for a different task: reject instead of overwrite.
+- Missing handoff: poll until timeout or abort, then reject.
+- Handoff older than the coordination age limit: reject as stale.
+- Malformed schema, unknown field, blank/invalid task ID, or digest mismatch: reject.
+- Agent B imports handoff before registration: allowed, but accept still requires B registration.
+- Agent A polling sees `submitted`: continue until accepted within timeout.
+- Agent A polling sees an unexpected state or different task ID: reject immediately.
+- Receipt write before accepted observation: reject.
+- Existing receipt differs from the current actor/task/state/PID: reject instead of overwrite.
+- Verifier sees missing/malformed receipts, same Pi PID, wrong actor, different task ID, non-accepted state, or digest mismatch: reject.
+- Repeated identical handoff/receipt write: succeed idempotently.
+
+## Acceptance Criteria
+
+- [ ] `kamn_live_agent_a_publish_task_handoff` writes the minimal validated handoff after Agent A creates a task.
+- [ ] `kamn_live_agent_b_receive_task_handoff` waits for, validates, and imports that task ID into Agent B's workflow.
+- [ ] `kamn_live_agent_a_wait_for_task_acceptance` polls through Agent A's existing MCP session and writes Agent A's accepted-state receipt.
+- [ ] `kamn_live_agent_b_write_task_receipt` writes Agent B's receipt only after B queries accepted state.
+- [ ] `kamn_live_verify_independent_actor_receipts` validates handoff/receipts and proves distinct Pi process IDs.
+- [ ] Coordination artifacts contain only their specified allowlisted fields.
+- [ ] Writes are idempotent for identical content and fail for conflicting content.
+- [ ] Polling honors timeout/abort and rejects stale or malformed artifacts.
+- [ ] Node tests cover success, field boundaries, digest tampering, conflict, stale/timeout/abort, receipt mismatch, and same-PID rejection.
+- [ ] Rust source/runbook contracts pin tool names, configuration, separate Pi commands, and claim boundary.
+- [ ] A real concurrent Pi run proves separate A/B Pi process IDs, distinct KAMN DIDs, independent MCP nonce sequences, and one matching accepted task ID.
+- [ ] A separate Pi verifier process validates the two actor receipts without becoming KAMN Agent C.
+- [ ] Formatting, strict clippy, targeted contracts, `make check`, canonical demo, and canonical verifier pass.
+
+## Files To Touch
+
+- `.pi/extensions/kamn-mvp/live-task-coordination.ts`
+- `.pi/extensions/kamn-mvp/live-task-coordination.test.ts`
+- `.pi/extensions/kamn-mvp/live-task-workflow.ts`
+- `.pi/extensions/kamn-mvp/live-task-workflow.test.ts`
+- `.pi/extensions/kamn-mvp/live-mcp-tools.ts`
+- `crates/kamn-e2e-harness/tests/mvp_demo_agent_harness_claim_contract.rs`
+- `crates/kamn-e2e-harness/tests/mvp_evaluator_demo_runbook_contract.rs`
+- `docs/validation/mvp-evaluator-demo.md`
+
+## Error Semantics
+
+All coordination and verification failures throw `Error` at the Pi tool boundary and report no partial success. Filesystem `ENOENT` is retryable only while waiting for the handoff; malformed or conflicting artifacts fail immediately. Workflow query errors retain existing MCP hard-fail semantics. The verifier reads artifacts without mutating them.
+
+## Test Plan
+
+RED:
+
+- Add pure Node tests for handoff/receipt write-read-verify behavior and every failure mode.
+- Extend workflow tests to require external task import, accepted-state polling, and receipt observation access.
+- Extend Rust source/runbook contracts with coordination tools/configuration and separate Pi-process commands.
+
+GREEN:
+
+- Implement the minimal coordination artifact module and workflow methods.
+- Register five coordination/verifier tools and document the concurrent evaluator sequence.
+
+REFACTOR:
+
+- Keep artifact IO/digest validation separate from MCP workflow state and Pi registration adapters.
+- Verify all files/functions remain within repository limits and remove duplicated validation.
+
+INTEGRATION:
+
+- Start one disposable local node and fresh Agent A/B keys.
+- Launch Agent B Pi first so it waits for handoff, then Agent A Pi so it creates/publishes/polls.
+- Run a separate verifier-only Pi process over the completed artifacts.
+- Inspect node logs and structured receipts, then run all local gates and canonical proof commands.


### PR DESCRIPTION
## Human Summary

- Adds a bounded handoff so Agent A and Agent B can run as separate Pi processes while coordinating one real service-backed task.
- Keeps each actor's persistent MCP child and nonce sequence isolated; Agent A remains alive polling while Agent B accepts and queries the task.
- Emits minimal integrity-protected actor receipts and verifies matching accepted task state plus distinct Pi process IDs.
- Keeps coordination artifacts non-secret and explicitly excludes Agent C, disclosure asymmetry, settlement, asset movement, and restart durability.

## Testing

- RED: coordination module import failed before implementation.
- RED: workflow external task import failed before implementation.
- RED: Pi source contract failed on the missing coordination module.
- RED: runbook contract failed on the missing handoff tool.
- `node --no-warnings --experimental-strip-types --test .pi/extensions/kamn-mvp/mcp-session.test.ts .pi/extensions/kamn-mvp/live-task-workflow.test.ts .pi/extensions/kamn-mvp/live-task-coordination.test.ts` (three consecutive passes, 24 tests each)
- `cargo test -p kamn-e2e-harness --test mvp_demo_agent_harness_claim_contract --test mvp_evaluator_demo_runbook_contract` (24 tests)
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `make check`
- `make demo-mvp` (`GO`)
- `cargo run -p kamn-e2e-harness -- verify-mvp-demo --report .kamn/demo/latest/proof/report.json`
- Real concurrent Pi `openai-codex/gpt-5.5` actor run against local `kamn-node` and two real `kamn-mcp-server` children.
- Verifier-only Pi run passed over the completed handoff and actor receipts.
- Live evidence: shared task `task-local-0a62c90e4539f111`; Agent A Pi PID `99763`; Agent B Pi PID `98097`; distinct DIDs and independent nonce streams; both receipts state `accepted`.

## Notes for Reviewers

- Review exact artifact field allowlists and idempotent conflict behavior in `.pi/extensions/kamn-mvp/live-task-coordination.ts`.
- SHA-256 fields provide artifact integrity checks, not identity signatures; live node logs and distinct process receipts are the execution evidence.
- The shared filesystem is a bounded handoff/evidence surface, not a general queue or broker.

## AI Agent Details

- Issue: #7082
- Spec: `specs/7082-independent-pi-task-actors.md`
- Agent A tools: register, create, publish handoff, wait for acceptance.
- Agent B tools: register, receive handoff, accept, query, write receipt.
- Verifier Pi has no KAMN identity/key configuration and only reads coordination artifacts.

Closes #7082

shell_loc_delta_actual: 0
rust_loc_delta_actual: 23
shell_to_rust_ratio_delta_actual: 0.0
shell_surface_ratio_target_status: neutral
