### PR TITLE
[7092] Make devnet settlement idempotent and recoverable

### DIFF
--- a/crates/kamn-agent-lib/src/client.rs
+++ b/crates/kamn-agent-lib/src/client.rs
@@ -152,6 +152,18 @@ impl ServiceApiHttpClient {
         Ok(self.inner.accept_task(task_id, auth)?)
     }
 
+    /// Accepts one task with a canonical transition payload.
+    pub fn accept_task_with_payload(
+        &self,
+        task_id: &str,
+        payload: &str,
+        auth: &ServiceRequestAuth,
+    ) -> Result<ServiceTaskStatus, AgentLibError> {
+        Ok(self
+            .inner
+            .accept_task_with_payload(task_id, payload, auth)?)
+    }
+
     /// Completes one task via `POST /v1/tasks/{id}/complete`.
     pub fn complete_task(
         &self,
@@ -159,6 +171,18 @@ impl ServiceApiHttpClient {
         auth: &ServiceRequestAuth,
     ) -> Result<ServiceTaskStatus, AgentLibError> {
         Ok(self.inner.complete_task(task_id, auth)?)
+    }
+
+    /// Completes one task with a canonical evidence payload.
+    pub fn complete_task_with_payload(
+        &self,
+        task_id: &str,
+        payload: &str,
+        auth: &ServiceRequestAuth,
+    ) -> Result<ServiceTaskStatus, AgentLibError> {
+        Ok(self
+            .inner
+            .complete_task_with_payload(task_id, payload, auth)?)
     }
 
     /// Funds escrow via `POST /v1/escrow/fund`.
@@ -177,6 +201,18 @@ impl ServiceApiHttpClient {
         auth: &ServiceRequestAuth,
     ) -> Result<ServiceEscrowStatus, AgentLibError> {
         Ok(self.inner.release_escrow(escrow_id, auth)?)
+    }
+
+    /// Releases escrow with a canonical idempotency payload.
+    pub fn release_escrow_with_payload(
+        &self,
+        escrow_id: &str,
+        payload: &str,
+        auth: &ServiceRequestAuth,
+    ) -> Result<ServiceEscrowStatus, AgentLibError> {
+        Ok(self
+            .inner
+            .release_escrow_with_payload(escrow_id, payload, auth)?)
     }
 
     /// Registers content lifecycle via `POST /v1/content/register`.

--- a/crates/kamn-agent-lib/src/lib.rs
+++ b/crates/kamn-agent-lib/src/lib.rs
@@ -6,7 +6,7 @@ use std::sync::Mutex;
 use auth::KamnAuthHeaders;
 use client::ServiceApiHttpClient;
 use envelope::{build_and_sign_envelope, CanonicalMessageEnvelope};
-use kamn_sdk::{service_agent_registration_payload, AgentMetadata};
+use kamn_sdk::service_agent_registration_payload;
 use kolme::KolmeClient;
 use nonce::{NonceTracker, NonceTrackerError};
 
@@ -15,10 +15,10 @@ pub use identity::AgentIdentity;
 pub use kolme::{KolmeProofReceipt, KolmeProofVerification};
 
 pub use kamn_sdk::{
-    ServiceAgentProfile, ServiceBridgeStatus, ServiceBridgeSubmission, ServiceChannelMessages,
-    ServiceChannelReceipt, ServiceContentRegistration, ServiceContentStatus, ServiceEscrowStatus,
-    ServiceHealthStatus, ServiceMessageReceipt, ServiceMessageStatus, ServiceTaskReceipt,
-    ServiceTaskStatus,
+    AgentMetadata, ServiceAgentProfile, ServiceBridgeStatus, ServiceBridgeSubmission,
+    ServiceChannelMessages, ServiceChannelReceipt, ServiceContentRegistration,
+    ServiceContentStatus, ServiceEscrowStatus, ServiceHealthStatus, ServiceMessageReceipt,
+    ServiceMessageStatus, ServiceTaskReceipt, ServiceTaskStatus,
 };
 
 /// Authentication helpers.
@@ -222,28 +222,48 @@ impl KamnAgentHandle {
 
     /// Accepts one task through the service API.
     pub fn accept_task(&self, task_id: &str) -> Result<ServiceTaskStatus, AgentLibError> {
+        self.accept_task_with_payload(task_id, "{}")
+    }
+
+    /// Accepts one task with a canonical transition payload.
+    pub fn accept_task_with_payload(
+        &self,
+        task_id: &str,
+        payload: &str,
+    ) -> Result<ServiceTaskStatus, AgentLibError> {
         let nonce = self.next_nonce()?;
         let auth = self.service_client.build_auth(
             self.identity.did(),
             self.identity.signing_key(),
             nonce,
-            "{}",
+            payload,
             Some("tasks:write"),
         )?;
-        self.service_client.accept_task(task_id, &auth)
+        self.service_client
+            .accept_task_with_payload(task_id, payload, &auth)
     }
 
     /// Completes one task through the service API.
     pub fn complete_task(&self, task_id: &str) -> Result<ServiceTaskStatus, AgentLibError> {
+        self.complete_task_with_payload(task_id, "{}")
+    }
+
+    /// Completes one task with a canonical evidence payload.
+    pub fn complete_task_with_payload(
+        &self,
+        task_id: &str,
+        payload: &str,
+    ) -> Result<ServiceTaskStatus, AgentLibError> {
         let nonce = self.next_nonce()?;
         let auth = self.service_client.build_auth(
             self.identity.did(),
             self.identity.signing_key(),
             nonce,
-            "{}",
+            payload,
             Some("tasks:write"),
         )?;
-        self.service_client.complete_task(task_id, &auth)
+        self.service_client
+            .complete_task_with_payload(task_id, payload, &auth)
     }
 
     /// Funds escrow through the service API.
@@ -261,15 +281,25 @@ impl KamnAgentHandle {
 
     /// Releases one escrow through the service API.
     pub fn release_escrow(&self, escrow_id: &str) -> Result<ServiceEscrowStatus, AgentLibError> {
+        self.release_escrow_with_payload(escrow_id, "{}")
+    }
+
+    /// Releases escrow with a canonical idempotency payload.
+    pub fn release_escrow_with_payload(
+        &self,
+        escrow_id: &str,
+        payload: &str,
+    ) -> Result<ServiceEscrowStatus, AgentLibError> {
         let nonce = self.next_nonce()?;
         let auth = self.service_client.build_auth(
             self.identity.did(),
             self.identity.signing_key(),
             nonce,
-            "{}",
+            payload,
             Some("escrow:write"),
         )?;
-        self.service_client.release_escrow(escrow_id, &auth)
+        self.service_client
+            .release_escrow_with_payload(escrow_id, payload, &auth)
     }
 
     /// Registers content lifecycle state through the service API.

--- a/crates/kamn-e2e-harness/src/mvp_demo/artifact_digest.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/artifact_digest.rs
@@ -62,7 +62,7 @@ fn tagged_sha256(value: &str) -> String {
     format!("sha256:{}", sha256_hex(value))
 }
 
-fn sha256_hex(value: &str) -> String {
+pub(crate) fn sha256_hex(value: &str) -> String {
     const HEX: &[u8; 16] = b"0123456789abcdef";
     let digest = Sha256::digest(value.as_bytes());
     let mut output = String::with_capacity(64);

--- a/crates/kamn-e2e-harness/src/mvp_demo/devnet_settlement_grant_bootstrap.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/devnet_settlement_grant_bootstrap.rs
@@ -1,0 +1,62 @@
+use std::path::Path;
+
+use kamn_agent_lib::AgentIdentity;
+
+use super::devnet_settlement_service::CREATOR_AGENT_NAME;
+use super::report::escape_json;
+
+const GRANT_ID: &str = "mvp-demo-task-create";
+
+pub(super) fn write_creator_grant_bootstrap(
+    state_file: &Path,
+    run_dir: &Path,
+) -> Result<(), String> {
+    let identity = AgentIdentity::from_agent_name(CREATOR_AGENT_NAME)
+        .map_err(|error| format!("failed to derive MVP creator identity: {error}"))?;
+    let grant = grant_json(identity.did().as_str(), GRANT_ID);
+    let state = state_json(grant.as_str());
+    std::fs::write(state_file, state)
+        .map_err(|error| format!("failed to bootstrap MVP creator grant: {error}"))?;
+    let proof = proof_json(identity.did().as_str(), grant.as_str());
+    std::fs::write(
+        run_dir.join("proof/local-operator-grant-bootstrap.json"),
+        proof,
+    )
+    .map_err(|error| format!("failed to write MVP creator grant proof: {error}"))
+}
+
+fn state_json(grant: &str) -> String {
+    format!(
+        "{{\"schema_version\":\"kamn.runtime.service-api-message-store.v4\",\"messages\":{{}},\"channel_messages\":{{}},\"agent_grants\":{{\"{GRANT_ID}\":{grant}}}}}"
+    )
+}
+
+fn proof_json(did: &str, grant: &str) -> String {
+    format!(
+        "{{\"schema_version\":\"kamn.mvp.local-operator-grant.v1\",\"claim_scope\":\"local-only\",\"actor_did\":\"{}\",\"grant\":{grant}}}",
+        escape_json(did),
+    )
+}
+
+fn grant_json(did: &str, id: &str) -> String {
+    format!(
+        "{{\"did\":\"{}\",\"resource\":\"transaction:new\",\"role\":\"initiator\",\"action\":\"task:create\",\"status\":\"active\",\"idempotency_key\":\"{}\"}}",
+        escape_json(did), escape_json(id),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn local_operator_bootstrap_grants_only_task_creation() {
+        let json = grant_json("kamn:did:agent:creator-contract", GRANT_ID);
+
+        assert!(json.contains(r#""resource":"transaction:new""#));
+        assert!(json.contains(r#""role":"initiator""#));
+        assert!(json.contains(r#""action":"task:create""#));
+        assert!(!json.contains(r#""resource":"*""#));
+        assert!(!json.contains("escrow:release"));
+    }
+}

--- a/crates/kamn-e2e-harness/src/mvp_demo/devnet_settlement_live.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/devnet_settlement_live.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use super::devnet_settlement::DevnetSettlementEvidence;
 use super::devnet_settlement_build::build_node_binary;
-use super::devnet_settlement_node::launch_and_drive_service_api;
+use super::devnet_settlement_node::{launch_and_drive_service_api, ServiceApiRun};
 use super::devnet_settlement_solana::{balance_pair, solana_pubkey, validate_balance_movement};
 use super::devnet_settlement_state::persisted_signature;
 use super::live_task_binding::LiveTaskBinding;
@@ -32,7 +32,7 @@ pub(super) fn collect_live_devnet_settlement(
         before,
         after,
         persisted,
-        service_api.escrow_id,
+        service_api,
         binding,
     ))
 }
@@ -63,7 +63,7 @@ fn evidence(
     before: super::devnet_settlement_solana::BalancePair,
     after: super::devnet_settlement_solana::BalancePair,
     persisted: String,
-    escrow_id: String,
+    service_api: ServiceApiRun,
     binding: Option<&LiveTaskBinding>,
 ) -> DevnetSettlementEvidence {
     DevnetSettlementEvidence {
@@ -73,8 +73,8 @@ fn evidence(
         payer_pubkey: payer,
         recipient_pubkey: config.recipient_pubkey,
         lamports: config.lamports,
-        escrow_id,
-        task_id: binding.map(|value| value.task_id.clone()),
+        escrow_id: service_api.escrow_id,
+        task_id: Some(service_api.task_id),
         task_binding_digest: binding.map(|value| value.digest.clone()),
         settlement_tx_signature: persisted.clone(),
         settlement_commitment: config.commitment,

--- a/crates/kamn-e2e-harness/src/mvp_demo/devnet_settlement_node.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/devnet_settlement_node.rs
@@ -154,3 +154,22 @@ fn terminate_child(child: &mut Child) {
     let _ = child.kill();
     let _ = child.wait();
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn local_operator_bootstrap_grants_only_task_creation() {
+        let json = bootstrap_state_json(
+            "kamn:did:agent:creator-contract",
+            "mvp-demo-task-create",
+        );
+
+        assert!(json.contains(r#""resource":"transaction:new""#));
+        assert!(json.contains(r#""role":"initiator""#));
+        assert!(json.contains(r#""action":"task:create""#));
+        assert!(!json.contains(r#""resource":"*""#));
+        assert!(!json.contains("escrow:release"));
+    }
+}

--- a/crates/kamn-e2e-harness/src/mvp_demo/devnet_settlement_node.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/devnet_settlement_node.rs
@@ -11,6 +11,7 @@ use super::live_task_binding::LiveTaskBinding;
 
 pub(super) struct ServiceApiRun {
     pub(super) escrow_id: String,
+    pub(super) task_id: String,
 }
 
 pub(super) fn launch_and_drive_service_api(
@@ -23,15 +24,19 @@ pub(super) fn launch_and_drive_service_api(
     let endpoint = format!("http://127.0.0.1:{port}");
     let mut child = spawn_node(run_dir, state_file, port, config)?;
     wait_for_tcp_ready(port, &mut child)?;
-    let escrow_id = match drive_escrow_release(endpoint.as_str(), run_dir, binding) {
-        Ok(value) => value,
-        Err(error) => {
-            terminate_child(&mut child);
-            return Err(error);
-        }
-    };
+    let settlement =
+        match drive_escrow_release(endpoint.as_str(), run_dir, binding, config.lamports) {
+            Ok(value) => value,
+            Err(error) => {
+                terminate_child(&mut child);
+                return Err(error);
+            }
+        };
     terminate_child(&mut child);
-    Ok(ServiceApiRun { escrow_id })
+    Ok(ServiceApiRun {
+        escrow_id: settlement.escrow_id,
+        task_id: settlement.task_id,
+    })
 }
 
 fn spawn_node(

--- a/crates/kamn-e2e-harness/src/mvp_demo/devnet_settlement_node.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/devnet_settlement_node.rs
@@ -5,6 +5,7 @@ use std::process::{Child, Command, Stdio};
 use std::time::{Duration, Instant};
 
 use super::devnet_settlement_build::node_binary_path;
+use super::devnet_settlement_grant_bootstrap::write_creator_grant_bootstrap;
 use super::devnet_settlement_live::LiveSettlementConfig;
 use super::devnet_settlement_service::drive_escrow_release;
 use super::live_task_binding::LiveTaskBinding;
@@ -22,6 +23,7 @@ pub(super) fn launch_and_drive_service_api(
 ) -> Result<ServiceApiRun, String> {
     let port = reserve_local_port()?;
     let endpoint = format!("http://127.0.0.1:{port}");
+    write_creator_grant_bootstrap(state_file, run_dir)?;
     let mut child = spawn_node(run_dir, state_file, port, config)?;
     wait_for_tcp_ready(port, &mut child)?;
     let settlement =
@@ -153,23 +155,4 @@ fn reject_early_exit(child: &mut Child) -> Result<(), String> {
 fn terminate_child(child: &mut Child) {
     let _ = child.kill();
     let _ = child.wait();
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn local_operator_bootstrap_grants_only_task_creation() {
-        let json = bootstrap_state_json(
-            "kamn:did:agent:creator-contract",
-            "mvp-demo-task-create",
-        );
-
-        assert!(json.contains(r#""resource":"transaction:new""#));
-        assert!(json.contains(r#""role":"initiator""#));
-        assert!(json.contains(r#""action":"task:create""#));
-        assert!(!json.contains(r#""resource":"*""#));
-        assert!(!json.contains("escrow:release"));
-    }
 }

--- a/crates/kamn-e2e-harness/src/mvp_demo/devnet_settlement_service.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/devnet_settlement_service.rs
@@ -1,7 +1,11 @@
 use std::path::Path;
 
 use super::live_task_binding::LiveTaskBinding;
-use kamn_agent_lib::KamnAgentHandle;
+use kamn_agent_lib::{AgentMetadata, KamnAgentHandle};
+
+mod agreement;
+
+use agreement::SettlementAgreement;
 
 const SDK_TIMEOUT_ENV: &str = "KAMN_SDK_SERVICE_TIMEOUT_SECONDS";
 const LIVE_SETTLEMENT_TIMEOUT_SECONDS: &str = "90";
@@ -10,25 +14,63 @@ pub(super) fn drive_escrow_release(
     endpoint: &str,
     run_dir: &Path,
     binding: Option<&LiveTaskBinding>,
-) -> Result<String, String> {
+    amount_lamports: u64,
+) -> Result<SettlementRun, String> {
     let _timeout = EnvOverride::set(SDK_TIMEOUT_ENV, LIVE_SETTLEMENT_TIMEOUT_SECONDS);
-    let handle = KamnAgentHandle::connect(
-        endpoint,
-        "http://127.0.0.1:13000",
-        "kamn-mvp-devnet-settlement",
-    )
-    .map_err(|error| format!("failed to create KAMN agent handle: {error}"))?;
-    let payload = fund_payload(run_dir, binding)?;
+    let creator = agent(endpoint, "kamn-mvp-devnet-settlement-creator")?;
+    let provider = agent(endpoint, "kamn-mvp-devnet-settlement-provider")?;
+    register(&creator, "creator")?;
+    register(&provider, "provider")?;
+    let agreement =
+        SettlementAgreement::new(run_dir, binding, amount_lamports, &creator, &provider)?;
+    let task = creator
+        .create_task(agreement.task_payload().as_str())
+        .map_err(|error| format!("failed to create MVP demo task: {error}"))?;
+    provider
+        .accept_task_with_payload(task.task_id.as_str(), agreement.accept_payload().as_str())
+        .map_err(|error| format!("failed to accept MVP demo task: {error}"))?;
+    let payload = agreement.fund_payload(task.task_id.as_str());
     write_funding_payload(run_dir, payload.as_str())?;
-    let funded = handle
+    let funded = creator
         .fund_escrow(payload.as_str())
         .map_err(|error| format!("failed to fund MVP demo escrow: {error}"))?;
     require_expected_escrow_id(payload.as_str(), funded.escrow_id.as_str())?;
-    let released = handle
-        .release_escrow(funded.escrow_id.as_str())
+    provider
+        .complete_task_with_payload(task.task_id.as_str(), agreement.complete_payload().as_str())
+        .map_err(|error| format!("failed to complete MVP demo task: {error}"))?;
+    let released = creator
+        .release_escrow_with_payload(
+            funded.escrow_id.as_str(),
+            agreement.release_payload().as_str(),
+        )
         .map_err(|error| format!("failed to release MVP demo escrow: {error}"))?;
     require_released(released.state.as_str())?;
-    Ok(released.escrow_id)
+    Ok(SettlementRun {
+        escrow_id: released.escrow_id,
+        task_id: task.task_id,
+    })
+}
+
+pub(super) struct SettlementRun {
+    pub(super) escrow_id: String,
+    pub(super) task_id: String,
+}
+
+fn agent(endpoint: &str, name: &str) -> Result<KamnAgentHandle, String> {
+    KamnAgentHandle::connect(endpoint, "http://127.0.0.1:13000", name)
+        .map_err(|error| format!("failed to create KAMN agent handle: {error}"))
+}
+
+fn register(handle: &KamnAgentHandle, role: &str) -> Result<(), String> {
+    let metadata = AgentMetadata {
+        agent_type: format!("mvp-settlement-{role}"),
+        model_family: "deterministic-e2e-harness".to_owned(),
+        capabilities: vec!["task-settlement".to_owned()],
+    };
+    handle
+        .register_agent(&metadata)
+        .map(|_| ())
+        .map_err(|error| format!("failed to register MVP demo {role}: {error}"))
 }
 
 fn require_released(state: &str) -> Result<(), String> {
@@ -59,22 +101,6 @@ impl Drop for EnvOverride {
             Some(value) => std::env::set_var(self.name, value),
             None => std::env::remove_var(self.name),
         }
-    }
-}
-
-fn fund_payload(run_dir: &Path, binding: Option<&LiveTaskBinding>) -> Result<String, String> {
-    let run_id = run_dir
-        .file_name()
-        .and_then(|value| value.to_str())
-        .ok_or_else(|| "failed to derive MVP demo run id for escrow payload".to_owned())?;
-    match binding {
-        Some(value) => Ok(format!(
-            "{{\"schema_version\":\"kamn.mvp.devnet-settlement.v2\",\"run_id\":\"{run_id}\",\"task_id\":\"{}\",\"task_binding_digest\":\"{}\"}}",
-            value.task_id, value.digest
-        )),
-        None => Ok(format!(
-            "{{\"schema_version\":\"kamn.mvp.devnet-settlement.v1\",\"run_id\":\"{run_id}\"}}"
-        )),
     }
 }
 
@@ -125,7 +151,12 @@ mod tests {
             agent_b_pid: 2,
             agent_c_pid: 3,
         };
-        let raw = fund_payload(run_dir, Some(&binding)).expect("funding payload");
+        let creator = agent("http://127.0.0.1:1", "contract-creator").expect("creator");
+        let provider = agent("http://127.0.0.1:1", "contract-provider").expect("provider");
+        let agreement =
+            SettlementAgreement::new(run_dir, Some(&binding), 1_000_000, &creator, &provider)
+                .expect("agreement");
+        let raw = agreement.fund_payload("task-settlement");
         for field in [
             "task_id",
             "transaction_id",

--- a/crates/kamn-e2e-harness/src/mvp_demo/devnet_settlement_service.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/devnet_settlement_service.rs
@@ -187,4 +187,14 @@ mod tests {
     fn funded_rehearsal_paces_release_past_sender_window() {
         assert!(release_pacing_delay() > std::time::Duration::from_secs(5));
     }
+
+    #[test]
+    fn funded_rehearsal_retries_only_recoverable_settlement_visibility() {
+        assert!(should_retry_release(
+            "service api live settlement evidence failed: confirmation missing"
+        ));
+        assert!(should_retry_release("SETTLEMENT_OUTCOME_AMBIGUOUS"));
+        assert!(!should_retry_release("ACTION_NOT_GRANTED"));
+        assert!(!should_retry_release("SETTLEMENT_INTENT_CONFLICT"));
+    }
 }

--- a/crates/kamn-e2e-harness/src/mvp_demo/devnet_settlement_service.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/devnet_settlement_service.rs
@@ -177,4 +177,9 @@ mod tests {
         assert!(raw.contains(r#""network":"solana-devnet""#));
         assert!(raw.contains(r#""release_policy":"task-completed""#));
     }
+
+    #[test]
+    fn funded_rehearsal_paces_release_past_sender_window() {
+        assert!(release_pacing_delay() > std::time::Duration::from_secs(5));
+    }
 }

--- a/crates/kamn-e2e-harness/src/mvp_demo/devnet_settlement_service.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/devnet_settlement_service.rs
@@ -9,6 +9,7 @@ use agreement::SettlementAgreement;
 
 const SDK_TIMEOUT_ENV: &str = "KAMN_SDK_SERVICE_TIMEOUT_SECONDS";
 const LIVE_SETTLEMENT_TIMEOUT_SECONDS: &str = "90";
+pub(super) const CREATOR_AGENT_NAME: &str = "kamn-mvp-devnet-settlement-creator";
 
 pub(super) fn drive_escrow_release(
     endpoint: &str,
@@ -17,7 +18,7 @@ pub(super) fn drive_escrow_release(
     amount_lamports: u64,
 ) -> Result<SettlementRun, String> {
     let _timeout = EnvOverride::set(SDK_TIMEOUT_ENV, LIVE_SETTLEMENT_TIMEOUT_SECONDS);
-    let creator = agent(endpoint, "kamn-mvp-devnet-settlement-creator")?;
+    let creator = agent(endpoint, CREATOR_AGENT_NAME)?;
     let provider = agent(endpoint, "kamn-mvp-devnet-settlement-provider")?;
     register(&creator, "creator")?;
     register(&provider, "provider")?;

--- a/crates/kamn-e2e-harness/src/mvp_demo/devnet_settlement_service.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/devnet_settlement_service.rs
@@ -39,6 +39,7 @@ pub(super) fn drive_escrow_release(
     provider
         .complete_task_with_payload(task.task_id.as_str(), agreement.complete_payload().as_str())
         .map_err(|error| format!("failed to complete MVP demo task: {error}"))?;
+    std::thread::sleep(release_pacing_delay());
     let released = creator
         .release_escrow_with_payload(
             funded.escrow_id.as_str(),
@@ -50,6 +51,10 @@ pub(super) fn drive_escrow_release(
         escrow_id: released.escrow_id,
         task_id: task.task_id,
     })
+}
+
+fn release_pacing_delay() -> std::time::Duration {
+    std::time::Duration::from_millis(5_100)
 }
 
 pub(super) struct SettlementRun {

--- a/crates/kamn-e2e-harness/src/mvp_demo/devnet_settlement_service.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/devnet_settlement_service.rs
@@ -20,10 +20,35 @@ pub(super) fn drive_escrow_release(
     let _timeout = EnvOverride::set(SDK_TIMEOUT_ENV, LIVE_SETTLEMENT_TIMEOUT_SECONDS);
     let creator = agent(endpoint, CREATOR_AGENT_NAME)?;
     let provider = agent(endpoint, "kamn-mvp-devnet-settlement-provider")?;
-    register(&creator, "creator")?;
-    register(&provider, "provider")?;
     let agreement =
         SettlementAgreement::new(run_dir, binding, amount_lamports, &creator, &provider)?;
+    let prepared = prepare_completed_escrow(run_dir, &creator, &provider, &agreement)?;
+    std::thread::sleep(release_pacing_delay());
+    let released = release_with_reconciliation(
+        &creator,
+        prepared.escrow_id.as_str(),
+        agreement.release_payload().as_str(),
+    )?;
+    require_released(released.state.as_str())?;
+    Ok(SettlementRun {
+        escrow_id: released.escrow_id,
+        task_id: prepared.task_id,
+    })
+}
+
+struct PreparedEscrow {
+    task_id: String,
+    escrow_id: String,
+}
+
+fn prepare_completed_escrow(
+    run_dir: &Path,
+    creator: &KamnAgentHandle,
+    provider: &KamnAgentHandle,
+    agreement: &SettlementAgreement,
+) -> Result<PreparedEscrow, String> {
+    register(creator, "creator")?;
+    register(provider, "provider")?;
     let task = creator
         .create_task(agreement.task_payload().as_str())
         .map_err(|error| format!("failed to create MVP demo task: {error}"))?;
@@ -39,16 +64,9 @@ pub(super) fn drive_escrow_release(
     provider
         .complete_task_with_payload(task.task_id.as_str(), agreement.complete_payload().as_str())
         .map_err(|error| format!("failed to complete MVP demo task: {error}"))?;
-    std::thread::sleep(release_pacing_delay());
-    let released = release_with_reconciliation(
-        &creator,
-        funded.escrow_id.as_str(),
-        agreement.release_payload().as_str(),
-    )?;
-    require_released(released.state.as_str())?;
-    Ok(SettlementRun {
-        escrow_id: released.escrow_id,
+    Ok(PreparedEscrow {
         task_id: task.task_id,
+        escrow_id: funded.escrow_id,
     })
 }
 
@@ -171,59 +189,5 @@ fn deterministic_body_tag(payload: &[u8]) -> u64 {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn funded_rehearsal_payload_carries_canonical_task_agreement() {
-        let run_dir = Path::new("/tmp/run-contract");
-        let binding = LiveTaskBinding {
-            artifact_path: "binding.json".to_owned(),
-            digest: "a".repeat(64),
-            task_id: "task-external".to_owned(),
-            agent_a_pid: 1,
-            agent_b_pid: 2,
-            agent_c_pid: 3,
-        };
-        let creator = agent("http://127.0.0.1:1", "contract-creator").expect("creator");
-        let provider = agent("http://127.0.0.1:1", "contract-provider").expect("provider");
-        let agreement =
-            SettlementAgreement::new(run_dir, Some(&binding), 1_000_000, &creator, &provider)
-                .expect("agreement");
-        let raw = agreement.fund_payload("task-settlement");
-        for field in [
-            "task_id",
-            "transaction_id",
-            "beneficiary_did",
-            "amount_lamports",
-            "network",
-            "terms_digest",
-            "release_authority_did",
-            "release_policy",
-            "idempotency_key",
-        ] {
-            assert!(
-                raw.contains(format!("\"{field}\":").as_str()),
-                "missing canonical field {field}"
-            );
-        }
-        assert!(raw.contains(r#""network":"solana-devnet""#));
-        assert!(raw.contains(r#""release_policy":"task-completed""#));
-    }
-
-    #[test]
-    fn funded_rehearsal_paces_release_past_sender_window() {
-        assert!(release_pacing_delay() > std::time::Duration::from_secs(5));
-    }
-
-    #[test]
-    fn funded_rehearsal_retries_only_recoverable_settlement_visibility() {
-        assert_eq!(release_attempt_limit(), 15);
-        assert!(should_retry_release(
-            "service api live settlement evidence failed: confirmation missing"
-        ));
-        assert!(should_retry_release("SETTLEMENT_OUTCOME_AMBIGUOUS"));
-        assert!(!should_retry_release("ACTION_NOT_GRANTED"));
-        assert!(!should_retry_release("SETTLEMENT_INTENT_CONFLICT"));
-    }
-}
+#[path = "devnet_settlement_service_tests.rs"]
+mod tests;

--- a/crates/kamn-e2e-harness/src/mvp_demo/devnet_settlement_service.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/devnet_settlement_service.rs
@@ -61,16 +61,23 @@ fn release_with_reconciliation(
     escrow_id: &str,
     payload: &str,
 ) -> Result<kamn_agent_lib::ServiceEscrowStatus, String> {
-    for attempt in 0..3 {
+    let attempts = release_attempt_limit();
+    for attempt in 0..attempts {
         match creator.release_escrow_with_payload(escrow_id, payload) {
             Ok(released) => return Ok(released),
-            Err(error) if attempt < 2 && should_retry_release(error.to_string().as_str()) => {
+            Err(error)
+                if attempt + 1 < attempts && should_retry_release(error.to_string().as_str()) =>
+            {
                 std::thread::sleep(std::time::Duration::from_secs(2));
             }
             Err(error) => return Err(format!("failed to release MVP demo escrow: {error}")),
         }
     }
     Err("failed to reconcile MVP demo escrow release".to_owned())
+}
+
+fn release_attempt_limit() -> usize {
+    15
 }
 
 fn should_retry_release(error: &str) -> bool {
@@ -211,6 +218,7 @@ mod tests {
 
     #[test]
     fn funded_rehearsal_retries_only_recoverable_settlement_visibility() {
+        assert_eq!(release_attempt_limit(), 15);
         assert!(should_retry_release(
             "service api live settlement evidence failed: confirmation missing"
         ));

--- a/crates/kamn-e2e-harness/src/mvp_demo/devnet_settlement_service.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/devnet_settlement_service.rs
@@ -40,12 +40,11 @@ pub(super) fn drive_escrow_release(
         .complete_task_with_payload(task.task_id.as_str(), agreement.complete_payload().as_str())
         .map_err(|error| format!("failed to complete MVP demo task: {error}"))?;
     std::thread::sleep(release_pacing_delay());
-    let released = creator
-        .release_escrow_with_payload(
-            funded.escrow_id.as_str(),
-            agreement.release_payload().as_str(),
-        )
-        .map_err(|error| format!("failed to release MVP demo escrow: {error}"))?;
+    let released = release_with_reconciliation(
+        &creator,
+        funded.escrow_id.as_str(),
+        agreement.release_payload().as_str(),
+    )?;
     require_released(released.state.as_str())?;
     Ok(SettlementRun {
         escrow_id: released.escrow_id,
@@ -55,6 +54,28 @@ pub(super) fn drive_escrow_release(
 
 fn release_pacing_delay() -> std::time::Duration {
     std::time::Duration::from_millis(5_100)
+}
+
+fn release_with_reconciliation(
+    creator: &KamnAgentHandle,
+    escrow_id: &str,
+    payload: &str,
+) -> Result<kamn_agent_lib::ServiceEscrowStatus, String> {
+    for attempt in 0..3 {
+        match creator.release_escrow_with_payload(escrow_id, payload) {
+            Ok(released) => return Ok(released),
+            Err(error) if attempt < 2 && should_retry_release(error.to_string().as_str()) => {
+                std::thread::sleep(std::time::Duration::from_secs(2));
+            }
+            Err(error) => return Err(format!("failed to release MVP demo escrow: {error}")),
+        }
+    }
+    Err("failed to reconcile MVP demo escrow release".to_owned())
+}
+
+fn should_retry_release(error: &str) -> bool {
+    error.contains("SETTLEMENT_OUTCOME_AMBIGUOUS")
+        || error.contains("live settlement evidence failed")
 }
 
 pub(super) struct SettlementRun {

--- a/crates/kamn-e2e-harness/src/mvp_demo/devnet_settlement_service.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/devnet_settlement_service.rs
@@ -109,3 +109,40 @@ fn deterministic_body_tag(payload: &[u8]) -> u64 {
         acc.wrapping_mul(0x00000100000001B3) ^ u64::from(*byte)
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn funded_rehearsal_payload_carries_canonical_task_agreement() {
+        let run_dir = Path::new("/tmp/run-contract");
+        let binding = LiveTaskBinding {
+            artifact_path: "binding.json".to_owned(),
+            digest: "a".repeat(64),
+            task_id: "task-external".to_owned(),
+            agent_a_pid: 1,
+            agent_b_pid: 2,
+            agent_c_pid: 3,
+        };
+        let raw = fund_payload(run_dir, Some(&binding)).expect("funding payload");
+        for field in [
+            "task_id",
+            "transaction_id",
+            "beneficiary_did",
+            "amount_lamports",
+            "network",
+            "terms_digest",
+            "release_authority_did",
+            "release_policy",
+            "idempotency_key",
+        ] {
+            assert!(
+                raw.contains(format!("\"{field}\":").as_str()),
+                "missing canonical field {field}"
+            );
+        }
+        assert!(raw.contains(r#""network":"solana-devnet""#));
+        assert!(raw.contains(r#""release_policy":"task-completed""#));
+    }
+}

--- a/crates/kamn-e2e-harness/src/mvp_demo/devnet_settlement_service/agreement.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/devnet_settlement_service/agreement.rs
@@ -1,0 +1,80 @@
+use std::path::Path;
+
+use kamn_agent_lib::KamnAgentHandle;
+
+use super::super::artifact_digest::sha256_hex;
+use super::super::live_task_binding::LiveTaskBinding;
+use super::super::report::escape_json;
+
+pub(super) struct SettlementAgreement {
+    transaction_id: String,
+    terms_digest: String,
+    completion_digest: String,
+    creator_did: String,
+    provider_did: String,
+    amount_lamports: u64,
+}
+
+impl SettlementAgreement {
+    pub(super) fn new(
+        run_dir: &Path,
+        binding: Option<&LiveTaskBinding>,
+        amount_lamports: u64,
+        creator: &KamnAgentHandle,
+        provider: &KamnAgentHandle,
+    ) -> Result<Self, String> {
+        let run_id = run_dir
+            .file_name()
+            .and_then(|value| value.to_str())
+            .ok_or_else(|| "failed to derive MVP demo run id".to_owned())?;
+        let creator_did = creator.identity().did().to_string();
+        let provider_did = provider.identity().did().to_string();
+        let binding_digest = binding.map_or("unbound", |value| value.digest.as_str());
+        let seed =
+            format!("{run_id}:{creator_did}:{provider_did}:{amount_lamports}:{binding_digest}");
+        let digest = sha256_hex(seed.as_str());
+        Ok(Self {
+            transaction_id: format!("mvp-devnet-{}", &digest[..16]),
+            terms_digest: digest,
+            completion_digest: sha256_hex(format!("completed:{seed}").as_str()),
+            creator_did,
+            provider_did,
+            amount_lamports,
+        })
+    }
+
+    pub(super) fn task_payload(&self) -> String {
+        format!(
+            "{{\"provider_did\":\"{}\",\"transaction_id\":\"{}\",\"terms_digest\":\"{}\",\"idempotency_key\":\"{}-create\"}}",
+            escape_json(self.provider_did.as_str()), self.transaction_id, self.terms_digest,
+            self.transaction_id,
+        )
+    }
+
+    pub(super) fn accept_payload(&self) -> String {
+        format!("{{\"idempotency_key\":\"{}-accept\"}}", self.transaction_id)
+    }
+
+    pub(super) fn complete_payload(&self) -> String {
+        format!(
+            "{{\"idempotency_key\":\"{}-complete\",\"completion_evidence_digest\":\"{}\"}}",
+            self.transaction_id, self.completion_digest,
+        )
+    }
+
+    pub(super) fn release_payload(&self) -> String {
+        format!(
+            "{{\"idempotency_key\":\"{}-release\"}}",
+            self.transaction_id
+        )
+    }
+
+    pub(super) fn fund_payload(&self, task_id: &str) -> String {
+        format!(
+            "{{\"task_id\":\"{}\",\"transaction_id\":\"{}\",\"beneficiary_did\":\"{}\",\"amount_lamports\":{},\"network\":\"solana-devnet\",\"terms_digest\":\"{}\",\"release_authority_did\":\"{}\",\"release_policy\":\"task-completed\",\"idempotency_key\":\"{}-fund\"}}",
+            escape_json(task_id), self.transaction_id, escape_json(self.provider_did.as_str()),
+            self.amount_lamports, self.terms_digest, escape_json(self.creator_did.as_str()),
+            self.transaction_id,
+        )
+    }
+}

--- a/crates/kamn-e2e-harness/src/mvp_demo/devnet_settlement_service_tests.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/devnet_settlement_service_tests.rs
@@ -1,0 +1,56 @@
+use super::*;
+
+#[test]
+fn funded_rehearsal_payload_carries_canonical_task_agreement() {
+    let run_dir = Path::new("/tmp/run-contract");
+    let binding = LiveTaskBinding {
+        artifact_path: "binding.json".to_owned(),
+        digest: "a".repeat(64),
+        task_id: "task-external".to_owned(),
+        agent_a_pid: 1,
+        agent_b_pid: 2,
+        agent_c_pid: 3,
+    };
+    let creator = agent("http://127.0.0.1:1", "contract-creator").expect("creator");
+    let provider = agent("http://127.0.0.1:1", "contract-provider").expect("provider");
+    let agreement =
+        SettlementAgreement::new(run_dir, Some(&binding), 1_000_000, &creator, &provider)
+            .expect("agreement");
+    let raw = agreement.fund_payload("task-settlement");
+    for field in required_funding_fields() {
+        assert!(
+            raw.contains(format!("\"{field}\":").as_str()),
+            "missing {field}"
+        );
+    }
+    assert!(raw.contains(r#""network":"solana-devnet""#));
+    assert!(raw.contains(r#""release_policy":"task-completed""#));
+}
+
+fn required_funding_fields() -> [&'static str; 9] {
+    [
+        "task_id",
+        "transaction_id",
+        "beneficiary_did",
+        "amount_lamports",
+        "network",
+        "terms_digest",
+        "release_authority_did",
+        "release_policy",
+        "idempotency_key",
+    ]
+}
+
+#[test]
+fn funded_rehearsal_paces_release_past_sender_window() {
+    assert!(release_pacing_delay() > std::time::Duration::from_secs(5));
+}
+
+#[test]
+fn funded_rehearsal_retries_only_recoverable_settlement_visibility() {
+    assert_eq!(release_attempt_limit(), 15);
+    assert!(should_retry_release("live settlement evidence failed"));
+    assert!(should_retry_release("SETTLEMENT_OUTCOME_AMBIGUOUS"));
+    assert!(!should_retry_release("ACTION_NOT_GRANTED"));
+    assert!(!should_retry_release("SETTLEMENT_INTENT_CONFLICT"));
+}

--- a/crates/kamn-e2e-harness/src/mvp_demo/mod.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/mod.rs
@@ -10,6 +10,7 @@ mod artifact_digest;
 mod command_config;
 mod devnet_settlement;
 mod devnet_settlement_build;
+mod devnet_settlement_grant_bootstrap;
 mod devnet_settlement_json;
 mod devnet_settlement_live;
 mod devnet_settlement_node;

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests.rs
@@ -16,6 +16,8 @@ mod task_escrow_live_settlement_contract_tests;
 mod task_escrow_restart_contract_tests;
 #[path = "task_escrow_persistence_contract_tests/task_escrow_routes_contract_tests.rs"]
 mod task_escrow_routes_contract_tests;
+#[path = "task_escrow_persistence_contract_tests/task_escrow_settlement_reconciliation_contract_tests.rs"]
+mod task_escrow_settlement_reconciliation_contract_tests;
 #[path = "task_escrow_persistence_contract_tests/task_escrow_solana_asset_movement_contract_tests.rs"]
 mod task_escrow_solana_asset_movement_contract_tests;
 #[path = "task_escrow_persistence_contract_tests/task_escrow_solana_asset_movement_live_contract_tests.rs"]

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests.rs
@@ -16,6 +16,8 @@ mod task_escrow_live_settlement_contract_tests;
 mod task_escrow_restart_contract_tests;
 #[path = "task_escrow_persistence_contract_tests/task_escrow_routes_contract_tests.rs"]
 mod task_escrow_routes_contract_tests;
+#[path = "task_escrow_persistence_contract_tests/task_escrow_settlement_concurrency_contract_tests.rs"]
+mod task_escrow_settlement_concurrency_contract_tests;
 #[path = "task_escrow_persistence_contract_tests/task_escrow_settlement_reconciliation_contract_tests.rs"]
 mod task_escrow_settlement_reconciliation_contract_tests;
 #[path = "task_escrow_persistence_contract_tests/task_escrow_solana_asset_movement_contract_tests.rs"]

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/support.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/support.rs
@@ -16,7 +16,7 @@ pub(super) use env_support::{
 pub(super) use request_support::{
     accept_task, authorized_signed_request, complete_task, create_task, fund_escrow, query_task,
     raw_signed_request, register_agent_profile, release_escrow, release_escrow_response,
-    SignedRequest,
+    release_escrow_response_with_key, SignedRequest,
 };
 pub(super) use solana_asset_movement_support::{
     assert_persisted_solana_signature_metadata,

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/support.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/support.rs
@@ -14,9 +14,9 @@ pub(super) use env_support::{
     set_live_solana_bridge_rpc_url_env,
 };
 pub(super) use request_support::{
-    accept_task, authorized_signed_request, complete_task, create_task, fund_escrow, query_task,
-    raw_signed_request, register_agent_profile, release_escrow, release_escrow_response,
-    release_escrow_response_with_key, SignedRequest,
+    accept_task, authorized_signed_request, complete_task, create_task, fund_escrow,
+    provision_signed_request_grant, query_task, raw_signed_request, register_agent_profile,
+    release_escrow, release_escrow_response, release_escrow_response_with_key, SignedRequest,
 };
 pub(super) use solana_asset_movement_support::{
     assert_persisted_solana_signature_metadata,

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/support.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/support.rs
@@ -15,13 +15,14 @@ pub(super) use env_support::{
 };
 pub(super) use request_support::{
     accept_task, authorized_signed_request, complete_task, create_task, fund_escrow, query_task,
-    raw_signed_request, register_agent_profile, release_escrow, SignedRequest,
+    raw_signed_request, register_agent_profile, release_escrow, release_escrow_response,
+    SignedRequest,
 };
 pub(super) use solana_asset_movement_support::{
     assert_persisted_solana_signature_metadata,
     assert_released_escrow_has_solana_signature_metadata, build_live_solana_asset_movement_context,
-    fund_and_release_live_escrow, release_live_escrow_across_restart, release_live_escrow_twice,
-    settlement_tx_signature, LiveSolanaAssetMovementParams,
+    fund_and_release_live_escrow, fund_live_escrow, release_live_escrow_across_restart,
+    release_live_escrow_twice, settlement_tx_signature, LiveSolanaAssetMovementParams,
 };
 pub(super) use state_support::{
     build_task_escrow_snapshot, set_state_file_env, state_hash, unique_named_state_file,

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/support/request_support.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/support/request_support.rs
@@ -6,7 +6,9 @@ mod escrow_support;
 #[path = "request_support/task_support.rs"]
 mod task_support;
 
-pub(crate) use escrow_support::{fund_escrow, release_escrow, release_escrow_response};
+pub(crate) use escrow_support::{
+    fund_escrow, release_escrow, release_escrow_response, release_escrow_response_with_key,
+};
 pub(crate) use task_support::{
     accept_task, complete_task, create_task, query_task, register_agent_profile,
 };

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/support/request_support.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/support/request_support.rs
@@ -6,7 +6,7 @@ mod escrow_support;
 #[path = "request_support/task_support.rs"]
 mod task_support;
 
-pub(crate) use escrow_support::{fund_escrow, release_escrow};
+pub(crate) use escrow_support::{fund_escrow, release_escrow, release_escrow_response};
 pub(crate) use task_support::{
     accept_task, complete_task, create_task, query_task, register_agent_profile,
 };

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/support/request_support.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/support/request_support.rs
@@ -56,6 +56,10 @@ pub(crate) fn authorized_signed_request(
     raw_signed_request(snapshot, bind_addr, request)
 }
 
+pub(crate) fn provision_signed_request_grant(request: &SignedRequest<'_>) {
+    super::authorization_fixture::provision_request_grant(request);
+}
+
 fn signed_request(
     snapshot: &ServiceApiSnapshot,
     bind_addr: &str,

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/support/request_support/escrow_support.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/support/request_support/escrow_support.rs
@@ -46,7 +46,25 @@ pub(crate) fn release_escrow_response(
     nonce: u64,
     escrow_id: &str,
 ) -> String {
-    let body = format!(r#"{{"idempotency_key":"escrow-release-{nonce}"}}"#);
+    release_escrow_response_with_key(
+        snapshot,
+        bind_addr,
+        caller_did,
+        nonce,
+        escrow_id,
+        format!("escrow-release-{nonce}").as_str(),
+    )
+}
+
+pub(crate) fn release_escrow_response_with_key(
+    snapshot: &ServiceApiSnapshot,
+    bind_addr: &str,
+    caller_did: &str,
+    nonce: u64,
+    escrow_id: &str,
+    idempotency_key: &str,
+) -> String {
+    let body = serde_json::json!({"idempotency_key": idempotency_key}).to_string();
     let response = signed_request(
         snapshot,
         bind_addr,

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/support/request_support/escrow_support.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/support/request_support/escrow_support.rs
@@ -21,7 +21,7 @@ pub(crate) fn fund_escrow(
             extra_headers: &[],
         },
     );
-    assert!(response.contains("HTTP/1.1 200 OK"));
+    assert!(response.contains("HTTP/1.1 200 OK"), "{response}");
     parse_service_api_payload(extract_http_response_body(response.as_str()))
         .expect("escrow fund payload should deserialize")
 }
@@ -47,7 +47,7 @@ pub(crate) fn release_escrow(
             extra_headers: &[],
         },
     );
-    assert!(response.contains("HTTP/1.1 200 OK"));
+    assert!(response.contains("HTTP/1.1 200 OK"), "{response}");
     parse_service_api_payload(extract_http_response_body(response.as_str()))
         .expect("escrow release payload should deserialize")
 }

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/support/request_support/escrow_support.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/support/request_support/escrow_support.rs
@@ -33,6 +33,19 @@ pub(crate) fn release_escrow(
     nonce: u64,
     escrow_id: &str,
 ) -> Value {
+    let response = release_escrow_response(snapshot, bind_addr, caller_did, nonce, escrow_id);
+    assert!(response.contains("HTTP/1.1 200 OK"), "{response}");
+    parse_service_api_payload(extract_http_response_body(response.as_str()))
+        .expect("escrow release payload should deserialize")
+}
+
+pub(crate) fn release_escrow_response(
+    snapshot: &ServiceApiSnapshot,
+    bind_addr: &str,
+    caller_did: &str,
+    nonce: u64,
+    escrow_id: &str,
+) -> String {
     let body = format!(r#"{{"idempotency_key":"escrow-release-{nonce}"}}"#);
     let response = signed_request(
         snapshot,
@@ -47,9 +60,7 @@ pub(crate) fn release_escrow(
             extra_headers: &[],
         },
     );
-    assert!(response.contains("HTTP/1.1 200 OK"), "{response}");
-    parse_service_api_payload(extract_http_response_body(response.as_str()))
-        .expect("escrow release payload should deserialize")
+    response
 }
 
 fn canonical_escrow_payload(caller_did: &str, nonce: u64, payload: &str) -> String {

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/support/solana_asset_movement_support/context.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/support/solana_asset_movement_support/context.rs
@@ -22,6 +22,7 @@ pub(crate) struct LiveSolanaAssetMovementParams<'a> {
     pub(crate) recipient_env: &'static str,
     pub(crate) lamports_env: &'static str,
     pub(crate) live_rpc_env: &'static str,
+    pub(crate) amount_lamports: u64,
 }
 
 pub(crate) fn build_live_solana_asset_movement_context(
@@ -34,6 +35,7 @@ pub(crate) fn build_live_solana_asset_movement_context(
         params.recipient_env,
         params.lamports_env,
         params.live_rpc_env,
+        params.amount_lamports,
     );
     let harness =
         build_asset_movement_harness(params.state_file_prefix, params.caller_did, params.api_bind);
@@ -72,12 +74,14 @@ fn build_live_solana_asset_movement_guards(
     recipient_env: &'static str,
     lamports_env: &'static str,
     live_rpc_env: &'static str,
+    amount_lamports: u64,
 ) -> LiveSolanaAssetMovementGuards {
+    let lamports = amount_lamports.to_string();
     LiveSolanaAssetMovementGuards {
         live_rpc_guard: set_live_solana_bridge_rpc_url_env(Some(live_rpc_env)),
         keypair_guard: EnvVarGuard::set(keypair_env, Some(fixture.keypair_file_text.as_str())),
         recipient_guard: EnvVarGuard::set(recipient_env, Some(fixture.recipient_pubkey.as_str())),
-        lamports_guard: EnvVarGuard::set(lamports_env, Some("1")),
+        lamports_guard: EnvVarGuard::set(lamports_env, Some(lamports.as_str())),
     }
 }
 

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_bound_escrow_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_bound_escrow_contract_tests.rs
@@ -21,6 +21,30 @@ fn integration_task_bound_escrow_funding_persists_canonical_agreement() {
 }
 
 #[test]
+fn integration_task_and_funding_issue_scoped_escrow_grants() {
+    let case = EscrowCase::new("runtime-grants");
+    let task = case.accepted_task();
+    let body = case.funding_body(task.task_id.as_str(), "escrow-runtime-grant");
+
+    let funded = case.raw_request(4, "POST", "/v1/escrow/fund", body.as_str());
+    assert!(funded.contains("HTTP/1.1 200 OK"), "{funded}");
+    let payload = response_payload(&funded);
+    case.complete_task(task.task_id.as_str(), 5);
+    let path = format!(
+        "/v1/escrow/{}/release",
+        payload["escrow_id"].as_str().expect("escrow id")
+    );
+    let released = case.raw_request(
+        6,
+        "POST",
+        path.as_str(),
+        r#"{"idempotency_key":"escrow-runtime-release"}"#,
+    );
+    assert!(released.contains("HTTP/1.1 200 OK"), "{released}");
+    case.cleanup();
+}
+
+#[test]
 fn integration_task_bound_escrow_rejects_release_before_task_completion() {
     let case = EscrowCase::new("early-release");
     let task = case.accepted_task();
@@ -184,6 +208,22 @@ impl EscrowCase {
                 nonce,
                 body,
                 extra_headers: &[],
+            },
+        )
+    }
+
+    fn raw_request(&self, nonce: u64, method: &str, path: &str, body: &str) -> String {
+        raw_signed_request(
+            &self.snapshot,
+            reserve_loopback_addr().as_str(),
+            SignedRequest {
+                max_requests: 1,
+                method,
+                path,
+                caller_did: ACTOR,
+                nonce,
+                body,
+                extra_headers: &[("X-KAMN-Authz-Scope", "escrow:write")],
             },
         )
     }

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_settlement_concurrency_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_settlement_concurrency_contract_tests.rs
@@ -1,0 +1,117 @@
+use super::super::*;
+use super::support::*;
+
+const ACTOR: &str = "kamn:did:agent:test-client-settlement-concurrency";
+const KEYPAIR_ENV: &str = "KAMN_SERVICE_API_LIVE_SOLANA_SETTLEMENT_KEYPAIR_FILE";
+const RECIPIENT_ENV: &str = "KAMN_SERVICE_API_LIVE_SOLANA_SETTLEMENT_RECIPIENT_PUBKEY";
+const LAMPORTS_ENV: &str = "KAMN_SERVICE_API_LIVE_SOLANA_SETTLEMENT_LAMPORTS";
+
+#[test]
+fn integration_concurrent_settlement_release_submits_one_transaction_identity() {
+    let _env = acquire_service_api_test_env();
+    let _override_guard =
+        crate::service_api_endpoint::set_test_live_solana_settlement_override(true);
+    let context = build_live_solana_asset_movement_context(params());
+    let escrow_id = fund_live_escrow(&context.harness, 181, 43);
+    let path = format!("/v1/escrow/{escrow_id}/release");
+    let body = r#"{"idempotency_key":"settlement-concurrent-release"}"#;
+    provision_signed_request_grant(&SignedRequest {
+        max_requests: 1,
+        method: "POST",
+        path: path.as_str(),
+        caller_did: ACTOR,
+        nonce: 183,
+        body,
+        extra_headers: &[],
+    });
+
+    let responses = concurrent_release_requests(&context.harness.snapshot, &path, body);
+
+    assert_eq!(
+        responses
+            .iter()
+            .filter(|response| response.contains("200 OK"))
+            .count(),
+        1
+    );
+    assert_eq!(
+        responses
+            .iter()
+            .filter(|response| response.contains("409 Conflict"))
+            .count(),
+        1
+    );
+    assert_eq!(
+        crate::service_api_endpoint::test_live_solana_settlement_submission_count(),
+        1
+    );
+}
+
+fn concurrent_release_requests(
+    snapshot: &crate::service_api_endpoint::ServiceApiSnapshot,
+    path: &str,
+    body: &str,
+) -> Vec<String> {
+    let bind_addr = reserve_loopback_addr();
+    with_api_server(snapshot, bind_addr.as_str(), 2, |addr| {
+        let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
+        thread::scope(|scope| {
+            [183_u64, 183_u64]
+                .into_iter()
+                .map(|nonce| {
+                    spawn_release(scope, barrier.clone(), snapshot, addr, path, body, nonce)
+                })
+                .collect::<Vec<_>>()
+                .into_iter()
+                .map(|handle| handle.join().expect("release request should complete"))
+                .collect()
+        })
+    })
+}
+
+fn spawn_release<'scope>(
+    scope: &'scope thread::Scope<'scope, '_>,
+    barrier: std::sync::Arc<std::sync::Barrier>,
+    snapshot: &'scope crate::service_api_endpoint::ServiceApiSnapshot,
+    addr: &'scope str,
+    path: &'scope str,
+    body: &'scope str,
+    nonce: u64,
+) -> thread::ScopedJoinHandle<'scope, String> {
+    scope.spawn(move || {
+        let nonce_text = nonce.to_string();
+        let signature = service_api_request_signature_for_fields(
+            ACTOR,
+            nonce,
+            state_hash(snapshot).as_str(),
+            body,
+        );
+        barrier.wait();
+        send_http_request_with_headers(
+            addr,
+            "POST",
+            path,
+            body,
+            &[
+                ("X-KAMN-Sender-DID", ACTOR),
+                ("X-KAMN-Request-Nonce", nonce_text.as_str()),
+                ("X-KAMN-Request-Signature", signature.as_str()),
+                ("X-KAMN-Authz-Scope", "escrow:write"),
+            ],
+        )
+    })
+}
+
+fn params() -> LiveSolanaAssetMovementParams<'static> {
+    LiveSolanaAssetMovementParams {
+        state_file_prefix: "kamn-node-settlement-concurrency-state",
+        caller_did: ACTOR,
+        api_bind: "127.0.0.1:34137",
+        keypair_prefix: "kamn-node-settlement-concurrency-keypair",
+        keypair_env: KEYPAIR_ENV,
+        recipient_env: RECIPIENT_ENV,
+        lamports_env: LAMPORTS_ENV,
+        live_rpc_env: "https://api.devnet.solana.com",
+        amount_lamports: 43,
+    }
+}

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_settlement_reconciliation_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_settlement_reconciliation_contract_tests.rs
@@ -84,6 +84,33 @@ fn integration_settlement_intent_rejects_conflicting_release_key_without_submiss
     );
 }
 
+#[test]
+fn integration_settlement_rejects_mismatched_confirmed_evidence_without_release() {
+    let _env = acquire_service_api_test_env();
+    let _override_guard =
+        crate::service_api_endpoint::set_test_live_solana_settlement_override(true);
+    crate::service_api_endpoint::set_test_live_solana_settlement_evidence_mismatch();
+    let context = build_live_solana_asset_movement_context(params_for("evidence-mismatch", 41));
+    let escrow_id = fund_live_escrow(&context.harness, 171, 41);
+
+    let response = release_escrow_response_with_key(
+        &context.harness.snapshot,
+        context.harness.bind_addr.as_str(),
+        context.harness.caller_did,
+        173,
+        escrow_id.as_str(),
+        "settlement-evidence-mismatch",
+    );
+    let state = read_state_json(context.harness.state_file.as_path());
+
+    assert!(
+        response.contains("SETTLEMENT_EVIDENCE_MISMATCH"),
+        "{response}"
+    );
+    assert_eq!(state["settlement_intents"][&escrow_id]["state"], "failed");
+    assert_ne!(state["escrows"][&escrow_id]["state"], "released");
+}
+
 fn params() -> LiveSolanaAssetMovementParams<'static> {
     params_for("reconciliation", 31)
 }

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_settlement_reconciliation_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_settlement_reconciliation_contract_tests.rs
@@ -47,9 +47,50 @@ fn integration_ambiguous_settlement_retry_reconciles_without_resubmission() {
     assert_eq!(state["escrows"][&escrow_id]["state"], "released");
 }
 
+#[test]
+fn integration_settlement_intent_rejects_conflicting_release_key_without_submission() {
+    let _env = acquire_service_api_test_env();
+    let _override_guard =
+        crate::service_api_endpoint::set_test_live_solana_settlement_ambiguous_after_submit();
+    let context = build_live_solana_asset_movement_context(params_for("conflict", 37));
+    let escrow_id = fund_live_escrow(&context.harness, 161, 37);
+    let first = release_escrow_response_with_key(
+        &context.harness.snapshot,
+        context.harness.bind_addr.as_str(),
+        context.harness.caller_did,
+        163,
+        escrow_id.as_str(),
+        "settlement-conflict-original",
+    );
+
+    let conflict = release_escrow_response_with_key(
+        &context.harness.snapshot,
+        context.harness.bind_addr.as_str(),
+        context.harness.caller_did,
+        164,
+        escrow_id.as_str(),
+        "settlement-conflict-different",
+    );
+
+    assert!(first.contains("SETTLEMENT_OUTCOME_AMBIGUOUS"), "{first}");
+    assert!(conflict.contains("HTTP/1.1 409 Conflict"), "{conflict}");
+    assert!(
+        conflict.contains("SETTLEMENT_INTENT_CONFLICT"),
+        "{conflict}"
+    );
+    assert_eq!(
+        crate::service_api_endpoint::test_live_solana_settlement_submission_count(),
+        1
+    );
+}
+
 fn params() -> LiveSolanaAssetMovementParams<'static> {
+    params_for("reconciliation", 31)
+}
+
+fn params_for(label: &str, amount_lamports: u64) -> LiveSolanaAssetMovementParams<'_> {
     LiveSolanaAssetMovementParams {
-        state_file_prefix: "kamn-node-settlement-reconciliation-state",
+        state_file_prefix: label,
         caller_did: "kamn:did:agent:test-client-settlement-reconciliation",
         api_bind: "127.0.0.1:34136",
         keypair_prefix: "kamn-node-settlement-reconciliation-keypair",
@@ -57,6 +98,6 @@ fn params() -> LiveSolanaAssetMovementParams<'static> {
         recipient_env: RECIPIENT_ENV,
         lamports_env: LAMPORTS_ENV,
         live_rpc_env: RPC_URL,
-        amount_lamports: 31,
+        amount_lamports,
     }
 }

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_settlement_reconciliation_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_settlement_reconciliation_contract_tests.rs
@@ -1,0 +1,62 @@
+use super::super::*;
+use super::support::*;
+
+const RPC_URL: &str = "https://api.devnet.solana.com";
+const KEYPAIR_ENV: &str = "KAMN_SERVICE_API_LIVE_SOLANA_SETTLEMENT_KEYPAIR_FILE";
+const RECIPIENT_ENV: &str = "KAMN_SERVICE_API_LIVE_SOLANA_SETTLEMENT_RECIPIENT_PUBKEY";
+const LAMPORTS_ENV: &str = "KAMN_SERVICE_API_LIVE_SOLANA_SETTLEMENT_LAMPORTS";
+
+#[test]
+fn integration_ambiguous_settlement_retry_reconciles_without_resubmission() {
+    let _env = acquire_service_api_test_env();
+    let _override_guard =
+        crate::service_api_endpoint::set_test_live_solana_settlement_ambiguous_after_submit();
+    let context = build_live_solana_asset_movement_context(params());
+    let escrow_id = fund_live_escrow(&context.harness, 151, 31);
+
+    let first = release_escrow_response_with_key(
+        &context.harness.snapshot,
+        context.harness.bind_addr.as_str(),
+        context.harness.caller_did,
+        153,
+        escrow_id.as_str(),
+        "settlement-reconcile-1",
+    );
+    crate::service_api_endpoint::set_test_live_solana_settlement_reconcile_confirmed();
+    let second = release_escrow_response_with_key(
+        &context.harness.snapshot,
+        context.harness.bind_addr.as_str(),
+        context.harness.caller_did,
+        154,
+        escrow_id.as_str(),
+        "settlement-reconcile-1",
+    );
+    let state = read_state_json(context.harness.state_file.as_path());
+
+    assert!(first.contains("SETTLEMENT_OUTCOME_AMBIGUOUS"), "{first}");
+    assert!(second.contains("HTTP/1.1 200 OK"), "{second}");
+    assert_eq!(
+        crate::service_api_endpoint::test_live_solana_settlement_submission_count(),
+        1,
+        "reconciliation must not submit the signed transaction again"
+    );
+    assert_eq!(
+        state["settlement_intents"][&escrow_id]["state"],
+        "confirmed"
+    );
+    assert_eq!(state["escrows"][&escrow_id]["state"], "released");
+}
+
+fn params() -> LiveSolanaAssetMovementParams<'static> {
+    LiveSolanaAssetMovementParams {
+        state_file_prefix: "kamn-node-settlement-reconciliation-state",
+        caller_did: "kamn:did:agent:test-client-settlement-reconciliation",
+        api_bind: "127.0.0.1:34136",
+        keypair_prefix: "kamn-node-settlement-reconciliation-keypair",
+        keypair_env: KEYPAIR_ENV,
+        recipient_env: RECIPIENT_ENV,
+        lamports_env: LAMPORTS_ENV,
+        live_rpc_env: RPC_URL,
+        amount_lamports: 31,
+    }
+}

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_solana_asset_movement_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_solana_asset_movement_contract_tests.rs
@@ -60,6 +60,30 @@ fn integration_service_api_endpoint_live_solana_asset_movement_release_persists_
 }
 
 #[test]
+fn integration_live_settlement_persists_prepared_intent_before_adapter_submission() {
+    let _env = acquire_service_api_test_env();
+    let _override_guard =
+        crate::service_api_endpoint::set_test_live_solana_settlement_override(true);
+    let context = build_live_solana_asset_movement_context(LiveSolanaAssetMovementParams {
+        state_file_prefix: "kamn-node-settlement-prepared-intent-state",
+        caller_did: "kamn:did:agent:test-client-settlement-prepared-intent",
+        api_bind: "127.0.0.1:34134",
+        keypair_prefix: "kamn-node-settlement-prepared-intent-keypair",
+        keypair_env: SOLANA_SETTLEMENT_KEYPAIR_FILE_ENV,
+        recipient_env: SOLANA_SETTLEMENT_RECIPIENT_ENV,
+        lamports_env: SOLANA_SETTLEMENT_LAMPORTS_ENV,
+        live_rpc_env: LIVE_SOLANA_DEVNET_RPC_URL,
+    });
+
+    fund_and_release_live_escrow(&context.harness, 131, 133, 23);
+
+    assert!(
+        crate::service_api_endpoint::test_live_settlement_observed_prepared_intent(),
+        "settlement intent must be durable before adapter submission"
+    );
+}
+
+#[test]
 fn integration_service_api_endpoint_live_solana_asset_movement_release_is_idempotent_for_repeated_submit(
 ) {
     let _env = acquire_service_api_test_env();

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_solana_asset_movement_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_solana_asset_movement_contract_tests.rs
@@ -2,8 +2,8 @@ use super::super::*;
 use super::support::{
     assert_persisted_solana_signature_metadata,
     assert_released_escrow_has_solana_signature_metadata, build_live_solana_asset_movement_context,
-    build_task_escrow_snapshot, fund_and_release_live_escrow, read_state_json,
-    release_live_escrow_across_restart, release_live_escrow_twice,
+    build_task_escrow_snapshot, fund_and_release_live_escrow, fund_live_escrow, read_state_json,
+    release_escrow_response, release_live_escrow_across_restart, release_live_escrow_twice,
     set_live_solana_bridge_rpc_url_env, settlement_tx_signature, LiveSolanaAssetMovementParams,
 };
 
@@ -34,6 +34,48 @@ fn integration_service_api_endpoint_live_solana_asset_movement_lane_fails_at_sta
         error.contains(SOLANA_SETTLEMENT_RECIPIENT_ENV),
         "startup error must identify missing Solana recipient env: {error}"
     );
+}
+
+#[test]
+fn integration_live_settlement_persists_ambiguous_outcome_without_release() {
+    let _env = acquire_service_api_test_env();
+    let _override_guard =
+        crate::service_api_endpoint::set_test_live_solana_settlement_ambiguous_after_submit();
+    let context = build_live_solana_asset_movement_context(LiveSolanaAssetMovementParams {
+        state_file_prefix: "kamn-node-settlement-ambiguous-state",
+        caller_did: "kamn:did:agent:test-client-settlement-ambiguous",
+        api_bind: "127.0.0.1:34135",
+        keypair_prefix: "kamn-node-settlement-ambiguous-keypair",
+        keypair_env: SOLANA_SETTLEMENT_KEYPAIR_FILE_ENV,
+        recipient_env: SOLANA_SETTLEMENT_RECIPIENT_ENV,
+        lamports_env: SOLANA_SETTLEMENT_LAMPORTS_ENV,
+        live_rpc_env: LIVE_SOLANA_DEVNET_RPC_URL,
+        amount_lamports: 29,
+    });
+    let escrow_id = fund_live_escrow(&context.harness, 141, 29);
+
+    let response = release_escrow_response(
+        &context.harness.snapshot,
+        context.harness.bind_addr.as_str(),
+        context.harness.caller_did,
+        143,
+        escrow_id.as_str(),
+    );
+    let state = read_state_json(context.harness.state_file.as_path());
+
+    assert!(
+        response.contains("HTTP/1.1 503 Service Unavailable"),
+        "{response}"
+    );
+    assert!(
+        response.contains("SETTLEMENT_OUTCOME_AMBIGUOUS"),
+        "{response}"
+    );
+    assert_eq!(
+        state["settlement_intents"][&escrow_id]["state"],
+        "ambiguous"
+    );
+    assert_ne!(state["escrows"][&escrow_id]["state"], "released");
 }
 
 #[test]

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_solana_asset_movement_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_solana_asset_movement_contract_tests.rs
@@ -99,6 +99,7 @@ fn integration_service_api_endpoint_live_solana_asset_movement_release_persists_
     let state_json = read_state_json(context.harness.state_file.as_path());
 
     assert_released_escrow_has_solana_signature_metadata(&released_escrow);
+    assert_eq!(released_escrow["claim_scope"], "devnet-backed");
     assert_persisted_solana_signature_metadata(&state_json, escrow_id.as_str());
 }
 

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_solana_asset_movement_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_solana_asset_movement_contract_tests.rs
@@ -51,6 +51,7 @@ fn integration_service_api_endpoint_live_solana_asset_movement_release_persists_
         recipient_env: SOLANA_SETTLEMENT_RECIPIENT_ENV,
         lamports_env: SOLANA_SETTLEMENT_LAMPORTS_ENV,
         live_rpc_env: LIVE_SOLANA_DEVNET_RPC_URL,
+        amount_lamports: 13,
     });
     let (escrow_id, released_escrow) = fund_and_release_live_escrow(&context.harness, 101, 103, 13);
     let state_json = read_state_json(context.harness.state_file.as_path());
@@ -73,6 +74,7 @@ fn integration_live_settlement_persists_prepared_intent_before_adapter_submissio
         recipient_env: SOLANA_SETTLEMENT_RECIPIENT_ENV,
         lamports_env: SOLANA_SETTLEMENT_LAMPORTS_ENV,
         live_rpc_env: LIVE_SOLANA_DEVNET_RPC_URL,
+        amount_lamports: 23,
     });
 
     fund_and_release_live_escrow(&context.harness, 131, 133, 23);
@@ -98,6 +100,7 @@ fn integration_service_api_endpoint_live_solana_asset_movement_release_is_idempo
         recipient_env: SOLANA_SETTLEMENT_RECIPIENT_ENV,
         lamports_env: SOLANA_SETTLEMENT_LAMPORTS_ENV,
         live_rpc_env: LIVE_SOLANA_DEVNET_RPC_URL,
+        amount_lamports: 17,
     });
     let (first, second) = release_live_escrow_twice(&context.harness, 111, 113, 114, 17);
 
@@ -123,6 +126,7 @@ fn integration_service_api_endpoint_live_solana_asset_movement_release_reuses_si
         recipient_env: SOLANA_SETTLEMENT_RECIPIENT_ENV,
         lamports_env: SOLANA_SETTLEMENT_LAMPORTS_ENV,
         live_rpc_env: LIVE_SOLANA_DEVNET_RPC_URL,
+        amount_lamports: 19,
     });
     let (first, second) =
         release_live_escrow_across_restart(&context.harness, "127.0.0.1:34133", 121, 123, 124, 19);

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_solana_asset_movement_live_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_solana_asset_movement_live_contract_tests.rs
@@ -1,7 +1,7 @@
 use super::super::*;
 use super::support::{
     accept_task, build_task_escrow_snapshot, complete_task, create_task, fund_escrow,
-    release_escrow, set_live_solana_bridge_rpc_url_env, set_state_file_env,
+    read_state_json, release_escrow, set_live_solana_bridge_rpc_url_env, set_state_file_env,
     unique_named_state_file,
 };
 use solana_commitment_config::CommitmentConfig;
@@ -151,7 +151,10 @@ fn submit_live_asset_movement_release() -> Value {
         199,
         task.task_id.as_str(),
     );
-    let fund_body = format!(r#"{{"task_id":"{}","amount":9}}"#, task.task_id);
+    let fund_body = format!(
+        r#"{{"task_id":"{}","amount":{LIVE_SETTLEMENT_LAMPORTS}}}"#,
+        task.task_id
+    );
     let funded = fund_escrow(
         &snapshot,
         bind_addr.as_str(),
@@ -186,6 +189,14 @@ fn assert_live_release_result(fixture: &LiveDevnetAssetMovementFixture, released
     assert_eq!(released["settlement_network"], "solana:devnet");
     assert_eq!(released["settlement_commitment"], "finalized");
     assert_eq!(released["settlement_receipt_hash"], signature);
+    assert_eq!(released["claim_scope"], "devnet-backed");
+    let escrow_id = released["escrow_id"].as_str().expect("escrow id");
+    let state = read_state_json(fixture.state_file.as_path());
+    assert_eq!(state["settlement_intents"][escrow_id]["state"], "confirmed");
+    assert_eq!(
+        state["settlement_intents"][escrow_id]["expected_signature"],
+        signature
+    );
 }
 
 fn wait_for_balance_at_least(client: &RpcClient, pubkey: &Pubkey, minimum: u64) {

--- a/crates/kamn-node/src/service_api_endpoint.rs
+++ b/crates/kamn-node/src/service_api_endpoint.rs
@@ -63,7 +63,7 @@ use tokio::sync::{Mutex, Notify, Semaphore};
 pub(crate) use escrow_models::ServiceApiEscrowStatusBody;
 use live_bridge_dispatch::LiveSolanaBridgeDispatchConfig;
 use live_settlement_dispatch::LiveSolanaSettlementConfig;
-use message_store::ServiceApiMessageStore;
+use message_store::{ServiceApiMessageStore, ServiceApiSettlementIntentRecord};
 pub(crate) use models::{
     ServiceApiAgentGetBody, ServiceApiAgentRegisterRequestBody, ServiceApiAgentSearchRequestBody,
     ServiceApiBridgeStatusBody, ServiceApiBridgeSubmitBody, ServiceApiChannelCreateBody,

--- a/crates/kamn-node/src/service_api_endpoint.rs
+++ b/crates/kamn-node/src/service_api_endpoint.rs
@@ -87,7 +87,8 @@ use websocket::ServiceApiWebsocketEventFanout;
 #[cfg(test)]
 pub(crate) use live_settlement_dispatch::{
     set_test_live_solana_settlement_ambiguous_after_submit,
-    set_test_live_solana_settlement_override, set_test_live_solana_settlement_reconcile_confirmed,
+    set_test_live_solana_settlement_evidence_mismatch, set_test_live_solana_settlement_override,
+    set_test_live_solana_settlement_reconcile_confirmed,
     test_live_settlement_observed_prepared_intent, test_live_solana_settlement_submission_count,
 };
 

--- a/crates/kamn-node/src/service_api_endpoint.rs
+++ b/crates/kamn-node/src/service_api_endpoint.rs
@@ -87,7 +87,8 @@ use websocket::ServiceApiWebsocketEventFanout;
 #[cfg(test)]
 pub(crate) use live_settlement_dispatch::{
     set_test_live_solana_settlement_ambiguous_after_submit,
-    set_test_live_solana_settlement_override, test_live_settlement_observed_prepared_intent,
+    set_test_live_solana_settlement_override, set_test_live_solana_settlement_reconcile_confirmed,
+    test_live_settlement_observed_prepared_intent, test_live_solana_settlement_submission_count,
 };
 
 pub(crate) const DEFAULT_SERVICE_API_MAX_REQUESTS: u64 = 1;

--- a/crates/kamn-node/src/service_api_endpoint.rs
+++ b/crates/kamn-node/src/service_api_endpoint.rs
@@ -85,7 +85,9 @@ pub(crate) use state_io::{
 use websocket::ServiceApiWebsocketEventFanout;
 
 #[cfg(test)]
-pub(crate) use live_settlement_dispatch::set_test_live_solana_settlement_override;
+pub(crate) use live_settlement_dispatch::{
+    set_test_live_solana_settlement_override, test_live_settlement_observed_prepared_intent,
+};
 
 pub(crate) const DEFAULT_SERVICE_API_MAX_REQUESTS: u64 = 1;
 pub(crate) const DEFAULT_SERVICE_API_IDLE_TIMEOUT_MS: u64 = 5_000;

--- a/crates/kamn-node/src/service_api_endpoint.rs
+++ b/crates/kamn-node/src/service_api_endpoint.rs
@@ -86,6 +86,7 @@ use websocket::ServiceApiWebsocketEventFanout;
 
 #[cfg(test)]
 pub(crate) use live_settlement_dispatch::{
+    set_test_live_solana_settlement_ambiguous_after_submit,
     set_test_live_solana_settlement_override, test_live_settlement_observed_prepared_intent,
 };
 

--- a/crates/kamn-node/src/service_api_endpoint/grant_test_support.rs
+++ b/crates/kamn-node/src/service_api_endpoint/grant_test_support.rs
@@ -11,7 +11,23 @@ pub(crate) fn provision_test_transaction_grant(
     let target = resolve_target(actor_did, method, path, body)?;
     let mut store = ServiceApiMessageStore::from_optional_state_file(Some(state_file))?;
     ensure_registered(&mut store, actor_did)?;
+    if active_grant_exists(&store, &target) {
+        return Ok(());
+    }
     store.provision_agent_grant(grant_record(&target))
+}
+
+fn active_grant_exists(
+    store: &ServiceApiMessageStore,
+    target: &auth::TransactionAuthorizationTarget,
+) -> bool {
+    store.snapshot.agent_grants.values().any(|grant| {
+        grant.did == target.actor_did
+            && grant.resource == target.resource
+            && grant.action == target.action
+            && grant.role == target.role
+            && grant.status == "active"
+    })
 }
 
 fn resolve_target(

--- a/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch.rs
+++ b/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch.rs
@@ -33,6 +33,7 @@ pub(super) fn submit_or_reconcile_live_settlement(
 #[cfg(test)]
 pub(crate) use test_support::{
     set_test_live_solana_settlement_ambiguous_after_submit,
-    set_test_live_solana_settlement_override, set_test_live_solana_settlement_reconcile_confirmed,
+    set_test_live_solana_settlement_evidence_mismatch, set_test_live_solana_settlement_override,
+    set_test_live_solana_settlement_reconcile_confirmed,
     test_live_settlement_observed_prepared_intent, test_live_solana_settlement_submission_count,
 };

--- a/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch.rs
+++ b/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch.rs
@@ -6,7 +6,7 @@ mod test_support;
 mod transport;
 
 pub(crate) use config::{resolve_live_solana_settlement_config, LiveSolanaSettlementConfig};
-pub(crate) use models::LiveSettlementEvidence;
+pub(crate) use models::{LiveSettlementEvidence, PreparedLiveSettlement};
 
 pub(super) fn collect_slot_backed_live_settlement_evidence(
     config: &super::live_bridge_dispatch::LiveSolanaBridgeDispatchConfig,
@@ -15,11 +15,19 @@ pub(super) fn collect_slot_backed_live_settlement_evidence(
     legacy::collect_slot_backed_live_settlement_evidence(config, escrow_id)
 }
 
-pub(super) fn collect_live_settlement_evidence(
+pub(super) fn prepare_live_settlement(
     config: &LiveSolanaSettlementConfig,
     escrow_id: &str,
+) -> Result<PreparedLiveSettlement, String> {
+    transport::prepare_live_settlement(config, escrow_id)
+}
+
+pub(super) fn submit_or_reconcile_live_settlement(
+    config: &LiveSolanaSettlementConfig,
+    prepared: &PreparedLiveSettlement,
+    escrow_id: &str,
 ) -> Result<LiveSettlementEvidence, String> {
-    transport::collect_live_settlement_evidence(config, escrow_id)
+    transport::submit_or_reconcile_live_settlement(config, prepared, escrow_id)
 }
 
 #[cfg(test)]

--- a/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch.rs
+++ b/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch.rs
@@ -23,4 +23,6 @@ pub(super) fn collect_live_settlement_evidence(
 }
 
 #[cfg(test)]
-pub(crate) use test_support::set_test_live_solana_settlement_override;
+pub(crate) use test_support::{
+    set_test_live_solana_settlement_override, test_live_settlement_observed_prepared_intent,
+};

--- a/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch.rs
+++ b/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch.rs
@@ -32,5 +32,6 @@ pub(super) fn submit_or_reconcile_live_settlement(
 
 #[cfg(test)]
 pub(crate) use test_support::{
+    set_test_live_solana_settlement_ambiguous_after_submit,
     set_test_live_solana_settlement_override, test_live_settlement_observed_prepared_intent,
 };

--- a/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch.rs
+++ b/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch.rs
@@ -33,5 +33,6 @@ pub(super) fn submit_or_reconcile_live_settlement(
 #[cfg(test)]
 pub(crate) use test_support::{
     set_test_live_solana_settlement_ambiguous_after_submit,
-    set_test_live_solana_settlement_override, test_live_settlement_observed_prepared_intent,
+    set_test_live_solana_settlement_override, set_test_live_solana_settlement_reconcile_confirmed,
+    test_live_settlement_observed_prepared_intent, test_live_solana_settlement_submission_count,
 };

--- a/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch/config.rs
+++ b/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch/config.rs
@@ -22,6 +22,12 @@ pub(crate) struct LiveSolanaSettlementConfig {
     pub(super) commitment_label: String,
 }
 
+impl LiveSolanaSettlementConfig {
+    pub(crate) fn commitment_label(&self) -> &str {
+        self.commitment_label.as_str()
+    }
+}
+
 pub(crate) fn resolve_live_solana_settlement_config(
     bridge_config: Option<&LiveSolanaBridgeDispatchConfig>,
 ) -> Result<Option<LiveSolanaSettlementConfig>, String> {

--- a/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch/legacy.rs
+++ b/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch/legacy.rs
@@ -19,5 +19,7 @@ pub(super) fn collect_slot_backed_live_settlement_evidence(
         settlement_tx_signature: String::new(),
         settlement_network: String::new(),
         settlement_commitment: String::new(),
+        recipient_pubkey: None,
+        amount_lamports: None,
     })
 }

--- a/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch/models.rs
+++ b/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch/models.rs
@@ -4,6 +4,8 @@ pub(crate) struct LiveSettlementEvidence {
     pub(crate) settlement_tx_signature: String,
     pub(crate) settlement_network: String,
     pub(crate) settlement_commitment: String,
+    pub(crate) recipient_pubkey: Option<String>,
+    pub(crate) amount_lamports: Option<u64>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch/models.rs
+++ b/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch/models.rs
@@ -17,3 +17,18 @@ pub(crate) struct PreparedLiveSettlement {
     pub(crate) amount_lamports: u64,
     pub(crate) network: String,
 }
+
+pub(super) fn build_live_settlement_evidence(
+    signature: String,
+    commitment: &str,
+    prepared: &PreparedLiveSettlement,
+) -> LiveSettlementEvidence {
+    LiveSettlementEvidence {
+        settlement_receipt_hash: signature.clone(),
+        settlement_tx_signature: signature,
+        settlement_network: "solana:devnet".to_owned(),
+        settlement_commitment: commitment.to_owned(),
+        recipient_pubkey: Some(prepared.recipient_pubkey.clone()),
+        amount_lamports: Some(prepared.amount_lamports),
+    }
+}

--- a/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch/models.rs
+++ b/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch/models.rs
@@ -5,3 +5,13 @@ pub(crate) struct LiveSettlementEvidence {
     pub(crate) settlement_network: String,
     pub(crate) settlement_commitment: String,
 }
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PreparedLiveSettlement {
+    pub(crate) expected_signature: String,
+    pub(crate) signed_transaction_digest: String,
+    pub(crate) signed_transaction_json: String,
+    pub(crate) recipient_pubkey: String,
+    pub(crate) amount_lamports: u64,
+    pub(crate) network: String,
+}

--- a/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch/test_support.rs
+++ b/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch/test_support.rs
@@ -1,11 +1,13 @@
 use super::models::{LiveSettlementEvidence, PreparedLiveSettlement};
 use super::LiveSolanaSettlementConfig;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Mutex, OnceLock};
 
 static TEST_LIVE_SOLANA_SETTLEMENT_OVERRIDE: OnceLock<Mutex<bool>> = OnceLock::new();
 static OBSERVED_PREPARED_INTENT: AtomicBool = AtomicBool::new(false);
 static AMBIGUOUS_AFTER_SUBMIT: AtomicBool = AtomicBool::new(false);
+static RECONCILE_CONFIRMED: AtomicBool = AtomicBool::new(false);
+static SUBMISSION_COUNT: AtomicU64 = AtomicU64::new(0);
 
 pub(crate) struct TestLiveSolanaSettlementOverrideGuard {
     previous: bool,
@@ -22,10 +24,21 @@ pub(crate) fn set_test_live_solana_settlement_override(
     let previous_ambiguous = AMBIGUOUS_AFTER_SUBMIT.swap(false, Ordering::SeqCst);
     *guard = enabled;
     OBSERVED_PREPARED_INTENT.store(false, Ordering::SeqCst);
+    RECONCILE_CONFIRMED.store(false, Ordering::SeqCst);
+    SUBMISSION_COUNT.store(0, Ordering::SeqCst);
     TestLiveSolanaSettlementOverrideGuard {
         previous,
         previous_ambiguous,
     }
+}
+
+pub(crate) fn set_test_live_solana_settlement_reconcile_confirmed() {
+    AMBIGUOUS_AFTER_SUBMIT.store(false, Ordering::SeqCst);
+    RECONCILE_CONFIRMED.store(true, Ordering::SeqCst);
+}
+
+pub(crate) fn test_live_solana_settlement_submission_count() -> u64 {
+    SUBMISSION_COUNT.load(Ordering::SeqCst)
 }
 
 pub(crate) fn set_test_live_solana_settlement_ambiguous_after_submit(
@@ -67,9 +80,11 @@ pub(crate) fn maybe_submit_test_live_settlement(
         return None;
     }
     OBSERVED_PREPARED_INTENT.store(prepared_intent_exists(escrow_id), Ordering::SeqCst);
+    SUBMISSION_COUNT.fetch_add(1, Ordering::SeqCst);
     if AMBIGUOUS_AFTER_SUBMIT.load(Ordering::SeqCst) {
         return Some(Err("SETTLEMENT_OUTCOME_AMBIGUOUS".to_owned()));
     }
+    let _reconciled = RECONCILE_CONFIRMED.load(Ordering::SeqCst);
     Some(Ok(LiveSettlementEvidence {
         settlement_receipt_hash: prepared.expected_signature.clone(),
         settlement_tx_signature: prepared.expected_signature.clone(),

--- a/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch/test_support.rs
+++ b/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch/test_support.rs
@@ -8,6 +8,7 @@ static OBSERVED_PREPARED_INTENT: AtomicBool = AtomicBool::new(false);
 static AMBIGUOUS_AFTER_SUBMIT: AtomicBool = AtomicBool::new(false);
 static RECONCILE_CONFIRMED: AtomicBool = AtomicBool::new(false);
 static SUBMISSION_COUNT: AtomicU64 = AtomicU64::new(0);
+static EVIDENCE_MISMATCH: AtomicBool = AtomicBool::new(false);
 
 pub(crate) struct TestLiveSolanaSettlementOverrideGuard {
     previous: bool,
@@ -26,6 +27,7 @@ pub(crate) fn set_test_live_solana_settlement_override(
     OBSERVED_PREPARED_INTENT.store(false, Ordering::SeqCst);
     RECONCILE_CONFIRMED.store(false, Ordering::SeqCst);
     SUBMISSION_COUNT.store(0, Ordering::SeqCst);
+    EVIDENCE_MISMATCH.store(false, Ordering::SeqCst);
     TestLiveSolanaSettlementOverrideGuard {
         previous,
         previous_ambiguous,
@@ -35,6 +37,10 @@ pub(crate) fn set_test_live_solana_settlement_override(
 pub(crate) fn set_test_live_solana_settlement_reconcile_confirmed() {
     AMBIGUOUS_AFTER_SUBMIT.store(false, Ordering::SeqCst);
     RECONCILE_CONFIRMED.store(true, Ordering::SeqCst);
+}
+
+pub(crate) fn set_test_live_solana_settlement_evidence_mismatch() {
+    EVIDENCE_MISMATCH.store(true, Ordering::SeqCst);
 }
 
 pub(crate) fn test_live_solana_settlement_submission_count() -> u64 {
@@ -99,6 +105,12 @@ fn success_evidence(
         settlement_tx_signature: prepared.expected_signature.clone(),
         settlement_network: prepared.network.clone(),
         settlement_commitment: config.commitment_label.clone(),
+        recipient_pubkey: Some(prepared.recipient_pubkey.clone()),
+        amount_lamports: Some(if EVIDENCE_MISMATCH.load(Ordering::SeqCst) {
+            prepared.amount_lamports + 1
+        } else {
+            prepared.amount_lamports
+        }),
     }
 }
 

--- a/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch/test_support.rs
+++ b/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch/test_support.rs
@@ -1,8 +1,10 @@
 use super::models::LiveSettlementEvidence;
 use super::LiveSolanaSettlementConfig;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Mutex, OnceLock};
 
 static TEST_LIVE_SOLANA_SETTLEMENT_OVERRIDE: OnceLock<Mutex<bool>> = OnceLock::new();
+static OBSERVED_PREPARED_INTENT: AtomicBool = AtomicBool::new(false);
 
 pub(crate) struct TestLiveSolanaSettlementOverrideGuard {
     previous: bool,
@@ -16,6 +18,7 @@ pub(crate) fn set_test_live_solana_settlement_override(
         .expect("override lock should not poison");
     let previous = *guard;
     *guard = enabled;
+    OBSERVED_PREPARED_INTENT.store(false, Ordering::SeqCst);
     TestLiveSolanaSettlementOverrideGuard { previous }
 }
 
@@ -29,12 +32,17 @@ pub(crate) fn maybe_collect_test_live_settlement_evidence(
     {
         return None;
     }
+    OBSERVED_PREPARED_INTENT.store(prepared_intent_exists(escrow_id), Ordering::SeqCst);
     Some(Ok(LiveSettlementEvidence {
         settlement_receipt_hash: deterministic_signature(escrow_id),
         settlement_tx_signature: deterministic_signature(escrow_id),
         settlement_network: "solana:devnet".to_owned(),
         settlement_commitment: config.commitment_label.clone(),
     }))
+}
+
+pub(crate) fn test_live_settlement_observed_prepared_intent() -> bool {
+    OBSERVED_PREPARED_INTENT.load(Ordering::SeqCst)
 }
 
 impl Drop for TestLiveSolanaSettlementOverrideGuard {
@@ -48,6 +56,25 @@ impl Drop for TestLiveSolanaSettlementOverrideGuard {
 
 fn override_state() -> &'static Mutex<bool> {
     TEST_LIVE_SOLANA_SETTLEMENT_OVERRIDE.get_or_init(|| Mutex::new(false))
+}
+
+fn prepared_intent_exists(escrow_id: &str) -> bool {
+    let Ok(path) = std::env::var("KAMN_SERVICE_API_STATE_FILE") else {
+        return false;
+    };
+    let Ok(raw) = std::fs::read_to_string(path) else {
+        return false;
+    };
+    let Ok(state) = serde_json::from_str::<serde_json::Value>(&raw) else {
+        return false;
+    };
+    state["settlement_intents"]
+        .as_array()
+        .is_some_and(|intents| {
+            intents
+                .iter()
+                .any(|intent| intent["escrow_id"] == escrow_id && intent["state"] == "prepared")
+        })
 }
 
 fn deterministic_signature(seed: &str) -> String {

--- a/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch/test_support.rs
+++ b/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch/test_support.rs
@@ -1,4 +1,4 @@
-use super::models::LiveSettlementEvidence;
+use super::models::{LiveSettlementEvidence, PreparedLiveSettlement};
 use super::LiveSolanaSettlementConfig;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Mutex, OnceLock};
@@ -22,8 +22,29 @@ pub(crate) fn set_test_live_solana_settlement_override(
     TestLiveSolanaSettlementOverrideGuard { previous }
 }
 
-pub(crate) fn maybe_collect_test_live_settlement_evidence(
+pub(crate) fn maybe_prepare_test_live_settlement(
     config: &LiveSolanaSettlementConfig,
+    escrow_id: &str,
+) -> Option<Result<PreparedLiveSettlement, String>> {
+    if !*override_state()
+        .lock()
+        .expect("override lock should not poison")
+    {
+        return None;
+    }
+    Some(Ok(PreparedLiveSettlement {
+        expected_signature: deterministic_signature(escrow_id),
+        signed_transaction_digest: format!("sha256:test-{escrow_id}"),
+        signed_transaction_json: format!("test-signed-transaction:{escrow_id}"),
+        recipient_pubkey: config.recipient_pubkey.to_string(),
+        amount_lamports: config.lamports,
+        network: "solana:devnet".to_owned(),
+    }))
+}
+
+pub(crate) fn maybe_submit_test_live_settlement(
+    config: &LiveSolanaSettlementConfig,
+    prepared: &PreparedLiveSettlement,
     escrow_id: &str,
 ) -> Option<Result<LiveSettlementEvidence, String>> {
     if !*override_state()
@@ -34,9 +55,9 @@ pub(crate) fn maybe_collect_test_live_settlement_evidence(
     }
     OBSERVED_PREPARED_INTENT.store(prepared_intent_exists(escrow_id), Ordering::SeqCst);
     Some(Ok(LiveSettlementEvidence {
-        settlement_receipt_hash: deterministic_signature(escrow_id),
-        settlement_tx_signature: deterministic_signature(escrow_id),
-        settlement_network: "solana:devnet".to_owned(),
+        settlement_receipt_hash: prepared.expected_signature.clone(),
+        settlement_tx_signature: prepared.expected_signature.clone(),
+        settlement_network: prepared.network.clone(),
         settlement_commitment: config.commitment_label.clone(),
     }))
 }
@@ -69,12 +90,9 @@ fn prepared_intent_exists(escrow_id: &str) -> bool {
         return false;
     };
     state["settlement_intents"]
-        .as_array()
-        .is_some_and(|intents| {
-            intents
-                .iter()
-                .any(|intent| intent["escrow_id"] == escrow_id && intent["state"] == "prepared")
-        })
+        .as_object()
+        .and_then(|intents| intents.get(escrow_id))
+        .is_some_and(|intent| intent["state"] == "prepared")
 }
 
 fn deterministic_signature(seed: &str) -> String {

--- a/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch/test_support.rs
+++ b/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch/test_support.rs
@@ -5,9 +5,11 @@ use std::sync::{Mutex, OnceLock};
 
 static TEST_LIVE_SOLANA_SETTLEMENT_OVERRIDE: OnceLock<Mutex<bool>> = OnceLock::new();
 static OBSERVED_PREPARED_INTENT: AtomicBool = AtomicBool::new(false);
+static AMBIGUOUS_AFTER_SUBMIT: AtomicBool = AtomicBool::new(false);
 
 pub(crate) struct TestLiveSolanaSettlementOverrideGuard {
     previous: bool,
+    previous_ambiguous: bool,
 }
 
 pub(crate) fn set_test_live_solana_settlement_override(
@@ -17,9 +19,20 @@ pub(crate) fn set_test_live_solana_settlement_override(
         .lock()
         .expect("override lock should not poison");
     let previous = *guard;
+    let previous_ambiguous = AMBIGUOUS_AFTER_SUBMIT.swap(false, Ordering::SeqCst);
     *guard = enabled;
     OBSERVED_PREPARED_INTENT.store(false, Ordering::SeqCst);
-    TestLiveSolanaSettlementOverrideGuard { previous }
+    TestLiveSolanaSettlementOverrideGuard {
+        previous,
+        previous_ambiguous,
+    }
+}
+
+pub(crate) fn set_test_live_solana_settlement_ambiguous_after_submit(
+) -> TestLiveSolanaSettlementOverrideGuard {
+    let guard = set_test_live_solana_settlement_override(true);
+    AMBIGUOUS_AFTER_SUBMIT.store(true, Ordering::SeqCst);
+    guard
 }
 
 pub(crate) fn maybe_prepare_test_live_settlement(
@@ -54,6 +67,9 @@ pub(crate) fn maybe_submit_test_live_settlement(
         return None;
     }
     OBSERVED_PREPARED_INTENT.store(prepared_intent_exists(escrow_id), Ordering::SeqCst);
+    if AMBIGUOUS_AFTER_SUBMIT.load(Ordering::SeqCst) {
+        return Some(Err("SETTLEMENT_OUTCOME_AMBIGUOUS".to_owned()));
+    }
     Some(Ok(LiveSettlementEvidence {
         settlement_receipt_hash: prepared.expected_signature.clone(),
         settlement_tx_signature: prepared.expected_signature.clone(),
@@ -72,6 +88,7 @@ impl Drop for TestLiveSolanaSettlementOverrideGuard {
             .lock()
             .expect("override lock should not poison");
         *guard = self.previous;
+        AMBIGUOUS_AFTER_SUBMIT.store(self.previous_ambiguous, Ordering::SeqCst);
     }
 }
 

--- a/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch/test_support.rs
+++ b/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch/test_support.rs
@@ -80,17 +80,26 @@ pub(crate) fn maybe_submit_test_live_settlement(
         return None;
     }
     OBSERVED_PREPARED_INTENT.store(prepared_intent_exists(escrow_id), Ordering::SeqCst);
+    if RECONCILE_CONFIRMED.load(Ordering::SeqCst) {
+        return Some(Ok(success_evidence(config, prepared)));
+    }
     SUBMISSION_COUNT.fetch_add(1, Ordering::SeqCst);
     if AMBIGUOUS_AFTER_SUBMIT.load(Ordering::SeqCst) {
         return Some(Err("SETTLEMENT_OUTCOME_AMBIGUOUS".to_owned()));
     }
-    let _reconciled = RECONCILE_CONFIRMED.load(Ordering::SeqCst);
-    Some(Ok(LiveSettlementEvidence {
+    Some(Ok(success_evidence(config, prepared)))
+}
+
+fn success_evidence(
+    config: &LiveSolanaSettlementConfig,
+    prepared: &PreparedLiveSettlement,
+) -> LiveSettlementEvidence {
+    LiveSettlementEvidence {
         settlement_receipt_hash: prepared.expected_signature.clone(),
         settlement_tx_signature: prepared.expected_signature.clone(),
         settlement_network: prepared.network.clone(),
         settlement_commitment: config.commitment_label.clone(),
-    }))
+    }
 }
 
 pub(crate) fn test_live_settlement_observed_prepared_intent() -> bool {

--- a/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch/transport.rs
+++ b/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch/transport.rs
@@ -83,16 +83,20 @@ fn submit_or_reconcile_live_settlement_via_rpc(
         return Err("live solana settlement submitted signature mismatch".to_owned());
     }
     let confirmed = confirm_live_settlement_signature(&client, &signature, config)?;
-    if !confirmed {
-        return Err(format!(
-            "live solana settlement confirmation missing at {}",
-            config.commitment_label
-        ));
-    }
+    require_confirmation(confirmed, config.commitment_label.as_str())?;
     Ok(build_live_settlement_evidence(
         signature.to_string(),
         config.commitment_label.as_str(),
         prepared,
+    ))
+}
+
+fn require_confirmation(confirmed: bool, commitment: &str) -> Result<(), String> {
+    if confirmed {
+        return Ok(());
+    }
+    Err(format!(
+        "SETTLEMENT_OUTCOME_AMBIGUOUS: confirmation missing at {commitment}"
     ))
 }
 

--- a/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch/transport.rs
+++ b/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch/transport.rs
@@ -4,43 +4,45 @@ use super::models::{
 use super::LiveSolanaSettlementConfig;
 use solana_rpc_client::rpc_client::RpcClient;
 use solana_sdk::signer::keypair::read_keypair_file;
-use solana_system_transaction as system_transaction;
 use std::str::FromStr;
 use std::time::Duration;
 
+mod transaction;
+use transaction::{build_live_settlement_transaction, validate_prepared_transaction};
+
 pub(super) fn prepare_live_settlement(
     config: &LiveSolanaSettlementConfig,
-    _escrow_id: &str,
+    escrow_id: &str,
 ) -> Result<PreparedLiveSettlement, String> {
     #[cfg(test)]
-    if let Some(result) =
-        super::test_support::maybe_prepare_test_live_settlement(config, _escrow_id)
+    if let Some(result) = super::test_support::maybe_prepare_test_live_settlement(config, escrow_id)
     {
         return result;
     }
-    prepare_live_settlement_via_rpc(config)
+    prepare_live_settlement_via_rpc(config, escrow_id)
 }
 
 pub(super) fn submit_or_reconcile_live_settlement(
     config: &LiveSolanaSettlementConfig,
     prepared: &PreparedLiveSettlement,
-    _escrow_id: &str,
+    escrow_id: &str,
 ) -> Result<LiveSettlementEvidence, String> {
     #[cfg(test)]
     if let Some(result) =
-        super::test_support::maybe_submit_test_live_settlement(config, prepared, _escrow_id)
+        super::test_support::maybe_submit_test_live_settlement(config, prepared, escrow_id)
     {
         return result;
     }
-    submit_or_reconcile_live_settlement_via_rpc(config, prepared)
+    submit_or_reconcile_live_settlement_via_rpc(config, prepared, escrow_id)
 }
 
 fn prepare_live_settlement_via_rpc(
     config: &LiveSolanaSettlementConfig,
+    escrow_id: &str,
 ) -> Result<PreparedLiveSettlement, String> {
     let keypair = read_settlement_keypair(config)?;
     let client = settlement_rpc_client(config);
-    let transaction = build_live_settlement_transaction(&client, config, &keypair)?;
+    let transaction = build_live_settlement_transaction(&client, config, &keypair, escrow_id)?;
     let signature = transaction
         .signatures
         .first()
@@ -63,12 +65,14 @@ fn prepare_live_settlement_via_rpc(
 fn submit_or_reconcile_live_settlement_via_rpc(
     config: &LiveSolanaSettlementConfig,
     prepared: &PreparedLiveSettlement,
+    escrow_id: &str,
 ) -> Result<LiveSettlementEvidence, String> {
     validate_prepared_config(config, prepared)?;
     let transaction: solana_sdk::transaction::Transaction =
         serde_json::from_str(prepared.signed_transaction_json.as_str()).map_err(|error| {
             format!("live solana settlement transaction decode failed: {error}")
         })?;
+    validate_prepared_transaction(&transaction, prepared, escrow_id)?;
     let client = settlement_rpc_client(config);
     let expected_signature =
         solana_sdk::signature::Signature::from_str(prepared.expected_signature.as_str())
@@ -147,22 +151,6 @@ fn settlement_rpc_client(config: &LiveSolanaSettlementConfig) -> RpcClient {
         Duration::from_secs(30),
         config.commitment,
     )
-}
-
-fn build_live_settlement_transaction(
-    client: &RpcClient,
-    config: &LiveSolanaSettlementConfig,
-    keypair: &solana_sdk::signer::keypair::Keypair,
-) -> Result<solana_sdk::transaction::Transaction, String> {
-    let latest_blockhash = client.get_latest_blockhash().map_err(|error| {
-        format!("live solana settlement latest blockhash lookup failed: {error}")
-    })?;
-    Ok(system_transaction::transfer(
-        keypair,
-        &config.recipient_pubkey,
-        config.lamports,
-        latest_blockhash,
-    ))
 }
 
 fn submit_live_settlement_transaction(

--- a/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch/transport.rs
+++ b/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch/transport.rs
@@ -164,8 +164,8 @@ fn submit_live_settlement_transaction(
     transaction: &solana_sdk::transaction::Transaction,
 ) -> Result<solana_sdk::signature::Signature, String> {
     client
-        .send_and_confirm_transaction(transaction)
-        .map_err(|error| format!("live solana settlement transaction submit failed: {error}"))
+        .send_transaction(transaction)
+        .map_err(|error| format!("SETTLEMENT_OUTCOME_AMBIGUOUS: submit failed: {error}"))
 }
 
 fn confirm_live_settlement_signature(
@@ -176,7 +176,9 @@ fn confirm_live_settlement_signature(
     client
         .confirm_transaction_with_commitment(signature, config.commitment)
         .map(|response| response.value)
-        .map_err(|error| format!("live solana settlement confirmation lookup failed: {error}"))
+        .map_err(|error| {
+            format!("SETTLEMENT_OUTCOME_AMBIGUOUS: confirmation lookup failed: {error}")
+        })
 }
 
 fn build_live_settlement_evidence(

--- a/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch/transport.rs
+++ b/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch/transport.rs
@@ -195,3 +195,15 @@ fn build_live_settlement_evidence(
         amount_lamports: Some(prepared.amount_lamports),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn false_confirmation_is_an_ambiguous_outcome() {
+        let error = require_confirmation(false, "finalized").expect_err("ambiguous result");
+
+        assert!(error.starts_with("SETTLEMENT_OUTCOME_AMBIGUOUS"));
+    }
+}

--- a/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch/transport.rs
+++ b/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch/transport.rs
@@ -1,30 +1,75 @@
-use super::models::LiveSettlementEvidence;
+use super::models::{LiveSettlementEvidence, PreparedLiveSettlement};
 use super::LiveSolanaSettlementConfig;
 use solana_rpc_client::rpc_client::RpcClient;
 use solana_sdk::signer::keypair::read_keypair_file;
 use solana_system_transaction as system_transaction;
 use std::time::Duration;
 
-pub(super) fn collect_live_settlement_evidence(
+pub(super) fn prepare_live_settlement(
     config: &LiveSolanaSettlementConfig,
+    _escrow_id: &str,
+) -> Result<PreparedLiveSettlement, String> {
+    #[cfg(test)]
+    if let Some(result) =
+        super::test_support::maybe_prepare_test_live_settlement(config, _escrow_id)
+    {
+        return result;
+    }
+    prepare_live_settlement_via_rpc(config)
+}
+
+pub(super) fn submit_or_reconcile_live_settlement(
+    config: &LiveSolanaSettlementConfig,
+    prepared: &PreparedLiveSettlement,
     _escrow_id: &str,
 ) -> Result<LiveSettlementEvidence, String> {
     #[cfg(test)]
     if let Some(result) =
-        super::test_support::maybe_collect_test_live_settlement_evidence(config, _escrow_id)
+        super::test_support::maybe_submit_test_live_settlement(config, prepared, _escrow_id)
     {
         return result;
     }
-    collect_live_settlement_evidence_via_rpc(config)
+    submit_or_reconcile_live_settlement_via_rpc(config, prepared)
 }
 
-fn collect_live_settlement_evidence_via_rpc(
+fn prepare_live_settlement_via_rpc(
     config: &LiveSolanaSettlementConfig,
-) -> Result<LiveSettlementEvidence, String> {
+) -> Result<PreparedLiveSettlement, String> {
     let keypair = read_settlement_keypair(config)?;
     let client = settlement_rpc_client(config);
     let transaction = build_live_settlement_transaction(&client, config, &keypair)?;
+    let signature = transaction
+        .signatures
+        .first()
+        .ok_or_else(|| "live solana settlement transaction signature missing".to_owned())?;
+    let json = serde_json::to_string(&transaction)
+        .map_err(|error| format!("live solana settlement transaction encode failed: {error}"))?;
+    Ok(PreparedLiveSettlement {
+        expected_signature: signature.to_string(),
+        signed_transaction_digest: format!(
+            "sha256:{:016x}",
+            crate::service_api_endpoint::deterministic_body_tag(json.as_bytes())
+        ),
+        signed_transaction_json: json,
+        recipient_pubkey: config.recipient_pubkey.to_string(),
+        amount_lamports: config.lamports,
+        network: "solana:devnet".to_owned(),
+    })
+}
+
+fn submit_or_reconcile_live_settlement_via_rpc(
+    config: &LiveSolanaSettlementConfig,
+    prepared: &PreparedLiveSettlement,
+) -> Result<LiveSettlementEvidence, String> {
+    let transaction: solana_sdk::transaction::Transaction =
+        serde_json::from_str(prepared.signed_transaction_json.as_str()).map_err(|error| {
+            format!("live solana settlement transaction decode failed: {error}")
+        })?;
+    let client = settlement_rpc_client(config);
     let signature = submit_live_settlement_transaction(&client, &transaction)?;
+    if signature.to_string() != prepared.expected_signature {
+        return Err("live solana settlement submitted signature mismatch".to_owned());
+    }
     let confirmed = confirm_live_settlement_signature(&client, &signature, config)?;
     if !confirmed {
         return Err(format!(

--- a/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch/transport.rs
+++ b/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch/transport.rs
@@ -3,6 +3,7 @@ use super::LiveSolanaSettlementConfig;
 use solana_rpc_client::rpc_client::RpcClient;
 use solana_sdk::signer::keypair::read_keypair_file;
 use solana_system_transaction as system_transaction;
+use std::str::FromStr;
 use std::time::Duration;
 
 pub(super) fn prepare_live_settlement(
@@ -61,11 +62,21 @@ fn submit_or_reconcile_live_settlement_via_rpc(
     config: &LiveSolanaSettlementConfig,
     prepared: &PreparedLiveSettlement,
 ) -> Result<LiveSettlementEvidence, String> {
+    validate_prepared_config(config, prepared)?;
     let transaction: solana_sdk::transaction::Transaction =
         serde_json::from_str(prepared.signed_transaction_json.as_str()).map_err(|error| {
             format!("live solana settlement transaction decode failed: {error}")
         })?;
     let client = settlement_rpc_client(config);
+    let expected_signature =
+        solana_sdk::signature::Signature::from_str(prepared.expected_signature.as_str())
+            .map_err(|error| format!("live solana settlement signature decode failed: {error}"))?;
+    if reconcile_known_signature(&client, &expected_signature, config)? {
+        return Ok(build_live_settlement_evidence(
+            prepared.expected_signature.clone(),
+            config.commitment_label.as_str(),
+        ));
+    }
     let signature = submit_live_settlement_transaction(&client, &transaction)?;
     if signature.to_string() != prepared.expected_signature {
         return Err("live solana settlement submitted signature mismatch".to_owned());
@@ -81,6 +92,34 @@ fn submit_or_reconcile_live_settlement_via_rpc(
         signature.to_string(),
         config.commitment_label.as_str(),
     ))
+}
+
+fn reconcile_known_signature(
+    client: &RpcClient,
+    signature: &solana_sdk::signature::Signature,
+    config: &LiveSolanaSettlementConfig,
+) -> Result<bool, String> {
+    let status = client
+        .get_signature_status_with_commitment_and_history(signature, config.commitment, true)
+        .map_err(|error| format!("live solana settlement status lookup failed: {error}"))?;
+    match status {
+        Some(Ok(())) => Ok(true),
+        Some(Err(error)) => Err(format!("SETTLEMENT_TRANSACTION_FAILED: {error}")),
+        None => Ok(false),
+    }
+}
+
+fn validate_prepared_config(
+    config: &LiveSolanaSettlementConfig,
+    prepared: &PreparedLiveSettlement,
+) -> Result<(), String> {
+    if prepared.recipient_pubkey != config.recipient_pubkey.to_string()
+        || prepared.amount_lamports != config.lamports
+        || prepared.network != "solana:devnet"
+    {
+        return Err("SETTLEMENT_AGREEMENT_MISMATCH".to_owned());
+    }
+    Ok(())
 }
 
 fn read_settlement_keypair(

--- a/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch/transport.rs
+++ b/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch/transport.rs
@@ -1,4 +1,6 @@
-use super::models::{LiveSettlementEvidence, PreparedLiveSettlement};
+use super::models::{
+    build_live_settlement_evidence, LiveSettlementEvidence, PreparedLiveSettlement,
+};
 use super::LiveSolanaSettlementConfig;
 use solana_rpc_client::rpc_client::RpcClient;
 use solana_sdk::signer::keypair::read_keypair_file;
@@ -185,29 +187,6 @@ fn confirm_live_settlement_signature(
         })
 }
 
-fn build_live_settlement_evidence(
-    settlement_tx_signature: String,
-    settlement_commitment: &str,
-    prepared: &PreparedLiveSettlement,
-) -> LiveSettlementEvidence {
-    LiveSettlementEvidence {
-        settlement_receipt_hash: settlement_tx_signature.clone(),
-        settlement_tx_signature,
-        settlement_network: "solana:devnet".to_owned(),
-        settlement_commitment: settlement_commitment.to_owned(),
-        recipient_pubkey: Some(prepared.recipient_pubkey.clone()),
-        amount_lamports: Some(prepared.amount_lamports),
-    }
-}
-
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn false_confirmation_is_an_ambiguous_outcome() {
-        let error = require_confirmation(false, "finalized").expect_err("ambiguous result");
-
-        assert!(error.starts_with("SETTLEMENT_OUTCOME_AMBIGUOUS"));
-    }
-}
+#[path = "transport_tests.rs"]
+mod tests;

--- a/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch/transport.rs
+++ b/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch/transport.rs
@@ -75,6 +75,7 @@ fn submit_or_reconcile_live_settlement_via_rpc(
         return Ok(build_live_settlement_evidence(
             prepared.expected_signature.clone(),
             config.commitment_label.as_str(),
+            prepared,
         ));
     }
     let signature = submit_live_settlement_transaction(&client, &transaction)?;
@@ -91,6 +92,7 @@ fn submit_or_reconcile_live_settlement_via_rpc(
     Ok(build_live_settlement_evidence(
         signature.to_string(),
         config.commitment_label.as_str(),
+        prepared,
     ))
 }
 
@@ -180,11 +182,14 @@ fn confirm_live_settlement_signature(
 fn build_live_settlement_evidence(
     settlement_tx_signature: String,
     settlement_commitment: &str,
+    prepared: &PreparedLiveSettlement,
 ) -> LiveSettlementEvidence {
     LiveSettlementEvidence {
         settlement_receipt_hash: settlement_tx_signature.clone(),
         settlement_tx_signature,
         settlement_network: "solana:devnet".to_owned(),
         settlement_commitment: settlement_commitment.to_owned(),
+        recipient_pubkey: Some(prepared.recipient_pubkey.clone()),
+        amount_lamports: Some(prepared.amount_lamports),
     }
 }

--- a/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch/transport/transaction.rs
+++ b/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch/transport/transaction.rs
@@ -1,0 +1,125 @@
+use super::*;
+use solana_sdk::{
+    hash::Hash, message::compiled_instruction::CompiledInstruction, pubkey::Pubkey,
+    signature::Keypair, transaction::Transaction,
+};
+use solana_system_transaction as system_transaction;
+
+const MEMO_PROGRAM_ID: &str = "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr";
+
+pub(super) fn build_live_settlement_transaction(
+    client: &RpcClient,
+    config: &LiveSolanaSettlementConfig,
+    keypair: &Keypair,
+    escrow_id: &str,
+) -> Result<Transaction, String> {
+    let blockhash = client.get_latest_blockhash().map_err(|error| {
+        format!("live solana settlement latest blockhash lookup failed: {error}")
+    })?;
+    build_escrow_bound_transaction(
+        keypair,
+        &config.recipient_pubkey,
+        config.lamports,
+        blockhash,
+        escrow_id,
+    )
+}
+
+pub(super) fn build_escrow_bound_transaction(
+    payer: &Keypair,
+    recipient: &Pubkey,
+    lamports: u64,
+    blockhash: Hash,
+    escrow_id: &str,
+) -> Result<Transaction, String> {
+    let mut transaction = system_transaction::transfer(payer, recipient, lamports, blockhash);
+    append_escrow_memo(&mut transaction, escrow_id)?;
+    transaction.sign(&[payer], blockhash);
+    Ok(transaction)
+}
+
+fn append_escrow_memo(transaction: &mut Transaction, escrow_id: &str) -> Result<(), String> {
+    let memo_program = Pubkey::from_str(MEMO_PROGRAM_ID)
+        .map_err(|error| format!("settlement memo program invalid: {error}"))?;
+    let index = u8::try_from(transaction.message.account_keys.len())
+        .map_err(|_| "settlement memo account index overflow".to_owned())?;
+    transaction.message.account_keys.push(memo_program);
+    transaction.message.header.num_readonly_unsigned_accounts += 1;
+    transaction.message.instructions.push(CompiledInstruction {
+        program_id_index: index,
+        accounts: Vec::new(),
+        data: format!("kamn-escrow:{escrow_id}").into_bytes(),
+    });
+    Ok(())
+}
+
+pub(super) fn validate_persisted_transaction(
+    json: &str,
+    expected_signature: &str,
+) -> Result<(), String> {
+    let transaction: Transaction = serde_json::from_str(json)
+        .map_err(|error| format!("settlement transaction integrity decode failed: {error}"))?;
+    let signature = transaction.signatures.first().map(ToString::to_string);
+    if signature.as_deref() != Some(expected_signature) || transaction.verify().is_err() {
+        return Err("settlement transaction integrity verification failed".to_owned());
+    }
+    Ok(())
+}
+
+pub(super) fn validate_prepared_transaction(
+    transaction: &Transaction,
+    prepared: &PreparedLiveSettlement,
+    escrow_id: &str,
+) -> Result<(), String> {
+    validate_persisted_transaction(
+        prepared.signed_transaction_json.as_str(),
+        prepared.expected_signature.as_str(),
+    )?;
+    validate_transfer_instruction(transaction, prepared)?;
+    validate_escrow_memo(transaction, escrow_id)
+}
+
+fn validate_transfer_instruction(
+    transaction: &Transaction,
+    prepared: &PreparedLiveSettlement,
+) -> Result<(), String> {
+    let instruction = transaction
+        .message
+        .instructions
+        .first()
+        .ok_or_else(|| "settlement transfer instruction missing".to_owned())?;
+    let recipient_index = *instruction
+        .accounts
+        .get(1)
+        .ok_or_else(|| "settlement transfer recipient missing".to_owned())?
+        as usize;
+    let recipient = transaction.message.account_keys.get(recipient_index);
+    let amount = instruction
+        .data
+        .get(4..12)
+        .and_then(|bytes| bytes.try_into().ok())
+        .map(u64::from_le_bytes);
+    if recipient.map(ToString::to_string).as_deref() == Some(prepared.recipient_pubkey.as_str())
+        && amount == Some(prepared.amount_lamports)
+    {
+        return Ok(());
+    }
+    Err("settlement transaction agreement verification failed".to_owned())
+}
+
+fn validate_escrow_memo(transaction: &Transaction, escrow_id: &str) -> Result<(), String> {
+    let expected = format!("kamn-escrow:{escrow_id}");
+    let memo_program = Pubkey::from_str(MEMO_PROGRAM_ID)
+        .map_err(|error| format!("settlement memo program invalid: {error}"))?;
+    if transaction.message.instructions.iter().any(|instruction| {
+        transaction
+            .message
+            .account_keys
+            .get(instruction.program_id_index as usize)
+            == Some(&memo_program)
+            && instruction.data == expected.as_bytes()
+    }) {
+        return Ok(());
+    }
+    Err("settlement transaction escrow binding verification failed".to_owned())
+}

--- a/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch/transport_tests.rs
+++ b/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch/transport_tests.rs
@@ -1,0 +1,8 @@
+use super::*;
+
+#[test]
+fn false_confirmation_is_an_ambiguous_outcome() {
+    let error = require_confirmation(false, "finalized").expect_err("ambiguous result");
+
+    assert!(error.starts_with("SETTLEMENT_OUTCOME_AMBIGUOUS"));
+}

--- a/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch/transport_tests.rs
+++ b/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch/transport_tests.rs
@@ -1,3 +1,4 @@
+use super::transaction::{build_escrow_bound_transaction, validate_persisted_transaction};
 use super::*;
 use solana_sdk::{hash::Hash, pubkey::Pubkey, signature::Keypair};
 
@@ -26,14 +27,9 @@ fn escrow_binding_makes_same_blockhash_transfers_unique() {
 fn persisted_transaction_integrity_rejects_tampering() {
     let payer = Keypair::new();
     let recipient = Pubkey::new_unique();
-    let mut transaction = build_escrow_bound_transaction(
-        &payer,
-        &recipient,
-        7,
-        Hash::new_unique(),
-        "escrow-a",
-    )
-    .expect("transaction");
+    let mut transaction =
+        build_escrow_bound_transaction(&payer, &recipient, 7, Hash::new_unique(), "escrow-a")
+            .expect("transaction");
     let expected = transaction.signatures[0].to_string();
     transaction.message.instructions[0].data.push(0);
     let json = serde_json::to_string(&transaction).expect("json");

--- a/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch/transport_tests.rs
+++ b/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch/transport_tests.rs
@@ -1,8 +1,44 @@
 use super::*;
+use solana_sdk::{hash::Hash, pubkey::Pubkey, signature::Keypair};
 
 #[test]
 fn false_confirmation_is_an_ambiguous_outcome() {
     let error = require_confirmation(false, "finalized").expect_err("ambiguous result");
 
     assert!(error.starts_with("SETTLEMENT_OUTCOME_AMBIGUOUS"));
+}
+
+#[test]
+fn escrow_binding_makes_same_blockhash_transfers_unique() {
+    let payer = Keypair::new();
+    let recipient = Pubkey::new_unique();
+    let blockhash = Hash::new_unique();
+
+    let first = build_escrow_bound_transaction(&payer, &recipient, 7, blockhash, "escrow-a")
+        .expect("first transaction");
+    let second = build_escrow_bound_transaction(&payer, &recipient, 7, blockhash, "escrow-b")
+        .expect("second transaction");
+
+    assert_ne!(first.signatures[0], second.signatures[0]);
+}
+
+#[test]
+fn persisted_transaction_integrity_rejects_tampering() {
+    let payer = Keypair::new();
+    let recipient = Pubkey::new_unique();
+    let mut transaction = build_escrow_bound_transaction(
+        &payer,
+        &recipient,
+        7,
+        Hash::new_unique(),
+        "escrow-a",
+    )
+    .expect("transaction");
+    let expected = transaction.signatures[0].to_string();
+    transaction.message.instructions[0].data.push(0);
+    let json = serde_json::to_string(&transaction).expect("json");
+
+    let error = validate_persisted_transaction(json.as_str(), expected.as_str())
+        .expect_err("tampering must fail");
+    assert!(error.contains("integrity"));
 }

--- a/crates/kamn-node/src/service_api_endpoint/message_store.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store.rs
@@ -57,6 +57,8 @@ pub(crate) use models::{
     ServiceApiPersistedAgentGrantRecord, ServiceApiRelayProgressCounts,
 };
 pub(crate) use store::escrow_fund_task_id;
+#[cfg(test)]
+pub(crate) use store::settlement_signature_is_available;
 pub(crate) use store::EscrowLifecycleError;
 pub(crate) use store::TaskLifecycleError;
 pub(crate) use store::{ServiceApiAuthorizationDecision, ServiceApiAuthorizationRequest};

--- a/crates/kamn-node/src/service_api_endpoint/message_store.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store.rs
@@ -49,6 +49,7 @@ use audit_export::{
 };
 use models::*;
 use runtime_evidence::build_data_layer_runtime_evidence;
+pub(crate) use task_models::ServiceApiSettlementIntentRecord;
 use task_models::*;
 
 pub(crate) use models::{

--- a/crates/kamn-node/src/service_api_endpoint/message_store/models.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/models.rs
@@ -152,6 +152,8 @@ pub(crate) struct ServiceApiPersistedMessageStoreSnapshot {
     pub(crate) task_transition_receipts: Vec<ServiceApiTaskTransitionReceiptRecord>,
     #[serde(default)]
     pub(crate) escrow_transition_receipts: Vec<ServiceApiEscrowTransitionReceiptRecord>,
+    #[serde(default)]
+    pub(crate) settlement_intents: BTreeMap<String, ServiceApiSettlementIntentRecord>,
 }
 
 impl Default for ServiceApiPersistedMessageStoreSnapshot {
@@ -170,6 +172,7 @@ impl Default for ServiceApiPersistedMessageStoreSnapshot {
             authorization_receipts: Vec::new(),
             task_transition_receipts: Vec::new(),
             escrow_transition_receipts: Vec::new(),
+            settlement_intents: BTreeMap::new(),
         }
     }
 }

--- a/crates/kamn-node/src/service_api_endpoint/message_store/store.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/store.rs
@@ -12,5 +12,7 @@ pub(crate) use authorization_ops::{
 };
 pub(crate) use query_ops::recipient_mailbox_channel_id;
 pub(crate) use task_escrow_ops::escrow_fund_task_id;
+#[cfg(test)]
+pub(crate) use task_escrow_ops::settlement_signature_is_available;
 pub(crate) use task_escrow_ops::EscrowLifecycleError;
 pub(crate) use task_escrow_ops::TaskLifecycleError;

--- a/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops.rs
@@ -50,6 +50,14 @@ impl ServiceApiMessageStore {
         settlement_intent::mark_ambiguous(self, escrow_id)
     }
 
+    pub(crate) fn mark_settlement_failed(
+        &mut self,
+        escrow_id: &str,
+        error_code: &str,
+    ) -> Result<(), String> {
+        settlement_intent::mark_failed(self, escrow_id, error_code)
+    }
+
     pub(crate) fn fund_bound_escrow(
         &mut self,
         actor: &str,

--- a/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops.rs
@@ -43,6 +43,13 @@ impl ServiceApiMessageStore {
         settlement_intent::finalize(self, escrow_id, settlement)
     }
 
+    pub(crate) fn mark_settlement_outcome_ambiguous(
+        &mut self,
+        escrow_id: &str,
+    ) -> Result<(), String> {
+        settlement_intent::mark_ambiguous(self, escrow_id)
+    }
+
     pub(crate) fn fund_bound_escrow(
         &mut self,
         actor: &str,

--- a/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops.rs
@@ -4,6 +4,7 @@ mod dispatch;
 mod escrow_lifecycle;
 mod lifecycle;
 mod settlement;
+mod settlement_intent;
 mod tasks;
 
 use dispatch::{
@@ -16,6 +17,32 @@ use settlement::{escrow_status_response, release_escrow_record};
 use tasks::{next_task_id, persist_task_created_audit_export};
 
 impl ServiceApiMessageStore {
+    pub(crate) fn prepare_settlement_intent(
+        &mut self,
+        actor: &str,
+        escrow_id: &str,
+        idempotency_key: &str,
+        prepared: &crate::service_api_endpoint::live_settlement_dispatch::PreparedLiveSettlement,
+    ) -> Result<ServiceApiSettlementIntentRecord, String> {
+        settlement_intent::prepare(self, actor, escrow_id, idempotency_key, prepared)
+    }
+
+    pub(crate) fn get_settlement_intent(
+        &mut self,
+        escrow_id: &str,
+    ) -> Result<Option<ServiceApiSettlementIntentRecord>, String> {
+        self.refresh_from_disk()?;
+        Ok(self.snapshot.settlement_intents.get(escrow_id).cloned())
+    }
+
+    pub(crate) fn finalize_settlement_intent(
+        &mut self,
+        escrow_id: &str,
+        settlement: &ServiceApiSettlementMetadata,
+    ) -> Result<Option<ServiceApiEscrowStatusBody>, String> {
+        settlement_intent::finalize(self, escrow_id, settlement)
+    }
+
     pub(crate) fn fund_bound_escrow(
         &mut self,
         actor: &str,
@@ -106,14 +133,6 @@ impl ServiceApiMessageStore {
                 ..ServiceApiSettlementMetadata::default()
             }),
         )
-    }
-
-    pub(crate) fn release_escrow_with_settlement_metadata(
-        &mut self,
-        escrow_id: &str,
-        settlement: &ServiceApiSettlementMetadata,
-    ) -> Result<Option<ServiceApiEscrowStatusBody>, String> {
-        self.release_escrow_inner(escrow_id, Some(settlement))
     }
 
     fn release_escrow_inner(

--- a/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops.rs
@@ -14,6 +14,8 @@ pub(crate) use escrow_lifecycle::EscrowLifecycleError;
 pub(crate) use lifecycle::TaskLifecycleError;
 pub(crate) use settlement::escrow_fund_task_id;
 use settlement::{escrow_status_response, release_escrow_record};
+#[cfg(test)]
+pub(crate) use settlement_intent::settlement_signature_is_available;
 use tasks::{next_task_id, persist_task_created_audit_export};
 
 impl ServiceApiMessageStore {

--- a/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/escrow_lifecycle.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/escrow_lifecycle.rs
@@ -5,7 +5,10 @@ mod agreement;
 mod receipt;
 mod retry;
 
-use agreement::{build_record, parse_fund, parse_release_key, validate_funding, validate_release};
+use agreement::{
+    build_record, issue_release_grant, parse_fund, parse_release_key, validate_funding,
+    validate_release,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum EscrowLifecycleError {
@@ -63,6 +66,7 @@ pub(super) fn fund(
         correlation_id,
     )?;
     store.snapshot.escrows.insert(escrow_id.clone(), record);
+    issue_release_grant(store, escrow_id.as_str(), actor);
     store.persist().map_err(persistence)?;
     Ok(receipt::response(
         &store.snapshot.escrows[&escrow_id],

--- a/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/escrow_lifecycle/agreement.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/escrow_lifecycle/agreement.rs
@@ -109,6 +109,25 @@ pub(super) fn build_record(
     }
 }
 
+pub(super) fn issue_release_grant(
+    store: &mut ServiceApiMessageStore,
+    escrow_id: &str,
+    authority: &str,
+) {
+    let key = format!("escrow-lifecycle:{escrow_id}:{authority}:escrow:release");
+    store.snapshot.agent_grants.insert(
+        key.clone(),
+        ServiceApiPersistedAgentGrantRecord {
+            did: authority.to_owned(),
+            resource: format!("escrow:{escrow_id}"),
+            role: "initiator".to_owned(),
+            action: "escrow:release".to_owned(),
+            status: "active".to_owned(),
+            idempotency_key: key,
+        },
+    );
+}
+
 fn validate_participants(
     actor: &str,
     input: &FundInput,

--- a/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/lifecycle/agreement.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/lifecycle/agreement.rs
@@ -74,12 +74,13 @@ pub(super) fn issue_grants(
     provider: &str,
 ) {
     for (did, action, role) in grant_contract(creator, provider) {
+        let resource = format!("task:{task_id}");
         let key = format!("task-lifecycle:{task_id}:{did}:{action}");
         store.snapshot.agent_grants.insert(
             key.clone(),
             ServiceApiPersistedAgentGrantRecord {
                 did: did.to_owned(),
-                resource: format!("task:{task_id}"),
+                resource,
                 role: role.to_owned(),
                 action: action.to_owned(),
                 status: "active".to_owned(),
@@ -92,12 +93,13 @@ pub(super) fn issue_grants(
 fn grant_contract<'a>(
     creator: &'a str,
     provider: &'a str,
-) -> [(&'a str, &'static str, &'static str); 4] {
+) -> [(&'a str, &'static str, &'static str); 5] {
     [
         (creator, "task:read", "participant"),
         (provider, "task:read", "participant"),
         (provider, "task:accept", "provider"),
         (provider, "task:complete", "provider"),
+        (creator, "escrow:fund", "initiator"),
     ]
 }
 

--- a/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/settlement.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/settlement.rs
@@ -40,8 +40,17 @@ pub(super) fn escrow_status_response(
         terms_digest: record.terms_digest.clone(),
         release_authority_did: record.release_authority_did.clone(),
         release_policy: record.release_policy.clone(),
-        claim_scope: "local-only".to_owned(),
+        claim_scope: escrow_claim_scope(record).to_owned(),
         receipt_id: None,
         settlement: record.settlement.clone(),
     }
+}
+
+fn escrow_claim_scope(record: &ServiceApiPersistedEscrowRecord) -> &'static str {
+    if record.settlement.settlement_tx_signature.is_some()
+        && record.settlement.settlement_network.as_deref() == Some("solana:devnet")
+    {
+        return "devnet-backed";
+    }
+    "local-only"
 }

--- a/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/settlement_intent.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/settlement_intent.rs
@@ -13,6 +13,13 @@ pub(super) fn prepare(
     if let Some(existing) = store.snapshot.settlement_intents.get(escrow_id) {
         return identical_or_conflict(existing, actor, idempotency_key, prepared);
     }
+    if !settlement_signature_is_available(
+        &store.snapshot,
+        escrow_id,
+        prepared.expected_signature.as_str(),
+    ) {
+        return Err("SETTLEMENT_SIGNATURE_REUSE".to_owned());
+    }
     let record = build_record(actor, escrow_id, idempotency_key, prepared);
     store
         .snapshot
@@ -20,6 +27,17 @@ pub(super) fn prepare(
         .insert(escrow_id.to_owned(), record.clone());
     store.persist()?;
     Ok(record)
+}
+
+pub(crate) fn settlement_signature_is_available(
+    snapshot: &ServiceApiPersistedMessageStoreSnapshot,
+    escrow_id: &str,
+    signature: &str,
+) -> bool {
+    snapshot
+        .settlement_intents
+        .values()
+        .all(|intent| intent.escrow_id == escrow_id || intent.expected_signature != signature)
 }
 
 pub(super) fn finalize(

--- a/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/settlement_intent.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/settlement_intent.rs
@@ -32,9 +32,27 @@ pub(super) fn finalize(
         return Err("settlement intent missing during finalize".to_owned());
     };
     intent.state = "confirmed".to_owned();
+    intent.submission_attempt_count += 1;
+    intent.last_error_code = None;
     let response = release_without_refresh(store, escrow_id, settlement)?;
     store.persist()?;
     Ok(response)
+}
+
+pub(super) fn mark_ambiguous(
+    store: &mut ServiceApiMessageStore,
+    escrow_id: &str,
+) -> Result<(), String> {
+    store.refresh_from_disk()?;
+    let intent = store
+        .snapshot
+        .settlement_intents
+        .get_mut(escrow_id)
+        .ok_or_else(|| "settlement intent missing during ambiguous outcome".to_owned())?;
+    intent.state = "ambiguous".to_owned();
+    intent.submission_attempt_count += 1;
+    intent.last_error_code = Some("SETTLEMENT_OUTCOME_AMBIGUOUS".to_owned());
+    store.persist()
 }
 
 fn validate_agreement(

--- a/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/settlement_intent.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/settlement_intent.rs
@@ -1,0 +1,108 @@
+use super::super::super::*;
+use crate::service_api_endpoint::live_settlement_dispatch::PreparedLiveSettlement;
+
+pub(super) fn prepare(
+    store: &mut ServiceApiMessageStore,
+    actor: &str,
+    escrow_id: &str,
+    idempotency_key: &str,
+    prepared: &PreparedLiveSettlement,
+) -> Result<ServiceApiSettlementIntentRecord, String> {
+    store.refresh_from_disk()?;
+    validate_agreement(store, escrow_id, prepared)?;
+    if let Some(existing) = store.snapshot.settlement_intents.get(escrow_id) {
+        return identical_or_conflict(existing, actor, idempotency_key, prepared);
+    }
+    let record = build_record(actor, escrow_id, idempotency_key, prepared);
+    store
+        .snapshot
+        .settlement_intents
+        .insert(escrow_id.to_owned(), record.clone());
+    store.persist()?;
+    Ok(record)
+}
+
+pub(super) fn finalize(
+    store: &mut ServiceApiMessageStore,
+    escrow_id: &str,
+    settlement: &ServiceApiSettlementMetadata,
+) -> Result<Option<ServiceApiEscrowStatusBody>, String> {
+    store.refresh_from_disk()?;
+    let Some(intent) = store.snapshot.settlement_intents.get_mut(escrow_id) else {
+        return Err("settlement intent missing during finalize".to_owned());
+    };
+    intent.state = "confirmed".to_owned();
+    let response = release_without_refresh(store, escrow_id, settlement)?;
+    store.persist()?;
+    Ok(response)
+}
+
+fn validate_agreement(
+    store: &ServiceApiMessageStore,
+    escrow_id: &str,
+    prepared: &PreparedLiveSettlement,
+) -> Result<(), String> {
+    let escrow = store
+        .snapshot
+        .escrows
+        .get(escrow_id)
+        .ok_or_else(|| "settlement escrow missing".to_owned())?;
+    if escrow.amount_lamports != Some(prepared.amount_lamports)
+        || escrow.network.as_deref() != Some("solana-devnet")
+        || prepared.network != "solana:devnet"
+    {
+        return Err("SETTLEMENT_AGREEMENT_MISMATCH".to_owned());
+    }
+    Ok(())
+}
+
+fn identical_or_conflict(
+    existing: &ServiceApiSettlementIntentRecord,
+    actor: &str,
+    key: &str,
+    prepared: &PreparedLiveSettlement,
+) -> Result<ServiceApiSettlementIntentRecord, String> {
+    if existing.actor_did == actor
+        && existing.idempotency_key == key
+        && existing.expected_signature == prepared.expected_signature
+        && existing.signed_transaction_digest == prepared.signed_transaction_digest
+    {
+        return Ok(existing.clone());
+    }
+    Err("SETTLEMENT_INTENT_CONFLICT".to_owned())
+}
+
+fn build_record(
+    actor: &str,
+    escrow_id: &str,
+    key: &str,
+    prepared: &PreparedLiveSettlement,
+) -> ServiceApiSettlementIntentRecord {
+    ServiceApiSettlementIntentRecord {
+        settlement_intent_id: format!("settlement-intent-{escrow_id}"),
+        escrow_id: escrow_id.to_owned(),
+        actor_did: actor.to_owned(),
+        idempotency_key: key.to_owned(),
+        recipient_pubkey: prepared.recipient_pubkey.clone(),
+        amount_lamports: prepared.amount_lamports,
+        network: prepared.network.clone(),
+        expected_signature: prepared.expected_signature.clone(),
+        signed_transaction_digest: prepared.signed_transaction_digest.clone(),
+        signed_transaction_json: prepared.signed_transaction_json.clone(),
+        state: "prepared".to_owned(),
+        submission_attempt_count: 0,
+        last_error_code: None,
+    }
+}
+
+fn release_without_refresh(
+    store: &mut ServiceApiMessageStore,
+    escrow_id: &str,
+    settlement: &ServiceApiSettlementMetadata,
+) -> Result<Option<ServiceApiEscrowStatusBody>, String> {
+    let Some(record) = store.snapshot.escrows.get_mut(escrow_id) else {
+        return Ok(None);
+    };
+    super::settlement::release_escrow_record(record, Some(settlement));
+    Ok(Some(super::settlement::escrow_status_response(record)))
+}

--- a/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/settlement_intent.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/settlement_intent.rs
@@ -55,6 +55,23 @@ pub(super) fn mark_ambiguous(
     store.persist()
 }
 
+pub(super) fn mark_failed(
+    store: &mut ServiceApiMessageStore,
+    escrow_id: &str,
+    error_code: &str,
+) -> Result<(), String> {
+    store.refresh_from_disk()?;
+    let intent = store
+        .snapshot
+        .settlement_intents
+        .get_mut(escrow_id)
+        .ok_or_else(|| "settlement intent missing during failed outcome".to_owned())?;
+    intent.state = "failed".to_owned();
+    intent.submission_attempt_count += 1;
+    intent.last_error_code = Some(error_code.to_owned());
+    store.persist()
+}
+
 fn validate_agreement(
     store: &ServiceApiMessageStore,
     escrow_id: &str,

--- a/crates/kamn-node/src/service_api_endpoint/message_store/task_models.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/task_models.rs
@@ -61,3 +61,21 @@ pub(crate) struct ServiceApiEscrowTransitionReceiptRecord {
     pub(crate) terms_digest: String,
     pub(crate) release_policy: String,
 }
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct ServiceApiSettlementIntentRecord {
+    pub(crate) settlement_intent_id: String,
+    pub(crate) escrow_id: String,
+    pub(crate) actor_did: String,
+    pub(crate) idempotency_key: String,
+    pub(crate) recipient_pubkey: String,
+    pub(crate) amount_lamports: u64,
+    pub(crate) network: String,
+    pub(crate) expected_signature: String,
+    pub(crate) signed_transaction_digest: String,
+    pub(crate) signed_transaction_json: String,
+    pub(crate) state: String,
+    pub(crate) submission_attempt_count: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) last_error_code: Option<String>,
+}

--- a/crates/kamn-node/src/service_api_endpoint/message_store/tests/authorization_contract_tests.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/tests/authorization_contract_tests.rs
@@ -73,6 +73,44 @@ fn unit_agent_grant_validation_rejects_generic_or_incompatible_authority() {
     assert!(store.snapshot.agent_grants.is_empty());
 }
 
+#[test]
+fn unit_settlement_signature_cannot_belong_to_two_escrows() {
+    let mut snapshot = ServiceApiPersistedMessageStoreSnapshot::default();
+    snapshot.settlement_intents.insert(
+        "escrow-a".to_owned(),
+        settlement_intent("escrow-a", "signature-shared"),
+    );
+
+    assert!(settlement_signature_is_available(
+        &snapshot,
+        "escrow-a",
+        "signature-shared"
+    ));
+    assert!(!settlement_signature_is_available(
+        &snapshot,
+        "escrow-b",
+        "signature-shared"
+    ));
+}
+
+fn settlement_intent(escrow_id: &str, signature: &str) -> ServiceApiSettlementIntentRecord {
+    ServiceApiSettlementIntentRecord {
+        settlement_intent_id: format!("intent-{escrow_id}"),
+        escrow_id: escrow_id.to_owned(),
+        actor_did: ACTOR_DID.to_owned(),
+        idempotency_key: "release-key".to_owned(),
+        recipient_pubkey: "recipient".to_owned(),
+        amount_lamports: 1,
+        network: "solana:devnet".to_owned(),
+        expected_signature: signature.to_owned(),
+        signed_transaction_digest: "digest".to_owned(),
+        signed_transaction_json: "json".to_owned(),
+        state: "prepared".to_owned(),
+        submission_attempt_count: 0,
+        last_error_code: None,
+    }
+}
+
 fn registered_store() -> ServiceApiMessageStore {
     let mut store = ServiceApiMessageStore {
         state_file: None,

--- a/crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/mutations/update_routes/state_routes_release.rs
+++ b/crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/mutations/update_routes/state_routes_release.rs
@@ -1,7 +1,9 @@
 use super::*;
 use crate::service_api_endpoint::live_settlement_dispatch::{
-    LiveSettlementEvidence, LiveSolanaSettlementConfig,
+    LiveSettlementEvidence, LiveSolanaSettlementConfig, PreparedLiveSettlement,
 };
+
+mod live_settlement;
 
 pub(super) async fn resolve_release_escrow_result(
     state: &Arc<ServiceApiRuntimeState>,
@@ -9,7 +11,7 @@ pub(super) async fn resolve_release_escrow_result(
     escrow_id: &str,
 ) -> Result<Result<Option<ServiceApiEscrowStatusBody>, String>, Box<Response>> {
     if let Some(config) = state.live_solana_settlement.as_ref() {
-        return release_escrow_with_live_solana_settlement(state, context, escrow_id, config).await;
+        return live_settlement::release(state, context, escrow_id, config).await;
     }
     let Some(config) = state.live_solana_bridge_dispatch.as_ref() else {
         let mut store = state.message_store.lock().await;
@@ -25,149 +27,6 @@ pub(super) fn live_settlement_evidence_error(error: &str) -> Response {
         "internal",
         REASON_CODE_LIVE_SETTLEMENT_EVIDENCE_FAILED,
         format!("service api live settlement evidence failed: {error}").as_str(),
-    )
-}
-
-async fn release_escrow_with_live_solana_settlement(
-    state: &Arc<ServiceApiRuntimeState>,
-    context: &ServiceApiRequestContext,
-    escrow_id: &str,
-    config: &LiveSolanaSettlementConfig,
-) -> Result<Result<Option<ServiceApiEscrowStatusBody>, String>, Box<Response>> {
-    let mut store = state.message_store.lock().await;
-    validate_release_eligibility(&mut store, context, escrow_id)?;
-    let existing = store
-        .get_escrow_status(escrow_id)
-        .map_err(|error| Box::new(super::super::super::persistence_error(error.as_str())))?;
-    if existing
-        .as_ref()
-        .is_some_and(|payload| payload.state == "released")
-    {
-        return Ok(Ok(existing));
-    }
-    let actor = super::super::super::task_actor(context)?;
-    let key = release_idempotency_key(context)?;
-    let prepared = resolve_prepared_settlement(&mut store, config, escrow_id)?;
-    if let Err(error) =
-        store.prepare_settlement_intent(actor.as_str(), escrow_id, key.as_str(), &prepared)
-    {
-        if error == "SETTLEMENT_INTENT_CONFLICT" {
-            return Err(Box::new(settlement_intent_conflict_error()));
-        }
-        return Err(Box::new(live_settlement_evidence_error(error.as_str())));
-    }
-    let evidence = match crate::service_api_endpoint::live_settlement_dispatch::submit_or_reconcile_live_settlement(
-        config, &prepared, escrow_id,
-    ) {
-        Ok(evidence) => evidence,
-        Err(error) if error == "SETTLEMENT_OUTCOME_AMBIGUOUS" => {
-            store.mark_settlement_outcome_ambiguous(escrow_id).map_err(|persist_error| {
-                Box::new(super::super::super::persistence_error(persist_error.as_str()))
-            })?;
-            return Err(Box::new(settlement_outcome_ambiguous_error()));
-        }
-        Err(error) => return Err(Box::new(live_settlement_evidence_error(error.as_str()))),
-    };
-    if !settlement_evidence_matches(&prepared, &evidence, config) {
-        store
-            .mark_settlement_failed(escrow_id, "SETTLEMENT_EVIDENCE_MISMATCH")
-            .map_err(|error| Box::new(super::super::super::persistence_error(error.as_str())))?;
-        return Err(Box::new(settlement_evidence_mismatch_error()));
-    }
-    Ok(store.finalize_settlement_intent(escrow_id, &settlement_metadata_from_evidence(evidence)))
-}
-
-fn settlement_evidence_matches(
-    prepared: &crate::service_api_endpoint::live_settlement_dispatch::PreparedLiveSettlement,
-    evidence: &LiveSettlementEvidence,
-    config: &LiveSolanaSettlementConfig,
-) -> bool {
-    evidence.settlement_tx_signature == prepared.expected_signature
-        && evidence.settlement_receipt_hash == prepared.expected_signature
-        && evidence.settlement_network == prepared.network
-        && evidence.settlement_commitment == config.commitment_label()
-        && evidence.recipient_pubkey.as_deref() == Some(prepared.recipient_pubkey.as_str())
-        && evidence.amount_lamports == Some(prepared.amount_lamports)
-}
-
-fn settlement_evidence_mismatch_error() -> Response {
-    super::payload::json_error_response(
-        StatusCode::INTERNAL_SERVER_ERROR,
-        "internal",
-        "SETTLEMENT_EVIDENCE_MISMATCH",
-        "confirmed settlement evidence does not match the durable intent",
-    )
-}
-
-fn settlement_outcome_ambiguous_error() -> Response {
-    super::payload::json_error_response(
-        StatusCode::SERVICE_UNAVAILABLE,
-        "unavailable",
-        "SETTLEMENT_OUTCOME_AMBIGUOUS",
-        "settlement submission outcome is ambiguous and requires reconciliation",
-    )
-}
-
-fn settlement_intent_conflict_error() -> Response {
-    super::payload::json_error_response(
-        StatusCode::CONFLICT,
-        "conflict",
-        "SETTLEMENT_INTENT_CONFLICT",
-        "settlement idempotency key conflicts with the durable intent",
-    )
-}
-
-fn resolve_prepared_settlement(
-    store: &mut ServiceApiMessageStore,
-    config: &LiveSolanaSettlementConfig,
-    escrow_id: &str,
-) -> Result<
-    crate::service_api_endpoint::live_settlement_dispatch::PreparedLiveSettlement,
-    Box<Response>,
-> {
-    let existing = store
-        .get_settlement_intent(escrow_id)
-        .map_err(|error| Box::new(super::super::super::persistence_error(error.as_str())))?;
-    if let Some(intent) = existing {
-        return Ok(prepared_from_intent(intent));
-    }
-    crate::service_api_endpoint::live_settlement_dispatch::prepare_live_settlement(
-        config, escrow_id,
-    )
-    .map_err(|error| Box::new(live_settlement_evidence_error(error.as_str())))
-}
-
-fn prepared_from_intent(
-    intent: ServiceApiSettlementIntentRecord,
-) -> crate::service_api_endpoint::live_settlement_dispatch::PreparedLiveSettlement {
-    crate::service_api_endpoint::live_settlement_dispatch::PreparedLiveSettlement {
-        expected_signature: intent.expected_signature,
-        signed_transaction_digest: intent.signed_transaction_digest,
-        signed_transaction_json: intent.signed_transaction_json,
-        recipient_pubkey: intent.recipient_pubkey,
-        amount_lamports: intent.amount_lamports,
-        network: intent.network,
-    }
-}
-
-fn release_idempotency_key(context: &ServiceApiRequestContext) -> Result<String, Box<Response>> {
-    let value: serde_json::Value = serde_json::from_str(context.parsed_request.body.as_str())
-        .map_err(|error| Box::new(invalid_release_key(error.to_string().as_str())))?;
-    value
-        .get("idempotency_key")
-        .and_then(serde_json::Value::as_str)
-        .map(str::trim)
-        .filter(|key| !key.is_empty())
-        .map(str::to_owned)
-        .ok_or_else(|| Box::new(invalid_release_key("release idempotency key is required")))
-}
-
-fn invalid_release_key(message: &str) -> Response {
-    super::payload::json_error_response(
-        StatusCode::BAD_REQUEST,
-        "bad_request",
-        "ESCROW_AGREEMENT_INVALID",
-        message,
     )
 }
 
@@ -207,15 +66,4 @@ fn validate_release_eligibility(
     store
         .validate_escrow_release_eligibility(actor.as_str(), escrow_id)
         .map_err(|error| Box::new(super::super::super::escrow_lifecycle_error_response(error)))
-}
-
-fn settlement_metadata_from_evidence(
-    evidence: LiveSettlementEvidence,
-) -> ServiceApiSettlementMetadata {
-    ServiceApiSettlementMetadata {
-        settlement_receipt_hash: Some(evidence.settlement_receipt_hash),
-        settlement_tx_signature: Some(evidence.settlement_tx_signature),
-        settlement_network: Some(evidence.settlement_network),
-        settlement_commitment: Some(evidence.settlement_commitment),
-    }
 }

--- a/crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/mutations/update_routes/state_routes_release.rs
+++ b/crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/mutations/update_routes/state_routes_release.rs
@@ -51,12 +51,28 @@ async fn release_escrow_with_live_solana_settlement(
     store
         .prepare_settlement_intent(actor.as_str(), escrow_id, key.as_str(), &prepared)
         .map_err(|error| Box::new(live_settlement_evidence_error(error.as_str())))?;
-    let evidence =
-        crate::service_api_endpoint::live_settlement_dispatch::submit_or_reconcile_live_settlement(
-            config, &prepared, escrow_id,
-        )
-        .map_err(|error| Box::new(live_settlement_evidence_error(error.as_str())))?;
+    let evidence = match crate::service_api_endpoint::live_settlement_dispatch::submit_or_reconcile_live_settlement(
+        config, &prepared, escrow_id,
+    ) {
+        Ok(evidence) => evidence,
+        Err(error) if error == "SETTLEMENT_OUTCOME_AMBIGUOUS" => {
+            store.mark_settlement_outcome_ambiguous(escrow_id).map_err(|persist_error| {
+                Box::new(super::super::super::persistence_error(persist_error.as_str()))
+            })?;
+            return Err(Box::new(settlement_outcome_ambiguous_error()));
+        }
+        Err(error) => return Err(Box::new(live_settlement_evidence_error(error.as_str()))),
+    };
     Ok(store.finalize_settlement_intent(escrow_id, &settlement_metadata_from_evidence(evidence)))
+}
+
+fn settlement_outcome_ambiguous_error() -> Response {
+    super::payload::json_error_response(
+        StatusCode::SERVICE_UNAVAILABLE,
+        "unavailable",
+        "SETTLEMENT_OUTCOME_AMBIGUOUS",
+        "settlement submission outcome is ambiguous and requires reconciliation",
+    )
 }
 
 fn resolve_prepared_settlement(

--- a/crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/mutations/update_routes/state_routes_release.rs
+++ b/crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/mutations/update_routes/state_routes_release.rs
@@ -68,7 +68,35 @@ async fn release_escrow_with_live_solana_settlement(
         }
         Err(error) => return Err(Box::new(live_settlement_evidence_error(error.as_str()))),
     };
+    if !settlement_evidence_matches(&prepared, &evidence, config) {
+        store
+            .mark_settlement_failed(escrow_id, "SETTLEMENT_EVIDENCE_MISMATCH")
+            .map_err(|error| Box::new(super::super::super::persistence_error(error.as_str())))?;
+        return Err(Box::new(settlement_evidence_mismatch_error()));
+    }
     Ok(store.finalize_settlement_intent(escrow_id, &settlement_metadata_from_evidence(evidence)))
+}
+
+fn settlement_evidence_matches(
+    prepared: &crate::service_api_endpoint::live_settlement_dispatch::PreparedLiveSettlement,
+    evidence: &LiveSettlementEvidence,
+    config: &LiveSolanaSettlementConfig,
+) -> bool {
+    evidence.settlement_tx_signature == prepared.expected_signature
+        && evidence.settlement_receipt_hash == prepared.expected_signature
+        && evidence.settlement_network == prepared.network
+        && evidence.settlement_commitment == config.commitment_label()
+        && evidence.recipient_pubkey.as_deref() == Some(prepared.recipient_pubkey.as_str())
+        && evidence.amount_lamports == Some(prepared.amount_lamports)
+}
+
+fn settlement_evidence_mismatch_error() -> Response {
+    super::payload::json_error_response(
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "internal",
+        "SETTLEMENT_EVIDENCE_MISMATCH",
+        "confirmed settlement evidence does not match the durable intent",
+    )
 }
 
 fn settlement_outcome_ambiguous_error() -> Response {

--- a/crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/mutations/update_routes/state_routes_release.rs
+++ b/crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/mutations/update_routes/state_routes_release.rs
@@ -45,15 +45,72 @@ async fn release_escrow_with_live_solana_settlement(
     {
         return Ok(Ok(existing));
     }
+    let actor = super::super::super::task_actor(context)?;
+    let key = release_idempotency_key(context)?;
+    let prepared = resolve_prepared_settlement(&mut store, config, escrow_id)?;
+    store
+        .prepare_settlement_intent(actor.as_str(), escrow_id, key.as_str(), &prepared)
+        .map_err(|error| Box::new(live_settlement_evidence_error(error.as_str())))?;
     let evidence =
-        crate::service_api_endpoint::live_settlement_dispatch::collect_live_settlement_evidence(
-            config, escrow_id,
+        crate::service_api_endpoint::live_settlement_dispatch::submit_or_reconcile_live_settlement(
+            config, &prepared, escrow_id,
         )
         .map_err(|error| Box::new(live_settlement_evidence_error(error.as_str())))?;
-    Ok(store.release_escrow_with_settlement_metadata(
-        escrow_id,
-        &settlement_metadata_from_evidence(evidence),
-    ))
+    Ok(store.finalize_settlement_intent(escrow_id, &settlement_metadata_from_evidence(evidence)))
+}
+
+fn resolve_prepared_settlement(
+    store: &mut ServiceApiMessageStore,
+    config: &LiveSolanaSettlementConfig,
+    escrow_id: &str,
+) -> Result<
+    crate::service_api_endpoint::live_settlement_dispatch::PreparedLiveSettlement,
+    Box<Response>,
+> {
+    let existing = store
+        .get_settlement_intent(escrow_id)
+        .map_err(|error| Box::new(super::super::super::persistence_error(error.as_str())))?;
+    if let Some(intent) = existing {
+        return Ok(prepared_from_intent(intent));
+    }
+    crate::service_api_endpoint::live_settlement_dispatch::prepare_live_settlement(
+        config, escrow_id,
+    )
+    .map_err(|error| Box::new(live_settlement_evidence_error(error.as_str())))
+}
+
+fn prepared_from_intent(
+    intent: ServiceApiSettlementIntentRecord,
+) -> crate::service_api_endpoint::live_settlement_dispatch::PreparedLiveSettlement {
+    crate::service_api_endpoint::live_settlement_dispatch::PreparedLiveSettlement {
+        expected_signature: intent.expected_signature,
+        signed_transaction_digest: intent.signed_transaction_digest,
+        signed_transaction_json: intent.signed_transaction_json,
+        recipient_pubkey: intent.recipient_pubkey,
+        amount_lamports: intent.amount_lamports,
+        network: intent.network,
+    }
+}
+
+fn release_idempotency_key(context: &ServiceApiRequestContext) -> Result<String, Box<Response>> {
+    let value: serde_json::Value = serde_json::from_str(context.parsed_request.body.as_str())
+        .map_err(|error| Box::new(invalid_release_key(error.to_string().as_str())))?;
+    value
+        .get("idempotency_key")
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|key| !key.is_empty())
+        .map(str::to_owned)
+        .ok_or_else(|| Box::new(invalid_release_key("release idempotency key is required")))
+}
+
+fn invalid_release_key(message: &str) -> Response {
+    super::payload::json_error_response(
+        StatusCode::BAD_REQUEST,
+        "bad_request",
+        "ESCROW_AGREEMENT_INVALID",
+        message,
+    )
 }
 
 async fn release_escrow_with_slot_backed_settlement(

--- a/crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/mutations/update_routes/state_routes_release.rs
+++ b/crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/mutations/update_routes/state_routes_release.rs
@@ -48,9 +48,14 @@ async fn release_escrow_with_live_solana_settlement(
     let actor = super::super::super::task_actor(context)?;
     let key = release_idempotency_key(context)?;
     let prepared = resolve_prepared_settlement(&mut store, config, escrow_id)?;
-    store
-        .prepare_settlement_intent(actor.as_str(), escrow_id, key.as_str(), &prepared)
-        .map_err(|error| Box::new(live_settlement_evidence_error(error.as_str())))?;
+    if let Err(error) =
+        store.prepare_settlement_intent(actor.as_str(), escrow_id, key.as_str(), &prepared)
+    {
+        if error == "SETTLEMENT_INTENT_CONFLICT" {
+            return Err(Box::new(settlement_intent_conflict_error()));
+        }
+        return Err(Box::new(live_settlement_evidence_error(error.as_str())));
+    }
     let evidence = match crate::service_api_endpoint::live_settlement_dispatch::submit_or_reconcile_live_settlement(
         config, &prepared, escrow_id,
     ) {
@@ -72,6 +77,15 @@ fn settlement_outcome_ambiguous_error() -> Response {
         "unavailable",
         "SETTLEMENT_OUTCOME_AMBIGUOUS",
         "settlement submission outcome is ambiguous and requires reconciliation",
+    )
+}
+
+fn settlement_intent_conflict_error() -> Response {
+    super::payload::json_error_response(
+        StatusCode::CONFLICT,
+        "conflict",
+        "SETTLEMENT_INTENT_CONFLICT",
+        "settlement idempotency key conflicts with the durable intent",
     )
 }
 

--- a/crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/mutations/update_routes/state_routes_release/live_settlement.rs
+++ b/crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/mutations/update_routes/state_routes_release/live_settlement.rs
@@ -1,0 +1,168 @@
+use super::*;
+
+mod errors;
+use errors::{
+    invalid_release_key, settlement_evidence_mismatch_error, settlement_intent_conflict_error,
+    settlement_outcome_ambiguous_error,
+};
+
+pub(super) async fn release(
+    state: &Arc<ServiceApiRuntimeState>,
+    context: &ServiceApiRequestContext,
+    escrow_id: &str,
+    config: &LiveSolanaSettlementConfig,
+) -> Result<Result<Option<ServiceApiEscrowStatusBody>, String>, Box<Response>> {
+    let mut store = state.message_store.lock().await;
+    validate_release_eligibility(&mut store, context, escrow_id)?;
+    if let Some(existing) = released_escrow(&mut store, escrow_id)? {
+        return Ok(Ok(Some(existing)));
+    }
+    let actor = super::super::super::super::task_actor(context)?;
+    let key = release_idempotency_key(context)?;
+    let prepared = resolve_prepared(&mut store, config, escrow_id)?;
+    persist_intent(
+        &mut store,
+        actor.as_str(),
+        escrow_id,
+        key.as_str(),
+        &prepared,
+    )?;
+    let evidence = submit(&mut store, config, &prepared, escrow_id)?;
+    validate_evidence(&mut store, config, &prepared, &evidence, escrow_id)?;
+    Ok(store.finalize_settlement_intent(escrow_id, &settlement_metadata_from_evidence(evidence)))
+}
+
+fn released_escrow(
+    store: &mut ServiceApiMessageStore,
+    escrow_id: &str,
+) -> Result<Option<ServiceApiEscrowStatusBody>, Box<Response>> {
+    let existing = store.get_escrow_status(escrow_id).map_err(|error| {
+        Box::new(super::super::super::super::persistence_error(
+            error.as_str(),
+        ))
+    })?;
+    Ok(existing.filter(|payload| payload.state == "released"))
+}
+
+fn persist_intent(
+    store: &mut ServiceApiMessageStore,
+    actor: &str,
+    escrow_id: &str,
+    key: &str,
+    prepared: &PreparedLiveSettlement,
+) -> Result<(), Box<Response>> {
+    match store.prepare_settlement_intent(actor, escrow_id, key, prepared) {
+        Ok(_) => Ok(()),
+        Err(error) if error == "SETTLEMENT_INTENT_CONFLICT" => {
+            Err(Box::new(settlement_intent_conflict_error()))
+        }
+        Err(error) => Err(Box::new(live_settlement_evidence_error(error.as_str()))),
+    }
+}
+
+fn submit(
+    store: &mut ServiceApiMessageStore,
+    config: &LiveSolanaSettlementConfig,
+    prepared: &PreparedLiveSettlement,
+    escrow_id: &str,
+) -> Result<LiveSettlementEvidence, Box<Response>> {
+    match live_settlement_dispatch::submit_or_reconcile_live_settlement(config, prepared, escrow_id)
+    {
+        Ok(evidence) => Ok(evidence),
+        Err(error) if error == "SETTLEMENT_OUTCOME_AMBIGUOUS" => {
+            store
+                .mark_settlement_outcome_ambiguous(escrow_id)
+                .map_err(|persist_error| {
+                    Box::new(super::super::super::super::persistence_error(
+                        persist_error.as_str(),
+                    ))
+                })?;
+            Err(Box::new(settlement_outcome_ambiguous_error()))
+        }
+        Err(error) => Err(Box::new(live_settlement_evidence_error(error.as_str()))),
+    }
+}
+
+fn validate_evidence(
+    store: &mut ServiceApiMessageStore,
+    config: &LiveSolanaSettlementConfig,
+    prepared: &PreparedLiveSettlement,
+    evidence: &LiveSettlementEvidence,
+    escrow_id: &str,
+) -> Result<(), Box<Response>> {
+    if evidence_matches(prepared, evidence, config) {
+        return Ok(());
+    }
+    store
+        .mark_settlement_failed(escrow_id, "SETTLEMENT_EVIDENCE_MISMATCH")
+        .map_err(|error| {
+            Box::new(super::super::super::super::persistence_error(
+                error.as_str(),
+            ))
+        })?;
+    Err(Box::new(settlement_evidence_mismatch_error()))
+}
+
+fn evidence_matches(
+    prepared: &PreparedLiveSettlement,
+    evidence: &LiveSettlementEvidence,
+    config: &LiveSolanaSettlementConfig,
+) -> bool {
+    evidence.settlement_tx_signature == prepared.expected_signature
+        && evidence.settlement_receipt_hash == prepared.expected_signature
+        && evidence.settlement_network == prepared.network
+        && evidence.settlement_commitment == config.commitment_label()
+        && evidence.recipient_pubkey.as_deref() == Some(prepared.recipient_pubkey.as_str())
+        && evidence.amount_lamports == Some(prepared.amount_lamports)
+}
+
+fn resolve_prepared(
+    store: &mut ServiceApiMessageStore,
+    config: &LiveSolanaSettlementConfig,
+    escrow_id: &str,
+) -> Result<PreparedLiveSettlement, Box<Response>> {
+    let existing = store.get_settlement_intent(escrow_id).map_err(|error| {
+        Box::new(super::super::super::super::persistence_error(
+            error.as_str(),
+        ))
+    })?;
+    if let Some(intent) = existing {
+        return Ok(prepared_from_intent(intent));
+    }
+    live_settlement_dispatch::prepare_live_settlement(config, escrow_id)
+        .map_err(|error| Box::new(live_settlement_evidence_error(error.as_str())))
+}
+
+fn prepared_from_intent(intent: ServiceApiSettlementIntentRecord) -> PreparedLiveSettlement {
+    PreparedLiveSettlement {
+        expected_signature: intent.expected_signature,
+        signed_transaction_digest: intent.signed_transaction_digest,
+        signed_transaction_json: intent.signed_transaction_json,
+        recipient_pubkey: intent.recipient_pubkey,
+        amount_lamports: intent.amount_lamports,
+        network: intent.network,
+    }
+}
+
+fn release_idempotency_key(context: &ServiceApiRequestContext) -> Result<String, Box<Response>> {
+    let value: serde_json::Value = serde_json::from_str(context.parsed_request.body.as_str())
+        .map_err(|error| Box::new(invalid_release_key(error.to_string().as_str())))?;
+    value
+        .get("idempotency_key")
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|key| !key.is_empty())
+        .map(str::to_owned)
+        .ok_or_else(|| Box::new(invalid_release_key("release idempotency key is required")))
+}
+
+fn settlement_metadata_from_evidence(
+    evidence: LiveSettlementEvidence,
+) -> ServiceApiSettlementMetadata {
+    ServiceApiSettlementMetadata {
+        settlement_receipt_hash: Some(evidence.settlement_receipt_hash),
+        settlement_tx_signature: Some(evidence.settlement_tx_signature),
+        settlement_network: Some(evidence.settlement_network),
+        settlement_commitment: Some(evidence.settlement_commitment),
+    }
+}

--- a/crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/mutations/update_routes/state_routes_release/live_settlement.rs
+++ b/crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/mutations/update_routes/state_routes_release/live_settlement.rs
@@ -69,7 +69,7 @@ fn submit(
     match live_settlement_dispatch::submit_or_reconcile_live_settlement(config, prepared, escrow_id)
     {
         Ok(evidence) => Ok(evidence),
-        Err(error) if error == "SETTLEMENT_OUTCOME_AMBIGUOUS" => {
+        Err(error) if error.starts_with("SETTLEMENT_OUTCOME_AMBIGUOUS") => {
             store
                 .mark_settlement_outcome_ambiguous(escrow_id)
                 .map_err(|persist_error| {

--- a/crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/mutations/update_routes/state_routes_release/live_settlement/errors.rs
+++ b/crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/mutations/update_routes/state_routes_release/live_settlement/errors.rs
@@ -1,0 +1,41 @@
+use super::*;
+
+pub(super) fn settlement_evidence_mismatch_error() -> Response {
+    json_error(
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "internal",
+        "SETTLEMENT_EVIDENCE_MISMATCH",
+        "confirmed settlement evidence does not match the durable intent",
+    )
+}
+
+pub(super) fn settlement_outcome_ambiguous_error() -> Response {
+    json_error(
+        StatusCode::SERVICE_UNAVAILABLE,
+        "unavailable",
+        "SETTLEMENT_OUTCOME_AMBIGUOUS",
+        "settlement submission outcome is ambiguous and requires reconciliation",
+    )
+}
+
+pub(super) fn settlement_intent_conflict_error() -> Response {
+    json_error(
+        StatusCode::CONFLICT,
+        "conflict",
+        "SETTLEMENT_INTENT_CONFLICT",
+        "settlement idempotency key conflicts with the durable intent",
+    )
+}
+
+pub(super) fn invalid_release_key(message: &str) -> Response {
+    json_error(
+        StatusCode::BAD_REQUEST,
+        "bad_request",
+        "ESCROW_AGREEMENT_INVALID",
+        message,
+    )
+}
+
+fn json_error(status: StatusCode, error: &str, code: &str, message: &str) -> Response {
+    super::super::super::payload::json_error_response(status, error, code, message)
+}

--- a/crates/kamn-sdk/src/service_client_content_routes.rs
+++ b/crates/kamn-sdk/src/service_client_content_routes.rs
@@ -22,9 +22,19 @@ impl ServiceApiClient {
         escrow_id: &str,
         auth: &ServiceRequestAuth,
     ) -> Result<ServiceEscrowStatus, SdkError> {
+        self.release_escrow_with_payload(escrow_id, "{}", auth)
+    }
+
+    /// Releases escrow with a canonical idempotency payload.
+    pub fn release_escrow_with_payload(
+        &self,
+        escrow_id: &str,
+        payload: &str,
+        auth: &ServiceRequestAuth,
+    ) -> Result<ServiceEscrowStatus, SdkError> {
         let escrow_id = normalize_route_segment("escrow_id", escrow_id)?;
         let route = format!("/v1/escrow/{escrow_id}/release");
-        let response = self.request("POST", route.as_str(), "{}", Some(auth))?;
+        let response = self.request("POST", route.as_str(), payload, Some(auth))?;
         expect_status(response.status, 200)?;
         parse_escrow_status(response.body.as_str())
     }

--- a/crates/kamn-sdk/src/service_client_message_task_routes.rs
+++ b/crates/kamn-sdk/src/service_client_message_task_routes.rs
@@ -116,9 +116,19 @@ impl ServiceApiClient {
         task_id: &str,
         auth: &ServiceRequestAuth,
     ) -> Result<ServiceTaskStatus, SdkError> {
+        self.accept_task_with_payload(task_id, "{}", auth)
+    }
+
+    /// Accepts one task with a canonical transition payload.
+    pub fn accept_task_with_payload(
+        &self,
+        task_id: &str,
+        payload: &str,
+        auth: &ServiceRequestAuth,
+    ) -> Result<ServiceTaskStatus, SdkError> {
         let task_id = normalize_route_segment("task_id", task_id)?;
         let route = format!("/v1/tasks/{task_id}/accept");
-        let response = self.request("POST", route.as_str(), "{}", Some(auth))?;
+        let response = self.request("POST", route.as_str(), payload, Some(auth))?;
         expect_status(response.status, 200)?;
         Ok(ServiceTaskStatus {
             task_id: json_string_field(response.body.as_str(), "task_id")?,
@@ -132,9 +142,19 @@ impl ServiceApiClient {
         task_id: &str,
         auth: &ServiceRequestAuth,
     ) -> Result<ServiceTaskStatus, SdkError> {
+        self.complete_task_with_payload(task_id, "{}", auth)
+    }
+
+    /// Completes one task with a canonical evidence payload.
+    pub fn complete_task_with_payload(
+        &self,
+        task_id: &str,
+        payload: &str,
+        auth: &ServiceRequestAuth,
+    ) -> Result<ServiceTaskStatus, SdkError> {
         let task_id = normalize_route_segment("task_id", task_id)?;
         let route = format!("/v1/tasks/{task_id}/complete");
-        let response = self.request("POST", route.as_str(), "{}", Some(auth))?;
+        let response = self.request("POST", route.as_str(), payload, Some(auth))?;
         expect_status(response.status, 200)?;
         Ok(ServiceTaskStatus {
             task_id: json_string_field(response.body.as_str(), "task_id")?,

--- a/crates/kamn-sdk/tests/live_transport_task_escrow.rs
+++ b/crates/kamn-sdk/tests/live_transport_task_escrow.rs
@@ -6,3 +6,31 @@ mod happy_path_contract_tests;
 mod malformed_payload_contract_tests;
 #[path = "live_transport_task_escrow/support.rs"]
 mod support;
+
+#[test]
+fn transition_routes_preserve_canonical_payloads() {
+    use kamn_sdk::{AgentDid, ServiceApiClient, ServiceRequestAuth};
+
+    let complete = r#"{"idempotency_key":"complete-1","completion_evidence_digest":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"}"#;
+    let release = r#"{"idempotency_key":"release-1"}"#;
+    let requests = vec![
+        support::expected_request("POST", "/v1/tasks/task-1/complete", complete),
+        support::expected_request("POST", "/v1/escrow/escrow-1/release", release),
+    ];
+    let (bind_addr, server) = support::spawn_expected_server(requests);
+    let client = ServiceApiClient::connect(format!("http://{bind_addr}").as_str()).expect("client");
+    let auth = ServiceRequestAuth::new(
+        AgentDid::parse("kamn:did:agent:transition-contract").expect("did"),
+        1,
+        "signature".to_owned(),
+    )
+    .expect("auth");
+
+    client
+        .complete_task_with_payload("task-1", complete, &auth)
+        .expect("complete response");
+    client
+        .release_escrow_with_payload("escrow-1", release, &auth)
+        .expect("release response");
+    server.join().expect("server").expect("request contract");
+}

--- a/crates/kamn-sdk/tests/live_transport_task_escrow.rs
+++ b/crates/kamn-sdk/tests/live_transport_task_escrow.rs
@@ -9,28 +9,50 @@ mod support;
 
 #[test]
 fn transition_routes_preserve_canonical_payloads() {
-    use kamn_sdk::{AgentDid, ServiceApiClient, ServiceRequestAuth};
+    use kamn_sdk::{service_signature_for_fields, AgentDid, ServiceApiClient, ServiceRequestAuth};
+
+    support::ensure_live_test_env();
 
     let complete = r#"{"idempotency_key":"complete-1","completion_evidence_digest":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"}"#;
     let release = r#"{"idempotency_key":"release-1"}"#;
     let requests = vec![
-        support::expected_request("POST", "/v1/tasks/task-1/complete", complete),
-        support::expected_request("POST", "/v1/escrow/escrow-1/release", release),
+        support::ExpectedRequest {
+            method: "POST",
+            path: "/v1/tasks/task-1/complete".to_owned(),
+            body: complete.to_owned(),
+            sender_did: "kamn:did:agent:transition-contract".to_owned(),
+            scope: "tasks:write",
+            response_status: 200,
+            response_body: r#"{"task_id":"task-1","state":"completed"}"#.to_owned(),
+        },
+        support::ExpectedRequest {
+            method: "POST",
+            path: "/v1/escrow/escrow-1/release".to_owned(),
+            body: release.to_owned(),
+            sender_did: "kamn:did:agent:transition-contract".to_owned(),
+            scope: "escrow:write",
+            response_status: 200,
+            response_body: r#"{"escrow_id":"escrow-1","state":"released"}"#.to_owned(),
+        },
     ];
     let (bind_addr, server) = support::spawn_expected_server(requests);
     let client = ServiceApiClient::connect(format!("http://{bind_addr}").as_str()).expect("client");
-    let auth = ServiceRequestAuth::new(
-        AgentDid::parse("kamn:did:agent:transition-contract").expect("did"),
-        1,
-        "signature".to_owned(),
-    )
-    .expect("auth");
+    let did = AgentDid::parse("kamn:did:agent:transition-contract").expect("did");
+    let complete_auth = transition_auth(&did, 1, complete, "tasks:write");
+    let release_auth = transition_auth(&did, 2, release, "escrow:write");
 
     client
-        .complete_task_with_payload("task-1", complete, &auth)
+        .complete_task_with_payload("task-1", complete, &complete_auth)
         .expect("complete response");
     client
-        .release_escrow_with_payload("escrow-1", release, &auth)
+        .release_escrow_with_payload("escrow-1", release, &release_auth)
         .expect("release response");
     server.join().expect("server").expect("request contract");
+
+    fn transition_auth(did: &AgentDid, nonce: u64, body: &str, scope: &str) -> ServiceRequestAuth {
+        let signature = service_signature_for_fields(did, nonce, "kamn-sdk-live", "1", body)
+            .expect("signature");
+        ServiceRequestAuth::new_with_scope(did.clone(), nonce, signature, Some(scope))
+            .expect("auth")
+    }
 }

--- a/specs/7092-idempotent-recoverable-devnet-settlement.md
+++ b/specs/7092-idempotent-recoverable-devnet-settlement.md
@@ -38,6 +38,9 @@ structured error and never return `released`.
 - Reuse the existing live settlement adapter, service API store, and proof
   surfaces. Do not add a generalized workflow engine or blockchain adapter.
 - External keypair paths remain runtime-only and never enter git or artifacts.
+- An expired or never-landed signed transaction remains recoverable only by
+  querying or resubmitting that exact transaction. This MVP does not generate a
+  replacement signature because doing so would weaken at-most-once settlement.
 
 ## Settlement Contract
 
@@ -72,6 +75,9 @@ Only then may the intent become `confirmed`/`reconciled` and escrow become
   `ambiguous`, returns `SETTLEMENT_OUTCOME_AMBIGUOUS`, and never reports release.
 - Restart with `prepared`, `submitted`, or `ambiguous`: query the persisted
   signature first and converge to confirmed, failed, or still ambiguous.
+- A transaction that remains absent after its blockhash expires stays
+  observably `ambiguous`; operator-driven replacement is roadmap work and is
+  not claimed by this issue.
 - Concurrent identical requests serialize through the durable intent and return
   one result; they cannot create a second transaction identity.
 - Proof/report regeneration reads persisted evidence and never submits.
@@ -168,16 +174,22 @@ reconcile it by the persisted signature before rollback or another rehearsal.
 
 ## Completion Evidence
 
-The final required-mode rehearsal is preserved at
-`.kamn/demo/run-68754-1783753805208/` and produced report status `GO` plus a
-canonical verifier `PASS`. Its task `task-local-9267453716be5563` and escrow
-`escrow-local-63d8bc55ff61d199` settled exactly one 1,000,000-lamport transfer
+The final escrow-bound required-mode rehearsal is preserved at
+`.kamn/demo/run-55450-1783755996034/` and produced report status `GO` plus a
+canonical verifier `PASS`. Its escrow `escrow-local-ab2190a8436d1bd7` settled
+exactly one 1,000,000-lamport transfer
 from `2FjUiacAXtokhA8YzGiyfVEdu5D9LxKFhjptJLrz4V9T` to
 `FV5LvudLjZQGCrPwXUY2JaVr26sQE15K25BGvsKWvyFe`. Solana devnet finalized
 signature
-`3iLFpQDi5QWwyqEkXhc5A76uDQnurbF1YtB2CbPt1Z6bkjD6xEY69PQiR6PHbB3DjW8eANLPxHEdXDuT3cksErdz`;
+`3qZigXwYm3msVGbv9h7ShujMNRxKidDxoXZ7MKExZN8Js7MvU8dfsPpWbTLoZcpNKVQp9DY3oijhojRJoTf2QB8W`;
 the persisted intent is `confirmed`, and the report carries the same signature,
 commitment, recipient, amount, and before/after balances.
+
+The earlier successful report at `.kamn/demo/run-68754-1783753805208/`
+predates cryptographic persisted-transaction validation and escrow-specific
+memo binding. It remains valid evidence for the earlier transaction shape but
+is superseded by the final rehearsal above and is not the completion artifact
+for the hardened implementation.
 
 Two earlier NO-GO rehearsals exposed the confirmation-visibility crash window.
 Both transfers finalized on devnet but their local escrow state remained

--- a/specs/7092-idempotent-recoverable-devnet-settlement.md
+++ b/specs/7092-idempotent-recoverable-devnet-settlement.md
@@ -1,0 +1,167 @@
+# Make Devnet Settlement Idempotent And Recoverable
+
+## Objective
+
+Bind exactly one Solana devnet transfer to one task-bound escrow release. Persist
+the transfer identity before submission, reconcile known signatures after
+timeouts or restart, and never report `released` without confirmed evidence
+matching the escrow agreement.
+
+## Inputs/Outputs
+
+The signed release request supplies an `idempotency_key`. The authenticated
+release authority, escrow ID, beneficiary, amount, and network come from the
+verified #7091 escrow agreement. Live configuration supplies the external
+keypair path, RPC URL, recipient public key, lamports, and commitment.
+
+A durable settlement intent contains:
+
+- intent ID, escrow ID, release idempotency key, and actor DID
+- recipient public key, amount, and `solana:devnet` network
+- deterministic signed transaction signature and signed transaction digest
+- `prepared`, `submitted`, `confirmed`, `reconciled`, `ambiguous`, or `failed`
+  state
+- submission attempt count and optional structured error code
+- confirmed commitment and balance/recipient evidence required by the existing
+  live proof surface
+
+Success returns the escrow in `released` state with the confirmed signature,
+network, commitment, and receipt linkage. Ambiguous or failed outcomes return a
+structured error and never return `released`.
+
+## Boundaries/Non-goals
+
+- Solana devnet only; no mainnet or economic-value claim.
+- No production custody, key management, dispute, refund, or multi-chain work.
+- No local simulation, dry-run, placeholder signature, or slot-only evidence
+  can satisfy asset-movement success.
+- Reuse the existing live settlement adapter, service API store, and proof
+  surfaces. Do not add a generalized workflow engine or blockchain adapter.
+- External keypair paths remain runtime-only and never enter git or artifacts.
+
+## Settlement Contract
+
+Before submission KAMN builds and signs the exact transfer transaction, derives
+its stable signature and digest, and persists a `prepared` intent. The intent
+must match the escrow beneficiary, amount, network, and release key. Conflicting
+reuse returns `SETTLEMENT_INTENT_CONFLICT` without submission.
+
+On first execution KAMN submits the already-signed transaction and increments
+the durable attempt count. Solana signatures identify the transaction, so retry
+must query the known signature before considering any submission. Resubmission
+may only send the identical signed transaction; KAMN must never build another
+transfer for an existing intent.
+
+Confirmed evidence must prove:
+
+- cluster/network is Solana devnet
+- signature equals the persisted expected signature
+- transaction recipient and lamports equal the escrow agreement
+- configured commitment is satisfied
+- existing balance evidence is internally consistent
+
+Only then may the intent become `confirmed`/`reconciled` and escrow become
+`released` in one durable state write.
+
+## Crash And Retry Semantics
+
+- Failure before durable `prepared` state: no submission and hard failure.
+- RPC failure known to occur before submission: intent becomes `failed`; no
+  success is reported.
+- Timeout or persistence failure after possible submission: intent becomes
+  `ambiguous`, returns `SETTLEMENT_OUTCOME_AMBIGUOUS`, and never reports release.
+- Restart with `prepared`, `submitted`, or `ambiguous`: query the persisted
+  signature first and converge to confirmed, failed, or still ambiguous.
+- Concurrent identical requests serialize through the durable intent and return
+  one result; they cannot create a second transaction identity.
+- Proof/report regeneration reads persisted evidence and never submits.
+
+## Failure Modes
+
+- Conflicting key or agreement: `SETTLEMENT_INTENT_CONFLICT` (409).
+- Missing or noncanonical escrow agreement: existing escrow lifecycle error.
+- Config recipient/amount/network mismatch: `SETTLEMENT_AGREEMENT_MISMATCH` (409).
+- Signature, recipient, amount, or network evidence mismatch:
+  `SETTLEMENT_EVIDENCE_MISMATCH` (500).
+- Unknown post-submit outcome: `SETTLEMENT_OUTCOME_AMBIGUOUS` (503).
+- Confirmed transaction failure: `SETTLEMENT_TRANSACTION_FAILED` (502).
+- Persistence error before submission: existing persistence error (500), with
+  no adapter call.
+
+All errors are observable and hard-fail. No fallback can mark an escrow
+released.
+
+## Acceptance Criteria
+
+- [ ] Intent is durably `prepared` before the external submit boundary.
+- [ ] Intent binds escrow, actor, recipient, bounded amount, devnet, release key,
+      expected signature, and signed transaction digest.
+- [ ] Identical retry reconciles the known signature before any resubmission.
+- [ ] Conflicting reuse returns `SETTLEMENT_INTENT_CONFLICT` without mutation.
+- [ ] Confirmed evidence validates signature, recipient, amount, devnet, and
+      commitment before release.
+- [ ] Ambiguous post-submit outcomes never report `released`.
+- [ ] Restart reconciliation converges without creating another transaction.
+- [ ] Concurrent release requests share one intent and transaction identity.
+- [ ] Proof generation cannot invoke submission.
+- [ ] Negative authorization and retry tests pass before funded rehearsal.
+- [ ] One bounded funded devnet rehearsal proves exactly one confirmed transfer.
+
+## Files To Touch
+
+- `crates/kamn-node/src/service_api_endpoint/message_store/` focused settlement
+  intent models and persistence operations
+- `crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch/`
+- `crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/mutations/update_routes/state_routes_release.rs`
+- task/escrow settlement, restart, concurrency, and live devnet contracts
+- MVP devnet settlement report/verifier only where persisted intent evidence is
+  required for an existing claim
+
+## Error Semantics
+
+Interior settlement code returns typed errors containing stable code, message,
+context IDs, and source cause where applicable. The HTTP entrypoint translates
+once. Intent persistence happens before network calls. Post-submit persistence
+failure must retain enough deterministic identity for reconciliation and must
+not be translated into ordinary RPC failure or local authorization success.
+
+## Test Plan
+
+RED:
+
+- Test adapter observes no persisted intent when submission begins.
+- A post-submit persistence failure followed by retry submits again.
+- Concurrent release requests can produce multiple adapter calls.
+- Restart cannot reconcile prepared/submitted/ambiguous state by signature.
+- Mismatched signature/recipient/amount evidence can mark escrow released.
+
+GREEN:
+
+- Add the minimal serde-defaulted settlement intent record and typed errors.
+- Split transaction preparation from submit/confirm so identity is known first.
+- Persist intent, submit the exact transaction, reconcile by signature, then
+  atomically persist confirmed intent and released escrow.
+
+REFACTOR:
+
+- Separate preparation, persistence, submission, reconciliation, and evidence
+  validation into focused modules under 200 lines and functions under 25 lines.
+- Keep the existing adapter boundary and dependency set.
+
+INTEGRATION:
+
+- Signed HTTP tests cover conflicts, no-submit denials, crash windows, restart,
+  concurrency, and proof retry.
+- Run targeted contracts, full `kamn-node`, formatting, strict workspace clippy,
+  and `make check`.
+- Run one real bounded transfer with the external funded devnet keypair. Record
+  signature, recipient, lamports, commitment, balances, persisted intent, and
+  verifier output. If RPC/keypair/funding is unavailable, record explicit
+  `NO-GO` and do not claim issue completion.
+
+## Rollback
+
+Each phase is a separate commit. Before live submission, retain a checkpoint
+with all deterministic tests green. A live rehearsal uses a fresh release key
+and bounded amount. Never delete state containing `submitted` or `ambiguous`;
+reconcile it by the persisted signature before rollback or another rehearsal.

--- a/specs/7092-idempotent-recoverable-devnet-settlement.md
+++ b/specs/7092-idempotent-recoverable-devnet-settlement.md
@@ -93,19 +93,19 @@ released.
 
 ## Acceptance Criteria
 
-- [ ] Intent is durably `prepared` before the external submit boundary.
-- [ ] Intent binds escrow, actor, recipient, bounded amount, devnet, release key,
+- [x] Intent is durably `prepared` before the external submit boundary.
+- [x] Intent binds escrow, actor, recipient, bounded amount, devnet, release key,
       expected signature, and signed transaction digest.
-- [ ] Identical retry reconciles the known signature before any resubmission.
-- [ ] Conflicting reuse returns `SETTLEMENT_INTENT_CONFLICT` without mutation.
-- [ ] Confirmed evidence validates signature, recipient, amount, devnet, and
+- [x] Identical retry reconciles the known signature before any resubmission.
+- [x] Conflicting reuse returns `SETTLEMENT_INTENT_CONFLICT` without mutation.
+- [x] Confirmed evidence validates signature, recipient, amount, devnet, and
       commitment before release.
-- [ ] Ambiguous post-submit outcomes never report `released`.
-- [ ] Restart reconciliation converges without creating another transaction.
-- [ ] Concurrent release requests share one intent and transaction identity.
-- [ ] Proof generation cannot invoke submission.
-- [ ] Negative authorization and retry tests pass before funded rehearsal.
-- [ ] One bounded funded devnet rehearsal proves exactly one confirmed transfer.
+- [x] Ambiguous post-submit outcomes never report `released`.
+- [x] Restart reconciliation converges without creating another transaction.
+- [x] Concurrent release requests share one intent and transaction identity.
+- [x] Proof generation cannot invoke submission.
+- [x] Negative authorization and retry tests pass before funded rehearsal.
+- [x] One bounded funded devnet rehearsal proves exactly one confirmed transfer.
 
 ## Files To Touch
 
@@ -165,3 +165,28 @@ Each phase is a separate commit. Before live submission, retain a checkpoint
 with all deterministic tests green. A live rehearsal uses a fresh release key
 and bounded amount. Never delete state containing `submitted` or `ambiguous`;
 reconcile it by the persisted signature before rollback or another rehearsal.
+
+## Completion Evidence
+
+The final required-mode rehearsal is preserved at
+`.kamn/demo/run-68754-1783753805208/` and produced report status `GO` plus a
+canonical verifier `PASS`. Its task `task-local-9267453716be5563` and escrow
+`escrow-local-63d8bc55ff61d199` settled exactly one 1,000,000-lamport transfer
+from `2FjUiacAXtokhA8YzGiyfVEdu5D9LxKFhjptJLrz4V9T` to
+`FV5LvudLjZQGCrPwXUY2JaVr26sQE15K25BGvsKWvyFe`. Solana devnet finalized
+signature
+`3iLFpQDi5QWwyqEkXhc5A76uDQnurbF1YtB2CbPt1Z6bkjD6xEY69PQiR6PHbB3DjW8eANLPxHEdXDuT3cksErdz`;
+the persisted intent is `confirmed`, and the report carries the same signature,
+commitment, recipient, amount, and before/after balances.
+
+Two earlier NO-GO rehearsals exposed the confirmation-visibility crash window.
+Both transfers finalized on devnet but their local escrow state remained
+non-released (`prepared` before the classification fix, then `ambiguous` before
+the retry horizon was extended). Their preserved signatures are
+`VpALZZJjfUBzLWr1rkm7YDAc4o3c6BzDbJZXxZsmgK9geUoPE7TA87UgQSsTgybEvNu6ciEW2GeZtif6oDFCUrD`
+and
+`4fBZ5NiFTQi7vhFvVQ3gDdzu3zC3g15W9ThLrgALQ5ySdNW3y161LubYBzMQgQK7FwbNkHP54yza9H8bhQAEBGEw`.
+They are not counted as successful MVP reports. This evidence drove the final
+post-submit ambiguity classification and bounded same-signature reconciliation
+behavior; the artifacts remain available for audit and must not be relabeled as
+successful escrows.


### PR DESCRIPTION
## Human Summary

- Makes Solana devnet escrow settlement durable and idempotent across retries, ambiguity, restart, and concurrent release attempts.
- Persists the exact signed transaction before submission, reconciles its known signature first, and releases escrow only from validated finalized evidence.
- Binds each signed transfer to its KAMN escrow and rejects tampered transactions or cross-escrow signature reuse.
- Produces a fresh required-mode local MVP report backed by one finalized 1,000,000-lamport devnet transfer.

Issue: https://github.com/njfio/kamn/issues/7092
Spec: `specs/7092-idempotent-recoverable-devnet-settlement.md`

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `make check`
- `cargo test -p kamn-node settlement -- --nocapture`
- `cargo test -p kamn-node`
- `cargo test -p kamn-e2e-harness`
- `KAMN_MVP_DEVNET_MODE=required KAMN_MVP_SOLANA_RPC_URL=https://api.devnet.solana.com make demo-mvp`
- `cargo run -p kamn-e2e-harness -- verify-mvp-demo --report .kamn/demo/latest/proof/report.json`

Devnet evidence:
- Run: `run-55450-1783755996034`
- Escrow: `escrow-local-ab2190a8436d1bd7`
- Signature: `3qZigXwYm3msVGbv9h7ShujMNRxKidDxoXZ7MKExZN8Js7MvU8dfsPpWbTLoZcpNKVQp9DY3oijhojRJoTf2QB8W`
- Commitment: `finalized`
- Verifier: `PASS`

## Notes for Reviewers

The main review focus is the prepare-submit-reconcile boundary and persisted transaction validation. A never-landed transaction whose blockhash expires remains explicitly `ambiguous`; this MVP does not generate a replacement signature because that would weaken the at-most-once guarantee.

No shell, workflow, or template surfaces changed, so the shell-surface DoD ratio fields do not apply.

## AI Agent Details

- Preserves the issue-required red/green/refactor/integration commit arc.
- Uses existing service API persistence and live Solana adapter surfaces.
- Security reassessment confirmed cross-escrow reuse and persisted-transaction tampering are fixed; no new settlement-path finding was identified.
- Production readiness and mainnet value movement remain explicitly not claimed.

Closes #7092