### PR TITLE
feat: bind tasks to creator and provider lifecycle

### DIFF
--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests.rs
@@ -1,5 +1,7 @@
 #[path = "task_escrow_persistence_contract_tests/support.rs"]
 mod support;
+#[path = "task_escrow_persistence_contract_tests/task_creator_provider_lifecycle_contract_tests.rs"]
+mod task_creator_provider_lifecycle_contract_tests;
 #[path = "task_escrow_persistence_contract_tests/task_escrow_authorization_contract_tests.rs"]
 mod task_escrow_authorization_contract_tests;
 #[path = "task_escrow_persistence_contract_tests/task_escrow_concurrent_replay_contract_tests.rs"]

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/support/request_support.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/support/request_support.rs
@@ -35,6 +35,7 @@ pub(crate) fn create_task(
     nonce: u64,
     payload: &str,
 ) -> ServiceApiTaskCreateBody {
+    let canonical_payload = canonical_task_payload(snapshot, bind_addr, caller_did, nonce, payload);
     let response = signed_request(
         snapshot,
         bind_addr,
@@ -44,13 +45,40 @@ pub(crate) fn create_task(
             path: "/v1/tasks/create",
             caller_did,
             nonce,
-            body: payload,
+            body: canonical_payload.as_str(),
             extra_headers: &[],
         },
     );
     assert!(response.contains("HTTP/1.1 201 Created"));
     parse_service_api_payload(extract_http_response_body(response.as_str()))
         .expect("task create payload should deserialize")
+}
+
+fn canonical_task_payload(
+    snapshot: &ServiceApiSnapshot,
+    bind_addr: &str,
+    caller_did: &str,
+    nonce: u64,
+    payload: &str,
+) -> String {
+    if payload.contains("\"provider_did\"") {
+        return payload.to_owned();
+    }
+    let provider = register_agent_profile(
+        snapshot,
+        bind_addr,
+        caller_did,
+        nonce - 1,
+        r#"{"agent_type":"provider","model_family":"test","capabilities":["tasks"]}"#,
+    );
+    serde_json::json!({
+        "provider_did": provider.did,
+        "transaction_id": format!("transaction-{nonce}"),
+        "terms_digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "idempotency_key": format!("create-{nonce}"),
+        "description": payload,
+    })
+    .to_string()
 }
 
 pub(crate) fn accept_task(
@@ -60,7 +88,7 @@ pub(crate) fn accept_task(
     nonce: u64,
     task_id: &str,
 ) {
-    let response = signed_request(
+    let response = raw_signed_request(
         snapshot,
         bind_addr,
         SignedRequest {
@@ -69,7 +97,7 @@ pub(crate) fn accept_task(
             path: format!("/v1/tasks/{task_id}/accept").as_str(),
             caller_did,
             nonce,
-            body: "",
+            body: r#"{"idempotency_key":"accept-task"}"#,
             extra_headers: &[],
         },
     );
@@ -83,7 +111,7 @@ pub(crate) fn query_task(
     nonce: u64,
     task_id: &str,
 ) -> Value {
-    let response = signed_request(
+    let response = raw_signed_request(
         snapshot,
         bind_addr,
         SignedRequest {

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_creator_provider_lifecycle_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_creator_provider_lifecycle_contract_tests.rs
@@ -1,11 +1,11 @@
 use super::super::*;
 use super::support::*;
-use crate::service_api_endpoint::ServiceApiSnapshot;
+use crate::service_api_endpoint::{ServiceApiSnapshot, ServiceApiTaskTransitionBody};
 use std::path::PathBuf;
 
 #[path = "task_creator_provider_lifecycle_contract_tests/payloads.rs"]
 mod payloads;
-use payloads::{assert_response, retry_body, valid_create_body};
+use payloads::{assert_response, completion_body, retry_body, valid_create_body};
 
 const CREATOR: &str = "kamn:did:agent:task-lifecycle-creator";
 const PROVIDER: &str = "kamn:did:agent:task-lifecycle-provider";
@@ -65,7 +65,7 @@ fn integration_task_complete_rejects_illegal_order_and_missing_evidence() {
     let task = case.create_valid_task(1);
     let complete_path = format!("/v1/tasks/{}/complete", task.task_id);
 
-    let early = case.authorized_request(
+    let early = case.raw_request(
         PROVIDER,
         2,
         "POST",
@@ -75,17 +75,17 @@ fn integration_task_complete_rejects_illegal_order_and_missing_evidence() {
     assert_response(&early, "409 Conflict", "TASK_STATE_CONFLICT");
 
     let accept_path = format!("/v1/tasks/{}/accept", task.task_id);
-    let accepted = case.authorized_request(
+    let accepted = case.raw_request(
         PROVIDER,
-        2,
+        3,
         "POST",
         accept_path.as_str(),
         retry_body("accept-valid"),
     );
     assert!(accepted.contains("HTTP/1.1 200 OK"), "{accepted}");
-    let missing_evidence = case.authorized_request(
+    let missing_evidence = case.raw_request(
         PROVIDER,
-        3,
+        4,
         "POST",
         complete_path.as_str(),
         retry_body("complete-missing-evidence"),
@@ -95,6 +95,90 @@ fn integration_task_complete_rejects_illegal_order_and_missing_evidence() {
         "400 Bad Request",
         "TASK_COMPLETION_EVIDENCE_INVALID",
     );
+    case.cleanup();
+}
+
+#[test]
+fn integration_task_create_retry_is_idempotent_and_conflict_safe() {
+    let case = LifecycleCase::new("create-idempotency");
+    case.register(PROVIDER, 1);
+    let first = case.create_valid_task(1);
+    let provider_did = test_service_api_sender_did(PROVIDER);
+    let body = valid_create_body(provider_did.as_str());
+
+    let retried = case.raw_request(CREATOR, 2, "POST", "/v1/tasks/create", body.as_str());
+    let retry_payload: ServiceApiTaskCreateBody =
+        parse_service_api_payload(extract_http_response_body(&retried)).expect("retry payload");
+    assert_eq!(retry_payload.task_id, first.task_id);
+
+    let conflict_body = body.replace("transaction-lifecycle-001", "transaction-conflict");
+    let conflict = case.raw_request(
+        CREATOR,
+        3,
+        "POST",
+        "/v1/tasks/create",
+        conflict_body.as_str(),
+    );
+    assert_response(&conflict, "409 Conflict", "TASK_IDEMPOTENCY_CONFLICT");
+    assert_eq!(case.state()["tasks"].as_object().unwrap().len(), 1);
+    case.cleanup();
+}
+
+#[test]
+fn integration_task_transition_retry_returns_one_durable_receipt() {
+    let case = LifecycleCase::new("transition-idempotency");
+    case.register(PROVIDER, 1);
+    let task = case.create_valid_task(1);
+    let path = format!("/v1/tasks/{}/accept", task.task_id);
+
+    let first = case.raw_request(PROVIDER, 2, "POST", path.as_str(), retry_body("accept-1"));
+    let retried = case.raw_request(PROVIDER, 3, "POST", path.as_str(), retry_body("accept-1"));
+    assert!(first.contains("HTTP/1.1 200 OK"), "{first}");
+    assert!(retried.contains("HTTP/1.1 200 OK"), "{retried}");
+    let first_payload: ServiceApiTaskTransitionBody =
+        parse_service_api_payload(extract_http_response_body(&first)).expect("first payload");
+    let retry_payload: ServiceApiTaskTransitionBody =
+        parse_service_api_payload(extract_http_response_body(&retried)).expect("retry payload");
+    assert_eq!(retry_payload, first_payload);
+    let state = case.state();
+    let receipts = state["task_transition_receipts"].as_array().unwrap();
+    assert_eq!(receipts.len(), 1);
+    assert_eq!(receipts[0]["action"], "task:accept");
+    assert_eq!(receipts[0]["transaction_id"], "transaction-lifecycle-001");
+    case.cleanup();
+}
+
+#[test]
+fn integration_task_completion_evidence_and_receipts_survive_restart() {
+    let case = LifecycleCase::new("restart-proof");
+    case.register(PROVIDER, 1);
+    let task = case.create_valid_task(1);
+    let accept_path = format!("/v1/tasks/{}/accept", task.task_id);
+    let complete_path = format!("/v1/tasks/{}/complete", task.task_id);
+    let accepted = case.raw_request(
+        PROVIDER,
+        2,
+        "POST",
+        accept_path.as_str(),
+        retry_body("accept-valid"),
+    );
+    assert!(accepted.contains("HTTP/1.1 200 OK"), "{accepted}");
+
+    let completion = completion_body("complete-valid");
+    let completed = case.raw_request(
+        PROVIDER,
+        3,
+        "POST",
+        complete_path.as_str(),
+        completion.as_str(),
+    );
+    assert!(completed.contains("HTTP/1.1 200 OK"), "{completed}");
+    let state = case.state();
+    assert_eq!(
+        state["tasks"][&task.task_id]["completion_evidence_digest"],
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    );
+    assert_eq!(state["task_transition_receipts"].as_array().unwrap().len(), 2);
     case.cleanup();
 }
 
@@ -129,12 +213,14 @@ impl LifecycleCase {
     }
 
     fn create_valid_task(&self, nonce: u64) -> ServiceApiTaskCreateBody {
+        let provider_did = test_service_api_sender_did(PROVIDER);
+        let body = valid_create_body(provider_did.as_str());
         create_task(
             &self.snapshot,
             reserve_loopback_addr().as_str(),
             CREATOR,
             nonce,
-            valid_create_body(),
+            body.as_str(),
         )
     }
 
@@ -151,6 +237,10 @@ impl LifecycleCase {
 
     fn raw_request(&self, actor: &str, nonce: u64, method: &str, path: &str, body: &str) -> String {
         signed_request(&self.snapshot, actor, nonce, method, path, body, false)
+    }
+
+    fn state(&self) -> serde_json::Value {
+        read_state_json(self.state_file.as_path())
     }
 
     fn cleanup(self) {

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_creator_provider_lifecycle_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_creator_provider_lifecycle_contract_tests.rs
@@ -1,0 +1,184 @@
+use super::super::*;
+use super::support::*;
+use crate::service_api_endpoint::ServiceApiSnapshot;
+use std::path::PathBuf;
+
+#[path = "task_creator_provider_lifecycle_contract_tests/payloads.rs"]
+mod payloads;
+use payloads::{assert_response, retry_body, valid_create_body};
+
+const CREATOR: &str = "kamn:did:agent:task-lifecycle-creator";
+const PROVIDER: &str = "kamn:did:agent:task-lifecycle-provider";
+const OUTSIDER: &str = "kamn:did:agent:task-lifecycle-outsider";
+
+#[test]
+fn integration_task_creation_rejects_incomplete_agreement() {
+    let case = LifecycleCase::new("incomplete-agreement");
+    let response = case.authorized_request(
+        CREATOR,
+        1,
+        "POST",
+        "/v1/tasks/create",
+        r#"{"description":"missing agreement"}"#,
+    );
+
+    assert_response(&response, "400 Bad Request", "TASK_AGREEMENT_INVALID");
+    case.cleanup();
+}
+
+#[test]
+fn integration_task_creation_issues_provider_accept_grant() {
+    let case = LifecycleCase::new("provider-grant");
+    case.register(PROVIDER, 1);
+    let task = case.create_valid_task(1);
+    let path = format!("/v1/tasks/{}/accept", task.task_id);
+
+    let response = case.raw_request(PROVIDER, 2, "POST", path.as_str(), retry_body("accept-1"));
+
+    assert!(response.contains("HTTP/1.1 200 OK"), "{response}");
+    case.cleanup();
+}
+
+#[test]
+fn integration_task_accept_rejects_granted_wrong_provider() {
+    let case = LifecycleCase::new("wrong-provider");
+    case.register(PROVIDER, 1);
+    let task = case.create_valid_task(1);
+    let path = format!("/v1/tasks/{}/accept", task.task_id);
+
+    let response = case.authorized_request(
+        OUTSIDER,
+        1,
+        "POST",
+        path.as_str(),
+        retry_body("wrong-provider-accept"),
+    );
+
+    assert_response(&response, "403 Forbidden", "TASK_PROVIDER_MISMATCH");
+    case.cleanup();
+}
+
+#[test]
+fn integration_task_complete_rejects_illegal_order_and_missing_evidence() {
+    let case = LifecycleCase::new("complete-contract");
+    case.register(PROVIDER, 1);
+    let task = case.create_valid_task(1);
+    let complete_path = format!("/v1/tasks/{}/complete", task.task_id);
+
+    let early = case.authorized_request(
+        PROVIDER,
+        2,
+        "POST",
+        complete_path.as_str(),
+        retry_body("complete-early"),
+    );
+    assert_response(&early, "409 Conflict", "TASK_STATE_CONFLICT");
+
+    let accept_path = format!("/v1/tasks/{}/accept", task.task_id);
+    let accepted = case.authorized_request(
+        PROVIDER,
+        2,
+        "POST",
+        accept_path.as_str(),
+        retry_body("accept-valid"),
+    );
+    assert!(accepted.contains("HTTP/1.1 200 OK"), "{accepted}");
+    let missing_evidence = case.authorized_request(
+        PROVIDER,
+        3,
+        "POST",
+        complete_path.as_str(),
+        retry_body("complete-missing-evidence"),
+    );
+    assert_response(
+        &missing_evidence,
+        "400 Bad Request",
+        "TASK_COMPLETION_EVIDENCE_INVALID",
+    );
+    case.cleanup();
+}
+
+struct LifecycleCase {
+    _env: ServiceApiTestEnvGuards,
+    _state_guard: EnvVarGuard,
+    snapshot: ServiceApiSnapshot,
+    state_file: PathBuf,
+}
+
+impl LifecycleCase {
+    fn new(label: &str) -> Self {
+        let env = acquire_service_api_test_env();
+        let state_file = unique_named_state_file(format!("kamn-task-lifecycle-{label}").as_str());
+        let (_, state_guard) = set_state_file_env(state_file.as_path());
+        Self {
+            _env: env,
+            _state_guard: state_guard,
+            snapshot: build_task_escrow_snapshot("127.0.0.1:34220"),
+            state_file,
+        }
+    }
+
+    fn register(&self, actor: &str, nonce: u64) {
+        register_agent_profile(
+            &self.snapshot,
+            reserve_loopback_addr().as_str(),
+            actor,
+            nonce,
+            r#"{"agent_type":"provider","model_family":"pi","capabilities":["tasks"]}"#,
+        );
+    }
+
+    fn create_valid_task(&self, nonce: u64) -> ServiceApiTaskCreateBody {
+        create_task(
+            &self.snapshot,
+            reserve_loopback_addr().as_str(),
+            CREATOR,
+            nonce,
+            valid_create_body(),
+        )
+    }
+
+    fn authorized_request(
+        &self,
+        actor: &str,
+        nonce: u64,
+        method: &str,
+        path: &str,
+        body: &str,
+    ) -> String {
+        signed_request(&self.snapshot, actor, nonce, method, path, body, true)
+    }
+
+    fn raw_request(&self, actor: &str, nonce: u64, method: &str, path: &str, body: &str) -> String {
+        signed_request(&self.snapshot, actor, nonce, method, path, body, false)
+    }
+
+    fn cleanup(self) {
+        let _ = fs::remove_file(self.state_file);
+    }
+}
+
+fn signed_request(
+    snapshot: &ServiceApiSnapshot,
+    actor: &str,
+    nonce: u64,
+    method: &str,
+    path: &str,
+    body: &str,
+    provision: bool,
+) -> String {
+    let request = SignedRequest {
+        max_requests: 1,
+        method,
+        path,
+        caller_did: actor,
+        nonce,
+        body,
+        extra_headers: &[("X-KAMN-Authz-Scope", "tasks:write")],
+    };
+    let bind_addr = reserve_loopback_addr();
+    if provision {
+        return authorized_signed_request(snapshot, bind_addr.as_str(), request);
+    }
+    raw_signed_request(snapshot, bind_addr.as_str(), request)
+}

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_creator_provider_lifecycle_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_creator_provider_lifecycle_contract_tests.rs
@@ -178,7 +178,10 @@ fn integration_task_completion_evidence_and_receipts_survive_restart() {
         state["tasks"][&task.task_id]["completion_evidence_digest"],
         "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
     );
-    assert_eq!(state["task_transition_receipts"].as_array().unwrap().len(), 2);
+    assert_eq!(
+        state["task_transition_receipts"].as_array().unwrap().len(),
+        2
+    );
     case.cleanup();
 }
 

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_creator_provider_lifecycle_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_creator_provider_lifecycle_contract_tests.rs
@@ -1,10 +1,11 @@
 use super::super::*;
-use super::support::*;
-use crate::service_api_endpoint::{ServiceApiSnapshot, ServiceApiTaskTransitionBody};
-use std::path::PathBuf;
+use crate::service_api_endpoint::ServiceApiTaskTransitionBody;
 
+#[path = "task_creator_provider_lifecycle_contract_tests/support.rs"]
+mod lifecycle_support;
 #[path = "task_creator_provider_lifecycle_contract_tests/payloads.rs"]
 mod payloads;
+use lifecycle_support::LifecycleCase;
 use payloads::{assert_response, completion_body, retry_body, valid_create_body};
 
 const CREATOR: &str = "kamn:did:agent:task-lifecycle-creator";
@@ -120,7 +121,13 @@ fn integration_task_create_retry_is_idempotent_and_conflict_safe() {
         conflict_body.as_str(),
     );
     assert_response(&conflict, "409 Conflict", "TASK_IDEMPOTENCY_CONFLICT");
-    assert_eq!(case.state()["tasks"].as_object().unwrap().len(), 1);
+    assert_eq!(
+        case.state()["tasks"]
+            .as_object()
+            .expect("tasks should be an object")
+            .len(),
+        1
+    );
     case.cleanup();
 }
 
@@ -141,7 +148,9 @@ fn integration_task_transition_retry_returns_one_durable_receipt() {
         parse_service_api_payload(extract_http_response_body(&retried)).expect("retry payload");
     assert_eq!(retry_payload, first_payload);
     let state = case.state();
-    let receipts = state["task_transition_receipts"].as_array().unwrap();
+    let receipts = state["task_transition_receipts"]
+        .as_array()
+        .expect("transition receipts should be an array");
     assert_eq!(receipts.len(), 1);
     assert_eq!(receipts[0]["action"], "task:accept");
     assert_eq!(receipts[0]["transaction_id"], "transaction-lifecycle-001");
@@ -179,99 +188,11 @@ fn integration_task_completion_evidence_and_receipts_survive_restart() {
         "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
     );
     assert_eq!(
-        state["task_transition_receipts"].as_array().unwrap().len(),
+        state["task_transition_receipts"]
+            .as_array()
+            .expect("transition receipts should be an array")
+            .len(),
         2
     );
     case.cleanup();
-}
-
-struct LifecycleCase {
-    _env: ServiceApiTestEnvGuards,
-    _state_guard: EnvVarGuard,
-    snapshot: ServiceApiSnapshot,
-    state_file: PathBuf,
-}
-
-impl LifecycleCase {
-    fn new(label: &str) -> Self {
-        let env = acquire_service_api_test_env();
-        let state_file = unique_named_state_file(format!("kamn-task-lifecycle-{label}").as_str());
-        let (_, state_guard) = set_state_file_env(state_file.as_path());
-        Self {
-            _env: env,
-            _state_guard: state_guard,
-            snapshot: build_task_escrow_snapshot("127.0.0.1:34220"),
-            state_file,
-        }
-    }
-
-    fn register(&self, actor: &str, nonce: u64) {
-        register_agent_profile(
-            &self.snapshot,
-            reserve_loopback_addr().as_str(),
-            actor,
-            nonce,
-            r#"{"agent_type":"provider","model_family":"pi","capabilities":["tasks"]}"#,
-        );
-    }
-
-    fn create_valid_task(&self, nonce: u64) -> ServiceApiTaskCreateBody {
-        let provider_did = test_service_api_sender_did(PROVIDER);
-        let body = valid_create_body(provider_did.as_str());
-        create_task(
-            &self.snapshot,
-            reserve_loopback_addr().as_str(),
-            CREATOR,
-            nonce,
-            body.as_str(),
-        )
-    }
-
-    fn authorized_request(
-        &self,
-        actor: &str,
-        nonce: u64,
-        method: &str,
-        path: &str,
-        body: &str,
-    ) -> String {
-        signed_request(&self.snapshot, actor, nonce, method, path, body, true)
-    }
-
-    fn raw_request(&self, actor: &str, nonce: u64, method: &str, path: &str, body: &str) -> String {
-        signed_request(&self.snapshot, actor, nonce, method, path, body, false)
-    }
-
-    fn state(&self) -> serde_json::Value {
-        read_state_json(self.state_file.as_path())
-    }
-
-    fn cleanup(self) {
-        let _ = fs::remove_file(self.state_file);
-    }
-}
-
-fn signed_request(
-    snapshot: &ServiceApiSnapshot,
-    actor: &str,
-    nonce: u64,
-    method: &str,
-    path: &str,
-    body: &str,
-    provision: bool,
-) -> String {
-    let request = SignedRequest {
-        max_requests: 1,
-        method,
-        path,
-        caller_did: actor,
-        nonce,
-        body,
-        extra_headers: &[("X-KAMN-Authz-Scope", "tasks:write")],
-    };
-    let bind_addr = reserve_loopback_addr();
-    if provision {
-        return authorized_signed_request(snapshot, bind_addr.as_str(), request);
-    }
-    raw_signed_request(snapshot, bind_addr.as_str(), request)
 }

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_creator_provider_lifecycle_contract_tests/payloads.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_creator_provider_lifecycle_contract_tests/payloads.rs
@@ -1,10 +1,6 @@
-pub(super) fn valid_create_body() -> &'static str {
-    concat!(
-        "{\"provider_did\":\"kamn:did:agent:task-lifecycle-provider\",",
-        "\"transaction_id\":\"transaction-lifecycle-001\",",
-        "\"terms_digest\":\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",",
-        "\"idempotency_key\":\"create-lifecycle-001\",",
-        "\"description\":\"canonical lifecycle task\"}"
+pub(super) fn valid_create_body(provider_did: &str) -> String {
+    format!(
+        r#"{{"provider_did":"{provider_did}","transaction_id":"transaction-lifecycle-001","terms_digest":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","idempotency_key":"create-lifecycle-001","description":"canonical lifecycle task"}}"#
     )
 }
 
@@ -18,6 +14,12 @@ pub(super) fn retry_body(idempotency_key: &str) -> &str {
         "accept-valid" => r#"{"idempotency_key":"accept-valid"}"#,
         _ => r#"{"idempotency_key":"complete-missing-evidence"}"#,
     }
+}
+
+pub(super) fn completion_body(idempotency_key: &str) -> String {
+    format!(
+        r#"{{"idempotency_key":"{idempotency_key}","completion_evidence_digest":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"}}"#
+    )
 }
 
 pub(super) fn assert_response(response: &str, status: &str, reason: &str) {

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_creator_provider_lifecycle_contract_tests/payloads.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_creator_provider_lifecycle_contract_tests/payloads.rs
@@ -1,0 +1,26 @@
+pub(super) fn valid_create_body() -> &'static str {
+    concat!(
+        "{\"provider_did\":\"kamn:did:agent:task-lifecycle-provider\",",
+        "\"transaction_id\":\"transaction-lifecycle-001\",",
+        "\"terms_digest\":\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",",
+        "\"idempotency_key\":\"create-lifecycle-001\",",
+        "\"description\":\"canonical lifecycle task\"}"
+    )
+}
+
+pub(super) fn retry_body(idempotency_key: &str) -> &str {
+    match idempotency_key {
+        "accept-1" => r#"{"idempotency_key":"accept-1"}"#,
+        "wrong-provider-accept" => r#"{"idempotency_key":"wrong-provider-accept"}"#,
+        "complete-early" => {
+            r#"{"idempotency_key":"complete-early","completion_evidence_digest":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"}"#
+        }
+        "accept-valid" => r#"{"idempotency_key":"accept-valid"}"#,
+        _ => r#"{"idempotency_key":"complete-missing-evidence"}"#,
+    }
+}
+
+pub(super) fn assert_response(response: &str, status: &str, reason: &str) {
+    assert!(response.contains(status), "{response}");
+    assert!(response.contains(reason), "{response}");
+}

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_creator_provider_lifecycle_contract_tests/support.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_creator_provider_lifecycle_contract_tests/support.rs
@@ -1,0 +1,108 @@
+use super::super::super::*;
+use super::super::support::{
+    authorized_signed_request, build_task_escrow_snapshot, create_task, raw_signed_request,
+    read_state_json, register_agent_profile, set_state_file_env, unique_named_state_file,
+    SignedRequest,
+};
+use super::payloads::valid_create_body;
+use super::{CREATOR, PROVIDER};
+use crate::service_api_endpoint::{ServiceApiSnapshot, ServiceApiTaskCreateBody};
+use std::path::PathBuf;
+
+pub(super) struct LifecycleCase {
+    _env: ServiceApiTestEnvGuards,
+    _state_guard: EnvVarGuard,
+    snapshot: ServiceApiSnapshot,
+    state_file: PathBuf,
+}
+
+impl LifecycleCase {
+    pub(super) fn new(label: &str) -> Self {
+        let env = acquire_service_api_test_env();
+        let state_file = unique_named_state_file(format!("kamn-task-lifecycle-{label}").as_str());
+        let (_, state_guard) = set_state_file_env(state_file.as_path());
+        Self {
+            _env: env,
+            _state_guard: state_guard,
+            snapshot: build_task_escrow_snapshot("127.0.0.1:34220"),
+            state_file,
+        }
+    }
+
+    pub(super) fn register(&self, actor: &str, nonce: u64) {
+        register_agent_profile(
+            &self.snapshot,
+            reserve_loopback_addr().as_str(),
+            actor,
+            nonce,
+            r#"{"agent_type":"provider","model_family":"pi","capabilities":["tasks"]}"#,
+        );
+    }
+
+    pub(super) fn create_valid_task(&self, nonce: u64) -> ServiceApiTaskCreateBody {
+        let provider_did = test_service_api_sender_did(PROVIDER);
+        let body = valid_create_body(provider_did.as_str());
+        create_task(
+            &self.snapshot,
+            reserve_loopback_addr().as_str(),
+            CREATOR,
+            nonce,
+            body.as_str(),
+        )
+    }
+
+    pub(super) fn authorized_request(
+        &self,
+        actor: &str,
+        nonce: u64,
+        method: &str,
+        path: &str,
+        body: &str,
+    ) -> String {
+        signed_request(&self.snapshot, actor, nonce, method, path, body, true)
+    }
+
+    pub(super) fn raw_request(
+        &self,
+        actor: &str,
+        nonce: u64,
+        method: &str,
+        path: &str,
+        body: &str,
+    ) -> String {
+        signed_request(&self.snapshot, actor, nonce, method, path, body, false)
+    }
+
+    pub(super) fn state(&self) -> serde_json::Value {
+        read_state_json(self.state_file.as_path())
+    }
+
+    pub(super) fn cleanup(self) {
+        let _ = fs::remove_file(self.state_file);
+    }
+}
+
+fn signed_request(
+    snapshot: &ServiceApiSnapshot,
+    actor: &str,
+    nonce: u64,
+    method: &str,
+    path: &str,
+    body: &str,
+    provision: bool,
+) -> String {
+    let request = SignedRequest {
+        max_requests: 1,
+        method,
+        path,
+        caller_did: actor,
+        nonce,
+        body,
+        extra_headers: &[("X-KAMN-Authz-Scope", "tasks:write")],
+    };
+    let bind_addr = reserve_loopback_addr();
+    if provision {
+        return authorized_signed_request(snapshot, bind_addr.as_str(), request);
+    }
+    raw_signed_request(snapshot, bind_addr.as_str(), request)
+}

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_authorization_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_authorization_contract_tests.rs
@@ -7,7 +7,6 @@ use crate::service_api_endpoint::ServiceApiSnapshot;
 use std::path::{Path, PathBuf};
 
 const TASK_CREATE_PATH: &str = "/v1/tasks/create";
-const TASK_CREATE_BODY: &str = r#"{"title":"authorized-task","description":"grant contract"}"#;
 
 #[test]
 fn integration_service_api_rejects_signed_unregistered_task_creator() {
@@ -120,6 +119,15 @@ impl AuthorizationCase {
     }
 
     fn create_task(&self, actor: &str, nonce: u64) -> String {
+        let provider_did = test_service_api_sender_did(actor);
+        let body = serde_json::json!({
+            "provider_did": provider_did,
+            "transaction_id": "transaction-authorization-contract",
+            "terms_digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "idempotency_key": "authorization-contract-create",
+            "description": "grant contract",
+        })
+        .to_string();
         raw_signed_request(
             &self.snapshot,
             reserve_loopback_addr().as_str(),
@@ -129,7 +137,7 @@ impl AuthorizationCase {
                 path: TASK_CREATE_PATH,
                 caller_did: actor,
                 nonce,
-                body: TASK_CREATE_BODY,
+                body: body.as_str(),
                 extra_headers: &[("X-KAMN-Authz-Scope", "tasks:write")],
             },
         )

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_concurrent_replay_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_concurrent_replay_contract_tests.rs
@@ -5,7 +5,6 @@ use std::path::Path;
 
 const ACTOR: &str = "kamn:did:agent:concurrent-replay";
 const PATH: &str = "/v1/tasks/create";
-const BODY: &str = r#"{"title":"authorized-task","description":"grant contract"}"#;
 
 #[test]
 fn integration_service_api_concurrent_same_nonce_records_one_authorization_decision() {
@@ -53,19 +52,20 @@ fn spawn_request<'scope>(
     nonce: u64,
 ) -> thread::ScopedJoinHandle<'scope, String> {
     scope.spawn(move || {
+        let body = canonical_body();
         let nonce_text = nonce.to_string();
         let signature = service_api_request_signature_for_fields(
             ACTOR,
             nonce,
             state_hash(snapshot).as_str(),
-            BODY,
+            body.as_str(),
         );
         barrier.wait();
         send_http_request_with_headers(
             addr,
             "POST",
             PATH,
-            BODY,
+            body.as_str(),
             &[
                 ("X-KAMN-Sender-DID", ACTOR),
                 ("X-KAMN-Request-Nonce", nonce_text.as_str()),
@@ -74,6 +74,17 @@ fn spawn_request<'scope>(
             ],
         )
     })
+}
+
+fn canonical_body() -> String {
+    serde_json::json!({
+        "provider_did": test_service_api_sender_did(ACTOR),
+        "transaction_id": "transaction-concurrent-replay",
+        "terms_digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "idempotency_key": "concurrent-replay-create",
+        "description": "grant contract",
+    })
+    .to_string()
 }
 
 fn provision_grant(path: &Path, actor: &str) {

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_routes_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_routes_contract_tests.rs
@@ -106,7 +106,7 @@ fn integration_service_api_endpoint_task_create_fails_loud_when_audit_export_wri
 }
 
 #[test]
-fn integration_service_api_endpoint_auto_dispatches_sdk_shaped_task_to_registered_worker() {
+fn integration_service_api_endpoint_does_not_auto_complete_provider_bound_task() {
     let dispatch = setup_dispatch_route_case();
     let (created_task, queried_task) = dispatch_task_to_registered_worker(&dispatch);
     let persisted = super::support::read_state_json(dispatch.state_file.as_path());
@@ -122,18 +122,17 @@ fn integration_service_api_endpoint_auto_dispatches_sdk_shaped_task_to_registere
 }
 
 #[test]
-fn integration_service_api_endpoint_task_query_fails_loud_when_no_dispatch_worker_exists() {
+fn integration_service_api_endpoint_bound_task_query_does_not_require_dispatch_worker() {
     let missing_worker = setup_missing_worker_route_case();
     let response = query_missing_worker_task(&missing_worker);
 
-    assert!(response.contains("HTTP/1.1 503 Service Unavailable"));
-    assert!(response.contains("service_api_task_dispatch_prerequisites_missing"));
-    assert!(response.contains("task dispatch prerequisites missing"));
+    assert!(response.contains("HTTP/1.1 200 OK"), "{response}");
+    assert!(response.contains(r#""state":"submitted""#), "{response}");
     let _ = fs::remove_file(missing_worker.state_file);
 }
 
 #[test]
-fn integration_service_api_endpoint_repeated_task_query_keeps_dispatched_task_terminal() {
+fn integration_service_api_endpoint_repeated_task_query_keeps_bound_task_submitted() {
     let dispatch = setup_dispatch_route_case();
     let (created_task, queried_task) = dispatch_task_to_registered_worker(&dispatch);
     let repeated_query = super::support::query_task(
@@ -152,7 +151,7 @@ fn integration_service_api_endpoint_repeated_task_query_keeps_dispatched_task_te
         task,
         dispatch.worker_did.as_str(),
     );
-    assert_eq!(repeated_query["state"], "completed");
+    assert_eq!(repeated_query["state"], "submitted");
     let _ = fs::remove_file(dispatch.state_file);
 }
 

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_routes_contract_tests/task_dispatch_support.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_routes_contract_tests/task_dispatch_support.rs
@@ -1,9 +1,12 @@
 use super::super::super::*;
+#[path = "task_dispatch_support/payloads.rs"]
+mod payloads;
 use super::super::support::{
     build_task_escrow_snapshot, create_task, query_task, raw_create_task_response,
     raw_signed_request, register_agent_profile, set_audit_export_file_env, set_state_file_env,
     unique_named_state_file, SignedRequest,
 };
+use payloads::canonical_dispatch_body;
 
 pub(super) fn setup_dispatch_route_case() -> DispatchRouteCase {
     let env = acquire_service_api_test_env();
@@ -113,18 +116,6 @@ pub(super) fn query_missing_worker_task(missing_worker: &MissingWorkerRouteCase)
             extra_headers: &[],
         },
     )
-}
-
-fn canonical_dispatch_body(provider: &str, task_type: &str, key: &str) -> String {
-    serde_json::json!({
-        "provider_did": provider,
-        "transaction_id": format!("transaction-{key}"),
-        "terms_digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-        "idempotency_key": key,
-        "task_type": task_type,
-        "description": "canonical dispatch task",
-    })
-    .to_string()
 }
 
 pub(super) fn setup_audit_export_failure_route_case() -> AuditExportFailureRouteCase {

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_routes_contract_tests/task_dispatch_support.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_routes_contract_tests/task_dispatch_support.rs
@@ -1,8 +1,8 @@
 use super::super::super::*;
 use super::super::support::{
-    authorized_signed_request, build_task_escrow_snapshot, create_task, query_task,
-    raw_create_task_response, register_agent_profile, set_audit_export_file_env,
-    set_state_file_env, unique_named_state_file, SignedRequest,
+    build_task_escrow_snapshot, create_task, query_task, raw_create_task_response,
+    raw_signed_request, register_agent_profile, set_audit_export_file_env, set_state_file_env,
+    unique_named_state_file, SignedRequest,
 };
 
 pub(super) fn setup_dispatch_route_case() -> DispatchRouteCase {
@@ -32,12 +32,17 @@ pub(super) fn setup_dispatch_route_case() -> DispatchRouteCase {
 pub(super) fn dispatch_task_to_registered_worker(
     dispatch: &DispatchRouteCase,
 ) -> (crate::service_api_endpoint::ServiceApiTaskCreateBody, Value) {
+    let body = canonical_dispatch_body(
+        dispatch.worker_did.as_str(),
+        "image-analysis",
+        "dispatch-create",
+    );
     let created_task = create_task(
         &dispatch.snapshot,
         dispatch.bind_addr.as_str(),
         dispatch.creator_did,
         302,
-        r#"{"creator":"kamn:did:agent:task-creator-dispatch","task_type":"image-analysis","description":"dispatch me"}"#,
+        body.as_str(),
     );
     let queried_task = query_task(
         &dispatch.snapshot,
@@ -56,8 +61,8 @@ pub(super) fn assert_dispatched_task_state(
     worker_did: &str,
 ) {
     assert_eq!(created_task.state, "submitted");
-    assert_eq!(queried_task["state"], "completed");
-    assert_eq!(persisted_task["state"], "completed");
+    assert_eq!(queried_task["state"], "submitted");
+    assert_eq!(persisted_task["state"], "submitted");
     assert_eq!(persisted_task["assignee"], worker_did);
 }
 
@@ -76,14 +81,26 @@ pub(super) fn setup_missing_worker_route_case() -> MissingWorkerRouteCase {
 }
 
 pub(super) fn query_missing_worker_task(missing_worker: &MissingWorkerRouteCase) -> String {
+    let provider = register_agent_profile(
+        &missing_worker.snapshot,
+        missing_worker.bind_addr.as_str(),
+        missing_worker.creator_did,
+        400,
+        r#"{"agent_type":"provider","model_family":"test","capabilities":["tasks"]}"#,
+    );
+    let body = canonical_dispatch_body(
+        provider.did.as_str(),
+        "vision-sync",
+        "missing-worker-create",
+    );
     let created_task = create_task(
         &missing_worker.snapshot,
         missing_worker.bind_addr.as_str(),
         missing_worker.creator_did,
         401,
-        r#"{"creator":"kamn:did:agent:task-creator-missing-worker","task_type":"vision-sync","description":"nobody can do this"}"#,
+        body.as_str(),
     );
-    authorized_signed_request(
+    raw_signed_request(
         &missing_worker.snapshot,
         missing_worker.bind_addr.as_str(),
         SignedRequest {
@@ -98,10 +115,32 @@ pub(super) fn query_missing_worker_task(missing_worker: &MissingWorkerRouteCase)
     )
 }
 
+fn canonical_dispatch_body(provider: &str, task_type: &str, key: &str) -> String {
+    serde_json::json!({
+        "provider_did": provider,
+        "transaction_id": format!("transaction-{key}"),
+        "terms_digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "idempotency_key": key,
+        "task_type": task_type,
+        "description": "canonical dispatch task",
+    })
+    .to_string()
+}
+
 pub(super) fn setup_audit_export_failure_route_case() -> AuditExportFailureRouteCase {
     let env = acquire_service_api_test_env();
     let state_file = unique_named_state_file("kamn-node-service-api-task-audit-export-failure");
     let (_state_file_text, state_file_guard) = set_state_file_env(state_file.as_path());
+    let snapshot = build_task_escrow_snapshot("127.0.0.1:34117");
+    let bind_addr = reserve_loopback_addr();
+    let caller_did = "kamn:did:agent:test-client-task-audit-failure";
+    let provider = register_agent_profile(
+        &snapshot,
+        bind_addr.as_str(),
+        caller_did,
+        50,
+        r#"{"agent_type":"provider","model_family":"test","capabilities":["tasks"]}"#,
+    );
     let invalid_export_file = std::env::temp_dir()
         .join(format!(
             "kamn-node-missing-audit-dir-{}",
@@ -112,24 +151,30 @@ pub(super) fn setup_audit_export_failure_route_case() -> AuditExportFailureRoute
         set_audit_export_file_env(invalid_export_file.as_path());
     AuditExportFailureRouteCase {
         _env: env,
-        snapshot: build_task_escrow_snapshot("127.0.0.1:34117"),
+        snapshot,
         state_file,
         _state_file_guard: state_file_guard,
         _audit_export_guard: audit_export_guard,
-        bind_addr: reserve_loopback_addr(),
-        caller_did: "kamn:did:agent:test-client-task-audit-failure",
+        bind_addr,
+        caller_did,
+        provider_did: provider.did,
     }
 }
 
 pub(super) fn create_task_with_broken_audit_export(
     failure: &AuditExportFailureRouteCase,
 ) -> String {
+    let body = canonical_dispatch_body(
+        failure.provider_did.as_str(),
+        "audit",
+        "audit-export-failure",
+    );
     raw_create_task_response(
         &failure.snapshot,
         failure.bind_addr.as_str(),
         failure.caller_did,
         51,
-        r#"{"title":"audit-task","description":"task audit export failure contract"}"#,
+        body.as_str(),
     )
 }
 
@@ -160,4 +205,5 @@ pub(super) struct AuditExportFailureRouteCase {
     _audit_export_guard: EnvVarGuard,
     pub(super) bind_addr: String,
     caller_did: &'static str,
+    provider_did: String,
 }

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_routes_contract_tests/task_dispatch_support/payloads.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_routes_contract_tests/task_dispatch_support/payloads.rs
@@ -1,0 +1,11 @@
+pub(super) fn canonical_dispatch_body(provider: &str, task_type: &str, key: &str) -> String {
+    serde_json::json!({
+        "provider_did": provider,
+        "transaction_id": format!("transaction-{key}"),
+        "terms_digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "idempotency_key": key,
+        "task_type": task_type,
+        "description": "canonical dispatch task",
+    })
+    .to_string()
+}

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/vertical_slice_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/vertical_slice_contract_tests.rs
@@ -7,7 +7,7 @@ use support::{
     list_mailbox_live, project_relay_to_recipient, query_message_live, query_task,
     read_audit_export_json, read_state_json, recipient_env_guards, register_agent_profile,
     send_message, set_audit_export_file_env, set_relay_spool_env, set_state_file_env,
-    spawn_api_server, VerticalSliceFiles,
+    spawn_api_server, transition_task, VerticalSliceFiles,
 };
 
 #[test]
@@ -153,8 +153,33 @@ fn dispatch_slice_task(
 ) -> (crate::service_api_endpoint::ServiceApiTaskCreateBody, Value) {
     register_vertical_slice_worker(case);
     let created_task = create_vertical_slice_task(case);
+    complete_vertical_slice_task(case, created_task.task_id.as_str());
     let queried_task = query_vertical_slice_task(case, created_task.task_id.as_str());
     (created_task, queried_task)
+}
+
+fn complete_vertical_slice_task(case: &VerticalSliceCase, task_id: &str) {
+    let provider = "kamn:did:agent:vertical-slice-recipient";
+    with_sender_env(case, || {
+        transition_task(
+            &case.sender_snapshot,
+            case.sender_bind_addr.as_str(),
+            provider,
+            705,
+            task_id,
+            "accept",
+            r#"{"idempotency_key":"vertical-slice-accept"}"#,
+        );
+        transition_task(
+            &case.sender_snapshot,
+            case.sender_bind_addr.as_str(),
+            provider,
+            706,
+            task_id,
+            "complete",
+            r#"{"idempotency_key":"vertical-slice-complete","completion_evidence_digest":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"}"#,
+        );
+    });
 }
 
 fn register_vertical_slice_worker(case: &VerticalSliceCase) {
@@ -174,25 +199,33 @@ fn create_vertical_slice_task(
 ) -> crate::service_api_endpoint::ServiceApiTaskCreateBody {
     with_sender_env(case, || {
         provision_vertical_slice_grant(case, "POST", "/v1/tasks/create");
+        let provider_did = test_service_api_sender_did("kamn:did:agent:vertical-slice-recipient");
+        let body = serde_json::json!({
+            "provider_did": provider_did,
+            "transaction_id": "transaction-vertical-slice",
+            "terms_digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "idempotency_key": "vertical-slice-create",
+            "task_type": "vertical-slice",
+            "description": "prove one working slice",
+        })
+        .to_string();
         create_task(
             &case.sender_snapshot,
             case.sender_bind_addr.as_str(),
             case.sender_did,
             705,
-            r#"{"creator":"kamn:did:agent:vertical-slice-sender","task_type":"vertical-slice","description":"prove one working slice"}"#,
+            body.as_str(),
         )
     })
 }
 
 fn query_vertical_slice_task(case: &VerticalSliceCase, task_id: &str) -> Value {
     with_sender_env(case, || {
-        let path = format!("/v1/tasks/{task_id}");
-        provision_vertical_slice_grant(case, "GET", path.as_str());
         query_task(
             &case.sender_snapshot,
             case.sender_bind_addr.as_str(),
             case.sender_did,
-            706,
+            707,
             task_id,
         )
     })

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/vertical_slice_contract_tests/support/request_support/live_request_support.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/vertical_slice_contract_tests/support/request_support/live_request_support.rs
@@ -119,6 +119,27 @@ pub(crate) fn query_task(
     ))
 }
 
+pub(crate) fn transition_task(
+    snapshot: &ServiceApiSnapshot,
+    bind_addr: &str,
+    caller_did: &str,
+    nonce: u64,
+    task_id: &str,
+    action: &str,
+    body: &str,
+) -> Value {
+    let path = format!("/v1/tasks/{task_id}/{action}");
+    parse_ok_payload(&signed_request(
+        snapshot,
+        bind_addr,
+        "POST",
+        path.as_str(),
+        caller_did,
+        nonce,
+        body,
+    ))
+}
+
 fn signed_request(
     snapshot: &ServiceApiSnapshot,
     bind_addr: &str,

--- a/crates/kamn-node/src/service_api_endpoint/message_store.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store.rs
@@ -54,4 +54,5 @@ pub(crate) use models::{
     ServiceApiPersistedAgentGrantRecord, ServiceApiRelayProgressCounts,
 };
 pub(crate) use store::escrow_fund_task_id;
+pub(crate) use store::TaskLifecycleError;
 pub(crate) use store::{ServiceApiAuthorizationDecision, ServiceApiAuthorizationRequest};

--- a/crates/kamn-node/src/service_api_endpoint/message_store.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store.rs
@@ -39,6 +39,7 @@ mod models;
 mod persistence;
 mod runtime_evidence;
 mod store;
+mod task_models;
 #[cfg(test)]
 mod tests;
 
@@ -48,6 +49,7 @@ use audit_export::{
 };
 use models::*;
 use runtime_evidence::build_data_layer_runtime_evidence;
+use task_models::*;
 
 pub(crate) use models::{
     ServiceApiAgentBalanceBody, ServiceApiAgentRegistrationStoreError, ServiceApiMessageStore,

--- a/crates/kamn-node/src/service_api_endpoint/message_store/models.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/models.rs
@@ -48,6 +48,16 @@ pub(crate) struct ServiceApiPersistedTaskRecord {
     pub(crate) description: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) assignee: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) provider_did: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) transaction_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) terms_digest: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) completion_evidence_digest: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) create_idempotency_key: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -115,6 +125,22 @@ pub(crate) struct ServiceApiAuthorizationReceiptRecord {
     pub(crate) reason_code: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct ServiceApiTaskTransitionReceiptRecord {
+    pub(crate) receipt_id: String,
+    pub(crate) correlation_id: String,
+    pub(crate) idempotency_key: String,
+    pub(crate) actor_did: String,
+    pub(crate) task_id: String,
+    pub(crate) transaction_id: String,
+    pub(crate) action: String,
+    pub(crate) prior_state: String,
+    pub(crate) resulting_state: String,
+    pub(crate) terms_digest: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) completion_evidence_digest: Option<String>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub(crate) struct ServiceApiAgentBalanceBody {
     pub(crate) did: String,
@@ -148,12 +174,14 @@ pub(crate) struct ServiceApiPersistedMessageStoreSnapshot {
     pub(crate) agent_grants: BTreeMap<String, ServiceApiPersistedAgentGrantRecord>,
     #[serde(default)]
     pub(crate) authorization_receipts: Vec<ServiceApiAuthorizationReceiptRecord>,
+    #[serde(default)]
+    pub(crate) task_transition_receipts: Vec<ServiceApiTaskTransitionReceiptRecord>,
 }
 
 impl Default for ServiceApiPersistedMessageStoreSnapshot {
     fn default() -> Self {
         Self {
-            schema_version: "kamn.runtime.service-api-message-store.v3".to_owned(),
+            schema_version: "kamn.runtime.service-api-message-store.v4".to_owned(),
             messages: BTreeMap::new(),
             channel_messages: BTreeMap::new(),
             auth_nonce_high_watermarks: BTreeMap::new(),
@@ -164,6 +192,7 @@ impl Default for ServiceApiPersistedMessageStoreSnapshot {
             agents: BTreeMap::new(),
             agent_grants: BTreeMap::new(),
             authorization_receipts: Vec::new(),
+            task_transition_receipts: Vec::new(),
         }
     }
 }

--- a/crates/kamn-node/src/service_api_endpoint/message_store/models.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/models.rs
@@ -125,22 +125,6 @@ pub(crate) struct ServiceApiAuthorizationReceiptRecord {
     pub(crate) reason_code: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub(crate) struct ServiceApiTaskTransitionReceiptRecord {
-    pub(crate) receipt_id: String,
-    pub(crate) correlation_id: String,
-    pub(crate) idempotency_key: String,
-    pub(crate) actor_did: String,
-    pub(crate) task_id: String,
-    pub(crate) transaction_id: String,
-    pub(crate) action: String,
-    pub(crate) prior_state: String,
-    pub(crate) resulting_state: String,
-    pub(crate) terms_digest: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub(crate) completion_evidence_digest: Option<String>,
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub(crate) struct ServiceApiAgentBalanceBody {
     pub(crate) did: String,

--- a/crates/kamn-node/src/service_api_endpoint/message_store/store.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/store.rs
@@ -12,3 +12,4 @@ pub(crate) use authorization_ops::{
 };
 pub(crate) use query_ops::recipient_mailbox_channel_id;
 pub(crate) use task_escrow_ops::escrow_fund_task_id;
+pub(crate) use task_escrow_ops::TaskLifecycleError;

--- a/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops.rs
@@ -6,15 +6,14 @@ mod settlement;
 mod tasks;
 
 use dispatch::{
-    dispatch_prerequisite_missing_error, dispatch_request_from_record,
-    parse_dispatchable_task_payload, select_dispatch_assignee,
+    dispatch_prerequisite_missing_error, dispatch_request_from_record, select_dispatch_assignee,
 };
 pub(crate) use lifecycle::TaskLifecycleError;
 pub(crate) use settlement::escrow_fund_task_id;
 use settlement::{
     build_escrow_record, escrow_status_response, next_escrow_id, release_escrow_record,
 };
-use tasks::{build_task_record, next_task_id, persist_task_created_audit_export};
+use tasks::{next_task_id, persist_task_created_audit_export};
 
 impl ServiceApiMessageStore {
     pub(crate) fn create_bound_task(
@@ -36,29 +35,6 @@ impl ServiceApiMessageStore {
         lifecycle::transition_bound_task(self, actor_did, task_id, action, payload, correlation_id)
     }
 
-    pub(crate) fn create_task(
-        &mut self,
-        payload: &str,
-    ) -> Result<ServiceApiTaskCreateBody, String> {
-        self.refresh_from_disk()?;
-        let task_id = next_task_id(self, payload);
-        let dispatch_metadata = parse_dispatchable_task_payload(payload)?;
-        self.snapshot.tasks.insert(
-            task_id.clone(),
-            build_task_record(task_id.as_str(), dispatch_metadata),
-        );
-        self.persist()?;
-        persist_task_created_audit_export(self, task_id.as_str())?;
-        Ok(ServiceApiTaskCreateBody {
-            task_id,
-            state: "submitted".to_owned(),
-            transaction_id: None,
-            creator_did: None,
-            provider_did: None,
-            terms_digest: None,
-        })
-    }
-
     pub(crate) fn get_task(
         &mut self,
         task_id: &str,
@@ -71,28 +47,6 @@ impl ServiceApiMessageStore {
         Ok(Some(ServiceApiTaskGetBody {
             task_id: record.task_id.clone(),
             state: record.state.clone(),
-        }))
-    }
-
-    pub(crate) fn transition_task(
-        &mut self,
-        task_id: &str,
-        state: &str,
-    ) -> Result<Option<ServiceApiTaskTransitionBody>, String> {
-        self.refresh_from_disk()?;
-        let Some(record) = self.snapshot.tasks.get_mut(task_id) else {
-            return Ok(None);
-        };
-        record.state = state.to_owned();
-        self.persist()?;
-        Ok(Some(ServiceApiTaskTransitionBody {
-            task_id: task_id.to_owned(),
-            state: state.to_owned(),
-            transaction_id: None,
-            creator_did: None,
-            provider_did: None,
-            terms_digest: None,
-            receipt_id: None,
         }))
     }
 

--- a/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops.rs
@@ -1,6 +1,7 @@
 use super::super::*;
 
 mod dispatch;
+mod lifecycle;
 mod settlement;
 mod tasks;
 
@@ -8,6 +9,7 @@ use dispatch::{
     dispatch_prerequisite_missing_error, dispatch_request_from_record,
     parse_dispatchable_task_payload, select_dispatch_assignee,
 };
+pub(crate) use lifecycle::TaskLifecycleError;
 pub(crate) use settlement::escrow_fund_task_id;
 use settlement::{
     build_escrow_record, escrow_status_response, next_escrow_id, release_escrow_record,
@@ -15,6 +17,25 @@ use settlement::{
 use tasks::{build_task_record, next_task_id, persist_task_created_audit_export};
 
 impl ServiceApiMessageStore {
+    pub(crate) fn create_bound_task(
+        &mut self,
+        actor_did: &str,
+        payload: &str,
+    ) -> Result<ServiceApiTaskCreateBody, TaskLifecycleError> {
+        lifecycle::create_bound_task(self, actor_did, payload)
+    }
+
+    pub(crate) fn transition_bound_task(
+        &mut self,
+        actor_did: &str,
+        task_id: &str,
+        action: &str,
+        payload: &str,
+        correlation_id: &str,
+    ) -> Result<ServiceApiTaskTransitionBody, TaskLifecycleError> {
+        lifecycle::transition_bound_task(self, actor_did, task_id, action, payload, correlation_id)
+    }
+
     pub(crate) fn create_task(
         &mut self,
         payload: &str,
@@ -31,6 +52,10 @@ impl ServiceApiMessageStore {
         Ok(ServiceApiTaskCreateBody {
             task_id,
             state: "submitted".to_owned(),
+            transaction_id: None,
+            creator_did: None,
+            provider_did: None,
+            terms_digest: None,
         })
     }
 
@@ -63,6 +88,11 @@ impl ServiceApiMessageStore {
         Ok(Some(ServiceApiTaskTransitionBody {
             task_id: task_id.to_owned(),
             state: state.to_owned(),
+            transaction_id: None,
+            creator_did: None,
+            provider_did: None,
+            terms_digest: None,
+            receipt_id: None,
         }))
     }
 
@@ -149,6 +179,9 @@ impl ServiceApiMessageStore {
         let Some(record) = self.snapshot.tasks.get(task_id).cloned() else {
             return Ok(());
         };
+        if record.provider_did.is_some() {
+            return Ok(());
+        }
         if record.state != "submitted" {
             return Ok(());
         }

--- a/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/dispatch.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/dispatch.rs
@@ -7,27 +7,6 @@ pub(super) struct DispatchableTaskPayload {
     pub(super) description: String,
 }
 
-pub(super) fn parse_dispatchable_task_payload(
-    payload: &str,
-) -> Result<Option<DispatchableTaskPayload>, String> {
-    let root = match serde_json::from_str::<serde_json::Value>(payload) {
-        Ok(root) => root,
-        Err(_) => return Ok(None),
-    };
-    let Some(object) = root.as_object() else {
-        return Ok(None);
-    };
-    let has_dispatch_keys = object.contains_key("creator") || object.contains_key("task_type");
-    if !has_dispatch_keys {
-        return Ok(None);
-    }
-    Ok(Some(DispatchableTaskPayload {
-        creator_did: required_dispatch_field(object, "creator")?,
-        task_type: required_dispatch_field(object, "task_type")?,
-        description: required_dispatch_field(object, "description")?,
-    }))
-}
-
 pub(super) fn dispatch_request_from_record(
     record: &ServiceApiPersistedTaskRecord,
 ) -> Result<Option<DispatchableTaskPayload>, String> {
@@ -74,22 +53,4 @@ pub(super) fn select_dispatch_assignee(
 
 pub(super) fn dispatch_prerequisite_missing_error(task_type: &str) -> String {
     format!("task dispatch prerequisites missing: no registered worker for task_type {task_type}")
-}
-
-fn required_dispatch_field(
-    object: &serde_json::Map<String, serde_json::Value>,
-    field: &str,
-) -> Result<String, String> {
-    let Some(value) = object.get(field).and_then(serde_json::Value::as_str) else {
-        return Err(format!(
-            "task dispatch payload field `{field}` must be string"
-        ));
-    };
-    let trimmed = value.trim();
-    if trimmed.is_empty() {
-        return Err(format!(
-            "task dispatch payload field `{field}` must not be empty"
-        ));
-    }
-    Ok(trimmed.to_owned())
 }

--- a/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/lifecycle.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/lifecycle.rs
@@ -55,6 +55,9 @@ pub(super) fn transition_bound_task(
     correlation_id: &str,
 ) -> Result<ServiceApiTaskTransitionBody, TaskLifecycleError> {
     store.refresh_from_disk().map_err(persistence)?;
+    if !store.snapshot.tasks.contains_key(task_id) {
+        return Err(TaskLifecycleError::NotFound);
+    }
     let input = parse_transition(payload, action)?;
     if let Some(receipt) = find_transition_retry(store, actor_did, task_id, action, &input)? {
         return Ok(retry_response(store, receipt));

--- a/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/lifecycle.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/lifecycle.rs
@@ -1,7 +1,16 @@
 use super::super::super::*;
 use super::{next_task_id, persist_task_created_audit_export};
 
-const DIGEST_LEN: usize = 64;
+mod agreement;
+mod idempotency;
+mod input;
+mod receipt;
+
+use agreement::require_registered_provider;
+use agreement::{build_record, issue_grants, require_bound_provider, require_legal_transition};
+use idempotency::{find_create_retry, find_transition_retry};
+use input::{parse_create, parse_transition};
+use receipt::{create_response, retry_response, transition_response, ReceiptInput};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum TaskLifecycleError {
@@ -12,42 +21,21 @@ pub(crate) enum TaskLifecycleError {
     Persistence(String),
 }
 
-#[derive(Debug, Deserialize)]
-struct CreateInput {
-    provider_did: String,
-    transaction_id: String,
-    terms_digest: String,
-    idempotency_key: String,
-    #[serde(default)]
-    creator: Option<String>,
-    #[serde(default)]
-    task_type: Option<String>,
-    #[serde(default)]
-    description: Option<String>,
-}
-
-#[derive(Debug, Deserialize)]
-struct TransitionInput {
-    idempotency_key: String,
-    #[serde(default)]
-    completion_evidence_digest: Option<String>,
-}
-
 pub(super) fn create_bound_task(
     store: &mut ServiceApiMessageStore,
     actor_did: &str,
     payload: &str,
 ) -> Result<ServiceApiTaskCreateBody, TaskLifecycleError> {
     store.refresh_from_disk().map_err(persistence)?;
-    let input = parse_create_input(payload, actor_did)?;
+    let input = parse_create(payload, actor_did)?;
     require_registered_provider(store, input.provider_did.as_str())?;
     if let Some(existing) = find_create_retry(store, actor_did, &input)? {
         return Ok(create_response(existing));
     }
     let task_id = next_task_id(store, payload);
-    let record = bound_task_record(task_id.as_str(), actor_did, &input);
+    let record = build_record(task_id.as_str(), actor_did, &input);
     store.snapshot.tasks.insert(task_id.clone(), record);
-    issue_lifecycle_grants(
+    issue_grants(
         store,
         task_id.as_str(),
         actor_did,
@@ -67,9 +55,9 @@ pub(super) fn transition_bound_task(
     correlation_id: &str,
 ) -> Result<ServiceApiTaskTransitionBody, TaskLifecycleError> {
     store.refresh_from_disk().map_err(persistence)?;
-    let input = parse_transition_input(payload, action)?;
+    let input = parse_transition(payload, action)?;
     if let Some(receipt) = find_transition_retry(store, actor_did, task_id, action, &input)? {
-        return Ok(transition_response_from_receipt(store, receipt));
+        return Ok(retry_response(store, receipt));
     }
     let receipt_sequence = store.snapshot.task_transition_receipts.len() + 1;
     let record = store
@@ -84,14 +72,16 @@ pub(super) fn transition_bound_task(
     if action == "task:complete" {
         record.completion_evidence_digest = input.completion_evidence_digest;
     }
-    let receipt = build_transition_receipt(
+    let receipt = receipt::build(
         record,
-        actor_did,
-        action,
-        prior_state,
-        input.idempotency_key,
-        correlation_id,
-        receipt_sequence,
+        ReceiptInput {
+            actor: actor_did,
+            action,
+            prior_state,
+            idempotency_key: input.idempotency_key,
+            correlation_id,
+            sequence: receipt_sequence,
+        },
     )?;
     let response = transition_response(record, receipt.receipt_id.as_str());
     store.snapshot.task_transition_receipts.push(receipt);
@@ -99,284 +89,6 @@ pub(super) fn transition_bound_task(
     Ok(response)
 }
 
-fn find_create_retry<'a>(
-    store: &'a ServiceApiMessageStore,
-    actor: &str,
-    input: &CreateInput,
-) -> Result<Option<&'a ServiceApiPersistedTaskRecord>, TaskLifecycleError> {
-    let existing = store.snapshot.tasks.values().find(|task| {
-        task.creator_did.as_deref() == Some(actor)
-            && task.create_idempotency_key.as_deref() == Some(input.idempotency_key.as_str())
-    });
-    let Some(existing) = existing else {
-        return Ok(None);
-    };
-    if same_agreement(existing, input) {
-        return Ok(Some(existing));
-    }
-    Err(conflict(
-        "TASK_IDEMPOTENCY_CONFLICT",
-        "creation idempotency key was reused",
-    ))
-}
-
-fn same_agreement(record: &ServiceApiPersistedTaskRecord, input: &CreateInput) -> bool {
-    record.provider_did.as_deref() == Some(input.provider_did.as_str())
-        && record.transaction_id.as_deref() == Some(input.transaction_id.as_str())
-        && record.terms_digest.as_deref() == Some(input.terms_digest.as_str())
-        && record.task_type == input.task_type
-        && record.description == input.description
-}
-
-fn find_transition_retry<'a>(
-    store: &'a ServiceApiMessageStore,
-    actor: &str,
-    task_id: &str,
-    action: &str,
-    input: &TransitionInput,
-) -> Result<Option<&'a ServiceApiTaskTransitionReceiptRecord>, TaskLifecycleError> {
-    let receipt = store
-        .snapshot
-        .task_transition_receipts
-        .iter()
-        .find(|receipt| {
-            receipt.actor_did == actor && receipt.idempotency_key == input.idempotency_key
-        });
-    let Some(receipt) = receipt else {
-        return Ok(None);
-    };
-    if receipt.task_id == task_id
-        && receipt.action == action
-        && receipt.completion_evidence_digest == input.completion_evidence_digest
-    {
-        return Ok(Some(receipt));
-    }
-    Err(conflict(
-        "TASK_IDEMPOTENCY_CONFLICT",
-        "transition idempotency key was reused",
-    ))
-}
-
-fn build_transition_receipt(
-    record: &ServiceApiPersistedTaskRecord,
-    actor: &str,
-    action: &str,
-    prior_state: String,
-    idempotency_key: String,
-    correlation_id: &str,
-    sequence: usize,
-) -> Result<ServiceApiTaskTransitionReceiptRecord, TaskLifecycleError> {
-    Ok(ServiceApiTaskTransitionReceiptRecord {
-        receipt_id: format!("task-transition-receipt-{sequence:08}"),
-        correlation_id: correlation_id.to_owned(),
-        idempotency_key,
-        actor_did: actor.to_owned(),
-        task_id: record.task_id.clone(),
-        transaction_id: required_agreement(&record.transaction_id)?,
-        action: action.to_owned(),
-        prior_state,
-        resulting_state: record.state.clone(),
-        terms_digest: required_agreement(&record.terms_digest)?,
-        completion_evidence_digest: record.completion_evidence_digest.clone(),
-    })
-}
-
-fn required_agreement(value: &Option<String>) -> Result<String, TaskLifecycleError> {
-    value.clone().ok_or_else(|| {
-        conflict(
-            "TASK_AGREEMENT_MIGRATION_REQUIRED",
-            "legacy task agreement is incomplete",
-        )
-    })
-}
-
-fn create_response(record: &ServiceApiPersistedTaskRecord) -> ServiceApiTaskCreateBody {
-    ServiceApiTaskCreateBody {
-        task_id: record.task_id.clone(),
-        state: record.state.clone(),
-        transaction_id: record.transaction_id.clone(),
-        creator_did: record.creator_did.clone(),
-        provider_did: record.provider_did.clone(),
-        terms_digest: record.terms_digest.clone(),
-    }
-}
-
-fn transition_response(
-    record: &ServiceApiPersistedTaskRecord,
-    receipt_id: &str,
-) -> ServiceApiTaskTransitionBody {
-    ServiceApiTaskTransitionBody {
-        task_id: record.task_id.clone(),
-        state: record.state.clone(),
-        transaction_id: record.transaction_id.clone(),
-        creator_did: record.creator_did.clone(),
-        provider_did: record.provider_did.clone(),
-        terms_digest: record.terms_digest.clone(),
-        receipt_id: Some(receipt_id.to_owned()),
-    }
-}
-
-fn transition_response_from_receipt(
-    store: &ServiceApiMessageStore,
-    receipt: &ServiceApiTaskTransitionReceiptRecord,
-) -> ServiceApiTaskTransitionBody {
-    let record = &store.snapshot.tasks[&receipt.task_id];
-    transition_response(record, receipt.receipt_id.as_str())
-}
-
-fn parse_create_input(payload: &str, actor: &str) -> Result<CreateInput, TaskLifecycleError> {
-    let input: CreateInput =
-        serde_json::from_str(payload).map_err(|error| agreement(error.to_string()))?;
-    AgentDid::parse(input.provider_did.as_str())
-        .map_err(|error| bad("TASK_PROVIDER_INVALID", error.to_string()))?;
-    if input
-        .creator
-        .as_deref()
-        .is_some_and(|creator| creator != actor)
-    {
-        return Err(bad(
-            "TASK_CREATOR_MISMATCH",
-            "body creator differs from authenticated actor",
-        ));
-    }
-    if input.transaction_id.trim().is_empty()
-        || input.idempotency_key.trim().is_empty()
-        || !valid_digest(&input.terms_digest)
-    {
-        return Err(agreement(
-            "transaction, terms digest, and idempotency key are required",
-        ));
-    }
-    Ok(input)
-}
-
-fn parse_transition_input(
-    payload: &str,
-    action: &str,
-) -> Result<TransitionInput, TaskLifecycleError> {
-    let input: TransitionInput = serde_json::from_str(payload)
-        .map_err(|error| bad("TASK_AGREEMENT_INVALID", error.to_string()))?;
-    if input.idempotency_key.trim().is_empty() {
-        return Err(bad(
-            "TASK_AGREEMENT_INVALID",
-            "transition idempotency key is required",
-        ));
-    }
-    if action == "task:complete"
-        && !input
-            .completion_evidence_digest
-            .as_deref()
-            .is_some_and(valid_digest)
-    {
-        return Err(bad(
-            "TASK_COMPLETION_EVIDENCE_INVALID",
-            "completion evidence digest is required",
-        ));
-    }
-    Ok(input)
-}
-
-fn require_registered_provider(
-    store: &ServiceApiMessageStore,
-    did: &str,
-) -> Result<(), TaskLifecycleError> {
-    if store
-        .snapshot
-        .agents
-        .get(did)
-        .is_some_and(|agent| agent.registered)
-    {
-        return Ok(());
-    }
-    Err(bad(
-        "TASK_PROVIDER_NOT_REGISTERED",
-        "task provider is not registered",
-    ))
-}
-
-fn require_bound_provider(
-    record: &ServiceApiPersistedTaskRecord,
-    actor: &str,
-) -> Result<(), TaskLifecycleError> {
-    let provider = record.provider_did.as_deref().ok_or_else(|| {
-        conflict(
-            "TASK_AGREEMENT_MIGRATION_REQUIRED",
-            "legacy task agreement is incomplete",
-        )
-    })?;
-    if provider == actor {
-        return Ok(());
-    }
-    Err(TaskLifecycleError::Forbidden(
-        "TASK_PROVIDER_MISMATCH",
-        "actor is not the assigned provider".to_owned(),
-    ))
-}
-
-fn require_legal_transition(state: &str, action: &str) -> Result<&'static str, TaskLifecycleError> {
-    match (state, action) {
-        ("submitted", "task:accept") => Ok("accepted"),
-        ("accepted", "task:complete") => Ok("completed"),
-        _ => Err(conflict(
-            "TASK_STATE_CONFLICT",
-            "task transition is not legal from current state",
-        )),
-    }
-}
-
-fn bound_task_record(
-    id: &str,
-    creator: &str,
-    input: &CreateInput,
-) -> ServiceApiPersistedTaskRecord {
-    ServiceApiPersistedTaskRecord {
-        task_id: id.to_owned(),
-        state: "submitted".to_owned(),
-        creator_did: Some(creator.to_owned()),
-        task_type: input.task_type.clone(),
-        description: input.description.clone(),
-        assignee: Some(input.provider_did.clone()),
-        provider_did: Some(input.provider_did.clone()),
-        transaction_id: Some(input.transaction_id.clone()),
-        terms_digest: Some(input.terms_digest.clone()),
-        completion_evidence_digest: None,
-        create_idempotency_key: Some(input.idempotency_key.clone()),
-    }
-}
-
-fn issue_lifecycle_grants(
-    store: &mut ServiceApiMessageStore,
-    task_id: &str,
-    creator: &str,
-    provider: &str,
-) {
-    for (did, action, role) in [
-        (creator, "task:read", "participant"),
-        (provider, "task:read", "participant"),
-        (provider, "task:accept", "provider"),
-        (provider, "task:complete", "provider"),
-    ] {
-        let key = format!("task-lifecycle:{task_id}:{did}:{action}");
-        store.snapshot.agent_grants.insert(
-            key.clone(),
-            ServiceApiPersistedAgentGrantRecord {
-                did: did.to_owned(),
-                resource: format!("task:{task_id}"),
-                role: role.to_owned(),
-                action: action.to_owned(),
-                status: "active".to_owned(),
-                idempotency_key: key,
-            },
-        );
-    }
-}
-
-fn valid_digest(value: &str) -> bool {
-    value.len() == DIGEST_LEN
-        && value
-            .bytes()
-            .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
-}
 fn bad(code: &'static str, message: impl Into<String>) -> TaskLifecycleError {
     TaskLifecycleError::BadRequest(code, message.into())
 }

--- a/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/lifecycle.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/lifecycle.rs
@@ -1,0 +1,391 @@
+use super::super::super::*;
+use super::{next_task_id, persist_task_created_audit_export};
+
+const DIGEST_LEN: usize = 64;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum TaskLifecycleError {
+    BadRequest(&'static str, String),
+    Forbidden(&'static str, String),
+    Conflict(&'static str, String),
+    NotFound,
+    Persistence(String),
+}
+
+#[derive(Debug, Deserialize)]
+struct CreateInput {
+    provider_did: String,
+    transaction_id: String,
+    terms_digest: String,
+    idempotency_key: String,
+    #[serde(default)]
+    creator: Option<String>,
+    #[serde(default)]
+    task_type: Option<String>,
+    #[serde(default)]
+    description: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TransitionInput {
+    idempotency_key: String,
+    #[serde(default)]
+    completion_evidence_digest: Option<String>,
+}
+
+pub(super) fn create_bound_task(
+    store: &mut ServiceApiMessageStore,
+    actor_did: &str,
+    payload: &str,
+) -> Result<ServiceApiTaskCreateBody, TaskLifecycleError> {
+    store.refresh_from_disk().map_err(persistence)?;
+    let input = parse_create_input(payload, actor_did)?;
+    require_registered_provider(store, input.provider_did.as_str())?;
+    if let Some(existing) = find_create_retry(store, actor_did, &input)? {
+        return Ok(create_response(existing));
+    }
+    let task_id = next_task_id(store, payload);
+    let record = bound_task_record(task_id.as_str(), actor_did, &input);
+    store.snapshot.tasks.insert(task_id.clone(), record);
+    issue_lifecycle_grants(
+        store,
+        task_id.as_str(),
+        actor_did,
+        input.provider_did.as_str(),
+    );
+    store.persist().map_err(persistence)?;
+    persist_task_created_audit_export(store, task_id.as_str()).map_err(persistence)?;
+    Ok(create_response(&store.snapshot.tasks[&task_id]))
+}
+
+pub(super) fn transition_bound_task(
+    store: &mut ServiceApiMessageStore,
+    actor_did: &str,
+    task_id: &str,
+    action: &str,
+    payload: &str,
+    correlation_id: &str,
+) -> Result<ServiceApiTaskTransitionBody, TaskLifecycleError> {
+    store.refresh_from_disk().map_err(persistence)?;
+    let input = parse_transition_input(payload, action)?;
+    if let Some(receipt) = find_transition_retry(store, actor_did, task_id, action, &input)? {
+        return Ok(transition_response_from_receipt(store, receipt));
+    }
+    let receipt_sequence = store.snapshot.task_transition_receipts.len() + 1;
+    let record = store
+        .snapshot
+        .tasks
+        .get_mut(task_id)
+        .ok_or(TaskLifecycleError::NotFound)?;
+    require_bound_provider(record, actor_did)?;
+    let target = require_legal_transition(record.state.as_str(), action)?;
+    let prior_state = record.state.clone();
+    record.state = target.to_owned();
+    if action == "task:complete" {
+        record.completion_evidence_digest = input.completion_evidence_digest;
+    }
+    let receipt = build_transition_receipt(
+        record,
+        actor_did,
+        action,
+        prior_state,
+        input.idempotency_key,
+        correlation_id,
+        receipt_sequence,
+    )?;
+    let response = transition_response(record, receipt.receipt_id.as_str());
+    store.snapshot.task_transition_receipts.push(receipt);
+    store.persist().map_err(persistence)?;
+    Ok(response)
+}
+
+fn find_create_retry<'a>(
+    store: &'a ServiceApiMessageStore,
+    actor: &str,
+    input: &CreateInput,
+) -> Result<Option<&'a ServiceApiPersistedTaskRecord>, TaskLifecycleError> {
+    let existing = store.snapshot.tasks.values().find(|task| {
+        task.creator_did.as_deref() == Some(actor)
+            && task.create_idempotency_key.as_deref() == Some(input.idempotency_key.as_str())
+    });
+    let Some(existing) = existing else {
+        return Ok(None);
+    };
+    if same_agreement(existing, input) {
+        return Ok(Some(existing));
+    }
+    Err(conflict(
+        "TASK_IDEMPOTENCY_CONFLICT",
+        "creation idempotency key was reused",
+    ))
+}
+
+fn same_agreement(record: &ServiceApiPersistedTaskRecord, input: &CreateInput) -> bool {
+    record.provider_did.as_deref() == Some(input.provider_did.as_str())
+        && record.transaction_id.as_deref() == Some(input.transaction_id.as_str())
+        && record.terms_digest.as_deref() == Some(input.terms_digest.as_str())
+        && record.task_type == input.task_type
+        && record.description == input.description
+}
+
+fn find_transition_retry<'a>(
+    store: &'a ServiceApiMessageStore,
+    actor: &str,
+    task_id: &str,
+    action: &str,
+    input: &TransitionInput,
+) -> Result<Option<&'a ServiceApiTaskTransitionReceiptRecord>, TaskLifecycleError> {
+    let receipt = store
+        .snapshot
+        .task_transition_receipts
+        .iter()
+        .find(|receipt| {
+            receipt.actor_did == actor && receipt.idempotency_key == input.idempotency_key
+        });
+    let Some(receipt) = receipt else {
+        return Ok(None);
+    };
+    if receipt.task_id == task_id
+        && receipt.action == action
+        && receipt.completion_evidence_digest == input.completion_evidence_digest
+    {
+        return Ok(Some(receipt));
+    }
+    Err(conflict(
+        "TASK_IDEMPOTENCY_CONFLICT",
+        "transition idempotency key was reused",
+    ))
+}
+
+fn build_transition_receipt(
+    record: &ServiceApiPersistedTaskRecord,
+    actor: &str,
+    action: &str,
+    prior_state: String,
+    idempotency_key: String,
+    correlation_id: &str,
+    sequence: usize,
+) -> Result<ServiceApiTaskTransitionReceiptRecord, TaskLifecycleError> {
+    Ok(ServiceApiTaskTransitionReceiptRecord {
+        receipt_id: format!("task-transition-receipt-{sequence:08}"),
+        correlation_id: correlation_id.to_owned(),
+        idempotency_key,
+        actor_did: actor.to_owned(),
+        task_id: record.task_id.clone(),
+        transaction_id: required_agreement(&record.transaction_id)?,
+        action: action.to_owned(),
+        prior_state,
+        resulting_state: record.state.clone(),
+        terms_digest: required_agreement(&record.terms_digest)?,
+        completion_evidence_digest: record.completion_evidence_digest.clone(),
+    })
+}
+
+fn required_agreement(value: &Option<String>) -> Result<String, TaskLifecycleError> {
+    value.clone().ok_or_else(|| {
+        conflict(
+            "TASK_AGREEMENT_MIGRATION_REQUIRED",
+            "legacy task agreement is incomplete",
+        )
+    })
+}
+
+fn create_response(record: &ServiceApiPersistedTaskRecord) -> ServiceApiTaskCreateBody {
+    ServiceApiTaskCreateBody {
+        task_id: record.task_id.clone(),
+        state: record.state.clone(),
+        transaction_id: record.transaction_id.clone(),
+        creator_did: record.creator_did.clone(),
+        provider_did: record.provider_did.clone(),
+        terms_digest: record.terms_digest.clone(),
+    }
+}
+
+fn transition_response(
+    record: &ServiceApiPersistedTaskRecord,
+    receipt_id: &str,
+) -> ServiceApiTaskTransitionBody {
+    ServiceApiTaskTransitionBody {
+        task_id: record.task_id.clone(),
+        state: record.state.clone(),
+        transaction_id: record.transaction_id.clone(),
+        creator_did: record.creator_did.clone(),
+        provider_did: record.provider_did.clone(),
+        terms_digest: record.terms_digest.clone(),
+        receipt_id: Some(receipt_id.to_owned()),
+    }
+}
+
+fn transition_response_from_receipt(
+    store: &ServiceApiMessageStore,
+    receipt: &ServiceApiTaskTransitionReceiptRecord,
+) -> ServiceApiTaskTransitionBody {
+    let record = &store.snapshot.tasks[&receipt.task_id];
+    transition_response(record, receipt.receipt_id.as_str())
+}
+
+fn parse_create_input(payload: &str, actor: &str) -> Result<CreateInput, TaskLifecycleError> {
+    let input: CreateInput =
+        serde_json::from_str(payload).map_err(|error| agreement(error.to_string()))?;
+    AgentDid::parse(input.provider_did.as_str())
+        .map_err(|error| bad("TASK_PROVIDER_INVALID", error.to_string()))?;
+    if input
+        .creator
+        .as_deref()
+        .is_some_and(|creator| creator != actor)
+    {
+        return Err(bad(
+            "TASK_CREATOR_MISMATCH",
+            "body creator differs from authenticated actor",
+        ));
+    }
+    if input.transaction_id.trim().is_empty()
+        || input.idempotency_key.trim().is_empty()
+        || !valid_digest(&input.terms_digest)
+    {
+        return Err(agreement(
+            "transaction, terms digest, and idempotency key are required",
+        ));
+    }
+    Ok(input)
+}
+
+fn parse_transition_input(
+    payload: &str,
+    action: &str,
+) -> Result<TransitionInput, TaskLifecycleError> {
+    let input: TransitionInput = serde_json::from_str(payload)
+        .map_err(|error| bad("TASK_AGREEMENT_INVALID", error.to_string()))?;
+    if input.idempotency_key.trim().is_empty() {
+        return Err(bad(
+            "TASK_AGREEMENT_INVALID",
+            "transition idempotency key is required",
+        ));
+    }
+    if action == "task:complete"
+        && !input
+            .completion_evidence_digest
+            .as_deref()
+            .is_some_and(valid_digest)
+    {
+        return Err(bad(
+            "TASK_COMPLETION_EVIDENCE_INVALID",
+            "completion evidence digest is required",
+        ));
+    }
+    Ok(input)
+}
+
+fn require_registered_provider(
+    store: &ServiceApiMessageStore,
+    did: &str,
+) -> Result<(), TaskLifecycleError> {
+    if store
+        .snapshot
+        .agents
+        .get(did)
+        .is_some_and(|agent| agent.registered)
+    {
+        return Ok(());
+    }
+    Err(bad(
+        "TASK_PROVIDER_NOT_REGISTERED",
+        "task provider is not registered",
+    ))
+}
+
+fn require_bound_provider(
+    record: &ServiceApiPersistedTaskRecord,
+    actor: &str,
+) -> Result<(), TaskLifecycleError> {
+    let provider = record.provider_did.as_deref().ok_or_else(|| {
+        conflict(
+            "TASK_AGREEMENT_MIGRATION_REQUIRED",
+            "legacy task agreement is incomplete",
+        )
+    })?;
+    if provider == actor {
+        return Ok(());
+    }
+    Err(TaskLifecycleError::Forbidden(
+        "TASK_PROVIDER_MISMATCH",
+        "actor is not the assigned provider".to_owned(),
+    ))
+}
+
+fn require_legal_transition(state: &str, action: &str) -> Result<&'static str, TaskLifecycleError> {
+    match (state, action) {
+        ("submitted", "task:accept") => Ok("accepted"),
+        ("accepted", "task:complete") => Ok("completed"),
+        _ => Err(conflict(
+            "TASK_STATE_CONFLICT",
+            "task transition is not legal from current state",
+        )),
+    }
+}
+
+fn bound_task_record(
+    id: &str,
+    creator: &str,
+    input: &CreateInput,
+) -> ServiceApiPersistedTaskRecord {
+    ServiceApiPersistedTaskRecord {
+        task_id: id.to_owned(),
+        state: "submitted".to_owned(),
+        creator_did: Some(creator.to_owned()),
+        task_type: input.task_type.clone(),
+        description: input.description.clone(),
+        assignee: Some(input.provider_did.clone()),
+        provider_did: Some(input.provider_did.clone()),
+        transaction_id: Some(input.transaction_id.clone()),
+        terms_digest: Some(input.terms_digest.clone()),
+        completion_evidence_digest: None,
+        create_idempotency_key: Some(input.idempotency_key.clone()),
+    }
+}
+
+fn issue_lifecycle_grants(
+    store: &mut ServiceApiMessageStore,
+    task_id: &str,
+    creator: &str,
+    provider: &str,
+) {
+    for (did, action, role) in [
+        (creator, "task:read", "participant"),
+        (provider, "task:read", "participant"),
+        (provider, "task:accept", "provider"),
+        (provider, "task:complete", "provider"),
+    ] {
+        let key = format!("task-lifecycle:{task_id}:{did}:{action}");
+        store.snapshot.agent_grants.insert(
+            key.clone(),
+            ServiceApiPersistedAgentGrantRecord {
+                did: did.to_owned(),
+                resource: format!("task:{task_id}"),
+                role: role.to_owned(),
+                action: action.to_owned(),
+                status: "active".to_owned(),
+                idempotency_key: key,
+            },
+        );
+    }
+}
+
+fn valid_digest(value: &str) -> bool {
+    value.len() == DIGEST_LEN
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+}
+fn bad(code: &'static str, message: impl Into<String>) -> TaskLifecycleError {
+    TaskLifecycleError::BadRequest(code, message.into())
+}
+fn agreement(message: impl Into<String>) -> TaskLifecycleError {
+    bad("TASK_AGREEMENT_INVALID", message)
+}
+fn conflict(code: &'static str, message: impl Into<String>) -> TaskLifecycleError {
+    TaskLifecycleError::Conflict(code, message.into())
+}
+fn persistence(error: String) -> TaskLifecycleError {
+    TaskLifecycleError::Persistence(error)
+}

--- a/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/lifecycle/agreement.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/lifecycle/agreement.rs
@@ -1,0 +1,111 @@
+use super::input::CreateInput;
+use super::*;
+
+pub(super) fn require_registered_provider(
+    store: &ServiceApiMessageStore,
+    did: &str,
+) -> Result<(), TaskLifecycleError> {
+    if store
+        .snapshot
+        .agents
+        .get(did)
+        .is_some_and(|agent| agent.registered)
+    {
+        return Ok(());
+    }
+    Err(bad(
+        "TASK_PROVIDER_NOT_REGISTERED",
+        "task provider is not registered",
+    ))
+}
+
+pub(super) fn require_bound_provider(
+    record: &ServiceApiPersistedTaskRecord,
+    actor: &str,
+) -> Result<(), TaskLifecycleError> {
+    let provider = required_agreement(&record.provider_did)?;
+    if provider == actor {
+        return Ok(());
+    }
+    Err(TaskLifecycleError::Forbidden(
+        "TASK_PROVIDER_MISMATCH",
+        "actor is not the assigned provider".to_owned(),
+    ))
+}
+
+pub(super) fn require_legal_transition(
+    state: &str,
+    action: &str,
+) -> Result<&'static str, TaskLifecycleError> {
+    match (state, action) {
+        ("submitted", "task:accept") => Ok("accepted"),
+        ("accepted", "task:complete") => Ok("completed"),
+        _ => Err(conflict(
+            "TASK_STATE_CONFLICT",
+            "task transition is not legal from current state",
+        )),
+    }
+}
+
+pub(super) fn build_record(
+    id: &str,
+    creator: &str,
+    input: &CreateInput,
+) -> ServiceApiPersistedTaskRecord {
+    ServiceApiPersistedTaskRecord {
+        task_id: id.to_owned(),
+        state: "submitted".to_owned(),
+        creator_did: Some(creator.to_owned()),
+        task_type: input.task_type.clone(),
+        description: input.description.clone(),
+        assignee: Some(input.provider_did.clone()),
+        provider_did: Some(input.provider_did.clone()),
+        transaction_id: Some(input.transaction_id.clone()),
+        terms_digest: Some(input.terms_digest.clone()),
+        completion_evidence_digest: None,
+        create_idempotency_key: Some(input.idempotency_key.clone()),
+    }
+}
+
+pub(super) fn issue_grants(
+    store: &mut ServiceApiMessageStore,
+    task_id: &str,
+    creator: &str,
+    provider: &str,
+) {
+    for (did, action, role) in grant_contract(creator, provider) {
+        let key = format!("task-lifecycle:{task_id}:{did}:{action}");
+        store.snapshot.agent_grants.insert(
+            key.clone(),
+            ServiceApiPersistedAgentGrantRecord {
+                did: did.to_owned(),
+                resource: format!("task:{task_id}"),
+                role: role.to_owned(),
+                action: action.to_owned(),
+                status: "active".to_owned(),
+                idempotency_key: key,
+            },
+        );
+    }
+}
+
+fn grant_contract<'a>(
+    creator: &'a str,
+    provider: &'a str,
+) -> [(&'a str, &'static str, &'static str); 4] {
+    [
+        (creator, "task:read", "participant"),
+        (provider, "task:read", "participant"),
+        (provider, "task:accept", "provider"),
+        (provider, "task:complete", "provider"),
+    ]
+}
+
+pub(super) fn required_agreement(value: &Option<String>) -> Result<String, TaskLifecycleError> {
+    value.clone().ok_or_else(|| {
+        conflict(
+            "TASK_AGREEMENT_MIGRATION_REQUIRED",
+            "legacy task agreement is incomplete",
+        )
+    })
+}

--- a/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/lifecycle/idempotency.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/lifecycle/idempotency.rs
@@ -1,0 +1,68 @@
+use super::input::{CreateInput, TransitionInput};
+use super::*;
+
+pub(super) fn find_create_retry<'a>(
+    store: &'a ServiceApiMessageStore,
+    actor: &str,
+    input: &CreateInput,
+) -> Result<Option<&'a ServiceApiPersistedTaskRecord>, TaskLifecycleError> {
+    let existing = store.snapshot.tasks.values().find(|task| {
+        task.creator_did.as_deref() == Some(actor)
+            && task.create_idempotency_key.as_deref() == Some(input.idempotency_key.as_str())
+    });
+    let Some(existing) = existing else {
+        return Ok(None);
+    };
+    if same_agreement(existing, input) {
+        return Ok(Some(existing));
+    }
+    Err(conflict(
+        "TASK_IDEMPOTENCY_CONFLICT",
+        "creation idempotency key was reused",
+    ))
+}
+
+pub(super) fn find_transition_retry<'a>(
+    store: &'a ServiceApiMessageStore,
+    actor: &str,
+    task_id: &str,
+    action: &str,
+    input: &TransitionInput,
+) -> Result<Option<&'a ServiceApiTaskTransitionReceiptRecord>, TaskLifecycleError> {
+    let receipt = store
+        .snapshot
+        .task_transition_receipts
+        .iter()
+        .find(|receipt| {
+            receipt.actor_did == actor && receipt.idempotency_key == input.idempotency_key
+        });
+    let Some(receipt) = receipt else {
+        return Ok(None);
+    };
+    if retry_matches(receipt, task_id, action, input) {
+        return Ok(Some(receipt));
+    }
+    Err(conflict(
+        "TASK_IDEMPOTENCY_CONFLICT",
+        "transition idempotency key was reused",
+    ))
+}
+
+fn same_agreement(record: &ServiceApiPersistedTaskRecord, input: &CreateInput) -> bool {
+    record.provider_did.as_deref() == Some(input.provider_did.as_str())
+        && record.transaction_id.as_deref() == Some(input.transaction_id.as_str())
+        && record.terms_digest.as_deref() == Some(input.terms_digest.as_str())
+        && record.task_type == input.task_type
+        && record.description == input.description
+}
+
+fn retry_matches(
+    receipt: &ServiceApiTaskTransitionReceiptRecord,
+    task_id: &str,
+    action: &str,
+    input: &TransitionInput,
+) -> bool {
+    receipt.task_id == task_id
+        && receipt.action == action
+        && receipt.completion_evidence_digest == input.completion_evidence_digest
+}

--- a/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/lifecycle/input.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/lifecycle/input.rs
@@ -1,0 +1,94 @@
+use super::*;
+
+const DIGEST_LEN: usize = 64;
+
+#[derive(Debug, Deserialize)]
+pub(super) struct CreateInput {
+    pub(super) provider_did: String,
+    pub(super) transaction_id: String,
+    pub(super) terms_digest: String,
+    pub(super) idempotency_key: String,
+    #[serde(default)]
+    pub(super) creator: Option<String>,
+    #[serde(default)]
+    pub(super) task_type: Option<String>,
+    #[serde(default)]
+    pub(super) description: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct TransitionInput {
+    pub(super) idempotency_key: String,
+    #[serde(default)]
+    pub(super) completion_evidence_digest: Option<String>,
+}
+
+pub(super) fn parse_create(payload: &str, actor: &str) -> Result<CreateInput, TaskLifecycleError> {
+    let input: CreateInput =
+        serde_json::from_str(payload).map_err(|error| agreement(error.to_string()))?;
+    validate_provider(input.provider_did.as_str())?;
+    validate_creator(input.creator.as_deref(), actor)?;
+    validate_agreement(&input)?;
+    Ok(input)
+}
+
+pub(super) fn parse_transition(
+    payload: &str,
+    action: &str,
+) -> Result<TransitionInput, TaskLifecycleError> {
+    let input: TransitionInput = serde_json::from_str(payload)
+        .map_err(|error| bad("TASK_AGREEMENT_INVALID", error.to_string()))?;
+    if input.idempotency_key.trim().is_empty() {
+        return Err(agreement("transition idempotency key is required"));
+    }
+    validate_completion_evidence(action, input.completion_evidence_digest.as_deref())?;
+    Ok(input)
+}
+
+fn validate_provider(provider: &str) -> Result<(), TaskLifecycleError> {
+    AgentDid::parse(provider)
+        .map(|_| ())
+        .map_err(|error| bad("TASK_PROVIDER_INVALID", error.to_string()))
+}
+
+fn validate_creator(creator: Option<&str>, actor: &str) -> Result<(), TaskLifecycleError> {
+    if creator.is_none_or(|value| value == actor) {
+        return Ok(());
+    }
+    Err(bad(
+        "TASK_CREATOR_MISMATCH",
+        "body creator differs from authenticated actor",
+    ))
+}
+
+fn validate_agreement(input: &CreateInput) -> Result<(), TaskLifecycleError> {
+    if !input.transaction_id.trim().is_empty()
+        && !input.idempotency_key.trim().is_empty()
+        && valid_digest(input.terms_digest.as_str())
+    {
+        return Ok(());
+    }
+    Err(agreement(
+        "transaction, terms digest, and idempotency key are required",
+    ))
+}
+
+fn validate_completion_evidence(
+    action: &str,
+    digest: Option<&str>,
+) -> Result<(), TaskLifecycleError> {
+    if action != "task:complete" || digest.is_some_and(valid_digest) {
+        return Ok(());
+    }
+    Err(bad(
+        "TASK_COMPLETION_EVIDENCE_INVALID",
+        "completion evidence digest is required",
+    ))
+}
+
+fn valid_digest(value: &str) -> bool {
+    value.len() == DIGEST_LEN
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+}

--- a/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/lifecycle/receipt.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/lifecycle/receipt.rs
@@ -1,0 +1,63 @@
+use super::agreement::required_agreement;
+use super::*;
+
+pub(super) struct ReceiptInput<'a> {
+    pub(super) actor: &'a str,
+    pub(super) action: &'a str,
+    pub(super) prior_state: String,
+    pub(super) idempotency_key: String,
+    pub(super) correlation_id: &'a str,
+    pub(super) sequence: usize,
+}
+
+pub(super) fn build(
+    record: &ServiceApiPersistedTaskRecord,
+    input: ReceiptInput<'_>,
+) -> Result<ServiceApiTaskTransitionReceiptRecord, TaskLifecycleError> {
+    Ok(ServiceApiTaskTransitionReceiptRecord {
+        receipt_id: format!("task-transition-receipt-{:08}", input.sequence),
+        correlation_id: input.correlation_id.to_owned(),
+        idempotency_key: input.idempotency_key,
+        actor_did: input.actor.to_owned(),
+        task_id: record.task_id.clone(),
+        transaction_id: required_agreement(&record.transaction_id)?,
+        action: input.action.to_owned(),
+        prior_state: input.prior_state,
+        resulting_state: record.state.clone(),
+        terms_digest: required_agreement(&record.terms_digest)?,
+        completion_evidence_digest: record.completion_evidence_digest.clone(),
+    })
+}
+
+pub(super) fn create_response(record: &ServiceApiPersistedTaskRecord) -> ServiceApiTaskCreateBody {
+    ServiceApiTaskCreateBody {
+        task_id: record.task_id.clone(),
+        state: record.state.clone(),
+        transaction_id: record.transaction_id.clone(),
+        creator_did: record.creator_did.clone(),
+        provider_did: record.provider_did.clone(),
+        terms_digest: record.terms_digest.clone(),
+    }
+}
+
+pub(super) fn transition_response(
+    record: &ServiceApiPersistedTaskRecord,
+    receipt_id: &str,
+) -> ServiceApiTaskTransitionBody {
+    ServiceApiTaskTransitionBody {
+        task_id: record.task_id.clone(),
+        state: record.state.clone(),
+        transaction_id: record.transaction_id.clone(),
+        creator_did: record.creator_did.clone(),
+        provider_did: record.provider_did.clone(),
+        terms_digest: record.terms_digest.clone(),
+        receipt_id: Some(receipt_id.to_owned()),
+    }
+}
+
+pub(super) fn retry_response(
+    store: &ServiceApiMessageStore,
+    receipt: &ServiceApiTaskTransitionReceiptRecord,
+) -> ServiceApiTaskTransitionBody {
+    transition_response(&store.snapshot.tasks[&receipt.task_id], &receipt.receipt_id)
+}

--- a/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/tasks.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/tasks.rs
@@ -27,6 +27,11 @@ pub(super) fn build_task_record(
             .map(|metadata| metadata.task_type.clone()),
         description: dispatch_metadata.map(|metadata| metadata.description),
         assignee: None,
+        provider_did: None,
+        transaction_id: None,
+        terms_digest: None,
+        completion_evidence_digest: None,
+        create_idempotency_key: None,
     }
 }
 

--- a/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/tasks.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/tasks.rs
@@ -1,38 +1,13 @@
 use super::super::super::{
     audit_export::{persist_service_api_audit_export_event, service_api_task_created_audit_event},
-    models::ServiceApiPersistedTaskRecord,
     ServiceApiMessageStore,
 };
-use super::dispatch::DispatchableTaskPayload;
 use crate::service_api_endpoint::payload::deterministic_body_tag;
 
 pub(super) fn next_task_id(store: &ServiceApiMessageStore, payload: &str) -> String {
     next_local_task_escrow_id("task-local", payload, |candidate| {
         store.snapshot.tasks.contains_key(candidate)
     })
-}
-
-pub(super) fn build_task_record(
-    task_id: &str,
-    dispatch_metadata: Option<DispatchableTaskPayload>,
-) -> ServiceApiPersistedTaskRecord {
-    ServiceApiPersistedTaskRecord {
-        task_id: task_id.to_owned(),
-        state: "submitted".to_owned(),
-        creator_did: dispatch_metadata
-            .as_ref()
-            .map(|metadata| metadata.creator_did.clone()),
-        task_type: dispatch_metadata
-            .as_ref()
-            .map(|metadata| metadata.task_type.clone()),
-        description: dispatch_metadata.map(|metadata| metadata.description),
-        assignee: None,
-        provider_did: None,
-        transaction_id: None,
-        terms_digest: None,
-        completion_evidence_digest: None,
-        create_idempotency_key: None,
-    }
 }
 
 pub(super) fn persist_task_created_audit_export(

--- a/crates/kamn-node/src/service_api_endpoint/message_store/task_models.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/task_models.rs
@@ -1,0 +1,17 @@
+use super::*;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct ServiceApiTaskTransitionReceiptRecord {
+    pub(crate) receipt_id: String,
+    pub(crate) correlation_id: String,
+    pub(crate) idempotency_key: String,
+    pub(crate) actor_did: String,
+    pub(crate) task_id: String,
+    pub(crate) transaction_id: String,
+    pub(crate) action: String,
+    pub(crate) prior_state: String,
+    pub(crate) resulting_state: String,
+    pub(crate) terms_digest: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) completion_evidence_digest: Option<String>,
+}

--- a/crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes.rs
+++ b/crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes.rs
@@ -42,6 +42,34 @@ fn persistence_error(error: &str) -> Response {
     )
 }
 
+fn task_actor(context: &ServiceApiRequestContext) -> Result<String, Box<Response>> {
+    let target = super::auth::resolve_transaction_authorization_target(&context.parsed_request)
+        .map_err(|error| Box::new(forbidden(error.reason_code, error.message.as_str())))?;
+    target
+        .map(|target| target.actor_did)
+        .ok_or_else(|| Box::new(persistence_error("task authorization target is missing")))
+}
+
+fn task_lifecycle_error_response(error: message_store::TaskLifecycleError) -> Response {
+    use message_store::TaskLifecycleError::*;
+    match error {
+        BadRequest(code, message) => task_error(StatusCode::BAD_REQUEST, code, message),
+        Forbidden(code, message) => task_error(StatusCode::FORBIDDEN, code, message),
+        Conflict(code, message) => task_error(StatusCode::CONFLICT, code, message),
+        NotFound => super::payload::json_error_response(
+            StatusCode::NOT_FOUND,
+            "not-found",
+            "service_api_route_not_found",
+            "service api task not found",
+        ),
+        Persistence(message) => persistence_error(message.as_str()),
+    }
+}
+
+fn task_error(status: StatusCode, code: &'static str, message: String) -> Response {
+    super::payload::json_error_response(status, "task", code, message.as_str())
+}
+
 pub(super) async fn handle_service_api_http_route(
     State(state): State<Arc<ServiceApiRuntimeState>>,
     Extension(context): Extension<ServiceApiRequestContext>,

--- a/crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/mutations/create_routes.rs
+++ b/crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/mutations/create_routes.rs
@@ -44,6 +44,10 @@ async fn create_task(
     state: &Arc<ServiceApiRuntimeState>,
     context: &ServiceApiRequestContext,
 ) -> Response {
+    let actor_did = match super::super::task_actor(context) {
+        Ok(actor) => actor,
+        Err(response) => return *response,
+    };
     let result = {
         let mut store = state.message_store.lock().await;
         if let Err(response) =
@@ -51,7 +55,7 @@ async fn create_task(
         {
             return *response;
         }
-        store.create_task(context.parsed_request.body.as_str())
+        store.create_bound_task(actor_did.as_str(), context.parsed_request.body.as_str())
     };
     match result {
         Ok(payload) => {
@@ -60,7 +64,7 @@ async fn create_task(
                 .publish_task_submitted_event(&payload);
             contract_json(201, &payload)
         }
-        Err(error) => persistence_error("service api task persistence failed", error),
+        Err(error) => super::super::task_lifecycle_error_response(error),
     }
 }
 

--- a/crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/mutations/update_routes/state_routes.rs
+++ b/crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/mutations/update_routes/state_routes.rs
@@ -20,10 +20,10 @@ async fn task_route_response(
     path: &str,
 ) -> Option<Response> {
     if let Some(task_id) = super::payload::task_accept_path_id(path) {
-        return Some(task_transition(state, context, task_id, "accepted", true).await);
+        return Some(task_transition(state, context, task_id, "task:accept", true).await);
     }
     let task_id = super::payload::task_complete_path_id(path)?;
-    Some(task_transition(state, context, task_id, "completed", true).await)
+    Some(task_transition(state, context, task_id, "task:complete", true).await)
 }
 async fn persistence_route_response(
     state: &Arc<ServiceApiRuntimeState>,
@@ -54,6 +54,10 @@ async fn task_transition(
     target: &str,
     publish: bool,
 ) -> Response {
+    let actor_did = match super::super::super::task_actor(context) {
+        Ok(actor) => actor,
+        Err(response) => return *response,
+    };
     let result = {
         let mut store = state.message_store.lock().await;
         if let Err(response) =
@@ -61,10 +65,16 @@ async fn task_transition(
         {
             return *response;
         }
-        store.transition_task(task_id, target)
+        store.transition_bound_task(
+            actor_did.as_str(),
+            task_id,
+            target,
+            context.parsed_request.body.as_str(),
+            context.correlation_id.as_str(),
+        )
     };
     match result {
-        Ok(Some(payload)) => {
+        Ok(payload) => {
             if publish {
                 state
                     .websocket_events
@@ -72,8 +82,7 @@ async fn task_transition(
             }
             contract_json(200, &payload)
         }
-        Ok(None) => not_found(),
-        Err(error) => persistence_error("service api task persistence failed", error),
+        Err(error) => super::super::super::task_lifecycle_error_response(error),
     }
 }
 

--- a/crates/kamn-node/src/service_api_endpoint/models.rs
+++ b/crates/kamn-node/src/service_api_endpoint/models.rs
@@ -96,6 +96,14 @@ pub(crate) struct ServiceApiSettlementMetadata {
 pub(crate) struct ServiceApiTaskCreateBody {
     pub(crate) task_id: String,
     pub(crate) state: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) transaction_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) creator_did: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) provider_did: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) terms_digest: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -108,6 +116,16 @@ pub(crate) struct ServiceApiTaskGetBody {
 pub(crate) struct ServiceApiTaskTransitionBody {
     pub(crate) task_id: String,
     pub(crate) state: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) transaction_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) creator_did: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) provider_did: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) terms_digest: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) receipt_id: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/kamn-node/src/service_api_endpoint/payload.rs
+++ b/crates/kamn-node/src/service_api_endpoint/payload.rs
@@ -151,6 +151,10 @@ pub(super) fn render_service_api_endpoint_response(
         let payload = ServiceApiTaskCreateBody {
             task_id,
             state: "submitted".to_owned(),
+            transaction_id: None,
+            creator_did: None,
+            provider_did: None,
+            terms_digest: None,
         };
         return ServiceApiEndpointResponse {
             status_code: 201,
@@ -212,6 +216,11 @@ pub(super) fn render_service_api_endpoint_response(
             let payload = ServiceApiTaskTransitionBody {
                 task_id: task_id.to_owned(),
                 state: "accepted".to_owned(),
+                transaction_id: None,
+                creator_did: None,
+                provider_did: None,
+                terms_digest: None,
+                receipt_id: None,
             };
             return ServiceApiEndpointResponse {
                 status_code: 200,
@@ -223,6 +232,11 @@ pub(super) fn render_service_api_endpoint_response(
             let payload = ServiceApiTaskTransitionBody {
                 task_id: task_id.to_owned(),
                 state: "completed".to_owned(),
+                transaction_id: None,
+                creator_did: None,
+                provider_did: None,
+                terms_digest: None,
+                receipt_id: None,
             };
             return ServiceApiEndpointResponse {
                 status_code: 200,

--- a/crates/kamn-node/src/service_api_endpoint/websocket.rs
+++ b/crates/kamn-node/src/service_api_endpoint/websocket.rs
@@ -628,10 +628,19 @@ mod tests {
         fanout.publish_task_submitted_event(&ServiceApiTaskCreateBody {
             task_id: "task-1".to_owned(),
             state: "submitted".to_owned(),
+            transaction_id: None,
+            creator_did: None,
+            provider_did: None,
+            terms_digest: None,
         });
         fanout.publish_task_transition_event(&ServiceApiTaskTransitionBody {
             task_id: "task-1".to_owned(),
             state: "accepted".to_owned(),
+            transaction_id: None,
+            creator_did: None,
+            provider_did: None,
+            terms_digest: None,
+            receipt_id: None,
         });
         fanout.publish_bridge_submitted_event(&ServiceApiBridgeSubmitBody {
             bridge_id: "bridge-1".to_owned(),

--- a/specs/7090-task-creator-provider-lifecycle.md
+++ b/specs/7090-task-creator-provider-lifecycle.md
@@ -1,0 +1,211 @@
+# Bind Task Lifecycle To Creator And Assigned Provider
+
+## Objective
+
+Turn the existing generic task state into one durable agent transaction between
+an authenticated creator and one named provider. Bind every transition to an
+immutable transaction ID and terms digest, enforce the submitted -> accepted ->
+completed state machine, and emit durable transition receipts.
+
+## Inputs/Outputs
+
+Task creation input is JSON containing:
+
+- `provider_did`: one registered provider DID.
+- `transaction_id`: caller-supplied stable transaction identifier.
+- `terms_digest`: lowercase 64-character hex digest of canonical terms.
+- `idempotency_key`: stable creation retry key.
+- Optional `task_type` and `description` discovery metadata.
+- Optional legacy `creator`; when present it must equal the authenticated actor.
+
+The creator DID always comes from the verified request context, never from the
+body. Creation returns the task ID, transaction ID, creator DID, provider DID,
+terms digest, and `submitted` state.
+
+Task acceptance input is JSON containing `idempotency_key`. Completion input is
+JSON containing `idempotency_key` and a lowercase 64-character hex
+`completion_evidence_digest`. Transition responses include the same immutable
+task agreement fields, resulting state, and transition receipt ID.
+
+## Task Contract
+
+New tasks durably store:
+
+- task ID
+- transaction ID
+- creator DID
+- provider DID
+- terms digest
+- state
+- optional completion evidence digest
+- create idempotency key
+- optional task type and description
+
+Creation atomically issues exact active server-owned grants for the provider to
+`task:accept` and `task:complete` on `task:{task_id}`. It also issues exact
+`task:read` grants for creator and provider. Grant IDs are deterministic from
+task ID, actor, action, and role, so retrying creation cannot duplicate
+authority.
+
+The legal state machine is:
+
+1. Creator creates `submitted` task naming exactly one provider.
+2. Named provider accepts `submitted` -> `accepted`.
+3. Same provider completes `accepted` -> `completed` with evidence digest.
+
+No actor can reassign the provider or change transaction ID or terms digest.
+
+## Idempotency
+
+- Repeating create with the same creator, idempotency key, and canonical payload
+  returns the existing task.
+- Reusing a create idempotency key with different agreement fields fails.
+- Repeating a transition with the same actor, action, idempotency key, and
+  canonical payload returns the existing receipt and resulting task state.
+- Reusing a transition idempotency key with different task, actor, action, or
+  completion digest fails without mutation.
+- A new idempotency key for an already-applied transition returns an explicit
+  state conflict; it does not manufacture a second receipt.
+
+## Transition Receipts
+
+Every successful accept or complete transition appends one durable receipt with:
+
+- receipt ID
+- redacted correlation join key
+- idempotency key
+- actor DID
+- task ID
+- transaction ID
+- action
+- prior state
+- resulting state
+- terms digest
+- optional completion evidence digest
+
+Authorization denials continue to use #7089 authorization receipts. Domain
+state/order/idempotency denials return structured errors and do not append a
+successful transition receipt.
+
+## Boundaries/Non-goals
+
+- Do not implement escrow funding, release, Solana submission, or value movement.
+- Do not implement bidding, reassignment, delegation, teams, or a marketplace.
+- Do not trust body `creator`, provider headers, capabilities, or scope as actor
+  identity or authority.
+- Do not add a public grant administration API.
+- Do not add a generalized workflow engine.
+- Do not change message, content, bridge, websocket transport, or unrelated
+  authorization behavior.
+- Do not claim that task completion settles payment.
+
+## Failure Modes
+
+- Missing or invalid provider DID: `TASK_PROVIDER_INVALID`.
+- Provider is not registered: `TASK_PROVIDER_NOT_REGISTERED`.
+- Body creator differs from authenticated actor: `TASK_CREATOR_MISMATCH`.
+- Missing/invalid transaction ID or terms digest: `TASK_AGREEMENT_INVALID`.
+- Authenticated actor is not assigned provider: `TASK_PROVIDER_MISMATCH`.
+- Accept outside `submitted`: `TASK_STATE_CONFLICT`.
+- Complete outside `accepted`: `TASK_STATE_CONFLICT`.
+- Missing/invalid completion evidence digest: `TASK_COMPLETION_EVIDENCE_INVALID`.
+- Conflicting idempotency-key reuse: `TASK_IDEMPOTENCY_CONFLICT`.
+- Legacy task missing agreement fields: `TASK_AGREEMENT_MIGRATION_REQUIRED`.
+- Persistence or grant issuance failure: hard state persistence error; no partial
+  task, grant, transition, or receipt may be reported as successful.
+
+## Acceptance Criteria
+
+- [ ] Creation derives creator DID only from verified request context.
+- [ ] A new task persists one creator, one provider, transaction ID, terms
+      digest, create idempotency key, and submitted state.
+- [ ] Creation requires the named provider to be durably registered.
+- [ ] Creation issues deterministic exact read/accept/complete grants needed by
+      the real #7089 middleware path.
+- [ ] Only the assigned provider can accept and complete.
+- [ ] Creator, unrelated actor, and verifier cannot perform provider transitions.
+- [ ] Submitted tasks cannot complete; accepted tasks cannot accept again under
+      a new idempotency key.
+- [ ] Completion requires and persists a valid evidence digest.
+- [ ] Agreement identity cannot change after creation.
+- [ ] Identical retries return the existing task or transition receipt.
+- [ ] Conflicting retries fail without state or receipt mutation.
+- [ ] Successful transitions persist one secret-free receipt with agreement and
+      state linkage.
+- [ ] Task, grants, idempotency, and receipts survive restart.
+- [ ] Legacy snapshots load, but legacy incomplete tasks fail closed on protected
+      transitions with an explicit migration error.
+- [ ] A live HTTP integration test proves authenticated create -> provider accept
+      -> provider complete without mocking authorization or the message store.
+
+## Files To Touch
+
+- `crates/kamn-node/src/service_api_endpoint/models.rs`
+- `crates/kamn-node/src/service_api_endpoint/message_store/models.rs`
+- `crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops.rs`
+- focused task store/parser/receipt modules under that directory
+- task create and transition HTTP route handlers
+- #7089 grant validation/issuance store boundary
+- task/escrow service API integration tests
+- task response models in SDK/agent/MCP/CLI only where compilation or real path
+  parity requires them
+
+No new dependency is required.
+
+## Persistence And Compatibility
+
+- New snapshots use schema `kamn.service-api.state.v4`.
+- New task agreement and receipt collections are serde-defaulted so v3
+  snapshots load.
+- Existing incomplete task records remain readable for status/audit purposes but
+  protected transitions fail with `TASK_AGREEMENT_MIGRATION_REQUIRED`.
+- Creation, lifecycle grants, task mutation, and transition receipt persistence
+  occur under the existing message-store lock and one atomic state-file write.
+- No migration silently invents creator, provider, transaction, terms, or
+  evidence values.
+
+## Error Semantics
+
+Malformed task inputs return HTTP 400 in the standard JSON error envelope with
+the stable task reason code. Wrong actor or missing lifecycle grant returns HTTP
+403. Illegal state and idempotency conflicts return HTTP 409. Missing task
+returns HTTP 404. Persistence errors return HTTP 500 with the existing state
+persistence reason code.
+
+Interior code returns typed task lifecycle errors. HTTP entrypoints map each
+error once and log once. No fallback or partial success is permitted.
+
+## Test Plan
+
+RED:
+
+- Task creation currently accepts no provider, transaction, terms, or idempotency
+  contract and trusts optional body creator metadata.
+- Any granted actor can transition any task because store transitions receive no
+  actor identity.
+- Task can currently move directly from submitted to completed.
+- Completion currently accepts no evidence digest.
+- No lifecycle grant issuance, idempotent retry, or transition receipt exists.
+
+GREEN:
+
+- Add the minimal v4 task agreement, receipt, and idempotency models.
+- Parse and validate canonical create/transition payloads.
+- Pass verified actor and redacted correlation join key into store operations.
+- Enforce provider/state invariants and issue exact lifecycle grants.
+- Return structured lifecycle errors from real HTTP routes.
+
+REFACTOR:
+
+- Separate payload validation, state transition, receipt creation, and grant
+  issuance into focused modules.
+- Keep files at or below 200 lines and functions at or below 25 lines.
+- Remove duplicate task resource/action parsing and preserve fail-closed errors.
+
+INTEGRATION:
+
+- Exercise create -> accept -> restart -> complete through the live HTTP server.
+- Inspect persisted agreement, exact grants, receipts, and completion evidence.
+- Prove wrong actor, illegal order, duplicate retry, and conflicting retry paths.
+- Run targeted node/SDK/MCP/CLI task tests, full node tests, strict clippy,
+  formatting, and `make check`.

--- a/specs/7090-task-creator-provider-lifecycle.md
+++ b/specs/7090-task-creator-provider-lifecycle.md
@@ -116,26 +116,26 @@ successful transition receipt.
 
 ## Acceptance Criteria
 
-- [ ] Creation derives creator DID only from verified request context.
-- [ ] A new task persists one creator, one provider, transaction ID, terms
+- [x] Creation derives creator DID only from verified request context.
+- [x] A new task persists one creator, one provider, transaction ID, terms
       digest, create idempotency key, and submitted state.
-- [ ] Creation requires the named provider to be durably registered.
-- [ ] Creation issues deterministic exact read/accept/complete grants needed by
+- [x] Creation requires the named provider to be durably registered.
+- [x] Creation issues deterministic exact read/accept/complete grants needed by
       the real #7089 middleware path.
-- [ ] Only the assigned provider can accept and complete.
-- [ ] Creator, unrelated actor, and verifier cannot perform provider transitions.
-- [ ] Submitted tasks cannot complete; accepted tasks cannot accept again under
+- [x] Only the assigned provider can accept and complete.
+- [x] Creator, unrelated actor, and verifier cannot perform provider transitions.
+- [x] Submitted tasks cannot complete; accepted tasks cannot accept again under
       a new idempotency key.
-- [ ] Completion requires and persists a valid evidence digest.
-- [ ] Agreement identity cannot change after creation.
-- [ ] Identical retries return the existing task or transition receipt.
-- [ ] Conflicting retries fail without state or receipt mutation.
-- [ ] Successful transitions persist one secret-free receipt with agreement and
+- [x] Completion requires and persists a valid evidence digest.
+- [x] Agreement identity cannot change after creation.
+- [x] Identical retries return the existing task or transition receipt.
+- [x] Conflicting retries fail without state or receipt mutation.
+- [x] Successful transitions persist one secret-free receipt with agreement and
       state linkage.
-- [ ] Task, grants, idempotency, and receipts survive restart.
-- [ ] Legacy snapshots load, but legacy incomplete tasks fail closed on protected
+- [x] Task, grants, idempotency, and receipts survive restart.
+- [x] Legacy snapshots load, but legacy incomplete tasks fail closed on protected
       transitions with an explicit migration error.
-- [ ] A live HTTP integration test proves authenticated create -> provider accept
+- [x] A live HTTP integration test proves authenticated create -> provider accept
       -> provider complete without mocking authorization or the message store.
 
 ## Files To Touch
@@ -154,7 +154,7 @@ No new dependency is required.
 
 ## Persistence And Compatibility
 
-- New snapshots use schema `kamn.service-api.state.v4`.
+- New snapshots use schema `kamn.runtime.service-api-message-store.v4`.
 - New task agreement and receipt collections are serde-defaulted so v3
   snapshots load.
 - Existing incomplete task records remain readable for status/audit purposes but


### PR DESCRIPTION
## Human Summary

- Binds each canonical task to an authenticated creator, one registered provider, a stable transaction ID, and immutable terms digest.
- Enforces signed `submitted -> accepted -> completed` transitions by the assigned provider, with completion evidence and exact server-owned grants.
- Adds durable idempotency and transition receipts that survive restart and return stable retry responses.
- Keeps provider-bound task reads side-effect free; task completion does not claim settlement or asset movement.

Closes #7090

Spec: `specs/7090-task-creator-provider-lifecycle.md`

## Testing

- `CARGO_TARGET_DIR=target/mvp-demo-proof CARGO_BUILD_JOBS=1 cargo test -p kamn-node task_creator_provider_lifecycle_contract_tests -- --nocapture`
- `CARGO_TARGET_DIR=target/mvp-demo-proof CARGO_BUILD_JOBS=1 cargo test -p kamn-node task_escrow_persistence_contract_tests`
- `CARGO_TARGET_DIR=target/mvp-demo-proof CARGO_BUILD_JOBS=1 cargo test -p kamn-node` (649 passed, 1 explicitly ignored live-devnet test)
- `CARGO_TARGET_DIR=target/mvp-demo-proof CARGO_BUILD_JOBS=1 make check`

## Notes for Reviewers

Review the actor/grant boundary, idempotency conflict matching, receipt persistence, and the deliberate removal of read-time auto-completion for provider-bound tasks. Value movement remains out of scope and is reserved for downstream devnet-backed settlement issues.

## AI Agent Details

- Snapshot schema is `kamn.runtime.service-api-message-store.v4`; v3-compatible fields and receipt collections are serde-defaulted.
- Lifecycle code is split across agreement, input, idempotency, and receipt modules, each within the repository size policy.
- The working vertical slice now executes signed create, provider accept, and provider complete requests with evidence.