### PR TITLE
[7084] Prove independent Agent C restricted observation

### DIFF
--- a/.pi/extensions/kamn-mvp/live-task-coordination-tools.ts
+++ b/.pi/extensions/kamn-mvp/live-task-coordination-tools.ts
@@ -9,6 +9,10 @@ import {
 	writeTaskHandoff,
 } from "./live-task-coordination.ts";
 import type { LiveTaskWorkflow, WorkflowResult } from "./live-task-workflow.ts";
+import {
+	restrictedObservationConfig,
+	writeRestrictedTaskObservation,
+} from "./restricted-task-observation.ts";
 
 type WorkflowResolver = (cwd: string) => LiveTaskWorkflow;
 
@@ -18,6 +22,27 @@ export function registerLiveTaskCoordinationTools(pi: ExtensionAPI, resolveWorkf
 	registerAgentAWaitTool(pi, resolveWorkflow);
 	registerAgentBReceiptTool(pi, resolveWorkflow);
 	registerVerifierTool(pi);
+	registerAgentCObservationTool(pi);
+}
+
+function registerAgentCObservationTool(pi: ExtensionAPI) {
+	pi.registerTool({
+		name: "kamn_live_agent_c_verify_restricted_task_observation",
+		label: "KAMN Agent C Verify Restricted Task Observation",
+		description: "Verify a restricted task observation in a third independent Pi process.",
+		parameters: Type.Object({}),
+		executionMode: "sequential",
+		async execute(_id, _params, _signal, _onUpdate, ctx) {
+			const config = restrictedObservationConfig(process.env, ctx.cwd);
+			const result = await writeRestrictedTaskObservation(
+				config.handoffPath, config.agentAPath, config.agentBPath, config.observationPath, process.pid,
+			);
+			return {
+				content: [{ type: "text" as const, text: `Agent C verified the restricted task observation. Claim boundary: ${result.claim_boundary}.` }],
+				details: { claimBoundary: result.claim_boundary, result },
+			};
+		},
+	});
 }
 
 function registerPublishTool(pi: ExtensionAPI, resolveWorkflow: WorkflowResolver) {

--- a/.pi/extensions/kamn-mvp/live-task-coordination.ts
+++ b/.pi/extensions/kamn-mvp/live-task-coordination.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import { readFile, stat, writeFile } from "node:fs/promises";
 import { resolve } from "node:path";
+import type { VerifiedActorEvidence } from "./live-task-evidence.ts";
 
 const HANDOFF_SCHEMA = "kamn.mvp.live-task-handoff.v1";
 const RECEIPT_SCHEMA = "kamn.mvp.live-task-actor-receipt.v1";
@@ -17,15 +18,6 @@ type Environment = Record<string, string | undefined>;
 type Actor = "agent_a" | "agent_b";
 type Handoff = { schema_version: string; task_id: string; artifact_digest: string };
 type Receipt = Handoff & { actor: Actor; state: string; pi_process_id: number };
-export type VerifiedActorEvidence = {
-	task_id: string;
-	state: "accepted";
-	agent_a_pi_process_id: number;
-	agent_b_pi_process_id: number;
-	source_handoff_digest: string;
-	source_agent_a_receipt_digest: string;
-	source_agent_b_receipt_digest: string;
-};
 
 export async function writeTaskHandoff(path: string, taskId: string): Promise<void> {
 	assertSafePath(path);

--- a/.pi/extensions/kamn-mvp/live-task-coordination.ts
+++ b/.pi/extensions/kamn-mvp/live-task-coordination.ts
@@ -17,6 +17,15 @@ type Environment = Record<string, string | undefined>;
 type Actor = "agent_a" | "agent_b";
 type Handoff = { schema_version: string; task_id: string; artifact_digest: string };
 type Receipt = Handoff & { actor: Actor; state: string; pi_process_id: number };
+export type VerifiedActorEvidence = {
+	task_id: string;
+	state: "accepted";
+	agent_a_pi_process_id: number;
+	agent_b_pi_process_id: number;
+	source_handoff_digest: string;
+	source_agent_a_receipt_digest: string;
+	source_agent_b_receipt_digest: string;
+};
 
 export async function writeTaskHandoff(path: string, taskId: string): Promise<void> {
 	assertSafePath(path);
@@ -52,17 +61,34 @@ export async function writeActorReceipt(path: string, actor: Actor, taskId: stri
 }
 
 export async function verifyIndependentActorReceipts(handoffPath: string, agentAPath: string, agentBPath: string) {
+	const evidence = await readVerifiedActorEvidence(handoffPath, agentAPath, agentBPath);
+	return {
+		claim_boundary: "real local-only independent Pi actors",
+		task_id: evidence.task_id,
+		state: evidence.state,
+		agent_a_pi_process_id: evidence.agent_a_pi_process_id,
+		agent_b_pi_process_id: evidence.agent_b_pi_process_id,
+	};
+}
+
+export async function readVerifiedActorEvidence(
+	handoffPath: string,
+	agentAPath: string,
+	agentBPath: string,
+): Promise<VerifiedActorEvidence> {
 	const handoff = await readHandoff(handoffPath);
 	const agentA = await readReceipt(agentAPath, "agent_a");
 	const agentB = await readReceipt(agentBPath, "agent_b");
 	if (agentA.task_id !== handoff.task_id || agentB.task_id !== handoff.task_id) throw new Error("KAMN live actor receipt task ID mismatch");
 	if (agentA.pi_process_id === agentB.pi_process_id) throw new Error("KAMN live actor receipts must come from distinct Pi processes");
 	return {
-		claim_boundary: "real local-only independent Pi actors",
 		task_id: handoff.task_id,
 		state: "accepted",
 		agent_a_pi_process_id: agentA.pi_process_id,
 		agent_b_pi_process_id: agentB.pi_process_id,
+		source_handoff_digest: handoff.artifact_digest,
+		source_agent_a_receipt_digest: agentA.artifact_digest,
+		source_agent_b_receipt_digest: agentB.artifact_digest,
 	};
 }
 

--- a/.pi/extensions/kamn-mvp/live-task-evidence.ts
+++ b/.pi/extensions/kamn-mvp/live-task-evidence.ts
@@ -1,0 +1,9 @@
+export type VerifiedActorEvidence = {
+	task_id: string;
+	state: "accepted";
+	agent_a_pi_process_id: number;
+	agent_b_pi_process_id: number;
+	source_handoff_digest: string;
+	source_agent_a_receipt_digest: string;
+	source_agent_b_receipt_digest: string;
+};

--- a/.pi/extensions/kamn-mvp/restricted-task-observation.test.ts
+++ b/.pi/extensions/kamn-mvp/restricted-task-observation.test.ts
@@ -1,0 +1,138 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import test from "node:test";
+import { writeActorReceipt, writeTaskHandoff } from "./live-task-coordination.ts";
+import {
+	writeRestrictedTaskObservation,
+	verifyRestrictedTaskObservation,
+} from "./restricted-task-observation.ts";
+
+test("Agent C writes a minimal task-bound restricted observation", async () => {
+	const paths = await acceptedSources(101, 202);
+	const first = await writeRestrictedTaskObservation(paths.handoff, paths.agentA, paths.agentB, paths.observation, 303);
+	const second = await writeRestrictedTaskObservation(paths.handoff, paths.agentA, paths.agentB, paths.observation, 303);
+
+	assert.deepEqual(second, first);
+	assert.deepEqual(Object.keys(JSON.parse(await readFile(paths.observation, "utf8"))).sort(), [
+		"agent_c_pi_process_id",
+		"artifact_digest",
+		"private_field_count",
+		"private_payload_redacted",
+		"public_commitment",
+		"schema_version",
+		"source_agent_a_receipt_digest",
+		"source_agent_b_receipt_digest",
+		"source_handoff_digest",
+		"state",
+		"task_id",
+		"view_scope",
+	]);
+	assert.deepEqual(await verifyRestrictedTaskObservation(paths.observation), first);
+	assert.equal(first.claim_boundary, "real local-only independent Agent C artifact observation");
+	assert.equal(first.task_id, "task-live-c");
+	assert.equal(first.state, "accepted");
+	assert.equal(first.view_scope, "restricted-public");
+	assert.equal(first.private_field_count, 0);
+	assert.equal(first.private_payload_redacted, true);
+});
+
+test("Agent C observation binds all source digests and rejects conflicts", async () => {
+	const paths = await acceptedSources(101, 202);
+	const result = await writeRestrictedTaskObservation(paths.handoff, paths.agentA, paths.agentB, paths.observation, 303);
+	const artifact = JSON.parse(await readFile(paths.observation, "utf8"));
+
+	assert.equal(result.public_commitment, publicCommitment(artifact));
+	await assert.rejects(
+		writeRestrictedTaskObservation(paths.handoff, paths.agentA, paths.agentB, paths.observation, 404),
+		/conflicts/,
+	);
+	artifact.task_id = "task-altered";
+	await writeFile(paths.observation, JSON.stringify(artifact));
+	await assert.rejects(verifyRestrictedTaskObservation(paths.observation), /digest mismatch/);
+});
+
+test("Agent C observation rejects private fields and unrestricted scope", async () => {
+	const paths = await acceptedSources(101, 202);
+	await writeRestrictedTaskObservation(paths.handoff, paths.agentA, paths.agentB, paths.observation, 303);
+	const privateArtifact = JSON.parse(await readFile(paths.observation, "utf8"));
+	privateArtifact.participant_private_view_digest = "forbidden";
+	privateArtifact.artifact_digest = digestOf(privateArtifact);
+	await writeFile(paths.observation, JSON.stringify(privateArtifact));
+	await assert.rejects(verifyRestrictedTaskObservation(paths.observation), /field mismatch/);
+
+	const other = await acceptedSources(101, 202);
+	await writeRestrictedTaskObservation(other.handoff, other.agentA, other.agentB, other.observation, 303);
+	const scoped = JSON.parse(await readFile(other.observation, "utf8"));
+	scoped.view_scope = "participant-private";
+	scoped.private_field_count = 1;
+	scoped.private_payload_redacted = false;
+	scoped.artifact_digest = digestOf(scoped);
+	await writeFile(other.observation, JSON.stringify(scoped));
+	await assert.rejects(verifyRestrictedTaskObservation(other.observation), /restricted-public/);
+});
+
+test("Agent C must be a third distinct Pi process", async () => {
+	for (const agentCPid of [101, 202]) {
+		const paths = await acceptedSources(101, 202);
+		await assert.rejects(
+			writeRestrictedTaskObservation(paths.handoff, paths.agentA, paths.agentB, paths.observation, agentCPid),
+			/third distinct Pi process/,
+		);
+	}
+	const paths = await acceptedSources(101, 101);
+	await assert.rejects(
+		writeRestrictedTaskObservation(paths.handoff, paths.agentA, paths.agentB, paths.observation, 303),
+		/distinct Pi processes/,
+	);
+});
+
+test("Agent C rejects source task disagreement and non-accepted state", async () => {
+	const mismatched = await acceptedSources(101, 202, "task-other");
+	await assert.rejects(
+		writeRestrictedTaskObservation(mismatched.handoff, mismatched.agentA, mismatched.agentB, mismatched.observation, 303),
+		/task ID mismatch/,
+	);
+	const state = await acceptedSources(101, 202);
+	const receipt = JSON.parse(await readFile(state.agentB, "utf8"));
+	receipt.state = "submitted";
+	receipt.artifact_digest = digestOf(receipt);
+	await writeFile(state.agentB, JSON.stringify(receipt));
+	await assert.rejects(
+		writeRestrictedTaskObservation(state.handoff, state.agentA, state.agentB, state.observation, 303),
+		/state mismatch/,
+	);
+});
+
+async function acceptedSources(agentAPid: number, agentBPid: number, agentBTask = "task-live-c") {
+	const root = await mkdtemp(resolve(tmpdir(), "kamn-agent-c-observation-"));
+	const paths = {
+		handoff: resolve(root, "handoff.json"),
+		agentA: resolve(root, "agent-a.json"),
+		agentB: resolve(root, "agent-b.json"),
+		observation: resolve(root, "agent-c.json"),
+	};
+	await writeTaskHandoff(paths.handoff, "task-live-c");
+	await writeActorReceipt(paths.agentA, "agent_a", "task-live-c", "accepted", agentAPid);
+	await writeActorReceipt(paths.agentB, "agent_b", agentBTask, "accepted", agentBPid);
+	return paths;
+}
+
+function digestOf(artifact: Record<string, unknown>): string {
+	const unsigned = Object.fromEntries(Object.entries(artifact).filter(([key]) => key !== "artifact_digest"));
+	return createHash("sha256").update(JSON.stringify(unsigned)).digest("hex");
+}
+
+function publicCommitment(artifact: Record<string, unknown>): string {
+	return createHash("sha256")
+		.update(JSON.stringify({
+			task_id: artifact.task_id,
+			state: artifact.state,
+			source_handoff_digest: artifact.source_handoff_digest,
+			source_agent_a_receipt_digest: artifact.source_agent_a_receipt_digest,
+			source_agent_b_receipt_digest: artifact.source_agent_b_receipt_digest,
+		}))
+		.digest("hex");
+}

--- a/.pi/extensions/kamn-mvp/restricted-task-observation.test.ts
+++ b/.pi/extensions/kamn-mvp/restricted-task-observation.test.ts
@@ -8,6 +8,7 @@ import { writeActorReceipt, writeTaskHandoff } from "./live-task-coordination.ts
 import {
 	writeRestrictedTaskObservation,
 	verifyRestrictedTaskObservation,
+	restrictedObservationConfig,
 } from "./restricted-task-observation.ts";
 
 test("Agent C writes a minimal task-bound restricted observation", async () => {
@@ -30,7 +31,7 @@ test("Agent C writes a minimal task-bound restricted observation", async () => {
 		"task_id",
 		"view_scope",
 	]);
-	assert.deepEqual(await verifyRestrictedTaskObservation(paths.observation), first);
+	assert.deepEqual(await verifyWithSources(paths), first);
 	assert.equal(first.claim_boundary, "real local-only independent Agent C artifact observation");
 	assert.equal(first.task_id, "task-live-c");
 	assert.equal(first.state, "accepted");
@@ -53,9 +54,16 @@ test("Agent C observation binds all source digests and rejects conflicts", async
 		writeRestrictedTaskObservation(paths.handoff, paths.agentA, paths.agentB, paths.observation, 404),
 		/conflicts/,
 	);
+	const otherSources = await acceptedSources(404, 505);
+	await assert.rejects(
+		verifyRestrictedTaskObservation(
+			paths.observation, otherSources.handoff, otherSources.agentA, otherSources.agentB,
+		),
+		/source digest mismatch/,
+	);
 	artifact.task_id = "task-altered";
 	await writeFile(paths.observation, JSON.stringify(artifact));
-	await assert.rejects(verifyRestrictedTaskObservation(paths.observation), /digest mismatch/);
+	await assert.rejects(verifyWithSources(paths), /digest mismatch/);
 });
 
 test("Agent C observation rejects private fields and unrestricted scope", async () => {
@@ -65,7 +73,7 @@ test("Agent C observation rejects private fields and unrestricted scope", async 
 	privateArtifact.participant_private_view_digest = "forbidden";
 	privateArtifact.artifact_digest = digestOf(privateArtifact);
 	await writeFile(paths.observation, JSON.stringify(privateArtifact));
-	await assert.rejects(verifyRestrictedTaskObservation(paths.observation), /field mismatch/);
+	await assert.rejects(verifyWithSources(paths), /field mismatch/);
 
 	const other = await acceptedSources(101, 202);
 	await writeRestrictedTaskObservation(other.handoff, other.agentA, other.agentB, other.observation, 303);
@@ -75,7 +83,28 @@ test("Agent C observation rejects private fields and unrestricted scope", async 
 	scoped.private_payload_redacted = false;
 	scoped.artifact_digest = digestOf(scoped);
 	await writeFile(other.observation, JSON.stringify(scoped));
-	await assert.rejects(verifyRestrictedTaskObservation(other.observation), /restricted-public/);
+	await assert.rejects(verifyWithSources(other), /restricted-public/);
+});
+
+test("Agent C entrypoint rejects malformed sources and unsafe configuration", async () => {
+	const paths = await acceptedSources(101, 202);
+	const handoff = JSON.parse(await readFile(paths.handoff, "utf8"));
+	handoff.unexpected = "field";
+	await writeFile(paths.handoff, JSON.stringify(handoff));
+	await assert.rejects(
+		writeRestrictedTaskObservation(paths.handoff, paths.agentA, paths.agentB, paths.observation, 303),
+		/field mismatch/,
+	);
+	const env = {
+		KAMN_MVP_LIVE_TASK_HANDOFF_FILE: paths.handoff,
+		KAMN_MVP_LIVE_TASK_AGENT_A_RECEIPT_FILE: paths.agentA,
+		KAMN_MVP_LIVE_TASK_AGENT_B_RECEIPT_FILE: paths.agentB,
+	};
+	assert.throws(() => restrictedObservationConfig(env, process.cwd()), /AGENT_C_OBSERVATION_FILE/);
+	assert.throws(
+		() => restrictedObservationConfig({ ...env, KAMN_MVP_LIVE_TASK_AGENT_C_OBSERVATION_FILE: "/tmp/keypair-agent-c.json" }, process.cwd()),
+		/secret-like/,
+	);
 });
 
 test("Agent C must be a third distinct Pi process", async () => {
@@ -139,4 +168,8 @@ function publicCommitment(artifact: Record<string, unknown>): string {
 			source_agent_b_receipt_digest: artifact.source_agent_b_receipt_digest,
 		}))
 		.digest("hex");
+}
+
+function verifyWithSources(paths: { observation: string; handoff: string; agentA: string; agentB: string }) {
+	return verifyRestrictedTaskObservation(paths.observation, paths.handoff, paths.agentA, paths.agentB);
 }

--- a/.pi/extensions/kamn-mvp/restricted-task-observation.test.ts
+++ b/.pi/extensions/kamn-mvp/restricted-task-observation.test.ts
@@ -41,6 +41,10 @@ test("Agent C writes a minimal task-bound restricted observation", async () => {
 
 test("Agent C observation binds all source digests and rejects conflicts", async () => {
 	const paths = await acceptedSources(101, 202);
+	await assert.rejects(
+		writeRestrictedTaskObservation(paths.handoff, paths.agentA, paths.agentB, paths.handoff, 303),
+		/must differ from source artifacts/,
+	);
 	const result = await writeRestrictedTaskObservation(paths.handoff, paths.agentA, paths.agentB, paths.observation, 303);
 	const artifact = JSON.parse(await readFile(paths.observation, "utf8"));
 

--- a/.pi/extensions/kamn-mvp/restricted-task-observation.ts
+++ b/.pi/extensions/kamn-mvp/restricted-task-observation.ts
@@ -1,0 +1,137 @@
+import { createHash } from "node:crypto";
+import { readFile, writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { readVerifiedActorEvidence } from "./live-task-coordination.ts";
+
+const SCHEMA = "kamn.mvp.live-task-restricted-observation.v1";
+const CLAIM = "real local-only independent Agent C artifact observation";
+const SECRET_MARKERS = [".kamn/devnet", "auth.json", ".env", "keypair", "id_rsa", "oauth"];
+const FIELDS = [
+	"agent_c_pi_process_id", "artifact_digest", "private_field_count", "private_payload_redacted",
+	"public_commitment", "schema_version", "source_agent_a_receipt_digest",
+	"source_agent_b_receipt_digest", "source_handoff_digest", "state", "task_id", "view_scope",
+];
+type Environment = Record<string, string | undefined>;
+type Observation = {
+	schema_version: string;
+	task_id: string;
+	state: string;
+	view_scope: string;
+	private_field_count: number;
+	private_payload_redacted: boolean;
+	agent_c_pi_process_id: number;
+	source_handoff_digest: string;
+	source_agent_a_receipt_digest: string;
+	source_agent_b_receipt_digest: string;
+	public_commitment: string;
+	artifact_digest: string;
+};
+
+export async function writeRestrictedTaskObservation(
+	handoffPath: string, agentAPath: string, agentBPath: string, outputPath: string, agentCPid: number,
+) {
+	assertSafePath(outputPath);
+	const source = await readVerifiedActorEvidence(handoffPath, agentAPath, agentBPath);
+	assertThirdProcess(agentCPid, source.agent_a_pi_process_id, source.agent_b_pi_process_id);
+	const publicFields = {
+		task_id: source.task_id,
+		state: source.state,
+		source_handoff_digest: source.source_handoff_digest,
+		source_agent_a_receipt_digest: source.source_agent_a_receipt_digest,
+		source_agent_b_receipt_digest: source.source_agent_b_receipt_digest,
+	};
+	const unsigned = {
+		schema_version: SCHEMA, ...publicFields, view_scope: "restricted-public",
+		private_field_count: 0, private_payload_redacted: true, agent_c_pi_process_id: agentCPid,
+		public_commitment: digest(publicFields),
+	};
+	await writeIdempotent(outputPath, { ...unsigned, artifact_digest: digest(unsigned) });
+	return verifyRestrictedTaskObservation(outputPath);
+}
+
+export async function verifyRestrictedTaskObservation(path: string) {
+	assertSafePath(path);
+	const artifact = parse(await readFile(path, "utf8"));
+	assertPolicy(artifact);
+	return {
+		claim_boundary: CLAIM,
+		task_id: artifact.task_id,
+		state: artifact.state,
+		view_scope: artifact.view_scope,
+		private_field_count: artifact.private_field_count,
+		private_payload_redacted: artifact.private_payload_redacted,
+		agent_c_pi_process_id: artifact.agent_c_pi_process_id,
+		public_commitment: artifact.public_commitment,
+	};
+}
+
+export function restrictedObservationConfig(env: Environment, cwd: string) {
+	return {
+		handoffPath: configuredPath(env, "KAMN_MVP_LIVE_TASK_HANDOFF_FILE", cwd),
+		agentAPath: configuredPath(env, "KAMN_MVP_LIVE_TASK_AGENT_A_RECEIPT_FILE", cwd),
+		agentBPath: configuredPath(env, "KAMN_MVP_LIVE_TASK_AGENT_B_RECEIPT_FILE", cwd),
+		observationPath: configuredPath(env, "KAMN_MVP_LIVE_TASK_AGENT_C_OBSERVATION_FILE", cwd),
+	};
+}
+
+function parse(raw: string): Observation {
+	let artifact: Record<string, unknown>;
+	try { artifact = JSON.parse(raw) as Record<string, unknown>; } catch { throw new Error("KAMN Agent C observation is malformed JSON"); }
+	if (!artifact || Array.isArray(artifact) || artifact.schema_version !== SCHEMA) throw new Error("KAMN Agent C observation schema mismatch");
+	if (Object.keys(artifact).sort().join(",") !== FIELDS.join(",")) throw new Error("KAMN Agent C observation field mismatch");
+	const unsigned = Object.fromEntries(Object.entries(artifact).filter(([key]) => key !== "artifact_digest"));
+	if (artifact.artifact_digest !== digest(unsigned)) throw new Error("KAMN Agent C observation digest mismatch");
+	return artifact as Observation;
+}
+
+function assertPolicy(artifact: Observation) {
+	if (artifact.state !== "accepted") throw new Error("KAMN Agent C observation state must be accepted");
+	if (artifact.view_scope !== "restricted-public" || artifact.private_field_count !== 0 || artifact.private_payload_redacted !== true) {
+		throw new Error("KAMN Agent C observation must remain restricted-public with no private fields");
+	}
+	assertThirdProcess(artifact.agent_c_pi_process_id, 0, 0);
+	for (const value of [artifact.source_handoff_digest, artifact.source_agent_a_receipt_digest, artifact.source_agent_b_receipt_digest]) {
+		if (!/^[a-f0-9]{64}$/.test(value)) throw new Error("KAMN Agent C observation source digest is invalid");
+	}
+	const expected = digest({
+		task_id: artifact.task_id, state: artifact.state, source_handoff_digest: artifact.source_handoff_digest,
+		source_agent_a_receipt_digest: artifact.source_agent_a_receipt_digest,
+		source_agent_b_receipt_digest: artifact.source_agent_b_receipt_digest,
+	});
+	if (artifact.public_commitment !== expected) throw new Error("KAMN Agent C public commitment mismatch");
+}
+
+function assertThirdProcess(agentCPid: number, agentAPid: number, agentBPid: number) {
+	if (!Number.isInteger(agentCPid) || agentCPid <= 0 || agentCPid === agentAPid || agentCPid === agentBPid) {
+		throw new Error("KAMN Agent C must run in a third distinct Pi process");
+	}
+}
+
+async function writeIdempotent(path: string, artifact: Record<string, unknown>) {
+	const json = `${JSON.stringify(artifact)}\n`;
+	try { await writeFile(path, json, { flag: "wx", mode: 0o600 }); } catch (error) {
+		if (!isNodeError(error, "EEXIST")) throw error;
+		if (await readFile(path, "utf8") !== json) throw new Error("KAMN Agent C observation conflicts with existing artifact");
+	}
+}
+
+function configuredPath(env: Environment, name: string, cwd: string): string {
+	const value = env[name]?.trim();
+	if (!value) throw new Error(`Missing required environment variable: ${name}`);
+	const path = value.startsWith("/") ? value : resolve(cwd, value);
+	assertSafePath(path);
+	return path;
+}
+
+function assertSafePath(path: string) {
+	const lower = path.toLowerCase();
+	if (SECRET_MARKERS.some((marker) => lower.includes(marker))) throw new Error("Refusing secret-like KAMN Agent C observation path");
+}
+
+function digest(value: Record<string, unknown>): string {
+	return createHash("sha256").update(JSON.stringify(value)).digest("hex");
+}
+
+function isNodeError(error: unknown, code: string): boolean {
+	return error instanceof Error && "code" in error && error.code === code;
+}

--- a/.pi/extensions/kamn-mvp/restricted-task-observation.ts
+++ b/.pi/extensions/kamn-mvp/restricted-task-observation.ts
@@ -47,13 +47,18 @@ export async function writeRestrictedTaskObservation(
 		public_commitment: digest(publicFields),
 	};
 	await writeIdempotent(outputPath, { ...unsigned, artifact_digest: digest(unsigned) });
-	return verifyRestrictedTaskObservation(outputPath);
+	return verifyRestrictedTaskObservation(outputPath, handoffPath, agentAPath, agentBPath);
 }
 
-export async function verifyRestrictedTaskObservation(path: string) {
+export async function verifyRestrictedTaskObservation(
+	path: string, handoffPath: string, agentAPath: string, agentBPath: string,
+) {
 	assertSafePath(path);
 	const artifact = parse(await readFile(path, "utf8"));
 	assertPolicy(artifact);
+	const source = await readVerifiedActorEvidence(handoffPath, agentAPath, agentBPath);
+	assertBoundToSource(artifact, source);
+	assertThirdProcess(artifact.agent_c_pi_process_id, source.agent_a_pi_process_id, source.agent_b_pi_process_id);
 	return {
 		claim_boundary: CLAIM,
 		task_id: artifact.task_id,
@@ -64,6 +69,17 @@ export async function verifyRestrictedTaskObservation(path: string) {
 		agent_c_pi_process_id: artifact.agent_c_pi_process_id,
 		public_commitment: artifact.public_commitment,
 	};
+}
+
+function assertBoundToSource(artifact: Observation, source: Awaited<ReturnType<typeof readVerifiedActorEvidence>>) {
+	if (artifact.task_id !== source.task_id || artifact.state !== source.state) {
+		throw new Error("KAMN Agent C observation task or state mismatch");
+	}
+	const actual = [artifact.source_handoff_digest, artifact.source_agent_a_receipt_digest, artifact.source_agent_b_receipt_digest];
+	const expected = [source.source_handoff_digest, source.source_agent_a_receipt_digest, source.source_agent_b_receipt_digest];
+	if (actual.some((digestValue, index) => digestValue !== expected[index])) {
+		throw new Error("KAMN Agent C observation source digest mismatch");
+	}
 }
 
 export function restrictedObservationConfig(env: Environment, cwd: string) {

--- a/.pi/extensions/kamn-mvp/restricted-task-observation.ts
+++ b/.pi/extensions/kamn-mvp/restricted-task-observation.ts
@@ -31,6 +31,7 @@ export async function writeRestrictedTaskObservation(
 	handoffPath: string, agentAPath: string, agentBPath: string, outputPath: string, agentCPid: number,
 ) {
 	assertSafePath(outputPath);
+	assertDistinctOutput(outputPath, [handoffPath, agentAPath, agentBPath]);
 	const source = await readVerifiedActorEvidence(handoffPath, agentAPath, agentBPath);
 	assertThirdProcess(agentCPid, source.agent_a_pi_process_id, source.agent_b_pi_process_id);
 	const publicFields = {
@@ -126,6 +127,13 @@ function configuredPath(env: Environment, name: string, cwd: string): string {
 function assertSafePath(path: string) {
 	const lower = path.toLowerCase();
 	if (SECRET_MARKERS.some((marker) => lower.includes(marker))) throw new Error("Refusing secret-like KAMN Agent C observation path");
+}
+
+function assertDistinctOutput(outputPath: string, sourcePaths: string[]) {
+	const output = resolve(outputPath);
+	if (sourcePaths.some((path) => resolve(path) === output)) {
+		throw new Error("KAMN Agent C observation path must differ from source artifacts");
+	}
 }
 
 function digest(value: Record<string, unknown>): string {

--- a/crates/kamn-e2e-harness/tests/mvp_demo_agent_harness_claim_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_demo_agent_harness_claim_contract.rs
@@ -238,6 +238,8 @@ fn pi_extension_source() -> String {
         ".pi/extensions/kamn-mvp/mcp-session.ts",
         ".pi/extensions/kamn-mvp/live-task-workflow.ts",
         ".pi/extensions/kamn-mvp/live-task-coordination.ts",
+        ".pi/extensions/kamn-mvp/live-task-coordination-tools.ts",
+        ".pi/extensions/kamn-mvp/restricted-task-observation.ts",
     ]
     .map(|path| {
         std::fs::read_to_string(workspace_root().join(path))

--- a/crates/kamn-e2e-harness/tests/mvp_demo_agent_harness_claim_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_demo_agent_harness_claim_contract.rs
@@ -163,6 +163,9 @@ fn spec_c08_project_local_pi_extension_registers_kamn_tools() {
         "KAMN_MVP_LIVE_TASK_AGENT_A_RECEIPT_FILE",
         "KAMN_MVP_LIVE_TASK_AGENT_B_RECEIPT_FILE",
         "real local-only independent Pi actors",
+        "kamn_live_agent_c_verify_restricted_task_observation",
+        "KAMN_MVP_LIVE_TASK_AGENT_C_OBSERVATION_FILE",
+        "real local-only independent Agent C artifact observation",
     ] {
         assert!(source.contains(marker), "missing Pi tool marker: {marker}");
     }

--- a/crates/kamn-e2e-harness/tests/mvp_evaluator_demo_runbook_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_evaluator_demo_runbook_contract.rs
@@ -64,6 +64,11 @@ fn spec_c01_mvp_runbook_documents_pi_tool_harness_boundaries() {
         "Run this export block in each actor and verifier terminal",
         "Agent A and Agent B Pi process IDs must differ",
         "one or more `submitted` polls before its final `accepted` query",
+        "kamn_live_agent_c_verify_restricted_task_observation",
+        "KAMN_MVP_LIVE_TASK_AGENT_C_OBSERVATION_FILE",
+        "third independent Pi process",
+        "real local-only independent Agent C artifact observation",
+        "artifact-level disclosure boundary, not server-side authorization",
     ] {
         assert!(runbook.contains(needle), "{RUNBOOK} missing: {needle}");
     }

--- a/docs/validation/mvp-evaluator-demo.md
+++ b/docs/validation/mvp-evaluator-demo.md
@@ -198,6 +198,7 @@ export KAMN_MVP_LIVE_TASK_RUN_ID=run-7082-001
 export KAMN_MVP_LIVE_TASK_HANDOFF_FILE=/tmp/kamn-independent-${KAMN_MVP_LIVE_TASK_RUN_ID}-handoff.json
 export KAMN_MVP_LIVE_TASK_AGENT_A_RECEIPT_FILE=/tmp/kamn-independent-${KAMN_MVP_LIVE_TASK_RUN_ID}-agent-a.json
 export KAMN_MVP_LIVE_TASK_AGENT_B_RECEIPT_FILE=/tmp/kamn-independent-${KAMN_MVP_LIVE_TASK_RUN_ID}-agent-b.json
+export KAMN_MVP_LIVE_TASK_AGENT_C_OBSERVATION_FILE=/tmp/kamn-independent-${KAMN_MVP_LIVE_TASK_RUN_ID}-agent-c.json
 export KAMN_MVP_LIVE_TASK_COORDINATION_TIMEOUT_MS=60000
 ```
 
@@ -249,6 +250,30 @@ env -u OPENAI_API_KEY pi \
 ```
 
 The verifier requires matching accepted task IDs and distinct positive Pi process IDs; the Agent A and Agent B Pi process IDs must differ. Node logs show separate DIDs and nonce streams. Agent B uses register/accept/query requests, while Agent A may record one or more `submitted` polls before its final `accepted` query. Handoff and receipt artifacts are integrity-protected and contain no DIDs, task payload, keys, auth headers, signatures, nonces, or credentials. This proves real local-only independent Pi actors. It does not prove Agent C, disclosure asymmetry, escrow, settlement, asset movement, devnet execution, or restart durability.
+
+To prove a third independent Pi process can validate a task-bound restricted
+observation, run Agent C after Agent A and Agent B finish. Agent C has no KAMN
+name, key file, MCP child, or participant identity configuration:
+
+```bash
+env -u OPENAI_API_KEY pi \
+  --model openai-codex/gpt-5.5 \
+  --thinking medium \
+  --extension .pi/extensions/kamn-mvp/index.ts \
+  --no-builtin-tools \
+  --tools kamn_live_agent_c_verify_restricted_task_observation \
+  --approve --no-session \
+  -p "Use only the KAMN tool. Verify the restricted task observation as independent Agent C and report the claim boundary exactly."
+```
+
+The tool writes `KAMN_MVP_LIVE_TASK_AGENT_C_OBSERVATION_FILE` with only the
+accepted task ID, restricted-public policy markers, zero private fields, source
+artifact digests, a deterministic public commitment, the Agent C Pi process ID,
+and an integrity digest. Agent C must have a process ID different from Agent A
+and Agent B. Success reports `real local-only independent Agent C artifact observation`.
+This is an artifact-level disclosure boundary, not server-side authorization.
+It does not prove runtime role-based projection, escrow,
+settlement, asset movement, devnet execution, or restart durability.
 
 The evidence also records a `three_agent_boundary` summary derived from the
 verified report: local-only reports are marked `NOT_PRESENT`, while reports with

--- a/specs/7084-independent-agent-c-observation.md
+++ b/specs/7084-independent-agent-c-observation.md
@@ -1,0 +1,106 @@
+# Independent Agent C Restricted Task Observation
+
+## Objective
+
+Prove a third independent Pi process can verify a restricted-public observation
+for the same accepted task coordinated by independent Agent A and Agent B
+processes, without receiving participant-private or identity material.
+
+## Inputs/Outputs
+
+Inputs:
+
+- Existing live task handoff and accepted Agent A/B actor receipts.
+- `KAMN_MVP_LIVE_TASK_AGENT_C_OBSERVATION_FILE`: restricted observation path.
+- A third Pi process invoking only the Agent C observation tool.
+
+Outputs:
+
+- `kamn.mvp.live-task-restricted-observation.v1` with schema, task ID,
+  accepted state, public commitment, source artifact digests, zero private-field
+  count, restricted-public scope, redaction marker, and artifact digest.
+- Agent C result with its Pi process ID and the bounded claim
+  `real local-only independent Agent C artifact observation`.
+
+## Boundaries/Non-goals
+
+- Reuse the existing handoff and Agent A/B receipts as the source of truth.
+- The observation is an integrity-protected evaluator artifact, not a service
+  API response or authorization boundary.
+- Agent C must not register a KAMN identity or receive participant key material.
+- Do not expose DIDs, names, task payloads, credentials, auth headers,
+  signatures, nonces, participant-private fields, or private-view digests.
+- Do not claim server-side redaction, escrow, settlement, exchange, asset
+  movement, Solana devnet execution, or restart durability.
+- Add no dependency and no new runtime architecture.
+
+## Failure Modes
+
+- Missing, blank, secret-like, or unsafe observation path: fail before access.
+- Missing, malformed, altered, unknown-field, or conflicting source artifact:
+  fail without writing an observation.
+- Source task mismatch, non-accepted state, or duplicate Agent A/B process ID:
+  fail closed.
+- Agent C process ID equals Agent A or Agent B: fail closed.
+- Existing observation differs from the expected content: reject overwrite.
+- Observation has private fields, private scope, missing redaction, nonzero
+  private-field count, wrong public commitment, or digest mismatch: reject.
+
+## Acceptance Criteria
+
+- [ ] A builder derives one minimal restricted observation from the verified
+  handoff and Agent A/B receipts.
+- [ ] The observation binds the task, accepted state, source digests, and one
+  deterministic public commitment without copying participant-private data.
+- [ ] Agent C verifies the artifact from a Pi process distinct from Agent A/B.
+- [ ] Writes are idempotent for identical content and conflicting writes fail.
+- [ ] Unknown fields, tampering, task mismatch, same-PID reuse, private-field
+  leakage, private scope, and non-accepted state fail loudly.
+- [ ] The Pi extension exposes one Agent C tool with no KAMN identity config.
+- [ ] Node and Rust contracts pin the artifact fields, tool, configuration,
+  three-process runbook, and exact claim limitation.
+- [ ] A live three-process Pi rehearsal produces matching task evidence.
+- [ ] Existing targeted tests, formatter, strict clippy, `make check`, canonical
+  demo, and canonical report verifier remain green.
+
+## Files To Touch
+
+- `.pi/extensions/kamn-mvp/restricted-task-observation.ts`
+- `.pi/extensions/kamn-mvp/restricted-task-observation.test.ts`
+- `.pi/extensions/kamn-mvp/live-task-coordination-tools.ts`
+- `.pi/extensions/kamn-mvp/live-task-coordination.ts`
+- `crates/kamn-e2e-harness/tests/mvp_demo_agent_harness_claim_contract.rs`
+- `crates/kamn-e2e-harness/tests/mvp_evaluator_demo_runbook_contract.rs`
+- `docs/validation/mvp-evaluator-demo.md`
+
+## Error Semantics
+
+All validation and filesystem failures throw `Error` at the Pi tool boundary.
+No partial success or fallback is allowed. The Agent C tool reads source
+artifacts and writes only the restricted observation. Repeated identical writes
+succeed; conflicting existing evidence fails.
+
+## Test Plan
+
+RED:
+
+- Add Node tests for the artifact field allowlist, commitment binding,
+  idempotency, tampering, unknown/private fields, task mismatch, and all three
+  process-ID collision cases.
+- Extend Rust source and runbook contracts for the Agent C tool and boundary.
+
+GREEN:
+
+- Implement the minimal observation builder/verifier and register one Pi tool.
+- Document the third independent Pi command after Agent A/B completion.
+
+REFACTOR:
+
+- Keep source receipt parsing shared and observation policy isolated.
+- Verify changed files and functions satisfy repository size limits.
+
+INTEGRATION:
+
+- Run Agent A and Agent B concurrently against one disposable local node.
+- Run Agent C in a third Pi process over their accepted-task evidence.
+- Inspect the artifact allowlist and process IDs, then run all proof gates.

--- a/specs/7084-independent-agent-c-observation.md
+++ b/specs/7084-independent-agent-c-observation.md
@@ -69,6 +69,7 @@ Outputs:
 - `.pi/extensions/kamn-mvp/restricted-task-observation.test.ts`
 - `.pi/extensions/kamn-mvp/live-task-coordination-tools.ts`
 - `.pi/extensions/kamn-mvp/live-task-coordination.ts`
+- `.pi/extensions/kamn-mvp/live-task-evidence.ts`
 - `crates/kamn-e2e-harness/tests/mvp_demo_agent_harness_claim_contract.rs`
 - `crates/kamn-e2e-harness/tests/mvp_evaluator_demo_runbook_contract.rs`
 - `docs/validation/mvp-evaluator-demo.md`

--- a/specs/7084-independent-agent-c-observation.md
+++ b/specs/7084-independent-agent-c-observation.md
@@ -60,7 +60,7 @@ Outputs:
 - [x] Node and Rust contracts pin the artifact fields, tool, configuration,
   three-process runbook, and exact claim limitation.
 - [x] A live three-process Pi rehearsal produces matching task evidence.
-- [ ] Existing targeted tests, formatter, strict clippy, `make check`, canonical
+- [x] Existing targeted tests, formatter, strict clippy, `make check`, canonical
   demo, and canonical report verifier remain green.
 
 ## Files To Touch
@@ -118,3 +118,8 @@ INTEGRATION:
   fields, a redaction marker, source digests, and a public commitment.
 - The evidence remains artifact-level and does not claim server-side
   authorization, settlement, asset movement, or devnet execution.
+- `cargo fmt --check`, strict workspace clippy, and `make check` passed.
+- All 29 Pi extension tests, 23 harness claim contracts, and the runbook
+  contract passed.
+- `make demo-mvp` returned `GO` in optional-devnet local mode, with no value
+  movement claim, and the canonical report verifier returned `PASS`.

--- a/specs/7084-independent-agent-c-observation.md
+++ b/specs/7084-independent-agent-c-observation.md
@@ -48,18 +48,18 @@ Outputs:
 
 ## Acceptance Criteria
 
-- [ ] A builder derives one minimal restricted observation from the verified
+- [x] A builder derives one minimal restricted observation from the verified
   handoff and Agent A/B receipts.
-- [ ] The observation binds the task, accepted state, source digests, and one
+- [x] The observation binds the task, accepted state, source digests, and one
   deterministic public commitment without copying participant-private data.
-- [ ] Agent C verifies the artifact from a Pi process distinct from Agent A/B.
-- [ ] Writes are idempotent for identical content and conflicting writes fail.
-- [ ] Unknown fields, tampering, task mismatch, same-PID reuse, private-field
+- [x] Agent C verifies the artifact from a Pi process distinct from Agent A/B.
+- [x] Writes are idempotent for identical content and conflicting writes fail.
+- [x] Unknown fields, tampering, task mismatch, same-PID reuse, private-field
   leakage, private scope, and non-accepted state fail loudly.
-- [ ] The Pi extension exposes one Agent C tool with no KAMN identity config.
-- [ ] Node and Rust contracts pin the artifact fields, tool, configuration,
+- [x] The Pi extension exposes one Agent C tool with no KAMN identity config.
+- [x] Node and Rust contracts pin the artifact fields, tool, configuration,
   three-process runbook, and exact claim limitation.
-- [ ] A live three-process Pi rehearsal produces matching task evidence.
+- [x] A live three-process Pi rehearsal produces matching task evidence.
 - [ ] Existing targeted tests, formatter, strict clippy, `make check`, canonical
   demo, and canonical report verifier remain green.
 
@@ -105,3 +105,16 @@ INTEGRATION:
 - Run Agent A and Agent B concurrently against one disposable local node.
 - Run Agent C in a third Pi process over their accepted-task evidence.
 - Inspect the artifact allowlist and process IDs, then run all proof gates.
+
+## Integration Evidence
+
+- 2026-07-10: Agent A, Agent B, and Agent C ran as separate Pi processes with
+  PIDs `29023`, `27635`, and `32181`.
+- All three artifacts bound to accepted task `task-local-7c1b978c62c40958`.
+- The local service returned `201` for task creation and `200` for acceptance
+  and both participant task queries.
+- Agent C reported `real local-only independent Agent C artifact observation`.
+- The restricted observation had the exact 12-field allowlist, zero private
+  fields, a redaction marker, source digests, and a public commitment.
+- The evidence remains artifact-level and does not claim server-side
+  authorization, settlement, asset movement, or devnet execution.

--- a/specs/7084-independent-agent-c-observation.md
+++ b/specs/7084-independent-agent-c-observation.md
@@ -119,7 +119,12 @@ INTEGRATION:
 - The evidence remains artifact-level and does not claim server-side
   authorization, settlement, asset movement, or devnet execution.
 - `cargo fmt --check`, strict workspace clippy, and `make check` passed.
-- All 29 Pi extension tests, 23 harness claim contracts, and the runbook
+- All 30 Pi extension tests, 23 harness claim contracts, and the runbook
   contract passed.
+- Review-driven verification re-reads the handoff and both actor receipts,
+  compares task/state and all source digests, and rechecks all three Pi PIDs.
+- Post-fix Pi revalidation ran Agent C as PID `73743`; task and source digests
+  matched the original A/B evidence, all process IDs differed, scope remained
+  `restricted-public`, and private-field count remained zero.
 - `make demo-mvp` returned `GO` in optional-devnet local mode, with no value
   movement claim, and the canonical report verifier returned `PASS`.


### PR DESCRIPTION
## Human Summary

- Adds a third independent Pi actor that verifies a restricted-public observation for the same accepted task coordinated by Agent A and Agent B.
- Binds the observation to the live handoff and both actor receipts through source digests, task/state agreement, and three distinct Pi process IDs.
- Keeps Agent C evidence to an explicit 12-field allowlist with zero private fields and no identity, authentication, payload, nonce, signature, or credential material.
- Preserves the claim boundary: this is real local-only artifact observation, not server-side authorization, escrow, settlement, asset movement, or devnet execution.

Closes #7084

Spec: specs/7084-independent-agent-c-observation.md

## Testing

- RED: missing observation module, tool, and runbook contracts
- RED: source alias guard rejected only through a generic conflict
- RED: standalone verifier accepted unrelated valid source artifacts
- `node --experimental-strip-types --test .pi/extensions/kamn-mvp/*.test.ts` (30 passed)
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `make check`
- `cargo test -p kamn-e2e-harness --test mvp_demo_agent_harness_claim_contract --test mvp_evaluator_demo_runbook_contract -- --nocapture` (24 passed)
- `make demo-mvp` (GO, optional-devnet local mode; no value movement claim)
- `cargo run -p kamn-e2e-harness -- verify-mvp-demo --report .kamn/demo/latest/proof/report.json` (PASS)
- Live Pi rehearsal: Agent A, Agent B, and Agent C used distinct processes and one accepted task.
- Post-review Pi revalidation: task and source digests matched, all process IDs differed, Agent C remained restricted-public with zero private fields.
- Focused independent code re-review: APPROVE, no remaining actionable findings.

## Notes for Reviewers

The main review boundary is intentional: Agent C verifies an evaluator artifact derived from live local actor evidence. The KAMN service does not yet enforce participant-private versus restricted-public task projections. Any eventual value-movement claim must remain devnet-backed and is outside this PR.

shell_loc_delta_actual: 0
rust_loc_delta_actual: 10
shell_to_rust_ratio_delta_actual: 0.0
shell_surface_ratio_target_status: neutral

## AI Agent Details

- Added a source-bound restricted observation module and negative tests for integrity, privacy, PID reuse, path aliases, malformed sources, unsafe configuration, and unrelated-source forgery.
- Reused validated A/B receipt parsing and extracted the shared evidence shape to preserve file-size limits.
- Added one identity-free Pi tool and evaluator runbook command for Agent C.
- The canonical MVP report remains unchanged and honest about optional devnet mode.

Closes #7084