### PR TITLE
feat: enforce server-owned transaction grants

### DIFF
--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/residual_root_contract_tests/missing_resource_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/residual_root_contract_tests/missing_resource_contract_tests.rs
@@ -3,17 +3,24 @@ use crate::service_api_endpoint::ServiceApiSnapshot;
 
 #[test]
 fn regression_service_api_endpoint_rejects_unknown_task_and_escrow_resource_transitions() {
+    let _env = acquire_service_api_test_env();
     let (snapshot, state_hash) = missing_resource_snapshot();
     let caller_did = "kamn:did:agent:test-client-missing-resource";
+    let state_file = missing_resource_state_file();
+    let _state_guard = EnvVarGuard::set(
+        "KAMN_SERVICE_API_STATE_FILE",
+        Some(state_file.to_string_lossy().as_ref()),
+    );
+    provision_missing_resource_grants(state_file.as_path(), caller_did);
     let bind_addr = reserve_loopback_addr();
     let server = spawn_missing_resource_server(bind_addr.as_str(), snapshot);
     wait_for_endpoint_ready(bind_addr.as_str());
     assert_missing_task_and_escrow_paths(bind_addr.as_str(), caller_did, state_hash.as_str());
     assert_missing_resource_server_result(server);
+    let _ = std::fs::remove_file(state_file);
 }
 
 fn missing_resource_snapshot() -> (ServiceApiSnapshot, String) {
-    let _env = acquire_service_api_test_env();
     let parsed = parse_args(vec![
         "kamn-node".to_owned(),
         "--role".to_owned(),
@@ -32,6 +39,32 @@ fn missing_resource_snapshot() -> (ServiceApiSnapshot, String) {
         snapshot.chain_version.as_str()
     );
     (snapshot, state_hash)
+}
+
+fn missing_resource_state_file() -> std::path::PathBuf {
+    let timestamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("clock should be after unix epoch")
+        .as_nanos();
+    std::env::temp_dir().join(format!(
+        "kamn-missing-resource-{}-{}.json",
+        std::process::id(),
+        timestamp
+    ))
+}
+
+fn provision_missing_resource_grants(path: &std::path::Path, caller_did: &str) {
+    let actor_did = test_service_api_sender_did(caller_did);
+    for (_, method, route) in missing_resource_routes() {
+        crate::service_api_endpoint::provision_test_transaction_grant(
+            path.to_string_lossy().into_owned(),
+            actor_did.as_str(),
+            method,
+            route,
+            "",
+        )
+        .expect("missing-resource fixture grant should persist");
+    }
 }
 
 fn spawn_missing_resource_server(

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests.rs
@@ -1,5 +1,7 @@
 #[path = "task_escrow_persistence_contract_tests/support.rs"]
 mod support;
+#[path = "task_escrow_persistence_contract_tests/task_escrow_authorization_contract_tests.rs"]
+mod task_escrow_authorization_contract_tests;
 #[path = "task_escrow_persistence_contract_tests/task_escrow_live_settlement_contract_tests.rs"]
 mod task_escrow_live_settlement_contract_tests;
 #[path = "task_escrow_persistence_contract_tests/task_escrow_restart_contract_tests.rs"]

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests.rs
@@ -2,6 +2,8 @@
 mod support;
 #[path = "task_escrow_persistence_contract_tests/task_escrow_authorization_contract_tests.rs"]
 mod task_escrow_authorization_contract_tests;
+#[path = "task_escrow_persistence_contract_tests/task_escrow_concurrent_replay_contract_tests.rs"]
+mod task_escrow_concurrent_replay_contract_tests;
 #[path = "task_escrow_persistence_contract_tests/task_escrow_live_settlement_contract_tests.rs"]
 mod task_escrow_live_settlement_contract_tests;
 #[path = "task_escrow_persistence_contract_tests/task_escrow_restart_contract_tests.rs"]

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/support.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/support.rs
@@ -24,7 +24,8 @@ pub(super) use solana_asset_movement_support::{
     settlement_tx_signature, LiveSolanaAssetMovementParams,
 };
 pub(super) use state_support::{
-    build_task_escrow_snapshot, set_state_file_env, unique_named_state_file,
+    build_task_escrow_snapshot, set_state_file_env, state_hash, unique_named_state_file,
+    with_api_server,
 };
 
 use crate::service_api_endpoint::ServiceApiSnapshot;

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/support.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/support.rs
@@ -1,3 +1,5 @@
+#[path = "support/authorization_fixture.rs"]
+mod authorization_fixture;
 #[path = "support/env_support.rs"]
 mod env_support;
 #[path = "support/request_support.rs"]
@@ -12,8 +14,8 @@ pub(super) use env_support::{
     set_live_solana_bridge_rpc_url_env,
 };
 pub(super) use request_support::{
-    accept_task, create_task, fund_escrow, query_task, raw_signed_request, register_agent_profile,
-    release_escrow, SignedRequest,
+    accept_task, authorized_signed_request, create_task, fund_escrow, query_task,
+    raw_signed_request, register_agent_profile, release_escrow, SignedRequest,
 };
 pub(super) use solana_asset_movement_support::{
     assert_persisted_solana_signature_metadata,
@@ -34,7 +36,7 @@ pub(super) fn raw_create_task_response(
     nonce: u64,
     payload: &str,
 ) -> String {
-    request_support::raw_signed_request(
+    request_support::authorized_signed_request(
         snapshot,
         bind_addr,
         request_support::SignedRequest {

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/support/authorization_fixture.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/support/authorization_fixture.rs
@@ -1,0 +1,18 @@
+use super::super::super::*;
+use super::request_support::SignedRequest;
+
+pub(super) fn provision_request_grant(request: &SignedRequest<'_>) {
+    const STATE_FILE_ENV: &str = "KAMN_SERVICE_API_STATE_FILE";
+    let Ok(state_file) = std::env::var(STATE_FILE_ENV) else {
+        panic!("authorized request requires {STATE_FILE_ENV}");
+    };
+    let actor_did = test_service_api_sender_did(request.caller_did);
+    crate::service_api_endpoint::provision_test_transaction_grant(
+        state_file,
+        actor_did.as_str(),
+        request.method,
+        request.path,
+        request.body,
+    )
+    .expect("authorization fixture grant should persist");
+}

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/support/request_support.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/support/request_support.rs
@@ -188,12 +188,21 @@ pub(crate) fn raw_signed_request(
     })
 }
 
+pub(crate) fn authorized_signed_request(
+    snapshot: &ServiceApiSnapshot,
+    bind_addr: &str,
+    request: SignedRequest<'_>,
+) -> String {
+    super::authorization_fixture::provision_request_grant(&request);
+    raw_signed_request(snapshot, bind_addr, request)
+}
+
 fn signed_request(
     snapshot: &ServiceApiSnapshot,
     bind_addr: &str,
     request: SignedRequest<'_>,
 ) -> String {
-    raw_signed_request(snapshot, bind_addr, request)
+    authorized_signed_request(snapshot, bind_addr, request)
 }
 
 fn build_signed_header_values(

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_authorization_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_authorization_contract_tests.rs
@@ -72,6 +72,21 @@ fn integration_service_api_persists_revoked_grant_denial_across_restart() {
     case.cleanup();
 }
 
+#[test]
+fn integration_service_api_denial_does_not_consume_request_nonce() {
+    let case = AuthorizationCase::new("deny-nonce-retry");
+    let actor = "kamn:did:agent:deny-nonce-retry";
+    let registered_did = case.register(actor, 1);
+
+    let denied = case.create_task(actor, 2);
+    assert_forbidden(&denied, "ACTION_NOT_GRANTED");
+    provision_grant(&case.state_file, registered_did.as_str(), "active");
+
+    let retried = case.create_task(actor, 2);
+    assert!(retried.contains("HTTP/1.1 201 Created"), "{retried}");
+    case.cleanup();
+}
+
 struct AuthorizationCase {
     _env: ServiceApiTestEnvGuards,
     _state_file_guard: EnvVarGuard,

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_authorization_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_authorization_contract_tests.rs
@@ -1,7 +1,7 @@
 use super::super::*;
 use super::support::{
     build_task_escrow_snapshot, raw_signed_request, read_state_json, register_agent_profile,
-    set_state_file_env, state_hash, unique_named_state_file, with_api_server, SignedRequest,
+    set_state_file_env, unique_named_state_file, SignedRequest,
 };
 use crate::service_api_endpoint::ServiceApiSnapshot;
 use std::path::{Path, PathBuf};
@@ -85,89 +85,6 @@ fn integration_service_api_denial_does_not_consume_request_nonce() {
     let retried = case.create_task(actor, 2);
     assert!(retried.contains("HTTP/1.1 201 Created"), "{retried}");
     case.cleanup();
-}
-
-#[test]
-fn integration_service_api_concurrent_same_nonce_records_one_authorization_decision() {
-    let case = AuthorizationCase::new("concurrent-replay");
-    let actor = "kamn:did:agent:concurrent-replay";
-    let registered_did = case.register(actor, 1);
-    provision_grant(&case.state_file, registered_did.as_str(), "active");
-
-    let responses = concurrent_task_create_requests(&case.snapshot, actor, 2);
-
-    assert_eq!(
-        responses
-            .iter()
-            .filter(|r| r.contains("201 Created"))
-            .count(),
-        1
-    );
-    assert_eq!(
-        responses
-            .iter()
-            .filter(|r| r.contains("409 Conflict"))
-            .count(),
-        1
-    );
-    let state = read_state_json(&case.state_file);
-    assert_eq!(state["authorization_receipts"].as_array().unwrap().len(), 1);
-    assert_eq!(state["tasks"].as_object().unwrap().len(), 1);
-    case.cleanup();
-}
-
-fn concurrent_task_create_requests(
-    snapshot: &ServiceApiSnapshot,
-    actor: &str,
-    nonce: u64,
-) -> Vec<String> {
-    let bind_addr = reserve_loopback_addr();
-    with_api_server(snapshot, bind_addr.as_str(), 2, |addr| {
-        let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
-        thread::scope(|scope| {
-            let handles: Vec<_> = (0..2)
-                .map(|_| {
-                    spawn_task_create_request(scope, barrier.clone(), snapshot, addr, actor, nonce)
-                })
-                .collect();
-            handles
-                .into_iter()
-                .map(|handle| handle.join().unwrap())
-                .collect()
-        })
-    })
-}
-
-fn spawn_task_create_request<'scope>(
-    scope: &'scope thread::Scope<'scope, '_>,
-    barrier: std::sync::Arc<std::sync::Barrier>,
-    snapshot: &'scope ServiceApiSnapshot,
-    addr: &'scope str,
-    actor: &'scope str,
-    nonce: u64,
-) -> thread::ScopedJoinHandle<'scope, String> {
-    scope.spawn(move || {
-        let nonce_text = nonce.to_string();
-        let signature = service_api_request_signature_for_fields(
-            actor,
-            nonce,
-            state_hash(snapshot).as_str(),
-            TASK_CREATE_BODY,
-        );
-        barrier.wait();
-        send_http_request_with_headers(
-            addr,
-            "POST",
-            TASK_CREATE_PATH,
-            TASK_CREATE_BODY,
-            &[
-                ("X-KAMN-Sender-DID", actor),
-                ("X-KAMN-Request-Nonce", nonce_text.as_str()),
-                ("X-KAMN-Request-Signature", signature.as_str()),
-                ("X-KAMN-Authz-Scope", "tasks:write"),
-            ],
-        )
-    })
 }
 
 struct AuthorizationCase {

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_authorization_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_authorization_contract_tests.rs
@@ -1,0 +1,171 @@
+use super::super::*;
+use super::support::{
+    build_task_escrow_snapshot, raw_signed_request, read_state_json, register_agent_profile,
+    set_state_file_env, unique_named_state_file, SignedRequest,
+};
+use crate::service_api_endpoint::ServiceApiSnapshot;
+use std::path::{Path, PathBuf};
+
+const TASK_CREATE_PATH: &str = "/v1/tasks/create";
+const TASK_CREATE_BODY: &str = r#"{"title":"authorized-task","description":"grant contract"}"#;
+
+#[test]
+fn integration_service_api_rejects_signed_unregistered_task_creator() {
+    let case = AuthorizationCase::new("unregistered");
+    let response = case.create_task("kamn:did:agent:unregistered", 1);
+
+    assert_forbidden(&response, "AGENT_NOT_REGISTERED");
+    assert!(read_state_json(&case.state_file)["tasks"]
+        .as_object()
+        .is_some_and(|v| v.is_empty()));
+    case.cleanup();
+}
+
+#[test]
+fn integration_service_api_rejects_self_asserted_scope_without_grant() {
+    let case = AuthorizationCase::new("scope-without-grant");
+    let actor = "kamn:did:agent:scope-without-grant";
+    case.register(actor, 1);
+
+    let response = case.create_task(actor, 2);
+
+    assert_forbidden(&response, "ACTION_NOT_GRANTED");
+    assert_secret_free_denial_receipt(&case.state_file, actor);
+    case.cleanup();
+}
+
+#[test]
+fn integration_service_api_persists_active_grant_and_allow_receipt_across_restart() {
+    let case = AuthorizationCase::new("active-grant-restart");
+    let actor = "kamn:did:agent:active-grant";
+    case.register(actor, 1);
+    provision_grant(&case.state_file, actor, "active");
+
+    let response = case.create_task(actor, 2);
+
+    assert!(response.contains("HTTP/1.1 201 Created"), "{response}");
+    assert_decision_receipt(&case.state_file, actor, "allow", "AUTHORIZED");
+    case.cleanup();
+}
+
+#[test]
+fn integration_service_api_persists_revoked_grant_denial_across_restart() {
+    let case = AuthorizationCase::new("revoked-grant-restart");
+    let actor = "kamn:did:agent:revoked-grant";
+    case.register(actor, 1);
+    provision_grant(&case.state_file, actor, "revoked");
+
+    let response = case.create_task(actor, 2);
+
+    assert_forbidden(&response, "ACTION_NOT_GRANTED");
+    assert_decision_receipt(&case.state_file, actor, "deny", "ACTION_NOT_GRANTED");
+    case.cleanup();
+}
+
+struct AuthorizationCase {
+    _env: ServiceApiTestEnvGuards,
+    _state_file_guard: EnvVarGuard,
+    snapshot: ServiceApiSnapshot,
+    state_file: PathBuf,
+}
+
+impl AuthorizationCase {
+    fn new(label: &str) -> Self {
+        let env = acquire_service_api_test_env();
+        let state_file =
+            unique_named_state_file(format!("kamn-node-service-api-authz-{label}").as_str());
+        let (_, state_file_guard) = set_state_file_env(state_file.as_path());
+        Self {
+            _env: env,
+            _state_file_guard: state_file_guard,
+            snapshot: build_task_escrow_snapshot("127.0.0.1:34210"),
+            state_file,
+        }
+    }
+
+    fn register(&self, actor: &str, nonce: u64) {
+        register_agent_profile(
+            &self.snapshot,
+            reserve_loopback_addr().as_str(),
+            actor,
+            nonce,
+            r#"{"agent_type":"assistant","model_family":"pi","capabilities":["tasks:write"]}"#,
+        );
+    }
+
+    fn create_task(&self, actor: &str, nonce: u64) -> String {
+        raw_signed_request(
+            &self.snapshot,
+            reserve_loopback_addr().as_str(),
+            SignedRequest {
+                max_requests: 1,
+                method: "POST",
+                path: TASK_CREATE_PATH,
+                caller_did: actor,
+                nonce,
+                body: TASK_CREATE_BODY,
+                extra_headers: &[("X-KAMN-Authz-Scope", "tasks:write")],
+            },
+        )
+    }
+
+    fn cleanup(self) {
+        let _ = fs::remove_file(self.state_file);
+    }
+}
+
+fn provision_grant(path: &Path, actor: &str, status: &str) {
+    let mut state = read_state_json(path);
+    state["agent_grants"] = serde_json::json!({
+        "grant-task-create": {
+            "did": actor,
+            "resource": "transaction:new",
+            "role": "initiator",
+            "action": "task:create",
+            "status": status,
+            "idempotency_key": "grant-task-create"
+        }
+    });
+    fs::write(
+        path,
+        serde_json::to_vec_pretty(&state).expect("state should serialize"),
+    )
+    .expect("grant fixture should persist");
+}
+
+fn assert_forbidden(response: &str, reason_code: &str) {
+    assert!(response.contains("HTTP/1.1 403 Forbidden"), "{response}");
+    assert!(response.contains(reason_code), "{response}");
+}
+
+fn assert_secret_free_denial_receipt(path: &Path, actor: &str) {
+    assert_decision_receipt(path, actor, "deny", "ACTION_NOT_GRANTED");
+    let receipt = read_state_json(path)["authorization_receipts"][0].clone();
+    let rendered = receipt.to_string().to_ascii_lowercase();
+    for forbidden in [
+        "signature",
+        "public_key",
+        "nonce",
+        "authorization",
+        "description",
+    ] {
+        assert!(
+            !rendered.contains(forbidden),
+            "receipt leaked {forbidden}: {receipt}"
+        );
+    }
+}
+
+fn assert_decision_receipt(path: &Path, actor: &str, decision: &str, reason: &str) {
+    let state = read_state_json(path);
+    let receipt = &state["authorization_receipts"][0];
+    assert_eq!(receipt["actor_did"], actor);
+    assert_eq!(receipt["resource"], "transaction:new");
+    assert_eq!(receipt["action"], "task:create");
+    assert_eq!(receipt["role"], "initiator");
+    assert_eq!(receipt["decision"], decision);
+    assert_eq!(receipt["reason_code"], reason);
+    assert!(receipt["correlation_id"]
+        .as_str()
+        .is_some_and(|v| !v.is_empty()));
+}

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_authorization_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_authorization_contract_tests.rs
@@ -25,12 +25,12 @@ fn integration_service_api_rejects_signed_unregistered_task_creator() {
 fn integration_service_api_rejects_self_asserted_scope_without_grant() {
     let case = AuthorizationCase::new("scope-without-grant");
     let actor = "kamn:did:agent:scope-without-grant";
-    case.register(actor, 1);
+    let registered_did = case.register(actor, 1);
 
     let response = case.create_task(actor, 2);
 
     assert_forbidden(&response, "ACTION_NOT_GRANTED");
-    assert_secret_free_denial_receipt(&case.state_file, actor);
+    assert_secret_free_denial_receipt(&case.state_file, registered_did.as_str());
     case.cleanup();
 }
 
@@ -38,13 +38,18 @@ fn integration_service_api_rejects_self_asserted_scope_without_grant() {
 fn integration_service_api_persists_active_grant_and_allow_receipt_across_restart() {
     let case = AuthorizationCase::new("active-grant-restart");
     let actor = "kamn:did:agent:active-grant";
-    case.register(actor, 1);
-    provision_grant(&case.state_file, actor, "active");
+    let registered_did = case.register(actor, 1);
+    provision_grant(&case.state_file, registered_did.as_str(), "active");
 
     let response = case.create_task(actor, 2);
 
     assert!(response.contains("HTTP/1.1 201 Created"), "{response}");
-    assert_decision_receipt(&case.state_file, actor, "allow", "AUTHORIZED");
+    assert_decision_receipt(
+        &case.state_file,
+        registered_did.as_str(),
+        "allow",
+        "AUTHORIZED",
+    );
     case.cleanup();
 }
 
@@ -52,13 +57,18 @@ fn integration_service_api_persists_active_grant_and_allow_receipt_across_restar
 fn integration_service_api_persists_revoked_grant_denial_across_restart() {
     let case = AuthorizationCase::new("revoked-grant-restart");
     let actor = "kamn:did:agent:revoked-grant";
-    case.register(actor, 1);
-    provision_grant(&case.state_file, actor, "revoked");
+    let registered_did = case.register(actor, 1);
+    provision_grant(&case.state_file, registered_did.as_str(), "revoked");
 
     let response = case.create_task(actor, 2);
 
     assert_forbidden(&response, "ACTION_NOT_GRANTED");
-    assert_decision_receipt(&case.state_file, actor, "deny", "ACTION_NOT_GRANTED");
+    assert_decision_receipt(
+        &case.state_file,
+        registered_did.as_str(),
+        "deny",
+        "ACTION_NOT_GRANTED",
+    );
     case.cleanup();
 }
 
@@ -83,14 +93,15 @@ impl AuthorizationCase {
         }
     }
 
-    fn register(&self, actor: &str, nonce: u64) {
+    fn register(&self, actor: &str, nonce: u64) -> String {
         register_agent_profile(
             &self.snapshot,
             reserve_loopback_addr().as_str(),
             actor,
             nonce,
             r#"{"agent_type":"assistant","model_family":"pi","capabilities":["tasks:write"]}"#,
-        );
+        )
+        .did
     }
 
     fn create_task(&self, actor: &str, nonce: u64) -> String {
@@ -146,7 +157,7 @@ fn assert_secret_free_denial_receipt(path: &Path, actor: &str) {
         "signature",
         "public_key",
         "nonce",
-        "authorization",
+        "x-kamn-authz-scope",
         "description",
     ] {
         assert!(

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_authorization_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_authorization_contract_tests.rs
@@ -1,7 +1,7 @@
 use super::super::*;
 use super::support::{
     build_task_escrow_snapshot, raw_signed_request, read_state_json, register_agent_profile,
-    set_state_file_env, unique_named_state_file, SignedRequest,
+    set_state_file_env, state_hash, unique_named_state_file, with_api_server, SignedRequest,
 };
 use crate::service_api_endpoint::ServiceApiSnapshot;
 use std::path::{Path, PathBuf};
@@ -85,6 +85,89 @@ fn integration_service_api_denial_does_not_consume_request_nonce() {
     let retried = case.create_task(actor, 2);
     assert!(retried.contains("HTTP/1.1 201 Created"), "{retried}");
     case.cleanup();
+}
+
+#[test]
+fn integration_service_api_concurrent_same_nonce_records_one_authorization_decision() {
+    let case = AuthorizationCase::new("concurrent-replay");
+    let actor = "kamn:did:agent:concurrent-replay";
+    let registered_did = case.register(actor, 1);
+    provision_grant(&case.state_file, registered_did.as_str(), "active");
+
+    let responses = concurrent_task_create_requests(&case.snapshot, actor, 2);
+
+    assert_eq!(
+        responses
+            .iter()
+            .filter(|r| r.contains("201 Created"))
+            .count(),
+        1
+    );
+    assert_eq!(
+        responses
+            .iter()
+            .filter(|r| r.contains("409 Conflict"))
+            .count(),
+        1
+    );
+    let state = read_state_json(&case.state_file);
+    assert_eq!(state["authorization_receipts"].as_array().unwrap().len(), 1);
+    assert_eq!(state["tasks"].as_object().unwrap().len(), 1);
+    case.cleanup();
+}
+
+fn concurrent_task_create_requests(
+    snapshot: &ServiceApiSnapshot,
+    actor: &str,
+    nonce: u64,
+) -> Vec<String> {
+    let bind_addr = reserve_loopback_addr();
+    with_api_server(snapshot, bind_addr.as_str(), 2, |addr| {
+        let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
+        thread::scope(|scope| {
+            let handles: Vec<_> = (0..2)
+                .map(|_| {
+                    spawn_task_create_request(scope, barrier.clone(), snapshot, addr, actor, nonce)
+                })
+                .collect();
+            handles
+                .into_iter()
+                .map(|handle| handle.join().unwrap())
+                .collect()
+        })
+    })
+}
+
+fn spawn_task_create_request<'scope>(
+    scope: &'scope thread::Scope<'scope, '_>,
+    barrier: std::sync::Arc<std::sync::Barrier>,
+    snapshot: &'scope ServiceApiSnapshot,
+    addr: &'scope str,
+    actor: &'scope str,
+    nonce: u64,
+) -> thread::ScopedJoinHandle<'scope, String> {
+    scope.spawn(move || {
+        let nonce_text = nonce.to_string();
+        let signature = service_api_request_signature_for_fields(
+            actor,
+            nonce,
+            state_hash(snapshot).as_str(),
+            TASK_CREATE_BODY,
+        );
+        barrier.wait();
+        send_http_request_with_headers(
+            addr,
+            "POST",
+            TASK_CREATE_PATH,
+            TASK_CREATE_BODY,
+            &[
+                ("X-KAMN-Sender-DID", actor),
+                ("X-KAMN-Request-Nonce", nonce_text.as_str()),
+                ("X-KAMN-Request-Signature", signature.as_str()),
+                ("X-KAMN-Authz-Scope", "tasks:write"),
+            ],
+        )
+    })
 }
 
 struct AuthorizationCase {

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_concurrent_replay_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_concurrent_replay_contract_tests.rs
@@ -1,0 +1,119 @@
+use super::super::*;
+use super::support::*;
+use crate::service_api_endpoint::ServiceApiSnapshot;
+use std::path::Path;
+
+const ACTOR: &str = "kamn:did:agent:concurrent-replay";
+const PATH: &str = "/v1/tasks/create";
+const BODY: &str = r#"{"title":"authorized-task","description":"grant contract"}"#;
+
+#[test]
+fn integration_service_api_concurrent_same_nonce_records_one_authorization_decision() {
+    let _env = acquire_service_api_test_env();
+    let state_file = unique_named_state_file("kamn-node-service-api-concurrent-replay");
+    let (_, _state_guard) = set_state_file_env(state_file.as_path());
+    let snapshot = build_task_escrow_snapshot("127.0.0.1:34211");
+    let registered = register_agent_profile(
+        &snapshot,
+        reserve_loopback_addr().as_str(),
+        ACTOR,
+        1,
+        r#"{"agent_type":"assistant","model_family":"pi","capabilities":["tasks:write"]}"#,
+    );
+    provision_grant(state_file.as_path(), registered.did.as_str());
+
+    let responses = concurrent_requests(&snapshot, 2);
+
+    assert_response_counts(&responses);
+    assert_single_side_effect(state_file.as_path());
+    let _ = fs::remove_file(state_file);
+}
+
+fn concurrent_requests(snapshot: &ServiceApiSnapshot, nonce: u64) -> Vec<String> {
+    let bind_addr = reserve_loopback_addr();
+    with_api_server(snapshot, bind_addr.as_str(), 2, |addr| {
+        let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
+        thread::scope(|scope| {
+            let handles: Vec<_> = (0..2)
+                .map(|_| spawn_request(scope, barrier.clone(), snapshot, addr, nonce))
+                .collect();
+            handles
+                .into_iter()
+                .map(|handle| handle.join().expect("request thread should complete"))
+                .collect()
+        })
+    })
+}
+
+fn spawn_request<'scope>(
+    scope: &'scope thread::Scope<'scope, '_>,
+    barrier: std::sync::Arc<std::sync::Barrier>,
+    snapshot: &'scope ServiceApiSnapshot,
+    addr: &'scope str,
+    nonce: u64,
+) -> thread::ScopedJoinHandle<'scope, String> {
+    scope.spawn(move || {
+        let nonce_text = nonce.to_string();
+        let signature = service_api_request_signature_for_fields(
+            ACTOR,
+            nonce,
+            state_hash(snapshot).as_str(),
+            BODY,
+        );
+        barrier.wait();
+        send_http_request_with_headers(
+            addr,
+            "POST",
+            PATH,
+            BODY,
+            &[
+                ("X-KAMN-Sender-DID", ACTOR),
+                ("X-KAMN-Request-Nonce", nonce_text.as_str()),
+                ("X-KAMN-Request-Signature", signature.as_str()),
+                ("X-KAMN-Authz-Scope", "tasks:write"),
+            ],
+        )
+    })
+}
+
+fn provision_grant(path: &Path, actor: &str) {
+    let mut state = read_state_json(path);
+    state["agent_grants"] = serde_json::json!({"grant-task-create": {
+        "did": actor, "resource": "transaction:new", "role": "initiator",
+        "action": "task:create", "status": "active", "idempotency_key": "grant-task-create"
+    }});
+    fs::write(
+        path,
+        serde_json::to_vec_pretty(&state).expect("state should serialize"),
+    )
+    .expect("grant fixture should persist");
+}
+
+fn assert_response_counts(responses: &[String]) {
+    assert_eq!(
+        responses
+            .iter()
+            .filter(|r| r.contains("201 Created"))
+            .count(),
+        1
+    );
+    assert_eq!(
+        responses
+            .iter()
+            .filter(|r| r.contains("409 Conflict"))
+            .count(),
+        1
+    );
+}
+
+fn assert_single_side_effect(path: &Path) {
+    let state = read_state_json(path);
+    let receipts = state["authorization_receipts"]
+        .as_array()
+        .expect("authorization receipts should be an array");
+    let tasks = state["tasks"]
+        .as_object()
+        .expect("tasks should be an object");
+    assert_eq!(receipts.len(), 1);
+    assert_eq!(tasks.len(), 1);
+}

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_live_settlement_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_live_settlement_contract_tests.rs
@@ -1,7 +1,8 @@
 use super::super::*;
 use super::support::{
-    build_task_escrow_snapshot, fund_escrow, raw_signed_request, read_state_json, release_escrow,
-    set_live_solana_bridge_rpc_url_env, set_state_file_env, unique_named_state_file, SignedRequest,
+    authorized_signed_request, build_task_escrow_snapshot, fund_escrow, read_state_json,
+    release_escrow, set_live_solana_bridge_rpc_url_env, set_state_file_env,
+    unique_named_state_file, SignedRequest,
 };
 use crate::service_api_endpoint::ServiceApiSnapshot;
 
@@ -105,7 +106,7 @@ fn release_live_escrow_with_unreachable_rpc(
     amount: u64,
 ) -> String {
     let escrow_id = fund_live_escrow(harness, fund_nonce, amount);
-    raw_signed_request(
+    authorized_signed_request(
         &harness.snapshot,
         harness.bind_addr.as_str(),
         SignedRequest {

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_routes_contract_tests/task_dispatch_support.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_routes_contract_tests/task_dispatch_support.rs
@@ -1,8 +1,8 @@
 use super::super::super::*;
 use super::super::support::{
-    build_task_escrow_snapshot, create_task, query_task, raw_create_task_response,
-    raw_signed_request, register_agent_profile, set_audit_export_file_env, set_state_file_env,
-    unique_named_state_file, SignedRequest,
+    authorized_signed_request, build_task_escrow_snapshot, create_task, query_task,
+    raw_create_task_response, register_agent_profile, set_audit_export_file_env,
+    set_state_file_env, unique_named_state_file, SignedRequest,
 };
 
 pub(super) fn setup_dispatch_route_case() -> DispatchRouteCase {
@@ -83,7 +83,7 @@ pub(super) fn query_missing_worker_task(missing_worker: &MissingWorkerRouteCase)
         401,
         r#"{"creator":"kamn:did:agent:task-creator-missing-worker","task_type":"vision-sync","description":"nobody can do this"}"#,
     );
-    raw_signed_request(
+    authorized_signed_request(
         &missing_worker.snapshot,
         missing_worker.bind_addr.as_str(),
         SignedRequest {

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/vertical_slice_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/vertical_slice_contract_tests.rs
@@ -173,6 +173,7 @@ fn create_vertical_slice_task(
     case: &VerticalSliceCase,
 ) -> crate::service_api_endpoint::ServiceApiTaskCreateBody {
     with_sender_env(case, || {
+        provision_vertical_slice_grant(case, "POST", "/v1/tasks/create");
         create_task(
             &case.sender_snapshot,
             case.sender_bind_addr.as_str(),
@@ -185,6 +186,8 @@ fn create_vertical_slice_task(
 
 fn query_vertical_slice_task(case: &VerticalSliceCase, task_id: &str) -> Value {
     with_sender_env(case, || {
+        let path = format!("/v1/tasks/{task_id}");
+        provision_vertical_slice_grant(case, "GET", path.as_str());
         query_task(
             &case.sender_snapshot,
             case.sender_bind_addr.as_str(),
@@ -193,6 +196,18 @@ fn query_vertical_slice_task(case: &VerticalSliceCase, task_id: &str) -> Value {
             task_id,
         )
     })
+}
+
+fn provision_vertical_slice_grant(case: &VerticalSliceCase, method: &str, path: &str) {
+    let actor_did = test_service_api_sender_did(case.sender_did);
+    crate::service_api_endpoint::provision_test_transaction_grant(
+        case.files.sender_state_file.to_string_lossy().into_owned(),
+        actor_did.as_str(),
+        method,
+        path,
+        "",
+    )
+    .expect("vertical-slice authorization grant should persist");
 }
 
 fn cleanup_case(case: VerticalSliceCase) {

--- a/crates/kamn-node/src/service_api_endpoint.rs
+++ b/crates/kamn-node/src/service_api_endpoint.rs
@@ -1,4 +1,6 @@
 mod auth;
+#[cfg(test)]
+mod grant_test_support;
 mod live_bridge_dispatch;
 mod live_settlement_dispatch;
 mod message_store;
@@ -13,6 +15,9 @@ mod state_io;
 #[cfg(test)]
 mod tests;
 mod websocket;
+
+#[cfg(test)]
+pub(crate) use grant_test_support::provision_test_transaction_grant;
 
 use crate::{
     logging::{log_info, log_warn},
@@ -164,6 +169,10 @@ const REASON_CODE_AUTH_REPLAY_NONCE_DETECTED: &str = "service_api_auth_replay_no
 const REASON_CODE_AUTH_SCOPE_HEADER_MISSING: &str = "service_api_auth_scope_header_missing";
 const REASON_CODE_AUTH_SCOPE_INVALID: &str = "service_api_auth_scope_invalid";
 const REASON_CODE_AUTH_SCOPE_ROUTE_MISMATCH: &str = "service_api_auth_scope_route_mismatch";
+const REASON_CODE_AGENT_NOT_REGISTERED: &str = "AGENT_NOT_REGISTERED";
+const REASON_CODE_ACTION_NOT_GRANTED: &str = "ACTION_NOT_GRANTED";
+const REASON_CODE_RESOURCE_ROLE_MISMATCH: &str = "RESOURCE_ROLE_MISMATCH";
+const REASON_CODE_ACTION_AUTHORIZED: &str = "AUTHORIZED";
 pub(crate) const SERVICE_API_AUTH_REASON_TAXONOMY_VERSION: &str =
     "kamn.runtime.service-api-auth-reason-taxonomy.v1";
 pub(crate) const SERVICE_API_AUTH_REASON_CODES_CSV: &str = "service_api_auth_sender_did_header_missing,service_api_auth_sender_did_invalid,service_api_auth_nonce_header_missing,service_api_auth_nonce_invalid,service_api_auth_nonce_non_positive,service_api_auth_signature_header_missing,service_api_auth_did_key_binding_invalid,service_api_auth_signature_verification_failed,service_api_auth_replay_nonce_detected";
@@ -375,20 +384,28 @@ impl ServiceApiReplayGuard {
 
     fn record_nonce_if_fresh(&mut self, sender_did: &str, nonce: u64, now: Instant) -> bool {
         self.evict_expired(now);
-        if let Some(high_watermark) = self.highest_nonce_by_sender.get(sender_did) {
-            if nonce <= *high_watermark {
-                return false;
-            }
-        }
-        let entry = (sender_did.to_owned(), nonce);
-        if self.entries.contains(&entry) {
+        if !self.nonce_is_fresh(sender_did, nonce) {
             return false;
         }
+        let entry = (sender_did.to_owned(), nonce);
         self.entries.insert(entry.clone());
         self.insertion_order.push_back((entry.0, entry.1, now));
         self.seed_sender_nonce_high_watermark(sender_did, nonce);
         self.evict_over_capacity();
         true
+    }
+
+    fn check_nonce_is_fresh(&mut self, sender_did: &str, nonce: u64, now: Instant) -> bool {
+        self.evict_expired(now);
+        self.nonce_is_fresh(sender_did, nonce)
+    }
+
+    fn nonce_is_fresh(&self, sender_did: &str, nonce: u64) -> bool {
+        let above_high_watermark = self
+            .highest_nonce_by_sender
+            .get(sender_did)
+            .is_none_or(|high_watermark| nonce > *high_watermark);
+        above_high_watermark && !self.entries.contains(&(sender_did.to_owned(), nonce))
     }
 
     fn seed_sender_nonce_high_watermark(&mut self, sender_did: &str, nonce: u64) {

--- a/crates/kamn-node/src/service_api_endpoint/auth.rs
+++ b/crates/kamn-node/src/service_api_endpoint/auth.rs
@@ -1,6 +1,7 @@
 use super::*;
 
 mod anti_spam;
+mod grant_policy;
 mod request_auth;
 mod scope_policy;
 mod support;
@@ -11,6 +12,13 @@ mod tests;
 pub(crate) use anti_spam::enforce_sender_anti_spam;
 #[cfg(test)]
 pub(super) use anti_spam::map_anti_spam_rejection_to_reasoned_error;
+pub(crate) use grant_policy::resolve_transaction_authorization_target;
+#[cfg(test)]
+pub(crate) use grant_policy::TransactionAuthorizationTarget;
+#[cfg(test)]
 pub(crate) use request_auth::authorize_service_api_request;
+pub(crate) use request_auth::{
+    record_verified_service_api_request_nonce, verify_service_api_request_identity,
+};
 pub(crate) use scope_policy::enforce_request_scope_policy;
 pub(crate) use support::header_value;

--- a/crates/kamn-node/src/service_api_endpoint/auth.rs
+++ b/crates/kamn-node/src/service_api_endpoint/auth.rs
@@ -13,10 +13,7 @@ pub(crate) use anti_spam::enforce_sender_anti_spam;
 #[cfg(test)]
 pub(super) use anti_spam::map_anti_spam_rejection_to_reasoned_error;
 pub(crate) use grant_policy::resolve_transaction_authorization_target;
-#[cfg(test)]
 pub(crate) use grant_policy::TransactionAuthorizationTarget;
-#[cfg(test)]
-pub(crate) use request_auth::authorize_service_api_request;
 pub(crate) use request_auth::{
     record_verified_service_api_request_nonce, verify_service_api_request_identity,
 };

--- a/crates/kamn-node/src/service_api_endpoint/auth/grant_policy.rs
+++ b/crates/kamn-node/src/service_api_endpoint/auth/grant_policy.rs
@@ -12,7 +12,7 @@ pub(crate) struct TransactionAuthorizationTarget {
 pub(crate) fn resolve_transaction_authorization_target(
     request: &ParsedRequest,
 ) -> Result<Option<TransactionAuthorizationTarget>, ServiceApiReasonedError> {
-    if request.path == ROUTE_AGENTS_REGISTER {
+    if request.method == "POST" && request.path == ROUTE_AGENTS_REGISTER {
         return Ok(None);
     }
     let Some((resource, action, role)) = route_target(request)? else {
@@ -79,15 +79,9 @@ fn path_id<'a>(path: &'a str, prefix: &str, suffix: &str) -> Option<&'a str> {
 }
 
 fn escrow_fund_resource(request: &ParsedRequest) -> Result<String, ServiceApiReasonedError> {
-    let body = serde_json::from_str::<serde_json::Value>(request.body.as_str())
-        .map_err(|_| unresolved_resource_error("escrow fund payload must be json"))?;
-    let task_id = body
-        .get("task_id")
-        .and_then(serde_json::Value::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .ok_or_else(|| unresolved_resource_error("escrow fund task_id is required"))?;
-    Ok(task_resource(task_id))
+    super::message_store::escrow_fund_task_id(request.body.as_str())
+        .map(|task_id| task_resource(task_id.as_str()))
+        .map_err(|error| unresolved_resource_error(error.as_str()))
 }
 
 fn task_resource(task_id: &str) -> String {

--- a/crates/kamn-node/src/service_api_endpoint/auth/grant_policy.rs
+++ b/crates/kamn-node/src/service_api_endpoint/auth/grant_policy.rs
@@ -1,0 +1,106 @@
+use super::support::header_value;
+use super::*;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TransactionAuthorizationTarget {
+    pub(crate) actor_did: String,
+    pub(crate) resource: String,
+    pub(crate) action: &'static str,
+    pub(crate) role: &'static str,
+}
+
+pub(crate) fn resolve_transaction_authorization_target(
+    request: &ParsedRequest,
+) -> Result<Option<TransactionAuthorizationTarget>, ServiceApiReasonedError> {
+    if request.path == ROUTE_AGENTS_REGISTER {
+        return Ok(None);
+    }
+    let Some((resource, action, role)) = route_target(request)? else {
+        return Ok(None);
+    };
+    let actor_did = header_value(&request.headers, REQUEST_AUTH_SENDER_DID_HEADER)
+        .ok_or_else(missing_actor_error)?
+        .to_owned();
+    Ok(Some(TransactionAuthorizationTarget {
+        actor_did,
+        resource,
+        action,
+        role,
+    }))
+}
+
+fn route_target(
+    request: &ParsedRequest,
+) -> Result<Option<(String, &'static str, &'static str)>, ServiceApiReasonedError> {
+    let method = request.method.as_str();
+    let path = request.path.as_str();
+    if method == "POST" && path == ROUTE_TASKS_CREATE {
+        return Ok(Some((
+            "transaction:new".to_owned(),
+            "task:create",
+            "initiator",
+        )));
+    }
+    if method == "POST" && path == ROUTE_ESCROW_FUND {
+        return Ok(Some((
+            escrow_fund_resource(request)?,
+            "escrow:fund",
+            "initiator",
+        )));
+    }
+    Ok(dynamic_route_target(method, path))
+}
+
+fn dynamic_route_target(method: &str, path: &str) -> Option<(String, &'static str, &'static str)> {
+    if method == "GET" {
+        return task_id_for_read(path).map(|id| (task_resource(id), "task:read", "participant"));
+    }
+    if method != "POST" {
+        return None;
+    }
+    if let Some(id) = path_id(path, ROUTE_TASKS_PREFIX, ROUTE_TASKS_ACCEPT_SUFFIX) {
+        return Some((task_resource(id), "task:accept", "provider"));
+    }
+    if let Some(id) = path_id(path, ROUTE_TASKS_PREFIX, ROUTE_TASKS_COMPLETE_SUFFIX) {
+        return Some((task_resource(id), "task:complete", "provider"));
+    }
+    path_id(path, ROUTE_ESCROW_PREFIX, ROUTE_ESCROW_RELEASE_SUFFIX)
+        .map(|id| (format!("escrow:{id}"), "escrow:release", "initiator"))
+}
+
+fn task_id_for_read(path: &str) -> Option<&str> {
+    let id = path.strip_prefix(ROUTE_TASKS_PREFIX)?;
+    (!id.is_empty() && !id.contains('/')).then_some(id)
+}
+
+fn path_id<'a>(path: &'a str, prefix: &str, suffix: &str) -> Option<&'a str> {
+    let id = path.strip_prefix(prefix)?.strip_suffix(suffix)?;
+    (!id.is_empty() && !id.contains('/')).then_some(id)
+}
+
+fn escrow_fund_resource(request: &ParsedRequest) -> Result<String, ServiceApiReasonedError> {
+    let body = serde_json::from_str::<serde_json::Value>(request.body.as_str())
+        .map_err(|_| unresolved_resource_error("escrow fund payload must be json"))?;
+    let task_id = body
+        .get("task_id")
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| unresolved_resource_error("escrow fund task_id is required"))?;
+    Ok(task_resource(task_id))
+}
+
+fn task_resource(task_id: &str) -> String {
+    format!("task:{task_id}")
+}
+
+fn missing_actor_error() -> ServiceApiReasonedError {
+    ServiceApiReasonedError::new(
+        REASON_CODE_AUTH_SENDER_DID_HEADER_MISSING,
+        "verified authorization actor did is missing",
+    )
+}
+
+fn unresolved_resource_error(message: &str) -> ServiceApiReasonedError {
+    ServiceApiReasonedError::new(REASON_CODE_RESOURCE_ROLE_MISMATCH, message)
+}

--- a/crates/kamn-node/src/service_api_endpoint/auth/grant_policy.rs
+++ b/crates/kamn-node/src/service_api_endpoint/auth/grant_policy.rs
@@ -53,29 +53,20 @@ fn route_target(
 
 fn dynamic_route_target(method: &str, path: &str) -> Option<(String, &'static str, &'static str)> {
     if method == "GET" {
-        return task_id_for_read(path).map(|id| (task_resource(id), "task:read", "participant"));
+        return super::payload::task_path_id(path)
+            .map(|id| (task_resource(id), "task:read", "participant"));
     }
     if method != "POST" {
         return None;
     }
-    if let Some(id) = path_id(path, ROUTE_TASKS_PREFIX, ROUTE_TASKS_ACCEPT_SUFFIX) {
+    if let Some(id) = super::payload::task_accept_path_id(path) {
         return Some((task_resource(id), "task:accept", "provider"));
     }
-    if let Some(id) = path_id(path, ROUTE_TASKS_PREFIX, ROUTE_TASKS_COMPLETE_SUFFIX) {
+    if let Some(id) = super::payload::task_complete_path_id(path) {
         return Some((task_resource(id), "task:complete", "provider"));
     }
-    path_id(path, ROUTE_ESCROW_PREFIX, ROUTE_ESCROW_RELEASE_SUFFIX)
+    super::payload::escrow_release_path_id(path)
         .map(|id| (format!("escrow:{id}"), "escrow:release", "initiator"))
-}
-
-fn task_id_for_read(path: &str) -> Option<&str> {
-    let id = path.strip_prefix(ROUTE_TASKS_PREFIX)?;
-    (!id.is_empty() && !id.contains('/')).then_some(id)
-}
-
-fn path_id<'a>(path: &'a str, prefix: &str, suffix: &str) -> Option<&'a str> {
-    let id = path.strip_prefix(prefix)?.strip_suffix(suffix)?;
-    (!id.is_empty() && !id.contains('/')).then_some(id)
 }
 
 fn escrow_fund_resource(request: &ParsedRequest) -> Result<String, ServiceApiReasonedError> {

--- a/crates/kamn-node/src/service_api_endpoint/auth/request_auth.rs
+++ b/crates/kamn-node/src/service_api_endpoint/auth/request_auth.rs
@@ -9,7 +9,8 @@ mod signature;
 use failures::{invalid_nonce_failure, missing_nonce_failure, missing_signature_failure};
 use nonce::{record_fresh_nonce, require_request_nonce, verify_fresh_nonce, verify_positive_nonce};
 pub(super) use sender_binding::{
-    resolve_signer_public_key_for_request, sender_did_matches_signer_public_key,
+    require_valid_sender_did_header, resolve_signer_public_key_for_request,
+    sender_did_matches_signer_public_key,
 };
 use signature::{request_signature_matches, signature_verification_failure};
 
@@ -47,25 +48,6 @@ pub(crate) fn record_verified_service_api_request_nonce(
     let sender_did = require_valid_sender_did_header(request)?;
     let nonce = require_request_nonce(request)?;
     record_fresh_nonce(replay_guard, sender_did, nonce)
-}
-
-pub(super) fn require_valid_sender_did_header(
-    request: &ParsedRequest,
-) -> Result<&str, RequestAuthFailure> {
-    let sender_did =
-        header_value(&request.headers, REQUEST_AUTH_SENDER_DID_HEADER).ok_or_else(|| {
-            RequestAuthFailure::Unauthorized(ServiceApiReasonedError::new(
-                REASON_CODE_AUTH_SENDER_DID_HEADER_MISSING,
-                format!("missing required header: {REQUEST_AUTH_SENDER_DID_HEADER}"),
-            ))
-        })?;
-    AgentDid::parse(sender_did).map_err(|error| {
-        RequestAuthFailure::Unauthorized(ServiceApiReasonedError::new(
-            REASON_CODE_AUTH_SENDER_DID_INVALID,
-            format!("invalid sender did: {error}"),
-        ))
-    })?;
-    Ok(sender_did)
 }
 
 #[cfg(test)]

--- a/crates/kamn-node/src/service_api_endpoint/auth/request_auth.rs
+++ b/crates/kamn-node/src/service_api_endpoint/auth/request_auth.rs
@@ -7,18 +7,46 @@ mod sender_binding;
 mod signature;
 
 use failures::{invalid_nonce_failure, missing_nonce_failure, missing_signature_failure};
-use nonce::{record_fresh_nonce, require_request_nonce, verify_positive_nonce};
+use nonce::{record_fresh_nonce, require_request_nonce, verify_fresh_nonce, verify_positive_nonce};
 pub(super) use sender_binding::{
     resolve_signer_public_key_for_request, sender_did_matches_signer_public_key,
 };
 use signature::{request_signature_matches, signature_verification_failure};
 
+#[cfg(test)]
 pub(crate) fn authorize_service_api_request(
     state: &ServiceApiRuntimeState,
     request: &ParsedRequest,
     replay_guard: &mut ServiceApiReplayGuard,
 ) -> Result<(), RequestAuthFailure> {
     authorize_service_api_request_with_legacy_policy(state, request, replay_guard, false)
+}
+
+pub(crate) fn verify_service_api_request_identity(
+    state: &ServiceApiRuntimeState,
+    request: &ParsedRequest,
+    replay_guard: &mut ServiceApiReplayGuard,
+) -> Result<(), RequestAuthFailure> {
+    if !super::route_requires_auth(request.method.as_str(), request.path.as_str()) {
+        return Ok(());
+    }
+    let sender_did = require_valid_sender_did_header(request)?;
+    let nonce = require_request_nonce(request)?;
+    verify_positive_nonce(nonce)?;
+    verify_binding_and_signature(state, request, sender_did, nonce, false)?;
+    verify_fresh_nonce(replay_guard, sender_did, nonce)
+}
+
+pub(crate) fn record_verified_service_api_request_nonce(
+    request: &ParsedRequest,
+    replay_guard: &mut ServiceApiReplayGuard,
+) -> Result<(), RequestAuthFailure> {
+    if !super::route_requires_auth(request.method.as_str(), request.path.as_str()) {
+        return Ok(());
+    }
+    let sender_did = require_valid_sender_did_header(request)?;
+    let nonce = require_request_nonce(request)?;
+    record_fresh_nonce(replay_guard, sender_did, nonce)
 }
 
 pub(super) fn require_valid_sender_did_header(
@@ -40,6 +68,7 @@ pub(super) fn require_valid_sender_did_header(
     Ok(sender_did)
 }
 
+#[cfg(test)]
 pub(super) fn authorize_service_api_request_with_legacy_policy(
     state: &ServiceApiRuntimeState,
     request: &ParsedRequest,
@@ -61,6 +90,7 @@ pub(super) fn authorize_service_api_request_with_legacy_policy(
     )
 }
 
+#[cfg(test)]
 fn verify_request_auth_envelope(
     state: &ServiceApiRuntimeState,
     request: &ParsedRequest,

--- a/crates/kamn-node/src/service_api_endpoint/auth/request_auth/nonce.rs
+++ b/crates/kamn-node/src/service_api_endpoint/auth/request_auth/nonce.rs
@@ -28,8 +28,23 @@ pub(super) fn record_fresh_nonce(
     if replay_guard.record_nonce_if_fresh(sender_did, nonce, Instant::now()) {
         return Ok(());
     }
-    Err(RequestAuthFailure::Replay(ServiceApiReasonedError::new(
+    Err(replay_failure())
+}
+
+pub(super) fn verify_fresh_nonce(
+    replay_guard: &mut ServiceApiReplayGuard,
+    sender_did: &str,
+    nonce: u64,
+) -> Result<(), RequestAuthFailure> {
+    if replay_guard.check_nonce_is_fresh(sender_did, nonce, Instant::now()) {
+        return Ok(());
+    }
+    Err(replay_failure())
+}
+
+fn replay_failure() -> RequestAuthFailure {
+    RequestAuthFailure::Replay(ServiceApiReasonedError::new(
         REASON_CODE_AUTH_REPLAY_NONCE_DETECTED,
         "request nonce replay detected for sender",
-    )))
+    ))
 }

--- a/crates/kamn-node/src/service_api_endpoint/auth/request_auth/sender_binding.rs
+++ b/crates/kamn-node/src/service_api_endpoint/auth/request_auth/sender_binding.rs
@@ -3,6 +3,25 @@ use super::super::support::{
 };
 use super::*;
 
+pub(crate) fn require_valid_sender_did_header(
+    request: &ParsedRequest,
+) -> Result<&str, RequestAuthFailure> {
+    let sender_did =
+        header_value(&request.headers, REQUEST_AUTH_SENDER_DID_HEADER).ok_or_else(|| {
+            RequestAuthFailure::Unauthorized(ServiceApiReasonedError::new(
+                REASON_CODE_AUTH_SENDER_DID_HEADER_MISSING,
+                format!("missing required header: {REQUEST_AUTH_SENDER_DID_HEADER}"),
+            ))
+        })?;
+    AgentDid::parse(sender_did).map_err(|error| {
+        RequestAuthFailure::Unauthorized(ServiceApiReasonedError::new(
+            REASON_CODE_AUTH_SENDER_DID_INVALID,
+            format!("invalid sender did: {error}"),
+        ))
+    })?;
+    Ok(sender_did)
+}
+
 pub(crate) fn resolve_signer_public_key_for_request<'a>(
     headers: &'a BTreeMap<String, String>,
     fallback_public_key_hex: Option<&'a str>,

--- a/crates/kamn-node/src/service_api_endpoint/auth/tests.rs
+++ b/crates/kamn-node/src/service_api_endpoint/auth/tests.rs
@@ -1,3 +1,4 @@
+mod grant_policy_contract_tests;
 mod replay_guard_contract_tests;
 mod request_auth_contract_tests;
 mod scope_policy_contract_tests;

--- a/crates/kamn-node/src/service_api_endpoint/auth/tests/grant_policy_contract_tests.rs
+++ b/crates/kamn-node/src/service_api_endpoint/auth/tests/grant_policy_contract_tests.rs
@@ -1,0 +1,33 @@
+use super::super::*;
+
+#[test]
+fn unit_transaction_authorization_rejects_reserved_task_path_ids() {
+    for (method, path) in [
+        ("GET", "/v1/tasks/create"),
+        ("POST", "/v1/tasks/create/accept"),
+        ("POST", "/v1/tasks/create/complete"),
+    ] {
+        assert!(
+            resolve_target(method, path).is_none(),
+            "reserved route: {path}"
+        );
+    }
+}
+
+#[test]
+fn unit_transaction_authorization_rejects_reserved_escrow_path_ids() {
+    assert!(resolve_target("POST", "/v1/escrow/fund/release").is_none());
+}
+
+fn resolve_target(method: &str, path: &str) -> Option<TransactionAuthorizationTarget> {
+    let request = ParsedRequest {
+        method: method.to_owned(),
+        path: path.to_owned(),
+        body: String::new(),
+        headers: BTreeMap::from([(
+            REQUEST_AUTH_SENDER_DID_HEADER.to_owned(),
+            "kamn:did:agent:grant-policy".to_owned(),
+        )]),
+    };
+    resolve_transaction_authorization_target(&request).expect("target resolution should succeed")
+}

--- a/crates/kamn-node/src/service_api_endpoint/grant_test_support.rs
+++ b/crates/kamn-node/src/service_api_endpoint/grant_test_support.rs
@@ -1,0 +1,72 @@
+use super::message_store::ServiceApiPersistedAgentGrantRecord;
+use super::*;
+
+pub(crate) fn provision_test_transaction_grant(
+    state_file: String,
+    actor_did: &str,
+    method: &str,
+    path: &str,
+    body: &str,
+) -> Result<(), String> {
+    let target = resolve_target(actor_did, method, path, body)?;
+    let mut store = ServiceApiMessageStore::from_optional_state_file(Some(state_file))?;
+    ensure_registered(&mut store, actor_did)?;
+    store.provision_agent_grant(grant_record(&target))
+}
+
+fn resolve_target(
+    actor_did: &str,
+    method: &str,
+    path: &str,
+    body: &str,
+) -> Result<auth::TransactionAuthorizationTarget, String> {
+    let parsed = ParsedRequest {
+        method: method.to_owned(),
+        path: path.to_owned(),
+        body: body.to_owned(),
+        headers: BTreeMap::from([(
+            REQUEST_AUTH_SENDER_DID_HEADER.to_owned(),
+            actor_did.to_owned(),
+        )]),
+    };
+    auth::resolve_transaction_authorization_target(&parsed)
+        .map_err(|error| error.message)?
+        .ok_or_else(|| format!("test authorization target is not a transaction route: {path}"))
+}
+
+fn ensure_registered(store: &mut ServiceApiMessageStore, actor_did: &str) -> Result<(), String> {
+    if store
+        .snapshot
+        .agents
+        .get(actor_did)
+        .is_some_and(|agent| agent.registered)
+    {
+        return Ok(());
+    }
+    let registration = ServiceApiAgentRegisterRequestBody {
+        agent_type: "test-agent".to_owned(),
+        model_family: "test-runtime".to_owned(),
+        capabilities: vec!["transaction-test".to_owned()],
+    };
+    store
+        .register_agent_profile(actor_did, &registration)
+        .map(|_| ())
+        .map_err(|error| format!("test agent registration failed: {error:?}"))
+}
+
+fn grant_record(
+    target: &auth::TransactionAuthorizationTarget,
+) -> ServiceApiPersistedAgentGrantRecord {
+    let idempotency_key = format!(
+        "test-grant:{}:{}:{}:{}",
+        target.actor_did, target.resource, target.action, target.role
+    );
+    ServiceApiPersistedAgentGrantRecord {
+        did: target.actor_did.clone(),
+        resource: target.resource.clone(),
+        role: target.role.to_owned(),
+        action: target.action.to_owned(),
+        status: "active".to_owned(),
+        idempotency_key,
+    }
+}

--- a/crates/kamn-node/src/service_api_endpoint/message_store.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store.rs
@@ -53,4 +53,5 @@ pub(crate) use models::{
     ServiceApiAgentBalanceBody, ServiceApiAgentRegistrationStoreError, ServiceApiMessageStore,
     ServiceApiPersistedAgentGrantRecord, ServiceApiRelayProgressCounts,
 };
+pub(crate) use store::escrow_fund_task_id;
 pub(crate) use store::{ServiceApiAuthorizationDecision, ServiceApiAuthorizationRequest};

--- a/crates/kamn-node/src/service_api_endpoint/message_store.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store.rs
@@ -51,5 +51,6 @@ use runtime_evidence::build_data_layer_runtime_evidence;
 
 pub(crate) use models::{
     ServiceApiAgentBalanceBody, ServiceApiAgentRegistrationStoreError, ServiceApiMessageStore,
-    ServiceApiRelayProgressCounts,
+    ServiceApiPersistedAgentGrantRecord, ServiceApiRelayProgressCounts,
 };
+pub(crate) use store::{ServiceApiAuthorizationDecision, ServiceApiAuthorizationRequest};

--- a/crates/kamn-node/src/service_api_endpoint/message_store/models.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/models.rs
@@ -54,6 +54,8 @@ pub(crate) struct ServiceApiPersistedTaskRecord {
 pub(crate) struct ServiceApiPersistedEscrowRecord {
     pub(crate) escrow_id: String,
     pub(crate) state: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) task_id: Option<String>,
     #[serde(flatten, default)]
     pub(crate) settlement: ServiceApiSettlementMetadata,
 }

--- a/crates/kamn-node/src/service_api_endpoint/message_store/models.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/models.rs
@@ -91,6 +91,28 @@ pub(crate) struct ServiceApiPersistedAgentRecord {
     pub(crate) capabilities: Vec<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct ServiceApiPersistedAgentGrantRecord {
+    pub(crate) did: String,
+    pub(crate) resource: String,
+    pub(crate) role: String,
+    pub(crate) action: String,
+    pub(crate) status: String,
+    pub(crate) idempotency_key: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct ServiceApiAuthorizationReceiptRecord {
+    pub(crate) receipt_id: String,
+    pub(crate) correlation_id: String,
+    pub(crate) actor_did: String,
+    pub(crate) resource: String,
+    pub(crate) action: String,
+    pub(crate) role: String,
+    pub(crate) decision: String,
+    pub(crate) reason_code: String,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub(crate) struct ServiceApiAgentBalanceBody {
     pub(crate) did: String,
@@ -120,12 +142,16 @@ pub(crate) struct ServiceApiPersistedMessageStoreSnapshot {
     pub(crate) bridges: BTreeMap<String, ServiceApiPersistedBridgeRecord>,
     #[serde(default)]
     pub(crate) agents: BTreeMap<String, ServiceApiPersistedAgentRecord>,
+    #[serde(default)]
+    pub(crate) agent_grants: BTreeMap<String, ServiceApiPersistedAgentGrantRecord>,
+    #[serde(default)]
+    pub(crate) authorization_receipts: Vec<ServiceApiAuthorizationReceiptRecord>,
 }
 
 impl Default for ServiceApiPersistedMessageStoreSnapshot {
     fn default() -> Self {
         Self {
-            schema_version: "kamn.runtime.service-api-message-store.v2".to_owned(),
+            schema_version: "kamn.runtime.service-api-message-store.v3".to_owned(),
             messages: BTreeMap::new(),
             channel_messages: BTreeMap::new(),
             auth_nonce_high_watermarks: BTreeMap::new(),
@@ -134,6 +160,8 @@ impl Default for ServiceApiPersistedMessageStoreSnapshot {
             contents: BTreeMap::new(),
             bridges: BTreeMap::new(),
             agents: BTreeMap::new(),
+            agent_grants: BTreeMap::new(),
+            authorization_receipts: Vec::new(),
         }
     }
 }

--- a/crates/kamn-node/src/service_api_endpoint/message_store/store.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/store.rs
@@ -11,3 +11,4 @@ pub(crate) use authorization_ops::{
     ServiceApiAuthorizationDecision, ServiceApiAuthorizationRequest,
 };
 pub(crate) use query_ops::recipient_mailbox_channel_id;
+pub(crate) use task_escrow_ops::escrow_fund_task_id;

--- a/crates/kamn-node/src/service_api_endpoint/message_store/store.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/store.rs
@@ -1,4 +1,5 @@
 mod agent_ops;
+mod authorization_ops;
 mod content_bridge_ops;
 mod create_relay_ops;
 mod nonce_ops;
@@ -6,4 +7,7 @@ mod query_ops;
 mod task_escrow_ops;
 
 pub(crate) use agent_ops::normalize_agent_did;
+pub(crate) use authorization_ops::{
+    ServiceApiAuthorizationDecision, ServiceApiAuthorizationRequest,
+};
 pub(crate) use query_ops::recipient_mailbox_channel_id;

--- a/crates/kamn-node/src/service_api_endpoint/message_store/store/authorization_ops.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/store/authorization_ops.rs
@@ -1,5 +1,11 @@
 use super::super::*;
 
+mod grant_validation;
+
+use grant_validation::validate_persisted_grants;
+#[cfg(test)]
+use grant_validation::{identical_or_conflict, validate_grant};
+
 const GRANT_STATUS_ACTIVE: &str = "active";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -23,12 +29,23 @@ impl ServiceApiMessageStore {
         request: ServiceApiAuthorizationRequest<'_>,
     ) -> Result<ServiceApiAuthorizationDecision, String> {
         self.refresh_from_disk()?;
+        validate_persisted_grants(&self.snapshot)?;
         let decision = evaluate_authorization(&self.snapshot, &request);
         append_receipt(&mut self.snapshot, &request, &decision);
         self.persist()?;
         Ok(decision)
     }
 
+    pub(crate) fn revalidate_transaction_action(
+        &mut self,
+        request: ServiceApiAuthorizationRequest<'_>,
+    ) -> Result<ServiceApiAuthorizationDecision, String> {
+        self.refresh_from_disk()?;
+        validate_persisted_grants(&self.snapshot)?;
+        Ok(evaluate_authorization(&self.snapshot, &request))
+    }
+
+    #[cfg(test)]
     pub(crate) fn provision_agent_grant(
         &mut self,
         grant: ServiceApiPersistedAgentGrantRecord,
@@ -44,6 +61,7 @@ impl ServiceApiMessageStore {
         self.persist()
     }
 
+    #[cfg(test)]
     pub(crate) fn revoke_agent_grant(&mut self, idempotency_key: &str) -> Result<(), String> {
         self.refresh_from_disk()?;
         let grant = self
@@ -135,38 +153,4 @@ fn append_receipt(
             decision: if decision.allowed { "allow" } else { "deny" }.to_owned(),
             reason_code: decision.reason_code.to_owned(),
         });
-}
-
-fn validate_grant(grant: &ServiceApiPersistedAgentGrantRecord) -> Result<(), String> {
-    let fields = [
-        grant.did.as_str(),
-        grant.resource.as_str(),
-        grant.role.as_str(),
-        grant.action.as_str(),
-        grant.status.as_str(),
-        grant.idempotency_key.as_str(),
-    ];
-    if fields.iter().any(|field| field.trim().is_empty()) {
-        return Err("agent grant fields must not be empty".to_owned());
-    }
-    if grant.resource == "*" {
-        return Err("agent grant generic wildcard resource is forbidden".to_owned());
-    }
-    if !matches!(grant.status.as_str(), "active" | "revoked") {
-        return Err(format!("agent grant status is invalid: {}", grant.status));
-    }
-    Ok(())
-}
-
-fn identical_or_conflict(
-    existing: &ServiceApiPersistedAgentGrantRecord,
-    requested: &ServiceApiPersistedAgentGrantRecord,
-) -> Result<(), String> {
-    if existing == requested {
-        return Ok(());
-    }
-    Err(format!(
-        "agent grant idempotency key conflict: {}",
-        requested.idempotency_key
-    ))
 }

--- a/crates/kamn-node/src/service_api_endpoint/message_store/store/authorization_ops.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/store/authorization_ops.rs
@@ -1,0 +1,172 @@
+use super::super::*;
+
+const GRANT_STATUS_ACTIVE: &str = "active";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ServiceApiAuthorizationRequest<'a> {
+    pub(crate) correlation_id: &'a str,
+    pub(crate) actor_did: &'a str,
+    pub(crate) resource: &'a str,
+    pub(crate) action: &'a str,
+    pub(crate) role: &'a str,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ServiceApiAuthorizationDecision {
+    pub(crate) allowed: bool,
+    pub(crate) reason_code: &'static str,
+}
+
+impl ServiceApiMessageStore {
+    pub(crate) fn authorize_transaction_action(
+        &mut self,
+        request: ServiceApiAuthorizationRequest<'_>,
+    ) -> Result<ServiceApiAuthorizationDecision, String> {
+        self.refresh_from_disk()?;
+        let decision = evaluate_authorization(&self.snapshot, &request);
+        append_receipt(&mut self.snapshot, &request, &decision);
+        self.persist()?;
+        Ok(decision)
+    }
+
+    pub(crate) fn provision_agent_grant(
+        &mut self,
+        grant: ServiceApiPersistedAgentGrantRecord,
+    ) -> Result<(), String> {
+        self.refresh_from_disk()?;
+        validate_grant(&grant)?;
+        if let Some(existing) = self.snapshot.agent_grants.get(&grant.idempotency_key) {
+            return identical_or_conflict(existing, &grant);
+        }
+        self.snapshot
+            .agent_grants
+            .insert(grant.idempotency_key.clone(), grant);
+        self.persist()
+    }
+
+    pub(crate) fn revoke_agent_grant(&mut self, idempotency_key: &str) -> Result<(), String> {
+        self.refresh_from_disk()?;
+        let grant = self
+            .snapshot
+            .agent_grants
+            .get_mut(idempotency_key)
+            .ok_or_else(|| format!("agent grant not found: {idempotency_key}"))?;
+        if grant.status == "revoked" {
+            return Ok(());
+        }
+        grant.status = "revoked".to_owned();
+        self.persist()
+    }
+}
+
+fn evaluate_authorization(
+    snapshot: &ServiceApiPersistedMessageStoreSnapshot,
+    request: &ServiceApiAuthorizationRequest<'_>,
+) -> ServiceApiAuthorizationDecision {
+    if !actor_is_registered(snapshot, request.actor_did) {
+        return denied(REASON_CODE_AGENT_NOT_REGISTERED);
+    }
+    if let Some(grant) = exact_grant(snapshot, request) {
+        if grant.status == GRANT_STATUS_ACTIVE {
+            return ServiceApiAuthorizationDecision {
+                allowed: true,
+                reason_code: REASON_CODE_ACTION_AUTHORIZED,
+            };
+        }
+        return denied(REASON_CODE_ACTION_NOT_GRANTED);
+    }
+    if actor_has_action_grant(snapshot, request) {
+        return denied(REASON_CODE_RESOURCE_ROLE_MISMATCH);
+    }
+    denied(REASON_CODE_ACTION_NOT_GRANTED)
+}
+
+fn actor_is_registered(snapshot: &ServiceApiPersistedMessageStoreSnapshot, did: &str) -> bool {
+    snapshot
+        .agents
+        .get(did)
+        .is_some_and(|agent| agent.registered)
+}
+
+fn exact_grant<'a>(
+    snapshot: &'a ServiceApiPersistedMessageStoreSnapshot,
+    request: &ServiceApiAuthorizationRequest<'_>,
+) -> Option<&'a ServiceApiPersistedAgentGrantRecord> {
+    snapshot.agent_grants.values().find(|grant| {
+        grant.did == request.actor_did
+            && grant.action == request.action
+            && grant.resource == request.resource
+            && grant.role == request.role
+    })
+}
+
+fn actor_has_action_grant(
+    snapshot: &ServiceApiPersistedMessageStoreSnapshot,
+    request: &ServiceApiAuthorizationRequest<'_>,
+) -> bool {
+    snapshot
+        .agent_grants
+        .values()
+        .any(|grant| grant.did == request.actor_did && grant.action == request.action)
+}
+
+fn denied(reason_code: &'static str) -> ServiceApiAuthorizationDecision {
+    ServiceApiAuthorizationDecision {
+        allowed: false,
+        reason_code,
+    }
+}
+
+fn append_receipt(
+    snapshot: &mut ServiceApiPersistedMessageStoreSnapshot,
+    request: &ServiceApiAuthorizationRequest<'_>,
+    decision: &ServiceApiAuthorizationDecision,
+) {
+    let sequence = snapshot.authorization_receipts.len() + 1;
+    snapshot
+        .authorization_receipts
+        .push(ServiceApiAuthorizationReceiptRecord {
+            receipt_id: format!("authorization-receipt-{sequence:08}"),
+            correlation_id: request.correlation_id.to_owned(),
+            actor_did: request.actor_did.to_owned(),
+            resource: request.resource.to_owned(),
+            action: request.action.to_owned(),
+            role: request.role.to_owned(),
+            decision: if decision.allowed { "allow" } else { "deny" }.to_owned(),
+            reason_code: decision.reason_code.to_owned(),
+        });
+}
+
+fn validate_grant(grant: &ServiceApiPersistedAgentGrantRecord) -> Result<(), String> {
+    let fields = [
+        grant.did.as_str(),
+        grant.resource.as_str(),
+        grant.role.as_str(),
+        grant.action.as_str(),
+        grant.status.as_str(),
+        grant.idempotency_key.as_str(),
+    ];
+    if fields.iter().any(|field| field.trim().is_empty()) {
+        return Err("agent grant fields must not be empty".to_owned());
+    }
+    if grant.resource == "*" {
+        return Err("agent grant generic wildcard resource is forbidden".to_owned());
+    }
+    if !matches!(grant.status.as_str(), "active" | "revoked") {
+        return Err(format!("agent grant status is invalid: {}", grant.status));
+    }
+    Ok(())
+}
+
+fn identical_or_conflict(
+    existing: &ServiceApiPersistedAgentGrantRecord,
+    requested: &ServiceApiPersistedAgentGrantRecord,
+) -> Result<(), String> {
+    if existing == requested {
+        return Ok(());
+    }
+    Err(format!(
+        "agent grant idempotency key conflict: {}",
+        requested.idempotency_key
+    ))
+}

--- a/crates/kamn-node/src/service_api_endpoint/message_store/store/authorization_ops.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/store/authorization_ops.rs
@@ -4,7 +4,7 @@ mod grant_validation;
 
 use grant_validation::validate_persisted_grants;
 #[cfg(test)]
-use grant_validation::{identical_or_conflict, validate_grant};
+use grant_validation::{identical_or_conflict, reject_semantic_duplicate, validate_grant};
 
 const GRANT_STATUS_ACTIVE: &str = "active";
 
@@ -55,6 +55,7 @@ impl ServiceApiMessageStore {
         if let Some(existing) = self.snapshot.agent_grants.get(&grant.idempotency_key) {
             return identical_or_conflict(existing, &grant);
         }
+        reject_semantic_duplicate(&self.snapshot, &grant)?;
         self.snapshot
             .agent_grants
             .insert(grant.idempotency_key.clone(), grant);

--- a/crates/kamn-node/src/service_api_endpoint/message_store/store/authorization_ops/grant_validation.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/store/authorization_ops/grant_validation.rs
@@ -21,7 +21,46 @@ pub(super) fn validate_persisted_grants(
             ));
         }
     }
+    validate_semantic_uniqueness(snapshot)
+}
+
+#[cfg(test)]
+pub(super) fn reject_semantic_duplicate(
+    snapshot: &ServiceApiPersistedMessageStoreSnapshot,
+    requested: &ServiceApiPersistedAgentGrantRecord,
+) -> Result<(), String> {
+    if snapshot.agent_grants.values().any(|existing| {
+        existing.idempotency_key != requested.idempotency_key
+            && semantic_grants_match(existing, requested)
+    }) {
+        return Err("duplicate semantic grant authority is forbidden".to_owned());
+    }
     Ok(())
+}
+
+fn validate_semantic_uniqueness(
+    snapshot: &ServiceApiPersistedMessageStoreSnapshot,
+) -> Result<(), String> {
+    let grants: Vec<_> = snapshot.agent_grants.values().collect();
+    for (index, grant) in grants.iter().enumerate() {
+        if grants[index + 1..]
+            .iter()
+            .any(|candidate| semantic_grants_match(grant, candidate))
+        {
+            return Err("duplicate semantic grant authority is forbidden".to_owned());
+        }
+    }
+    Ok(())
+}
+
+fn semantic_grants_match(
+    left: &ServiceApiPersistedAgentGrantRecord,
+    right: &ServiceApiPersistedAgentGrantRecord,
+) -> bool {
+    left.did == right.did
+        && left.resource == right.resource
+        && left.role == right.role
+        && left.action == right.action
 }
 
 #[cfg(test)]

--- a/crates/kamn-node/src/service_api_endpoint/message_store/store/authorization_ops/grant_validation.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/store/authorization_ops/grant_validation.rs
@@ -1,0 +1,88 @@
+use super::super::super::*;
+
+pub(super) fn validate_grant(grant: &ServiceApiPersistedAgentGrantRecord) -> Result<(), String> {
+    validate_non_empty_fields(grant)?;
+    AgentDid::parse(grant.did.as_str())
+        .map_err(|error| format!("agent grant did is invalid: {error}"))?;
+    if !matches!(grant.status.as_str(), "active" | "revoked") {
+        return Err(format!("agent grant status is invalid: {}", grant.status));
+    }
+    validate_action_role_resource(grant)
+}
+
+pub(super) fn validate_persisted_grants(
+    snapshot: &ServiceApiPersistedMessageStoreSnapshot,
+) -> Result<(), String> {
+    for (key, grant) in &snapshot.agent_grants {
+        validate_grant(grant)?;
+        if key != &grant.idempotency_key {
+            return Err(format!(
+                "agent grant key does not match idempotency key: {key}"
+            ));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+pub(super) fn identical_or_conflict(
+    existing: &ServiceApiPersistedAgentGrantRecord,
+    requested: &ServiceApiPersistedAgentGrantRecord,
+) -> Result<(), String> {
+    if existing == requested {
+        return Ok(());
+    }
+    Err(format!(
+        "agent grant idempotency key conflict: {}",
+        requested.idempotency_key
+    ))
+}
+
+fn validate_non_empty_fields(grant: &ServiceApiPersistedAgentGrantRecord) -> Result<(), String> {
+    let fields = [
+        grant.did.as_str(),
+        grant.resource.as_str(),
+        grant.role.as_str(),
+        grant.action.as_str(),
+        grant.status.as_str(),
+        grant.idempotency_key.as_str(),
+    ];
+    if fields.iter().any(|field| field.trim().is_empty()) {
+        return Err("agent grant fields must not be empty".to_owned());
+    }
+    Ok(())
+}
+
+fn validate_action_role_resource(
+    grant: &ServiceApiPersistedAgentGrantRecord,
+) -> Result<(), String> {
+    let valid = match grant.action.as_str() {
+        "task:create" => grant.role == "initiator" && grant.resource == "transaction:new",
+        "task:read" => grant.role == "participant" && task_resource_is_valid(&grant.resource),
+        "task:accept" | "task:complete" => {
+            grant.role == "provider" && task_resource_is_valid(&grant.resource)
+        }
+        "escrow:fund" => grant.role == "initiator" && task_resource_is_valid(&grant.resource),
+        "escrow:release" => {
+            grant.role == "initiator" && resource_id_is_valid(&grant.resource, "escrow:")
+        }
+        _ => false,
+    };
+    if valid {
+        return Ok(());
+    }
+    Err(format!(
+        "agent grant action, role, and resource are incompatible: {}|{}|{}",
+        grant.action, grant.role, grant.resource
+    ))
+}
+
+fn task_resource_is_valid(resource: &str) -> bool {
+    resource_id_is_valid(resource, "task:")
+}
+
+fn resource_id_is_valid(resource: &str, prefix: &str) -> bool {
+    resource
+        .strip_prefix(prefix)
+        .is_some_and(|id| !id.is_empty() && !id.contains('/') && id != "*")
+}

--- a/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops.rs
@@ -8,6 +8,7 @@ use dispatch::{
     dispatch_prerequisite_missing_error, dispatch_request_from_record,
     parse_dispatchable_task_payload, select_dispatch_assignee,
 };
+pub(crate) use settlement::escrow_fund_task_id;
 use settlement::{
     build_escrow_record, escrow_status_response, next_escrow_id, release_escrow_record,
 };
@@ -70,10 +71,12 @@ impl ServiceApiMessageStore {
         payload: &str,
     ) -> Result<ServiceApiEscrowStatusBody, String> {
         self.refresh_from_disk()?;
+        let task_id = escrow_fund_task_id(payload)?;
         let escrow_id = next_escrow_id(self, payload);
-        self.snapshot
-            .escrows
-            .insert(escrow_id.clone(), build_escrow_record(escrow_id.as_str()));
+        self.snapshot.escrows.insert(
+            escrow_id.clone(),
+            build_escrow_record(escrow_id.as_str(), task_id),
+        );
         self.persist()?;
         Ok(ServiceApiEscrowStatusBody {
             escrow_id,

--- a/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/settlement.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/settlement.rs
@@ -6,12 +6,27 @@ pub(super) fn next_escrow_id(store: &ServiceApiMessageStore, payload: &str) -> S
     })
 }
 
-pub(super) fn build_escrow_record(escrow_id: &str) -> ServiceApiPersistedEscrowRecord {
+pub(super) fn build_escrow_record(
+    escrow_id: &str,
+    task_id: String,
+) -> ServiceApiPersistedEscrowRecord {
     ServiceApiPersistedEscrowRecord {
         escrow_id: escrow_id.to_owned(),
         state: "funded".to_owned(),
+        task_id: Some(task_id),
         settlement: ServiceApiSettlementMetadata::default(),
     }
+}
+
+pub(crate) fn escrow_fund_task_id(payload: &str) -> Result<String, String> {
+    let body = serde_json::from_str::<serde_json::Value>(payload)
+        .map_err(|error| format!("escrow fund payload must be json: {error}"))?;
+    body.get("task_id")
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+        .ok_or_else(|| "escrow fund task_id is required".to_owned())
 }
 
 pub(super) fn release_escrow_record(

--- a/crates/kamn-node/src/service_api_endpoint/message_store/tests.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/tests.rs
@@ -88,3 +88,6 @@ mod atomic_state_write_tests {
         let _ = fs::remove_dir(base_dir);
     }
 }
+
+#[path = "tests/authorization_contract_tests.rs"]
+mod authorization_contract_tests;

--- a/crates/kamn-node/src/service_api_endpoint/message_store/tests/authorization_contract_tests.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/tests/authorization_contract_tests.rs
@@ -23,6 +23,23 @@ fn unit_agent_grant_provisioning_is_idempotent_and_rejects_conflicts() {
 }
 
 #[test]
+fn unit_agent_grant_provisioning_rejects_duplicate_semantic_authority() {
+    let mut store = registered_store();
+    store
+        .provision_agent_grant(task_create_grant())
+        .expect("first grant should persist");
+    let mut duplicate = task_create_grant();
+    duplicate.idempotency_key = "grant-contract-create-duplicate".to_owned();
+
+    let error = store
+        .provision_agent_grant(duplicate)
+        .expect_err("duplicate semantic grant must fail");
+
+    assert_eq!(store.snapshot.agent_grants.len(), 1);
+    assert!(error.contains("duplicate semantic grant"));
+}
+
+#[test]
 fn unit_revoked_grant_revalidation_fails_closed_and_is_idempotent() {
     let mut store = registered_store();
     store

--- a/crates/kamn-node/src/service_api_endpoint/message_store/tests/authorization_contract_tests.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/tests/authorization_contract_tests.rs
@@ -1,0 +1,116 @@
+use super::super::*;
+
+const ACTOR_DID: &str = "kamn:did:agent:grant-contract";
+const GRANT_ID: &str = "grant-contract-create";
+
+#[test]
+fn unit_agent_grant_provisioning_is_idempotent_and_rejects_conflicts() {
+    let mut store = registered_store();
+    let grant = task_create_grant();
+
+    store
+        .provision_agent_grant(grant.clone())
+        .expect("first grant should persist");
+    store
+        .provision_agent_grant(grant)
+        .expect("identical grant should be idempotent");
+    let error = store
+        .provision_agent_grant(conflicting_grant())
+        .expect_err("conflicting idempotency key must fail");
+
+    assert_eq!(store.snapshot.agent_grants.len(), 1);
+    assert!(error.contains("idempotency key conflict"));
+}
+
+#[test]
+fn unit_revoked_grant_revalidation_fails_closed_and_is_idempotent() {
+    let mut store = registered_store();
+    store
+        .provision_agent_grant(task_create_grant())
+        .expect("grant should persist");
+    assert!(authorize(&mut store).allowed);
+
+    store
+        .revoke_agent_grant(GRANT_ID)
+        .expect("grant should revoke");
+    store
+        .revoke_agent_grant(GRANT_ID)
+        .expect("repeated revoke should be idempotent");
+
+    let decision = revalidate(&mut store);
+    assert!(!decision.allowed);
+    assert_eq!(decision.reason_code, REASON_CODE_ACTION_NOT_GRANTED);
+}
+
+#[test]
+fn unit_agent_grant_validation_rejects_generic_or_incompatible_authority() {
+    let mut store = registered_store();
+    let mut wildcard = task_create_grant();
+    wildcard.resource = "*".to_owned();
+    let mut wrong_role = task_create_grant();
+    wrong_role.idempotency_key = "grant-contract-wrong-role".to_owned();
+    wrong_role.role = "verifier".to_owned();
+
+    assert!(store.provision_agent_grant(wildcard).is_err());
+    assert!(store.provision_agent_grant(wrong_role).is_err());
+    assert!(store.snapshot.agent_grants.is_empty());
+}
+
+fn registered_store() -> ServiceApiMessageStore {
+    let mut store = ServiceApiMessageStore {
+        state_file: None,
+        audit_export_file: None,
+        snapshot: ServiceApiPersistedMessageStoreSnapshot::default(),
+    };
+    let registration = ServiceApiAgentRegisterRequestBody {
+        agent_type: "test-agent".to_owned(),
+        model_family: "test-runtime".to_owned(),
+        capabilities: vec!["task".to_owned()],
+    };
+    store
+        .register_agent_profile(ACTOR_DID, &registration)
+        .expect("actor should register");
+    store
+}
+
+fn task_create_grant() -> ServiceApiPersistedAgentGrantRecord {
+    ServiceApiPersistedAgentGrantRecord {
+        did: ACTOR_DID.to_owned(),
+        resource: "transaction:new".to_owned(),
+        role: "initiator".to_owned(),
+        action: "task:create".to_owned(),
+        status: "active".to_owned(),
+        idempotency_key: GRANT_ID.to_owned(),
+    }
+}
+
+fn conflicting_grant() -> ServiceApiPersistedAgentGrantRecord {
+    ServiceApiPersistedAgentGrantRecord {
+        action: "task:complete".to_owned(),
+        role: "provider".to_owned(),
+        resource: "task:other".to_owned(),
+        ..task_create_grant()
+    }
+}
+
+fn authorize(store: &mut ServiceApiMessageStore) -> ServiceApiAuthorizationDecision {
+    store
+        .authorize_transaction_action(request())
+        .expect("authorization should evaluate")
+}
+
+fn revalidate(store: &mut ServiceApiMessageStore) -> ServiceApiAuthorizationDecision {
+    store
+        .revalidate_transaction_action(request())
+        .expect("revalidation should evaluate")
+}
+
+fn request() -> ServiceApiAuthorizationRequest<'static> {
+    ServiceApiAuthorizationRequest {
+        correlation_id: "authz-test",
+        actor_did: ACTOR_DID,
+        resource: "transaction:new",
+        action: "task:create",
+        role: "initiator",
+    }
+}

--- a/crates/kamn-node/src/service_api_endpoint/middleware_impl/auth_flow/guards/request_validation.rs
+++ b/crates/kamn-node/src/service_api_endpoint/middleware_impl/auth_flow/guards/request_validation.rs
@@ -10,9 +10,25 @@ pub(super) async fn validate_request(
     request_started_at: Instant,
     is_websocket_route: bool,
 ) -> Result<(), Response> {
-    verify_request_identity(state, parsed_request, correlation_id, request_started_at).await?;
+    let mut replay_guard = state.replay_guard.lock().await;
+    verify_request_identity(
+        state,
+        parsed_request,
+        correlation_id,
+        request_started_at,
+        &mut replay_guard,
+    )
+    .await?;
     run_policy_checks(state, parsed_request, correlation_id, request_started_at).await?;
-    record_request_nonce(state, parsed_request, correlation_id, request_started_at).await?;
+    record_request_nonce(
+        state,
+        parsed_request,
+        correlation_id,
+        request_started_at,
+        &mut replay_guard,
+    )
+    .await?;
+    drop(replay_guard);
     policy_checks::validate_websocket_requirements(
         state,
         parsed_request,
@@ -28,11 +44,18 @@ async fn verify_request_identity(
     parsed_request: &ParsedRequest,
     correlation_id: &str,
     request_started_at: Instant,
+    replay_guard: &mut ServiceApiReplayGuard,
 ) -> Result<(), Response> {
     auth_checks::log_request_received(state, parsed_request, correlation_id, request_started_at)
         .await?;
-    auth_checks::verify_request_identity(state, parsed_request, correlation_id, request_started_at)
-        .await
+    auth_checks::verify_request_identity(
+        state,
+        parsed_request,
+        correlation_id,
+        request_started_at,
+        replay_guard,
+    )
+    .await
 }
 
 async fn run_policy_checks(
@@ -71,9 +94,16 @@ async fn record_request_nonce(
     parsed_request: &ParsedRequest,
     correlation_id: &str,
     request_started_at: Instant,
+    replay_guard: &mut ServiceApiReplayGuard,
 ) -> Result<(), Response> {
-    auth_checks::record_request_nonce(state, parsed_request, correlation_id, request_started_at)
-        .await
+    auth_checks::record_request_nonce(
+        state,
+        parsed_request,
+        correlation_id,
+        request_started_at,
+        replay_guard,
+    )
+    .await
 }
 
 pub(super) async fn internal_response(

--- a/crates/kamn-node/src/service_api_endpoint/middleware_impl/auth_flow/guards/request_validation.rs
+++ b/crates/kamn-node/src/service_api_endpoint/middleware_impl/auth_flow/guards/request_validation.rs
@@ -10,8 +10,9 @@ pub(super) async fn validate_request(
     request_started_at: Instant,
     is_websocket_route: bool,
 ) -> Result<(), Response> {
-    run_auth_checks(state, parsed_request, correlation_id, request_started_at).await?;
+    verify_request_identity(state, parsed_request, correlation_id, request_started_at).await?;
     run_policy_checks(state, parsed_request, correlation_id, request_started_at).await?;
+    record_request_nonce(state, parsed_request, correlation_id, request_started_at).await?;
     policy_checks::validate_websocket_requirements(
         state,
         parsed_request,
@@ -22,7 +23,7 @@ pub(super) async fn validate_request(
     .await
 }
 
-async fn run_auth_checks(
+async fn verify_request_identity(
     state: &Arc<ServiceApiRuntimeState>,
     parsed_request: &ParsedRequest,
     correlation_id: &str,
@@ -30,9 +31,8 @@ async fn run_auth_checks(
 ) -> Result<(), Response> {
     auth_checks::log_request_received(state, parsed_request, correlation_id, request_started_at)
         .await?;
-    auth_checks::authorize_request(state, parsed_request, correlation_id, request_started_at)
-        .await?;
-    auth_checks::persist_auth_nonce(state, parsed_request, correlation_id, request_started_at).await
+    auth_checks::verify_request_identity(state, parsed_request, correlation_id, request_started_at)
+        .await
 }
 
 async fn run_policy_checks(
@@ -43,6 +43,13 @@ async fn run_policy_checks(
 ) -> Result<(), Response> {
     policy_checks::enforce_scope_policy(state, parsed_request, correlation_id, request_started_at)
         .await?;
+    policy_checks::enforce_transaction_authorization(
+        state,
+        parsed_request,
+        correlation_id,
+        request_started_at,
+    )
+    .await?;
     policy_checks::enforce_sender_anti_spam(
         state,
         parsed_request,
@@ -57,6 +64,16 @@ async fn run_policy_checks(
         request_started_at,
     )
     .await
+}
+
+async fn record_request_nonce(
+    state: &Arc<ServiceApiRuntimeState>,
+    parsed_request: &ParsedRequest,
+    correlation_id: &str,
+    request_started_at: Instant,
+) -> Result<(), Response> {
+    auth_checks::record_request_nonce(state, parsed_request, correlation_id, request_started_at)
+        .await
 }
 
 pub(super) async fn internal_response(

--- a/crates/kamn-node/src/service_api_endpoint/middleware_impl/auth_flow/guards/request_validation/auth_checks.rs
+++ b/crates/kamn-node/src/service_api_endpoint/middleware_impl/auth_flow/guards/request_validation/auth_checks.rs
@@ -40,14 +40,14 @@ fn received_log_fields<'a>(
     ]
 }
 
-pub(super) async fn authorize_request(
+pub(super) async fn verify_request_identity(
     state: &Arc<ServiceApiRuntimeState>,
     parsed_request: &ParsedRequest,
     correlation_id: &str,
     request_started_at: Instant,
 ) -> Result<(), Response> {
     let mut replay_guard = state.replay_guard.lock().await;
-    match super::auth::authorize_service_api_request(
+    match super::auth::verify_service_api_request_identity(
         state.as_ref(),
         parsed_request,
         &mut replay_guard,
@@ -109,12 +109,22 @@ fn auth_error_details(
     }
 }
 
-pub(super) async fn persist_auth_nonce(
+pub(super) async fn record_request_nonce(
     state: &Arc<ServiceApiRuntimeState>,
     parsed_request: &ParsedRequest,
     correlation_id: &str,
     request_started_at: Instant,
 ) -> Result<(), Response> {
+    if let Err(error) = reserve_request_nonce(state, parsed_request).await {
+        return Err(auth_error_response(
+            state,
+            parsed_request,
+            correlation_id,
+            request_started_at,
+            error,
+        )
+        .await);
+    }
     let Some((sender_did, nonce)) = auth_nonce_persistence_input(parsed_request) else {
         return Ok(());
     };
@@ -129,6 +139,14 @@ pub(super) async fn persist_auth_nonce(
         )
         .await),
     }
+}
+
+async fn reserve_request_nonce(
+    state: &Arc<ServiceApiRuntimeState>,
+    parsed_request: &ParsedRequest,
+) -> Result<(), RequestAuthFailure> {
+    let mut replay_guard = state.replay_guard.lock().await;
+    super::auth::record_verified_service_api_request_nonce(parsed_request, &mut replay_guard)
 }
 
 fn auth_nonce_persistence_input(parsed_request: &ParsedRequest) -> Option<(&str, u64)> {

--- a/crates/kamn-node/src/service_api_endpoint/middleware_impl/auth_flow/guards/request_validation/auth_checks.rs
+++ b/crates/kamn-node/src/service_api_endpoint/middleware_impl/auth_flow/guards/request_validation/auth_checks.rs
@@ -45,12 +45,12 @@ pub(super) async fn verify_request_identity(
     parsed_request: &ParsedRequest,
     correlation_id: &str,
     request_started_at: Instant,
+    replay_guard: &mut ServiceApiReplayGuard,
 ) -> Result<(), Response> {
-    let mut replay_guard = state.replay_guard.lock().await;
     match super::auth::verify_service_api_request_identity(
         state.as_ref(),
         parsed_request,
-        &mut replay_guard,
+        replay_guard,
     ) {
         Ok(()) => Ok(()),
         Err(error) => Err(auth_error_response(
@@ -114,8 +114,9 @@ pub(super) async fn record_request_nonce(
     parsed_request: &ParsedRequest,
     correlation_id: &str,
     request_started_at: Instant,
+    replay_guard: &mut ServiceApiReplayGuard,
 ) -> Result<(), Response> {
-    if let Err(error) = reserve_request_nonce(state, parsed_request).await {
+    if let Err(error) = reserve_request_nonce(parsed_request, replay_guard) {
         return Err(auth_error_response(
             state,
             parsed_request,
@@ -141,12 +142,11 @@ pub(super) async fn record_request_nonce(
     }
 }
 
-async fn reserve_request_nonce(
-    state: &Arc<ServiceApiRuntimeState>,
+fn reserve_request_nonce(
     parsed_request: &ParsedRequest,
+    replay_guard: &mut ServiceApiReplayGuard,
 ) -> Result<(), RequestAuthFailure> {
-    let mut replay_guard = state.replay_guard.lock().await;
-    super::auth::record_verified_service_api_request_nonce(parsed_request, &mut replay_guard)
+    super::auth::record_verified_service_api_request_nonce(parsed_request, replay_guard)
 }
 
 fn auth_nonce_persistence_input(parsed_request: &ParsedRequest) -> Option<(&str, u64)> {

--- a/crates/kamn-node/src/service_api_endpoint/middleware_impl/auth_flow/guards/request_validation/policy_checks.rs
+++ b/crates/kamn-node/src/service_api_endpoint/middleware_impl/auth_flow/guards/request_validation/policy_checks.rs
@@ -1,5 +1,9 @@
 use super::super::*;
 
+mod transaction_authorization;
+
+pub(super) use transaction_authorization::enforce_transaction_authorization;
+
 pub(super) async fn enforce_scope_policy(
     state: &Arc<ServiceApiRuntimeState>,
     parsed_request: &ParsedRequest,

--- a/crates/kamn-node/src/service_api_endpoint/middleware_impl/auth_flow/guards/request_validation/policy_checks/transaction_authorization.rs
+++ b/crates/kamn-node/src/service_api_endpoint/middleware_impl/auth_flow/guards/request_validation/policy_checks/transaction_authorization.rs
@@ -6,34 +6,12 @@ pub(crate) async fn enforce_transaction_authorization(
     correlation_id: &str,
     request_started_at: Instant,
 ) -> Result<(), Response> {
-    let target = match super::auth::resolve_transaction_authorization_target(parsed_request) {
-        Ok(Some(target)) => target,
-        Ok(None) => return Ok(()),
-        Err(error) => {
-            return Err(authorization_response(
-                state,
-                parsed_request,
-                correlation_id,
-                request_started_at,
-                error.reason_code,
-                error.message.as_str(),
-            )
-            .await)
-        }
+    let Some(target) =
+        resolve_target(state, parsed_request, correlation_id, request_started_at).await?
+    else {
+        return Ok(());
     };
-    let receipt_correlation_id = redacted_receipt_correlation_id(correlation_id);
-    let request = message_store::ServiceApiAuthorizationRequest {
-        correlation_id: receipt_correlation_id.as_str(),
-        actor_did: target.actor_did.as_str(),
-        resource: target.resource.as_str(),
-        action: target.action,
-        role: target.role,
-    };
-    let decision = state
-        .message_store
-        .lock()
-        .await
-        .authorize_transaction_action(request);
+    let decision = evaluate_target(state, correlation_id, &target).await;
     resolve_authorization_decision(
         state,
         parsed_request,
@@ -42,6 +20,46 @@ pub(crate) async fn enforce_transaction_authorization(
         decision,
     )
     .await
+}
+
+async fn evaluate_target(
+    state: &Arc<ServiceApiRuntimeState>,
+    correlation_id: &str,
+    target: &super::auth::TransactionAuthorizationTarget,
+) -> Result<message_store::ServiceApiAuthorizationDecision, String> {
+    let receipt_correlation_id = redacted_receipt_correlation_id(correlation_id);
+    let request = message_store::ServiceApiAuthorizationRequest {
+        correlation_id: receipt_correlation_id.as_str(),
+        actor_did: target.actor_did.as_str(),
+        resource: target.resource.as_str(),
+        action: target.action,
+        role: target.role,
+    };
+    state
+        .message_store
+        .lock()
+        .await
+        .authorize_transaction_action(request)
+}
+
+async fn resolve_target(
+    state: &Arc<ServiceApiRuntimeState>,
+    parsed_request: &ParsedRequest,
+    correlation_id: &str,
+    request_started_at: Instant,
+) -> Result<Option<super::auth::TransactionAuthorizationTarget>, Response> {
+    match super::auth::resolve_transaction_authorization_target(parsed_request) {
+        Ok(target) => Ok(target),
+        Err(error) => Err(authorization_response(
+            state,
+            parsed_request,
+            correlation_id,
+            request_started_at,
+            error.reason_code,
+            error.message.as_str(),
+        )
+        .await),
+    }
 }
 
 async fn resolve_authorization_decision(
@@ -62,21 +80,38 @@ async fn resolve_authorization_decision(
             "transaction action is not authorized",
         )
         .await),
-        Err(error) => Err(super::super::internal_response(
+        Err(error) => Err(persistence_response(
             state,
-            request_started_at,
             parsed_request,
-            super::super::InternalResponseProjection {
-                correlation_id,
-                reason_code: REASON_CODE_STATE_PERSISTENCE_FAILED,
-                outcome: "persistence",
-                error_label: "internal",
-                status_code: StatusCode::INTERNAL_SERVER_ERROR,
-                message: error.as_str(),
-            },
+            correlation_id,
+            request_started_at,
+            error.as_str(),
         )
         .await),
     }
+}
+
+async fn persistence_response(
+    state: &Arc<ServiceApiRuntimeState>,
+    parsed_request: &ParsedRequest,
+    correlation_id: &str,
+    request_started_at: Instant,
+    message: &str,
+) -> Response {
+    super::super::internal_response(
+        state,
+        request_started_at,
+        parsed_request,
+        super::super::InternalResponseProjection {
+            correlation_id,
+            reason_code: REASON_CODE_STATE_PERSISTENCE_FAILED,
+            outcome: "persistence",
+            error_label: "internal",
+            status_code: StatusCode::INTERNAL_SERVER_ERROR,
+            message,
+        },
+    )
+    .await
 }
 
 async fn authorization_response(

--- a/crates/kamn-node/src/service_api_endpoint/middleware_impl/auth_flow/guards/request_validation/policy_checks/transaction_authorization.rs
+++ b/crates/kamn-node/src/service_api_endpoint/middleware_impl/auth_flow/guards/request_validation/policy_checks/transaction_authorization.rs
@@ -1,0 +1,111 @@
+use super::super::super::*;
+
+pub(crate) async fn enforce_transaction_authorization(
+    state: &Arc<ServiceApiRuntimeState>,
+    parsed_request: &ParsedRequest,
+    correlation_id: &str,
+    request_started_at: Instant,
+) -> Result<(), Response> {
+    let target = match super::auth::resolve_transaction_authorization_target(parsed_request) {
+        Ok(Some(target)) => target,
+        Ok(None) => return Ok(()),
+        Err(error) => {
+            return Err(authorization_response(
+                state,
+                parsed_request,
+                correlation_id,
+                request_started_at,
+                error.reason_code,
+                error.message.as_str(),
+            )
+            .await)
+        }
+    };
+    let receipt_correlation_id = redacted_receipt_correlation_id(correlation_id);
+    let request = message_store::ServiceApiAuthorizationRequest {
+        correlation_id: receipt_correlation_id.as_str(),
+        actor_did: target.actor_did.as_str(),
+        resource: target.resource.as_str(),
+        action: target.action,
+        role: target.role,
+    };
+    let decision = state
+        .message_store
+        .lock()
+        .await
+        .authorize_transaction_action(request);
+    resolve_authorization_decision(
+        state,
+        parsed_request,
+        correlation_id,
+        request_started_at,
+        decision,
+    )
+    .await
+}
+
+async fn resolve_authorization_decision(
+    state: &Arc<ServiceApiRuntimeState>,
+    parsed_request: &ParsedRequest,
+    correlation_id: &str,
+    request_started_at: Instant,
+    decision: Result<message_store::ServiceApiAuthorizationDecision, String>,
+) -> Result<(), Response> {
+    match decision {
+        Ok(decision) if decision.allowed => Ok(()),
+        Ok(decision) => Err(authorization_response(
+            state,
+            parsed_request,
+            correlation_id,
+            request_started_at,
+            decision.reason_code,
+            "transaction action is not authorized",
+        )
+        .await),
+        Err(error) => Err(super::super::internal_response(
+            state,
+            request_started_at,
+            parsed_request,
+            super::super::InternalResponseProjection {
+                correlation_id,
+                reason_code: REASON_CODE_STATE_PERSISTENCE_FAILED,
+                outcome: "persistence",
+                error_label: "internal",
+                status_code: StatusCode::INTERNAL_SERVER_ERROR,
+                message: error.as_str(),
+            },
+        )
+        .await),
+    }
+}
+
+async fn authorization_response(
+    state: &Arc<ServiceApiRuntimeState>,
+    parsed_request: &ParsedRequest,
+    correlation_id: &str,
+    request_started_at: Instant,
+    reason_code: &'static str,
+    message: &str,
+) -> Response {
+    super::super::internal_response(
+        state,
+        request_started_at,
+        parsed_request,
+        super::super::InternalResponseProjection {
+            correlation_id,
+            reason_code,
+            outcome: "forbidden",
+            error_label: "forbidden",
+            status_code: StatusCode::FORBIDDEN,
+            message,
+        },
+    )
+    .await
+}
+
+fn redacted_receipt_correlation_id(correlation_id: &str) -> String {
+    format!(
+        "service-api-authz:{:016x}",
+        deterministic_body_tag(correlation_id.as_bytes())
+    )
+}

--- a/crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes.rs
+++ b/crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes.rs
@@ -3,6 +3,45 @@ use super::*;
 mod mutations;
 mod queries;
 
+fn revalidate_transaction_authorization(
+    store: &mut ServiceApiMessageStore,
+    context: &ServiceApiRequestContext,
+) -> Result<(), Box<Response>> {
+    let target = super::auth::resolve_transaction_authorization_target(&context.parsed_request)
+        .map_err(|error| Box::new(forbidden(error.reason_code, error.message.as_str())))?;
+    let Some(target) = target else {
+        return Ok(());
+    };
+    let request = message_store::ServiceApiAuthorizationRequest {
+        correlation_id: "handler-revalidation",
+        actor_did: target.actor_did.as_str(),
+        resource: target.resource.as_str(),
+        action: target.action,
+        role: target.role,
+    };
+    match store.revalidate_transaction_action(request) {
+        Ok(decision) if decision.allowed => Ok(()),
+        Ok(decision) => Err(Box::new(forbidden(
+            decision.reason_code,
+            "transaction authorization changed before handler execution",
+        ))),
+        Err(error) => Err(Box::new(persistence_error(error.as_str()))),
+    }
+}
+
+fn forbidden(reason_code: &'static str, message: &str) -> Response {
+    super::payload::json_error_response(StatusCode::FORBIDDEN, "forbidden", reason_code, message)
+}
+
+fn persistence_error(error: &str) -> Response {
+    super::payload::json_error_response(
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "internal",
+        REASON_CODE_STATE_PERSISTENCE_FAILED,
+        format!("service api authorization revalidation failed: {error}").as_str(),
+    )
+}
+
 pub(super) async fn handle_service_api_http_route(
     State(state): State<Arc<ServiceApiRuntimeState>>,
     Extension(context): Extension<ServiceApiRequestContext>,

--- a/crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/mutations/create_routes.rs
+++ b/crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/mutations/create_routes.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+mod escrow;
+
 type ResponseError = Box<Response>;
 
 pub(super) async fn handle_post_route(
@@ -13,7 +15,7 @@ pub(super) async fn handle_post_route(
         ROUTE_AGENTS_REGISTER => Some(register_agent(state, context).await),
         ROUTE_CONTENT_REGISTER => Some(register_content(state, context).await),
         ROUTE_BRIDGE_SUBMIT => Some(submit_bridge(state, context).await),
-        ROUTE_ESCROW_FUND => Some(fund_escrow(state, context).await),
+        ROUTE_ESCROW_FUND => Some(escrow::fund_escrow(state, context).await),
         _ => None,
     }
 }
@@ -42,11 +44,15 @@ async fn create_task(
     state: &Arc<ServiceApiRuntimeState>,
     context: &ServiceApiRequestContext,
 ) -> Response {
-    let result = state
-        .message_store
-        .lock()
-        .await
-        .create_task(context.parsed_request.body.as_str());
+    let result = {
+        let mut store = state.message_store.lock().await;
+        if let Err(response) =
+            super::super::revalidate_transaction_authorization(&mut store, context)
+        {
+            return *response;
+        }
+        store.create_task(context.parsed_request.body.as_str())
+    };
     match result {
         Ok(payload) => {
             state
@@ -176,20 +182,5 @@ async fn submit_bridge(
             contract_json(202, &payload)
         }
         Err(error) => persistence_error("service api bridge persistence failed", error),
-    }
-}
-
-async fn fund_escrow(
-    state: &Arc<ServiceApiRuntimeState>,
-    context: &ServiceApiRequestContext,
-) -> Response {
-    let result = state
-        .message_store
-        .lock()
-        .await
-        .fund_escrow(context.parsed_request.body.as_str());
-    match result {
-        Ok(payload) => contract_json(200, &payload),
-        Err(error) => persistence_error("service api escrow persistence failed", error),
     }
 }

--- a/crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/mutations/create_routes/escrow.rs
+++ b/crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/mutations/create_routes/escrow.rs
@@ -1,0 +1,20 @@
+use super::super::*;
+
+pub(super) async fn fund_escrow(
+    state: &Arc<ServiceApiRuntimeState>,
+    context: &ServiceApiRequestContext,
+) -> Response {
+    let result = {
+        let mut store = state.message_store.lock().await;
+        if let Err(response) =
+            super::super::super::revalidate_transaction_authorization(&mut store, context)
+        {
+            return *response;
+        }
+        store.fund_escrow(context.parsed_request.body.as_str())
+    };
+    match result {
+        Ok(payload) => contract_json(200, &payload),
+        Err(error) => persistence_error("service api escrow persistence failed", error),
+    }
+}

--- a/crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/mutations/update_routes/state_routes.rs
+++ b/crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/mutations/update_routes/state_routes.rs
@@ -6,27 +6,32 @@ pub(super) async fn handle_post_route(
     context: &ServiceApiRequestContext,
 ) -> Option<Response> {
     let path = context.parsed_request.path.as_str();
-    if let Some(response) = task_route_response(state, path).await {
+    if let Some(response) = task_route_response(state, context, path).await {
         return Some(response);
     }
-    if let Some(response) = persistence_route_response(state, path).await {
+    if let Some(response) = persistence_route_response(state, context, path).await {
         return Some(response);
     }
     content_route_response(state, path).await
 }
-async fn task_route_response(state: &Arc<ServiceApiRuntimeState>, path: &str) -> Option<Response> {
+async fn task_route_response(
+    state: &Arc<ServiceApiRuntimeState>,
+    context: &ServiceApiRequestContext,
+    path: &str,
+) -> Option<Response> {
     if let Some(task_id) = super::payload::task_accept_path_id(path) {
-        return Some(task_transition(state, task_id, "accepted", true).await);
+        return Some(task_transition(state, context, task_id, "accepted", true).await);
     }
     let task_id = super::payload::task_complete_path_id(path)?;
-    Some(task_transition(state, task_id, "completed", true).await)
+    Some(task_transition(state, context, task_id, "completed", true).await)
 }
 async fn persistence_route_response(
     state: &Arc<ServiceApiRuntimeState>,
+    context: &ServiceApiRequestContext,
     path: &str,
 ) -> Option<Response> {
     if let Some(escrow_id) = super::payload::escrow_release_path_id(path) {
-        return Some(release_escrow(state, escrow_id).await);
+        return Some(release_escrow(state, context, escrow_id).await);
     }
     let bridge_id = super::payload::bridge_forward_path_id(path)?;
     Some(forward_bridge(state, bridge_id).await)
@@ -44,15 +49,20 @@ async fn content_route_response(
 
 async fn task_transition(
     state: &Arc<ServiceApiRuntimeState>,
+    context: &ServiceApiRequestContext,
     task_id: &str,
     target: &str,
     publish: bool,
 ) -> Response {
-    let result = state
-        .message_store
-        .lock()
-        .await
-        .transition_task(task_id, target);
+    let result = {
+        let mut store = state.message_store.lock().await;
+        if let Err(response) =
+            super::super::super::revalidate_transaction_authorization(&mut store, context)
+        {
+            return *response;
+        }
+        store.transition_task(task_id, target)
+    };
     match result {
         Ok(Some(payload)) => {
             if publish {
@@ -67,8 +77,12 @@ async fn task_transition(
     }
 }
 
-async fn release_escrow(state: &Arc<ServiceApiRuntimeState>, escrow_id: &str) -> Response {
-    let result = match resolve_release_escrow_result(state, escrow_id).await {
+async fn release_escrow(
+    state: &Arc<ServiceApiRuntimeState>,
+    context: &ServiceApiRequestContext,
+    escrow_id: &str,
+) -> Response {
+    let result = match resolve_release_escrow_result(state, context, escrow_id).await {
         Ok(result) => result,
         Err(error) => return live_settlement_evidence_error(error.as_str()),
     };

--- a/crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/mutations/update_routes/state_routes.rs
+++ b/crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/mutations/update_routes/state_routes.rs
@@ -1,5 +1,5 @@
 use super::super::*;
-use super::state_routes_release::{live_settlement_evidence_error, resolve_release_escrow_result};
+use super::state_routes_release::resolve_release_escrow_result;
 
 pub(super) async fn handle_post_route(
     state: &Arc<ServiceApiRuntimeState>,
@@ -84,7 +84,7 @@ async fn release_escrow(
 ) -> Response {
     let result = match resolve_release_escrow_result(state, context, escrow_id).await {
         Ok(result) => result,
-        Err(error) => return live_settlement_evidence_error(error.as_str()),
+        Err(response) => return *response,
     };
     match result {
         Ok(Some(payload)) => contract_json(200, &payload),

--- a/crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/mutations/update_routes/state_routes_release.rs
+++ b/crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/mutations/update_routes/state_routes_release.rs
@@ -7,7 +7,7 @@ pub(super) async fn resolve_release_escrow_result(
     state: &Arc<ServiceApiRuntimeState>,
     context: &ServiceApiRequestContext,
     escrow_id: &str,
-) -> Result<Result<Option<ServiceApiEscrowStatusBody>, String>, String> {
+) -> Result<Result<Option<ServiceApiEscrowStatusBody>, String>, Box<Response>> {
     if let Some(config) = state.live_solana_settlement.as_ref() {
         return release_escrow_with_live_solana_settlement(state, context, escrow_id, config).await;
     }
@@ -33,10 +33,12 @@ async fn release_escrow_with_live_solana_settlement(
     context: &ServiceApiRequestContext,
     escrow_id: &str,
     config: &LiveSolanaSettlementConfig,
-) -> Result<Result<Option<ServiceApiEscrowStatusBody>, String>, String> {
+) -> Result<Result<Option<ServiceApiEscrowStatusBody>, String>, Box<Response>> {
     let mut store = state.message_store.lock().await;
     revalidate_release(&mut store, context)?;
-    let existing = store.get_escrow_status(escrow_id)?;
+    let existing = store
+        .get_escrow_status(escrow_id)
+        .map_err(|error| Box::new(super::super::super::persistence_error(error.as_str())))?;
     if existing
         .as_ref()
         .is_some_and(|payload| payload.state == "released")
@@ -46,7 +48,8 @@ async fn release_escrow_with_live_solana_settlement(
     let evidence =
         crate::service_api_endpoint::live_settlement_dispatch::collect_live_settlement_evidence(
             config, escrow_id,
-        )?;
+        )
+        .map_err(|error| Box::new(live_settlement_evidence_error(error.as_str())))?;
     Ok(store.release_escrow_with_settlement_metadata(
         escrow_id,
         &settlement_metadata_from_evidence(evidence),
@@ -58,13 +61,14 @@ async fn release_escrow_with_slot_backed_settlement(
     context: &ServiceApiRequestContext,
     escrow_id: &str,
     config: &LiveSolanaBridgeDispatchConfig,
-) -> Result<Result<Option<ServiceApiEscrowStatusBody>, String>, String> {
+) -> Result<Result<Option<ServiceApiEscrowStatusBody>, String>, Box<Response>> {
     let mut store = state.message_store.lock().await;
     revalidate_release(&mut store, context)?;
     let evidence = crate::service_api_endpoint::live_settlement_dispatch::collect_slot_backed_live_settlement_evidence(
         config,
         escrow_id,
-    )?;
+    )
+    .map_err(|error| Box::new(live_settlement_evidence_error(error.as_str())))?;
     Ok(store.release_escrow_with_settlement_receipt_hash(
         escrow_id,
         evidence.settlement_receipt_hash.as_str(),
@@ -74,9 +78,8 @@ async fn release_escrow_with_slot_backed_settlement(
 fn revalidate_release(
     store: &mut ServiceApiMessageStore,
     context: &ServiceApiRequestContext,
-) -> Result<(), String> {
+) -> Result<(), Box<Response>> {
     super::super::super::revalidate_transaction_authorization(store, context)
-        .map_err(|_| "escrow release authorization changed before execution".to_owned())
 }
 
 fn settlement_metadata_from_evidence(

--- a/crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/mutations/update_routes/state_routes_release.rs
+++ b/crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/mutations/update_routes/state_routes_release.rs
@@ -5,15 +5,18 @@ use crate::service_api_endpoint::live_settlement_dispatch::{
 
 pub(super) async fn resolve_release_escrow_result(
     state: &Arc<ServiceApiRuntimeState>,
+    context: &ServiceApiRequestContext,
     escrow_id: &str,
 ) -> Result<Result<Option<ServiceApiEscrowStatusBody>, String>, String> {
     if let Some(config) = state.live_solana_settlement.as_ref() {
-        return release_escrow_with_live_solana_settlement(state, escrow_id, config).await;
+        return release_escrow_with_live_solana_settlement(state, context, escrow_id, config).await;
     }
     let Some(config) = state.live_solana_bridge_dispatch.as_ref() else {
-        return Ok(state.message_store.lock().await.release_escrow(escrow_id));
+        let mut store = state.message_store.lock().await;
+        revalidate_release(&mut store, context)?;
+        return Ok(store.release_escrow(escrow_id));
     };
-    release_escrow_with_slot_backed_settlement(state, escrow_id, config).await
+    release_escrow_with_slot_backed_settlement(state, context, escrow_id, config).await
 }
 
 pub(super) fn live_settlement_evidence_error(error: &str) -> Response {
@@ -27,10 +30,12 @@ pub(super) fn live_settlement_evidence_error(error: &str) -> Response {
 
 async fn release_escrow_with_live_solana_settlement(
     state: &Arc<ServiceApiRuntimeState>,
+    context: &ServiceApiRequestContext,
     escrow_id: &str,
     config: &LiveSolanaSettlementConfig,
 ) -> Result<Result<Option<ServiceApiEscrowStatusBody>, String>, String> {
     let mut store = state.message_store.lock().await;
+    revalidate_release(&mut store, context)?;
     let existing = store.get_escrow_status(escrow_id)?;
     if existing
         .as_ref()
@@ -50,21 +55,28 @@ async fn release_escrow_with_live_solana_settlement(
 
 async fn release_escrow_with_slot_backed_settlement(
     state: &Arc<ServiceApiRuntimeState>,
+    context: &ServiceApiRequestContext,
     escrow_id: &str,
     config: &LiveSolanaBridgeDispatchConfig,
 ) -> Result<Result<Option<ServiceApiEscrowStatusBody>, String>, String> {
+    let mut store = state.message_store.lock().await;
+    revalidate_release(&mut store, context)?;
     let evidence = crate::service_api_endpoint::live_settlement_dispatch::collect_slot_backed_live_settlement_evidence(
         config,
         escrow_id,
     )?;
-    Ok(state
-        .message_store
-        .lock()
-        .await
-        .release_escrow_with_settlement_receipt_hash(
-            escrow_id,
-            evidence.settlement_receipt_hash.as_str(),
-        ))
+    Ok(store.release_escrow_with_settlement_receipt_hash(
+        escrow_id,
+        evidence.settlement_receipt_hash.as_str(),
+    ))
+}
+
+fn revalidate_release(
+    store: &mut ServiceApiMessageStore,
+    context: &ServiceApiRequestContext,
+) -> Result<(), String> {
+    super::super::super::revalidate_transaction_authorization(store, context)
+        .map_err(|_| "escrow release authorization changed before execution".to_owned())
 }
 
 fn settlement_metadata_from_evidence(

--- a/crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/queries.rs
+++ b/crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/queries.rs
@@ -14,7 +14,7 @@ pub(super) async fn handle_get_route(
         return Some(channel_query(state, channel_id).await);
     }
     if let Some(task_id) = super::payload::task_path_id(context.parsed_request.path.as_str()) {
-        return Some(task_query(state, task_id).await);
+        return Some(task_query(state, context, task_id).await);
     }
     if let Some(content_id) = super::payload::content_path_id(context.parsed_request.path.as_str())
     {
@@ -61,8 +61,18 @@ async fn channel_query(state: &Arc<ServiceApiRuntimeState>, channel_id: &str) ->
     }
 }
 
-async fn task_query(state: &Arc<ServiceApiRuntimeState>, task_id: &str) -> Response {
-    let result = { state.message_store.lock().await.get_task(task_id) };
+async fn task_query(
+    state: &Arc<ServiceApiRuntimeState>,
+    context: &ServiceApiRequestContext,
+    task_id: &str,
+) -> Response {
+    let result = {
+        let mut store = state.message_store.lock().await;
+        if let Err(response) = super::revalidate_transaction_authorization(&mut store, context) {
+            return *response;
+        }
+        store.get_task(task_id)
+    };
     match result {
         Ok(Some(payload)) => contract_json(200, &payload),
         Ok(None) => not_found(),

--- a/crates/kamn-node/tests/service_api_endpoint_auth_module_extraction_contract.rs
+++ b/crates/kamn-node/tests/service_api_endpoint_auth_module_extraction_contract.rs
@@ -96,3 +96,15 @@ fn service_api_auth_root_is_extracted() {
         "crates/kamn-node/src/service_api_endpoint/auth",
     ));
 }
+
+#[test]
+fn escrow_release_revalidation_preserves_authorization_response() {
+    let source = std::fs::read_to_string(source_path(
+        "crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/mutations/\
+             update_routes/state_routes_release.rs",
+    ))
+    .expect("escrow release route source should exist");
+
+    assert!(source.contains("Err(response) => return *response"));
+    assert!(!source.contains(".map_err(|_| \"escrow release authorization changed"));
+}

--- a/crates/kamn-node/tests/service_api_endpoint_auth_module_extraction_contract.rs
+++ b/crates/kamn-node/tests/service_api_endpoint_auth_module_extraction_contract.rs
@@ -101,7 +101,7 @@ fn service_api_auth_root_is_extracted() {
 fn escrow_release_revalidation_preserves_authorization_response() {
     let source = std::fs::read_to_string(source_path(
         "crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/mutations/\
-             update_routes/state_routes_release.rs",
+             update_routes/state_routes.rs",
     ))
     .expect("escrow release route source should exist");
 

--- a/specs/7089-registered-identity-transaction-grants.md
+++ b/specs/7089-registered-identity-transaction-grants.md
@@ -89,21 +89,21 @@ resources are created and assigned.
 
 ## Acceptance Criteria
 
-- [ ] A signed unregistered actor cannot call any covered task/escrow route.
-- [ ] A registered actor without a matching grant cannot call a covered route.
-- [ ] `tasks:write` or `escrow:write` request scope alone never authorizes.
-- [ ] Active grants match actor DID, exact action, exact resource selector, role,
+- [x] A signed unregistered actor cannot call any covered task/escrow route.
+- [x] A registered actor without a matching grant cannot call a covered route.
+- [x] `tasks:write` or `escrow:write` request scope alone never authorizes.
+- [x] Active grants match actor DID, exact action, exact resource selector, role,
       and active status.
-- [ ] Registration and grant decisions reload from the service state file.
-- [ ] Identical grant provisioning/revocation is idempotent.
-- [ ] Conflicting idempotency-key reuse fails without replacing durable state.
-- [ ] Allow and deny decisions persist secret-free authorization receipts.
-- [ ] Every receipt identifies correlation ID, actor, resource, action, decision,
+- [x] Registration and grant decisions reload from the service state file.
+- [x] Identical grant provisioning/revocation is idempotent.
+- [x] Conflicting idempotency-key reuse fails without replacing durable state.
+- [x] Allow and deny decisions persist secret-free authorization receipts.
+- [x] Every receipt identifies correlation ID, actor, resource, action, decision,
       role, and reason code.
-- [ ] Registration remains callable by a valid unregistered signer.
-- [ ] Existing signature, route-scope, replay, and nonce-restart tests remain
+- [x] Registration remains callable by a valid unregistered signer.
+- [x] Existing signature, route-scope, replay, and nonce-restart tests remain
       green.
-- [ ] Real service API integration tests exercise the shared middleware and
+- [x] Real service API integration tests exercise the shared middleware and
       durable store without mocking either layer.
 
 ## Files To Touch
@@ -181,3 +181,31 @@ INTEGRATION:
 - Exercise registration, allowed action, denied action, revocation, restart,
   receipt inspection, and unchanged domain state through the live HTTP server.
 - Run targeted tests, formatting, strict clippy, and `make check`.
+
+## Completion Evidence
+
+- RED commit `7938c347`: four authorization contract tests failed before the
+  grant model and middleware gate existed.
+- GREEN commit `c3c3e8af`: persisted grants, receipts, and middleware policy
+  made the authorization contract tests pass.
+- REFACTOR commit `15495b92`: protected handlers revalidate grants while
+  holding the message-store lock; escrow records persist task ownership;
+  denied requests do not consume a nonce.
+- `cargo fmt --check` passed.
+- `CARGO_TARGET_DIR=target/mvp-demo-proof CARGO_BUILD_JOBS=1 cargo clippy -p
+  kamn-node --all-targets -- -D warnings` passed.
+- `CARGO_TARGET_DIR=target/mvp-demo-proof CARGO_BUILD_JOBS=1 cargo test -p
+  kamn-node` passed, including 639 binary tests and extraction contracts.
+- `CARGO_TARGET_DIR=target/mvp-demo-proof CARGO_BUILD_JOBS=1 cargo test -p
+  kamn-node service_api_endpoint_tests` passed with 161 service API tests.
+- `CARGO_TARGET_DIR=target/mvp-demo-proof CARGO_BUILD_JOBS=1 make check` passed
+  workspace formatting and strict all-target, all-feature clippy.
+
+## Deviations And Follow-up Boundaries
+
+- No public grant administration surface was added. Production authorization
+  consumes trusted preseeded state; test-only helpers provision fixture grants.
+- Task and escrow lifecycle code does not issue actor-facing grants in this
+  issue. Exact lifecycle issuance remains owned by #7090 and #7091.
+- Solana settlement behavior is unchanged and was not claimed as completion
+  evidence for this identity/grant slice.

--- a/specs/7089-registered-identity-transaction-grants.md
+++ b/specs/7089-registered-identity-transaction-grants.md
@@ -1,0 +1,183 @@
+# Enforce Registered Identity And Transaction-Scoped Grants
+
+## Objective
+
+Separate request authentication from business authorization for the KAMN
+transaction rail. A valid signature proves who sent a request; it does not prove
+that the signer is registered or allowed to act on a task or escrow resource.
+
+## Inputs/Outputs
+
+Inputs:
+
+- Existing DID/signature, nonce, replay, and route-scope checks.
+- Existing durable agent registrations and service API state file.
+- Signed request sender DID from verified middleware context.
+- Server-owned grant records provisioned through trusted runtime/store setup.
+
+Outputs:
+
+- A durable grant record containing actor DID, resource selector, role, allowed
+  action, status, and idempotency key.
+- A durable authorization decision receipt containing correlation ID, actor DID,
+  resource, action, decision, and stable reason code.
+- A middleware authorization gate for transaction-rail task and escrow routes.
+- Structured forbidden responses for unregistered and ungranted actors.
+
+## Authorization Contract
+
+The order for transaction-rail requests is:
+
+1. Parse request.
+2. Verify DID/key binding, signature, and nonce freshness.
+3. Enforce signed route-scope intent.
+4. Resolve actor, action, and resource from verified request context.
+5. Require a durable registered agent record.
+6. Require one active server-owned grant matching actor, action, and resource.
+7. Persist an allow or deny authorization receipt.
+8. Persist nonce high-watermark and continue to the handler only on allow.
+
+`POST /v1/agents/register` remains authentication-protected but is exempt from
+the registration and grant checks so an actor can register itself. Client
+registration capabilities are descriptive discovery metadata and never create
+authorization.
+
+The first slice covers these actions:
+
+- `POST /v1/tasks/create`: `task:create`, resource `transaction:new`.
+- `GET /v1/tasks/{id}`: `task:read`, resource `task:{id}`.
+- `POST /v1/tasks/{id}/accept`: `task:accept`, resource `task:{id}`.
+- `POST /v1/tasks/{id}/complete`: `task:complete`, resource `task:{id}`.
+- `POST /v1/escrow/fund`: `escrow:fund`, resource `task:{task_id}`.
+- `POST /v1/escrow/{id}/release`: `escrow:release`, resource `escrow:{id}`.
+
+An exact resource grant wins. The only wildcard allowed in this issue is the
+explicit bootstrap selector `transaction:new` for `task:create`; generic `*`
+resource grants are invalid. Later issues mint exact task and escrow grants as
+resources are created and assigned.
+
+## Boundaries/Non-goals
+
+- Do not modify signature, nonce, replay, or request-signing semantics.
+- Do not treat the signed scope header or self-declared capabilities as grants.
+- Do not add a grant administration HTTP, SDK, CLI, or MCP route in this issue.
+- Trusted store/runtime setup may provision and revoke grants; actor-facing
+  issuance is owned by later task/escrow lifecycle issues.
+- Do not implement a general RBAC/ABAC engine, organization policy, OAuth, or
+  external identity provider.
+- Do not change task ownership, escrow terms, or Solana settlement behavior.
+- Do not apply the new grant gate to unrelated message, content, bridge,
+  directory, or websocket routes in this slice.
+- Do not log or persist signatures, auth headers, public keys, nonces, raw task
+  bodies, completion data, or private payloads in authorization receipts.
+
+## Failure Modes
+
+- Validly signed unregistered actor: deny with `AGENT_NOT_REGISTERED`.
+- Registered actor without a matching active grant: deny with
+  `ACTION_NOT_GRANTED`.
+- Matching actor/action but wrong resource or role: deny with
+  `RESOURCE_ROLE_MISMATCH`.
+- Revoked grant: deny with `ACTION_NOT_GRANTED` and a revoked-grant context.
+- Invalid grant fields or conflicting idempotency-key reuse: hard persistence
+  error; do not replace the existing grant.
+- Authorization receipt persistence failure: return an internal persistence
+  error and do not reach the domain handler.
+- Denied request: persist the deny receipt but do not persist a consumed nonce,
+  mutate domain state, or call external settlement.
+- State reload failure: fail loud; never authorize from stale in-memory grants.
+
+## Acceptance Criteria
+
+- [ ] A signed unregistered actor cannot call any covered task/escrow route.
+- [ ] A registered actor without a matching grant cannot call a covered route.
+- [ ] `tasks:write` or `escrow:write` request scope alone never authorizes.
+- [ ] Active grants match actor DID, exact action, exact resource selector, role,
+      and active status.
+- [ ] Registration and grant decisions reload from the service state file.
+- [ ] Identical grant provisioning/revocation is idempotent.
+- [ ] Conflicting idempotency-key reuse fails without replacing durable state.
+- [ ] Allow and deny decisions persist secret-free authorization receipts.
+- [ ] Every receipt identifies correlation ID, actor, resource, action, decision,
+      role, and reason code.
+- [ ] Registration remains callable by a valid unregistered signer.
+- [ ] Existing signature, route-scope, replay, and nonce-restart tests remain
+      green.
+- [ ] Real service API integration tests exercise the shared middleware and
+      durable store without mocking either layer.
+
+## Files To Touch
+
+- `crates/kamn-node/src/service_api_endpoint.rs`
+- `crates/kamn-node/src/service_api_endpoint/auth/`
+- `crates/kamn-node/src/service_api_endpoint/middleware_impl/auth_flow/`
+- `crates/kamn-node/src/service_api_endpoint/message_store/models.rs`
+- `crates/kamn-node/src/service_api_endpoint/message_store/store.rs`
+- `crates/kamn-node/src/service_api_endpoint/message_store/store/agent_ops.rs`
+- `crates/kamn-node/src/main_tests/service_api_endpoint_tests/`
+- `crates/kamn-node/src/main_tests/service_api_endpoint_tests_split_contract/`
+
+No SDK signing change is expected. The SDK continues to send signed scope
+intent and receives the existing structured service error envelope.
+
+## Persistence And Compatibility
+
+- Add serde-defaulted grant and authorization-receipt collections to the
+  service API snapshot.
+- Bump newly created snapshots to a new schema version.
+- Existing snapshots without the collections load as empty and therefore fail
+  closed for covered transaction-rail actions until trusted grants are
+  provisioned.
+- Grant provisioning uses an explicit idempotency key and rejects conflicting
+  reuse.
+- Authorization receipts use deterministic sequence IDs within one snapshot and
+  are append-only.
+
+## Error Semantics
+
+Authentication failures retain their existing status and reason codes.
+Business authorization failures return HTTP `403 Forbidden` in the standard
+JSON error envelope:
+
+- `AGENT_NOT_REGISTERED`
+- `ACTION_NOT_GRANTED`
+- `RESOURCE_ROLE_MISMATCH`
+
+Persistence and receipt-write failures return HTTP `500` with the existing
+state-persistence reason code. Interior code returns typed decisions/errors;
+middleware maps each result once and records the decision once.
+
+## Test Plan
+
+RED:
+
+- Signed unregistered task creation is currently accepted.
+- Registered actor with no grant can currently reach escrow release.
+- Registered actor can self-assert `tasks:write` and reach task creation.
+- Active and revoked grant behavior does not survive restart because no grant
+  model exists.
+- No durable secret-free authorization decision receipt exists.
+- Conflicting grant idempotency-key reuse is not rejected.
+
+GREEN:
+
+- Add the minimal persisted grant and receipt models/store operations.
+- Resolve covered route actions/resources from method, path, and required body
+  fields.
+- Insert the business authorization stage after authn/scope and before nonce
+  persistence/handler dispatch.
+- Exempt self-registration only.
+
+REFACTOR:
+
+- Keep authentication, scope intent, grant evaluation, response mapping, and
+  persistence in separate small modules.
+- Centralize action/resource parsing and stable reason codes.
+- Verify file/function size limits, naming, duplication, and fail-closed paths.
+
+INTEGRATION:
+
+- Provision trusted grants in real state-file fixtures.
+- Exercise registration, allowed action, denied action, revocation, restart,
+  receipt inspection, and unchanged domain state through the live HTTP server.
+- Run targeted tests, formatting, strict clippy, and `make check`.

--- a/specs/7089-registered-identity-transaction-grants.md
+++ b/specs/7089-registered-identity-transaction-grants.md
@@ -19,8 +19,9 @@ Outputs:
 
 - A durable grant record containing actor DID, resource selector, role, allowed
   action, status, and idempotency key.
-- A durable authorization decision receipt containing correlation ID, actor DID,
-  resource, action, decision, and stable reason code.
+- A durable authorization decision receipt containing a deterministic redacted
+  correlation join key, actor DID, resource, action, decision, and stable
+  reason code.
 - A middleware authorization gate for transaction-rail task and escrow routes.
 - Structured forbidden responses for unregistered and ungranted actors.
 
@@ -98,8 +99,8 @@ resources are created and assigned.
 - [x] Identical grant provisioning/revocation is idempotent.
 - [x] Conflicting idempotency-key reuse fails without replacing durable state.
 - [x] Allow and deny decisions persist secret-free authorization receipts.
-- [x] Every receipt identifies correlation ID, actor, resource, action, decision,
-      role, and reason code.
+- [x] Every receipt identifies a redacted correlation join key, actor, resource,
+      action, decision, role, and reason code.
 - [x] Registration remains callable by a valid unregistered signer.
 - [x] Existing signature, route-scope, replay, and nonce-restart tests remain
       green.
@@ -195,7 +196,7 @@ INTEGRATION:
 - `CARGO_TARGET_DIR=target/mvp-demo-proof CARGO_BUILD_JOBS=1 cargo clippy -p
   kamn-node --all-targets -- -D warnings` passed.
 - `CARGO_TARGET_DIR=target/mvp-demo-proof CARGO_BUILD_JOBS=1 cargo test -p
-  kamn-node` passed, including 639 binary tests and extraction contracts.
+  kamn-node` passed, including 643 binary tests and extraction contracts.
 - `CARGO_TARGET_DIR=target/mvp-demo-proof CARGO_BUILD_JOBS=1 cargo test -p
   kamn-node service_api_endpoint_tests` passed with 161 service API tests.
 - `CARGO_TARGET_DIR=target/mvp-demo-proof CARGO_BUILD_JOBS=1 make check` passed
@@ -209,3 +210,9 @@ INTEGRATION:
   issue. Exact lifecycle issuance remains owned by #7090 and #7091.
 - Solana settlement behavior is unchanged and was not claimed as completion
   evidence for this identity/grant slice.
+- The transport correlation string embeds a request nonce, so receipts persist
+  `service-api-authz:<deterministic-hash>` rather than the raw transport value.
+  This keeps receipts joinable without violating the no-nonce receipt boundary.
+- Durable pre-dispatch pending state and post-dispatch recovery for live value
+  movement remain required in #7092. This issue only guarantees that grant
+  revalidation happens before dispatch and that denial is fail-closed.


### PR DESCRIPTION
## Human Summary

- Separates signed identity and scope intent from server-owned business authorization for task and escrow routes.
- Persists exact actor/resource/action/role grants and secret-free allow/deny receipts across restart.
- Revalidates grants under the store lock before protected mutations or settlement dispatch.
- Preserves replay safety under concurrent same-nonce requests and rejects duplicate semantic grants.
- Keeps lifecycle-issued grants and recoverable live settlement explicitly scoped to #7090, #7091, and #7092.

Closes #7089

Spec: `specs/7089-registered-identity-transaction-grants.md`
Parent: #7088

## Testing

- `cargo fmt --check`
- `CARGO_TARGET_DIR=target/mvp-demo-proof CARGO_BUILD_JOBS=1 cargo clippy -p kamn-node --all-targets -- -D warnings`
- `CARGO_TARGET_DIR=target/mvp-demo-proof CARGO_BUILD_JOBS=1 cargo test -p kamn-node`
- `CARGO_TARGET_DIR=target/mvp-demo-proof CARGO_BUILD_JOBS=1 cargo test -p kamn-node service_api_endpoint_tests`
- `CARGO_TARGET_DIR=target/mvp-demo-proof CARGO_BUILD_JOBS=1 make check`
- Targeted concurrent replay, denial retry, route parser parity, grant uniqueness, restart, and release-response contracts
- `make pre-push` attempted but not completed: its duplicate default-target all-feature clippy lane remained in a pathological long compile after the isolated workspace `make check` passed, so it was interrupted and is not claimed green.

## Notes for Reviewers

Review focus:
- replay guard is held from freshness verification through policy checks and nonce reservation;
- policy denial still leaves the nonce retryable;
- receipts use a deterministic redacted correlation join key because the transport correlation string embeds the nonce;
- live settlement still needs durable pending/final recovery in #7092 before retry-safe value movement is claimed.

No public grant-administration API is added. Production authorization consumes trusted preseeded grants until later lifecycle issues mint exact grants.

shell_loc_delta_actual: 0
rust_loc_delta_actual: 0
shell_to_rust_ratio_delta_actual: 0.0
shell_surface_ratio_target_status: neutral

## AI Agent Details

- State schema v3 adds serde-defaulted `agent_grants` and `authorization_receipts`.
- Covered actions: task create/read/accept/complete and escrow fund/release.
- Stable denials: `AGENT_NOT_REGISTERED`, `ACTION_NOT_GRANTED`, `RESOURCE_ROLE_MISMATCH`.
- Existing v2 snapshots load with empty grants and fail closed for covered routes.
- Test-only provisioning helpers preserve legacy route fixtures without changing production authorization.
