### PR TITLE
feat: add server-owned transaction disclosure views

### DIFF
--- a/crates/kamn-agent-lib/src/client.rs
+++ b/crates/kamn-agent-lib/src/client.rs
@@ -9,6 +9,9 @@ use kamn_sdk::{
 };
 use std::env;
 
+#[path = "client/projection_routes.rs"]
+mod projection_routes;
+
 const DEFAULT_CHAIN_ID: &str = "kamn-devnet";
 const DEFAULT_CHAIN_VERSION: &str = "v0.1.0";
 const AGENT_CHAIN_ID_ENV: &str = "KAMN_AGENT_CHAIN_ID";

--- a/crates/kamn-agent-lib/src/client/projection_routes.rs
+++ b/crates/kamn-agent-lib/src/client/projection_routes.rs
@@ -1,0 +1,21 @@
+use super::*;
+
+impl ServiceApiHttpClient {
+    /// Queries the participant-private task projection without rewriting it.
+    pub fn get_task_participant_projection(
+        &self,
+        task_id: &str,
+        auth: &ServiceRequestAuth,
+    ) -> Result<String, AgentLibError> {
+        Ok(self.inner.get_task_participant_projection(task_id, auth)?)
+    }
+
+    /// Queries the restricted-public task projection without rewriting it.
+    pub fn get_task_verifier_projection(
+        &self,
+        task_id: &str,
+        auth: &ServiceRequestAuth,
+    ) -> Result<String, AgentLibError> {
+        Ok(self.inner.get_task_verifier_projection(task_id, auth)?)
+    }
+}

--- a/crates/kamn-agent-lib/src/lib.rs
+++ b/crates/kamn-agent-lib/src/lib.rs
@@ -35,6 +35,7 @@ pub mod identity;
 pub mod kolme;
 /// Monotonic nonce tracking.
 pub mod nonce;
+mod projection;
 
 /// Top-level phase-1 facade for authenticated KAMN operations.
 #[derive(Debug)]

--- a/crates/kamn-agent-lib/src/projection.rs
+++ b/crates/kamn-agent-lib/src/projection.rs
@@ -1,0 +1,31 @@
+use super::*;
+
+impl KamnAgentHandle {
+    /// Queries this agent's participant-private task projection.
+    pub fn query_participant_task_projection(
+        &self,
+        task_id: &str,
+    ) -> Result<String, AgentLibError> {
+        let auth = self.task_read_auth()?;
+        self.service_client
+            .get_task_participant_projection(task_id, &auth)
+    }
+
+    /// Queries the restricted-public task projection available to this agent.
+    pub fn query_verifier_task_projection(&self, task_id: &str) -> Result<String, AgentLibError> {
+        let auth = self.task_read_auth()?;
+        self.service_client
+            .get_task_verifier_projection(task_id, &auth)
+    }
+
+    fn task_read_auth(&self) -> Result<kamn_sdk::ServiceRequestAuth, AgentLibError> {
+        let nonce = self.next_nonce()?;
+        self.service_client.build_auth(
+            self.identity.did(),
+            self.identity.signing_key(),
+            nonce,
+            "",
+            Some("tasks:read"),
+        )
+    }
+}

--- a/crates/kamn-e2e-harness/src/mvp_demo/devnet_settlement_service.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/devnet_settlement_service.rs
@@ -4,8 +4,11 @@ use super::live_task_binding::LiveTaskBinding;
 use kamn_agent_lib::{AgentMetadata, KamnAgentHandle};
 
 mod agreement;
+mod escrow_id;
+mod projections;
 
 use agreement::SettlementAgreement;
+pub(super) use escrow_id::expected_escrow_id;
 
 const SDK_TIMEOUT_ENV: &str = "KAMN_SDK_SERVICE_TIMEOUT_SECONDS";
 const LIVE_SETTLEMENT_TIMEOUT_SECONDS: &str = "90";
@@ -30,6 +33,14 @@ pub(super) fn drive_escrow_release(
         agreement.release_payload().as_str(),
     )?;
     require_released(released.state.as_str())?;
+    std::thread::sleep(release_pacing_delay());
+    projections::capture_runtime_task_projections(
+        endpoint,
+        run_dir,
+        &creator,
+        &provider,
+        prepared.task_id.as_str(),
+    )?;
     Ok(SettlementRun {
         escrow_id: released.escrow_id,
         task_id: prepared.task_id,
@@ -173,19 +184,6 @@ fn require_expected_escrow_id(payload: &str, escrow_id: &str) -> Result<(), Stri
             "devnet settlement escrow ID mismatch: expected {expected}, found {escrow_id}"
         ))
     }
-}
-
-pub(super) fn expected_escrow_id(payload: &str) -> String {
-    format!(
-        "escrow-local-{:016x}",
-        deterministic_body_tag(payload.as_bytes())
-    )
-}
-
-fn deterministic_body_tag(payload: &[u8]) -> u64 {
-    payload.iter().fold(0xcbf29ce484222325_u64, |acc, byte| {
-        acc.wrapping_mul(0x00000100000001B3) ^ u64::from(*byte)
-    })
 }
 
 #[cfg(test)]

--- a/crates/kamn-e2e-harness/src/mvp_demo/devnet_settlement_service/escrow_id.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/devnet_settlement_service/escrow_id.rs
@@ -1,0 +1,12 @@
+pub(super) fn expected_escrow_id(payload: &str) -> String {
+    format!(
+        "escrow-local-{:016x}",
+        deterministic_body_tag(payload.as_bytes())
+    )
+}
+
+fn deterministic_body_tag(payload: &[u8]) -> u64 {
+    payload.iter().fold(0xcbf29ce484222325_u64, |acc, byte| {
+        acc.wrapping_mul(0x00000100000001B3) ^ u64::from(*byte)
+    })
+}

--- a/crates/kamn-e2e-harness/src/mvp_demo/devnet_settlement_service/escrow_id.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/devnet_settlement_service/escrow_id.rs
@@ -1,4 +1,4 @@
-pub(super) fn expected_escrow_id(payload: &str) -> String {
+pub(crate) fn expected_escrow_id(payload: &str) -> String {
     format!(
         "escrow-local-{:016x}",
         deterministic_body_tag(payload.as_bytes())

--- a/crates/kamn-e2e-harness/src/mvp_demo/devnet_settlement_service/projections.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/devnet_settlement_service/projections.rs
@@ -1,0 +1,118 @@
+use std::path::Path;
+
+use kamn_agent_lib::KamnAgentHandle;
+
+use super::super::devnet_settlement_json::json_string_value;
+
+const AGENT_A_FILE: &str = "runtime-agent-a-participant-view.json";
+const AGENT_B_FILE: &str = "runtime-agent-b-participant-view.json";
+const AGENT_C_FILE: &str = "runtime-agent-c-verifier-view.json";
+
+pub(super) fn capture_runtime_task_projections(
+    endpoint: &str,
+    run_dir: &Path,
+    creator: &KamnAgentHandle,
+    provider: &KamnAgentHandle,
+    task_id: &str,
+) -> Result<(), String> {
+    let verifier = super::agent(endpoint, "kamn-mvp-devnet-settlement-verifier")?;
+    super::register(&verifier, "verifier")?;
+    let agent_a = participant_projection(creator, task_id, "creator")?;
+    let agent_b = participant_projection(provider, task_id, "provider")?;
+    let agent_c = verifier_projection(&verifier, task_id)?;
+    validate_runtime_projection_bodies(&agent_a, &agent_b, &agent_c, task_id)?;
+    write_projection(run_dir, AGENT_A_FILE, agent_a.as_str())?;
+    write_projection(run_dir, AGENT_B_FILE, agent_b.as_str())?;
+    write_projection(run_dir, AGENT_C_FILE, agent_c.as_str())
+}
+
+fn participant_projection(
+    agent: &KamnAgentHandle,
+    task_id: &str,
+    role: &str,
+) -> Result<String, String> {
+    agent
+        .query_participant_task_projection(task_id)
+        .map_err(|error| format!("failed to query {role} participant projection: {error}"))
+}
+
+fn verifier_projection(agent: &KamnAgentHandle, task_id: &str) -> Result<String, String> {
+    agent
+        .query_verifier_task_projection(task_id)
+        .map_err(|error| format!("failed to query verifier projection: {error}"))
+}
+
+fn validate_runtime_projection_bodies(
+    agent_a: &str,
+    agent_b: &str,
+    agent_c: &str,
+    task_id: &str,
+) -> Result<(), String> {
+    require_field(agent_a, "task_id", task_id, "Agent A")?;
+    require_field(agent_b, "task_id", task_id, "Agent B")?;
+    require_field(agent_c, "task_id", task_id, "Agent C")?;
+    require_matching_commitments(agent_a, agent_b, agent_c)?;
+    require_private_boundary(agent_a, agent_b, agent_c)
+}
+
+fn require_field(raw: &str, field: &str, expected: &str, agent: &str) -> Result<(), String> {
+    if json_string_value(raw, field).as_deref() == Ok(expected) {
+        return Ok(());
+    }
+    Err(format!("{agent} projection {field} mismatch"))
+}
+
+fn require_matching_commitments(a: &str, b: &str, c: &str) -> Result<(), String> {
+    let commitment = json_string_value(a, "public_commitment")?;
+    if json_string_value(b, "public_commitment").as_deref() == Ok(commitment.as_str())
+        && json_string_value(c, "public_commitment").as_deref() == Ok(commitment.as_str())
+    {
+        return Ok(());
+    }
+    Err("runtime projection public commitment mismatch".to_owned())
+}
+
+fn require_private_boundary(a: &str, b: &str, c: &str) -> Result<(), String> {
+    if a.contains("\"task_receipt_ids\":[")
+        && b.contains("\"task_receipt_ids\":[")
+        && !c.contains("\"task_receipt_ids\"")
+        && !c.contains("\"completion_evidence_digest\"")
+    {
+        return Ok(());
+    }
+    Err("runtime projection private boundary mismatch".to_owned())
+}
+
+fn write_projection(run_dir: &Path, file: &str, raw: &str) -> Result<(), String> {
+    let path = run_dir.join("proof").join(file);
+    std::fs::write(path.as_path(), raw).map_err(|error| {
+        format!(
+            "failed to write runtime projection {}: {error}",
+            path.display()
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_runtime_projection_bodies;
+
+    #[test]
+    fn runtime_projection_validation_enforces_private_boundary() {
+        let a = participant("creator");
+        let b = participant("provider");
+        let c = r#"{"task_id":"task-1","public_commitment":"fnv1a64:a"}"#;
+        validate_runtime_projection_bodies(a.as_str(), b.as_str(), c, "task-1")
+            .expect("valid runtime projections");
+        assert!(
+            validate_runtime_projection_bodies(a.as_str(), b.as_str(), a.as_str(), "task-1")
+                .is_err()
+        );
+    }
+
+    fn participant(role: &str) -> String {
+        format!(
+            r#"{{"task_id":"task-1","participant_role":"{role}","public_commitment":"fnv1a64:a","task_receipt_ids":["receipt-1"]}}"#
+        )
+    }
+}

--- a/crates/kamn-e2e-harness/src/mvp_demo/report_artifacts.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/report_artifacts.rs
@@ -31,6 +31,7 @@ fn artifact_entries(input: &DemoReportInput<'_>) -> Vec<(&'static str, String)> 
         entries.push(("devnet_escrow_funding_request", funding_request));
     }
     if input.devnet_settlement.is_some() && input.live_task_binding.is_some() {
+        entries.extend(runtime_projection_entries(input));
         entries.push(("three_agent_transcript", three_agent_transcript_path(input)));
         entries.push(("agent_a_view", agent_a_view_path(input)));
         entries.push(("agent_b_view", agent_b_view_path(input)));
@@ -49,6 +50,27 @@ fn artifact_entries(input: &DemoReportInput<'_>) -> Vec<(&'static str, String)> 
         ));
     }
     entries
+}
+
+fn runtime_projection_entries(input: &DemoReportInput<'_>) -> Vec<(&'static str, String)> {
+    [
+        (
+            "runtime_agent_a_participant_view",
+            "runtime-agent-a-participant-view.json",
+        ),
+        (
+            "runtime_agent_b_participant_view",
+            "runtime-agent-b-participant-view.json",
+        ),
+        (
+            "runtime_agent_c_verifier_view",
+            "runtime-agent-c-verifier-view.json",
+        ),
+    ]
+    .into_iter()
+    .map(|(key, file)| (key, run_proof_path(input, file)))
+    .filter(|(_, path)| std::path::Path::new(path).is_file())
+    .collect()
 }
 
 fn base_artifact_entries(input: &DemoReportInput<'_>) -> Vec<(&'static str, String)> {

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests.rs
@@ -24,3 +24,5 @@ mod task_escrow_settlement_reconciliation_contract_tests;
 mod task_escrow_solana_asset_movement_contract_tests;
 #[path = "task_escrow_persistence_contract_tests/task_escrow_solana_asset_movement_live_contract_tests.rs"]
 mod task_escrow_solana_asset_movement_live_contract_tests;
+#[path = "task_escrow_persistence_contract_tests/task_projection_contract_tests.rs"]
+mod task_projection_contract_tests;

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests.rs
@@ -26,3 +26,5 @@ mod task_escrow_solana_asset_movement_contract_tests;
 mod task_escrow_solana_asset_movement_live_contract_tests;
 #[path = "task_escrow_persistence_contract_tests/task_projection_contract_tests.rs"]
 mod task_projection_contract_tests;
+#[path = "task_escrow_persistence_contract_tests/task_projection_settlement_contract_tests.rs"]
+mod task_projection_settlement_contract_tests;

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/support.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/support.rs
@@ -22,7 +22,8 @@ pub(super) use solana_asset_movement_support::{
     assert_persisted_solana_signature_metadata,
     assert_released_escrow_has_solana_signature_metadata, build_live_solana_asset_movement_context,
     fund_and_release_live_escrow, fund_live_escrow, release_live_escrow_across_restart,
-    release_live_escrow_twice, settlement_tx_signature, LiveSolanaAssetMovementParams,
+    release_live_escrow_twice, settlement_tx_signature, AssetMovementHarness,
+    LiveSolanaAssetMovementContext, LiveSolanaAssetMovementParams,
 };
 pub(super) use state_support::{
     build_task_escrow_snapshot, set_state_file_env, state_hash, unique_named_state_file,

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_projection_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_projection_contract_tests.rs
@@ -46,6 +46,12 @@ fn integration_verifier_projection_is_allowlisted_and_matches_public_commitment(
     );
     assert_eq!(verifier["task_id"], participant["task_id"]);
     assert_eq!(verifier["escrow_id"], participant["escrow_id"]);
+    assert!(
+        verifier["public_commitment"]
+            .as_str()
+            .is_some_and(|value| value.starts_with("sha256:") && value.len() == 71),
+        "{verifier}"
+    );
     assert!(verifier.get("task_receipt_ids").is_none());
     assert!(verifier.get("completion_evidence_digest").is_none());
     case.cleanup();

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_projection_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_projection_contract_tests.rs
@@ -1,11 +1,15 @@
 use super::super::*;
-use super::support::*;
 use serde_json::Value;
 
-const CREATOR: &str = "kamn:did:agent:projection-creator";
-const PROVIDER: &str = "kamn:did:agent:projection-provider";
-const VERIFIER: &str = "kamn:did:agent:projection-verifier";
-const OUTSIDER: &str = "kamn:did:agent:projection-outsider";
+#[path = "task_projection_contract_tests/support.rs"]
+mod projection_support;
+use projection_support::ProjectionCase;
+
+pub(super) const CREATOR: &str = "kamn:did:agent:projection-creator";
+pub(super) const PROVIDER: &str = "kamn:did:agent:projection-provider";
+pub(super) const VERIFIER: &str = "kamn:did:agent:projection-verifier";
+pub(super) const OUTSIDER: &str = "kamn:did:agent:projection-outsider";
+const UNREGISTERED: &str = "kamn:did:agent:projection-unregistered";
 
 #[test]
 fn integration_participants_receive_private_runtime_projection() {
@@ -62,94 +66,50 @@ fn integration_unrelated_agent_cannot_retrieve_participant_projection() {
     case.cleanup();
 }
 
-struct ProjectionCase {
-    _env: ServiceApiTestEnvGuards,
-    _state_guard: EnvVarGuard,
-    snapshot: crate::service_api_endpoint::ServiceApiSnapshot,
-    state_file: std::path::PathBuf,
+#[test]
+fn integration_unregistered_agent_cannot_retrieve_verifier_projection() {
+    let case = ProjectionCase::new("unregistered-verifier");
+    let task_id = case.seed_transaction();
+
+    let response = case.query(UNREGISTERED, 1, &task_id, "verifier-view");
+
+    assert!(response.contains("HTTP/1.1 403 Forbidden"), "{response}");
+    assert!(response.contains("AGENT_NOT_REGISTERED"), "{response}");
+    case.cleanup();
 }
 
-impl ProjectionCase {
-    fn new(label: &str) -> Self {
-        let env = acquire_service_api_test_env();
-        let state_file = unique_named_state_file(format!("kamn-projection-{label}").as_str());
-        let (_, state_guard) = set_state_file_env(state_file.as_path());
-        Self {
-            _env: env,
-            _state_guard: state_guard,
-            snapshot: build_task_escrow_snapshot("127.0.0.1:34250"),
-            state_file,
-        }
-    }
+#[test]
+fn integration_projection_requires_bound_escrow() {
+    let case = ProjectionCase::new("missing-escrow");
+    let task_id = case.seed_task();
 
-    fn seed_transaction(&self) -> String {
-        self.register(CREATOR, 1);
-        self.register(PROVIDER, 1);
-        self.register(VERIFIER, 1);
-        self.register(OUTSIDER, 1);
-        let provider = test_service_api_sender_did(PROVIDER);
-        let body = serde_json::json!({
-            "provider_did": provider,
-            "transaction_id": "transaction-projection-001",
-            "terms_digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-            "idempotency_key": "create-projection-001",
-            "description": "runtime disclosure projection",
-        });
-        let task = create_task(
-            &self.snapshot,
-            reserve_loopback_addr().as_str(),
-            CREATOR,
-            2,
-            body.to_string().as_str(),
-        );
-        accept_task(
-            &self.snapshot,
-            reserve_loopback_addr().as_str(),
-            PROVIDER,
-            2,
-            task.task_id.as_str(),
-        );
-        let escrow = serde_json::json!({"task_id": task.task_id, "amount_lamports": 10_000});
-        fund_escrow(
-            &self.snapshot,
-            reserve_loopback_addr().as_str(),
-            CREATOR,
-            3,
-            escrow.to_string().as_str(),
-        );
-        task.task_id
-    }
+    let response = case.query(VERIFIER, 2, &task_id, "verifier-view");
 
-    fn register(&self, actor: &str, nonce: u64) {
-        register_agent_profile(
-            &self.snapshot,
-            reserve_loopback_addr().as_str(),
-            actor,
-            nonce,
-            r#"{"agent_type":"agent","model_family":"pi","capabilities":["tasks"]}"#,
-        );
-    }
+    assert!(response.contains("HTTP/1.1 409 Conflict"), "{response}");
+    assert!(
+        response.contains("TASK_ESCROW_BINDING_MISSING"),
+        "{response}"
+    );
+    case.cleanup();
+}
 
-    fn query(&self, actor: &str, nonce: u64, task_id: &str, view: &str) -> String {
-        let path = format!("/v1/tasks/{task_id}/{view}");
-        authorized_signed_request(
-            &self.snapshot,
-            reserve_loopback_addr().as_str(),
-            SignedRequest {
-                max_requests: 1,
-                method: "GET",
-                path: path.as_str(),
-                caller_did: actor,
-                nonce,
-                body: "",
-                extra_headers: &[("X-KAMN-Authz-Scope", "tasks:read")],
-            },
-        )
-    }
+#[test]
+fn integration_projection_fails_closed_for_inconsistent_durable_state() {
+    let case = ProjectionCase::new("inconsistent-state");
+    let task_id = case.seed_transaction();
+    case.replace_escrow_transaction_id("transaction-tampered");
 
-    fn cleanup(self) {
-        let _ = fs::remove_file(self.state_file);
-    }
+    let response = case.query(VERIFIER, 2, &task_id, "verifier-view");
+
+    assert!(
+        response.contains("HTTP/1.1 500 Internal Server Error"),
+        "{response}"
+    );
+    assert!(
+        response.contains("TRANSACTION_PROJECTION_INCONSISTENT"),
+        "{response}"
+    );
+    case.cleanup();
 }
 
 fn payload(response: &str) -> Value {

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_projection_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_projection_contract_tests.rs
@@ -1,0 +1,162 @@
+use super::super::*;
+use super::support::*;
+use serde_json::Value;
+
+const CREATOR: &str = "kamn:did:agent:projection-creator";
+const PROVIDER: &str = "kamn:did:agent:projection-provider";
+const VERIFIER: &str = "kamn:did:agent:projection-verifier";
+const OUTSIDER: &str = "kamn:did:agent:projection-outsider";
+
+#[test]
+fn integration_participants_receive_private_runtime_projection() {
+    let case = ProjectionCase::new("participant-private");
+    let task_id = case.seed_transaction();
+
+    let creator = case.query(CREATOR, 4, &task_id, "participant-view");
+    let provider = case.query(PROVIDER, 3, &task_id, "participant-view");
+
+    assert_ok(&creator);
+    assert_ok(&provider);
+    let creator = payload(&creator);
+    let provider = payload(&provider);
+    assert_eq!(creator["view_scope"], "participant-private");
+    assert_eq!(creator["participant_role"], "creator");
+    assert_eq!(provider["participant_role"], "provider");
+    assert!(creator["task_receipt_ids"].is_array());
+    assert_eq!(creator["public_commitment"], provider["public_commitment"]);
+    case.cleanup();
+}
+
+#[test]
+fn integration_verifier_projection_is_allowlisted_and_matches_public_commitment() {
+    let case = ProjectionCase::new("verifier-allowlist");
+    let task_id = case.seed_transaction();
+
+    let participant = payload(&case.query(CREATOR, 4, &task_id, "participant-view"));
+    let verifier = payload(&case.query(VERIFIER, 2, &task_id, "verifier-view"));
+
+    assert_eq!(verifier["view_scope"], "restricted-public");
+    assert_eq!(
+        verifier["public_commitment"],
+        participant["public_commitment"]
+    );
+    assert_eq!(verifier["task_id"], participant["task_id"]);
+    assert_eq!(verifier["escrow_id"], participant["escrow_id"]);
+    assert!(verifier.get("task_receipt_ids").is_none());
+    assert!(verifier.get("completion_evidence_digest").is_none());
+    case.cleanup();
+}
+
+#[test]
+fn integration_unrelated_agent_cannot_retrieve_participant_projection() {
+    let case = ProjectionCase::new("participant-denial");
+    let task_id = case.seed_transaction();
+
+    let response = case.query(OUTSIDER, 2, &task_id, "participant-view");
+
+    assert!(response.contains("HTTP/1.1 403 Forbidden"), "{response}");
+    assert!(
+        response.contains("TASK_PARTICIPANT_VIEW_FORBIDDEN"),
+        "{response}"
+    );
+    case.cleanup();
+}
+
+struct ProjectionCase {
+    _env: ServiceApiTestEnvGuards,
+    _state_guard: EnvVarGuard,
+    snapshot: crate::service_api_endpoint::ServiceApiSnapshot,
+    state_file: std::path::PathBuf,
+}
+
+impl ProjectionCase {
+    fn new(label: &str) -> Self {
+        let env = acquire_service_api_test_env();
+        let state_file = unique_named_state_file(format!("kamn-projection-{label}").as_str());
+        let (_, state_guard) = set_state_file_env(state_file.as_path());
+        Self {
+            _env: env,
+            _state_guard: state_guard,
+            snapshot: build_task_escrow_snapshot("127.0.0.1:34250"),
+            state_file,
+        }
+    }
+
+    fn seed_transaction(&self) -> String {
+        self.register(CREATOR, 1);
+        self.register(PROVIDER, 1);
+        self.register(VERIFIER, 1);
+        self.register(OUTSIDER, 1);
+        let provider = test_service_api_sender_did(PROVIDER);
+        let body = serde_json::json!({
+            "provider_did": provider,
+            "transaction_id": "transaction-projection-001",
+            "terms_digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "idempotency_key": "create-projection-001",
+            "description": "runtime disclosure projection",
+        });
+        let task = create_task(
+            &self.snapshot,
+            reserve_loopback_addr().as_str(),
+            CREATOR,
+            2,
+            body.to_string().as_str(),
+        );
+        accept_task(
+            &self.snapshot,
+            reserve_loopback_addr().as_str(),
+            PROVIDER,
+            2,
+            task.task_id.as_str(),
+        );
+        let escrow = serde_json::json!({"task_id": task.task_id, "amount_lamports": 10_000});
+        fund_escrow(
+            &self.snapshot,
+            reserve_loopback_addr().as_str(),
+            CREATOR,
+            3,
+            escrow.to_string().as_str(),
+        );
+        task.task_id
+    }
+
+    fn register(&self, actor: &str, nonce: u64) {
+        register_agent_profile(
+            &self.snapshot,
+            reserve_loopback_addr().as_str(),
+            actor,
+            nonce,
+            r#"{"agent_type":"agent","model_family":"pi","capabilities":["tasks"]}"#,
+        );
+    }
+
+    fn query(&self, actor: &str, nonce: u64, task_id: &str, view: &str) -> String {
+        let path = format!("/v1/tasks/{task_id}/{view}");
+        authorized_signed_request(
+            &self.snapshot,
+            reserve_loopback_addr().as_str(),
+            SignedRequest {
+                max_requests: 1,
+                method: "GET",
+                path: path.as_str(),
+                caller_did: actor,
+                nonce,
+                body: "",
+                extra_headers: &[("X-KAMN-Authz-Scope", "tasks:read")],
+            },
+        )
+    }
+
+    fn cleanup(self) {
+        let _ = fs::remove_file(self.state_file);
+    }
+}
+
+fn payload(response: &str) -> Value {
+    assert_ok(response);
+    parse_service_api_payload(extract_http_response_body(response)).expect("projection payload")
+}
+
+fn assert_ok(response: &str) {
+    assert!(response.contains("HTTP/1.1 200 OK"), "{response}");
+}

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_projection_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_projection_contract_tests.rs
@@ -112,6 +112,25 @@ fn integration_projection_fails_closed_for_inconsistent_durable_state() {
     case.cleanup();
 }
 
+#[test]
+fn integration_projection_rejects_missing_required_public_facts() {
+    let case = ProjectionCase::new("missing-public-fact");
+    let task_id = case.seed_transaction();
+    case.remove_escrow_field("amount_lamports");
+
+    let response = case.query(VERIFIER, 2, &task_id, "verifier-view");
+
+    assert!(
+        response.contains("HTTP/1.1 500 Internal Server Error"),
+        "{response}"
+    );
+    assert!(
+        response.contains("TRANSACTION_PROJECTION_INCONSISTENT"),
+        "{response}"
+    );
+    case.cleanup();
+}
+
 fn payload(response: &str) -> Value {
     assert_ok(response);
     parse_service_api_payload(extract_http_response_body(response)).expect("projection payload")

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_projection_contract_tests/support.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_projection_contract_tests/support.rs
@@ -1,0 +1,112 @@
+use super::super::super::*;
+use super::super::support::*;
+use super::{CREATOR, OUTSIDER, PROVIDER, VERIFIER};
+
+pub(super) struct ProjectionCase {
+    _env: ServiceApiTestEnvGuards,
+    _state_guard: EnvVarGuard,
+    snapshot: crate::service_api_endpoint::ServiceApiSnapshot,
+    state_file: std::path::PathBuf,
+}
+
+impl ProjectionCase {
+    pub(super) fn new(label: &str) -> Self {
+        let env = acquire_service_api_test_env();
+        let state_file = unique_named_state_file(format!("kamn-projection-{label}").as_str());
+        let (_, state_guard) = set_state_file_env(state_file.as_path());
+        Self {
+            _env: env,
+            _state_guard: state_guard,
+            snapshot: build_task_escrow_snapshot("127.0.0.1:34250"),
+            state_file,
+        }
+    }
+
+    pub(super) fn seed_transaction(&self) -> String {
+        let task_id = self.seed_task();
+        let escrow = serde_json::json!({"task_id": task_id, "amount_lamports": 10_000});
+        fund_escrow(
+            &self.snapshot,
+            reserve_loopback_addr().as_str(),
+            CREATOR,
+            3,
+            escrow.to_string().as_str(),
+        );
+        task_id
+    }
+
+    pub(super) fn seed_task(&self) -> String {
+        self.register_actors();
+        let body = task_body();
+        let task = create_task(
+            &self.snapshot,
+            reserve_loopback_addr().as_str(),
+            CREATOR,
+            2,
+            body.to_string().as_str(),
+        );
+        accept_task(
+            &self.snapshot,
+            reserve_loopback_addr().as_str(),
+            PROVIDER,
+            2,
+            task.task_id.as_str(),
+        );
+        task.task_id
+    }
+
+    pub(super) fn query(&self, actor: &str, nonce: u64, task_id: &str, view: &str) -> String {
+        let path = format!("/v1/tasks/{task_id}/{view}");
+        raw_signed_request(
+            &self.snapshot,
+            reserve_loopback_addr().as_str(),
+            SignedRequest {
+                max_requests: 1,
+                method: "GET",
+                path: path.as_str(),
+                caller_did: actor,
+                nonce,
+                body: "",
+                extra_headers: &[("X-KAMN-Authz-Scope", "tasks:read")],
+            },
+        )
+    }
+
+    pub(super) fn replace_escrow_transaction_id(&self, replacement: &str) {
+        let mut state = read_state_json(self.state_file.as_path());
+        let escrows = state["escrows"].as_object_mut().expect("escrow map");
+        let escrow = escrows.values_mut().next().expect("bound escrow");
+        escrow["transaction_id"] = serde_json::Value::String(replacement.to_owned());
+        fs::write(
+            self.state_file.as_path(),
+            serde_json::to_vec(&state).expect("state json"),
+        )
+        .expect("write tampered state");
+    }
+
+    pub(super) fn cleanup(self) {
+        let _ = fs::remove_file(self.state_file);
+    }
+
+    fn register_actors(&self) {
+        for actor in [CREATOR, PROVIDER, VERIFIER, OUTSIDER] {
+            register_agent_profile(
+                &self.snapshot,
+                reserve_loopback_addr().as_str(),
+                actor,
+                1,
+                r#"{"agent_type":"agent","model_family":"pi","capabilities":["tasks"]}"#,
+            );
+        }
+    }
+}
+
+fn task_body() -> serde_json::Value {
+    serde_json::json!({
+        "provider_did": test_service_api_sender_did(PROVIDER),
+        "transaction_id": "transaction-projection-001",
+        "terms_digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "idempotency_key": "create-projection-001",
+        "description": "runtime disclosure projection",
+    })
+}

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_projection_contract_tests/support.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_projection_contract_tests/support.rs
@@ -77,9 +77,21 @@ impl ProjectionCase {
         let escrows = state["escrows"].as_object_mut().expect("escrow map");
         let escrow = escrows.values_mut().next().expect("bound escrow");
         escrow["transaction_id"] = serde_json::Value::String(replacement.to_owned());
+        self.write_state(&state);
+    }
+
+    pub(super) fn remove_escrow_field(&self, field: &str) {
+        let mut state = read_state_json(self.state_file.as_path());
+        let escrows = state["escrows"].as_object_mut().expect("escrow map");
+        let escrow = escrows.values_mut().next().expect("bound escrow");
+        escrow.as_object_mut().expect("escrow record").remove(field);
+        self.write_state(&state);
+    }
+
+    fn write_state(&self, state: &serde_json::Value) {
         fs::write(
             self.state_file.as_path(),
-            serde_json::to_vec(&state).expect("state json"),
+            serde_json::to_vec(state).expect("state json"),
         )
         .expect("write tampered state");
     }

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_projection_settlement_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_projection_settlement_contract_tests.rs
@@ -54,4 +54,44 @@ fn integration_participant_projection_uses_persisted_settlement_evidence() {
         released["settlement_tx_signature"]
     );
     assert_eq!(projection["settlement_commitment"], "finalized");
+    assert_failed_intent_is_rejected(
+        &context.harness.snapshot,
+        context.harness.bind_addr.as_str(),
+        context.harness.state_file.as_path(),
+        task_id,
+        &escrow_id,
+    );
+}
+
+fn assert_failed_intent_is_rejected(
+    snapshot: &crate::service_api_endpoint::ServiceApiSnapshot,
+    bind_addr: &str,
+    state_file: &std::path::Path,
+    task_id: &str,
+    escrow_id: &str,
+) {
+    mark_intent_failed(state_file, escrow_id);
+    let path = format!("/v1/tasks/{task_id}/participant-view");
+    let response = raw_signed_request(
+        snapshot,
+        bind_addr,
+        SignedRequest {
+            max_requests: 1,
+            method: "GET",
+            path: path.as_str(),
+            caller_did: ACTOR,
+            nonce: 185,
+            body: "",
+            extra_headers: &[("X-KAMN-Authz-Scope", "tasks:read")],
+        },
+    );
+    assert!(response.contains("500 Internal Server Error"), "{response}");
+    assert!(response.contains("TRANSACTION_PROJECTION_INCONSISTENT"));
+}
+
+fn mark_intent_failed(state_file: &std::path::Path, escrow_id: &str) {
+    let mut state = read_state_json(state_file);
+    state["settlement_intents"][escrow_id]["state"] = Value::String("failed".to_owned());
+    fs::write(state_file, serde_json::to_vec(&state).expect("state json"))
+        .expect("write tampered settlement intent");
 }

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_projection_settlement_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_projection_settlement_contract_tests.rs
@@ -12,7 +12,22 @@ fn integration_participant_projection_uses_persisted_settlement_evidence() {
     let _env = acquire_service_api_test_env();
     let _override_guard =
         crate::service_api_endpoint::set_test_live_solana_settlement_override(true);
-    let context = build_live_solana_asset_movement_context(LiveSolanaAssetMovementParams {
+    let context = projection_context();
+    let (escrow_id, released) = fund_and_release_live_escrow(&context.harness, 181, 183, 31);
+    let task_id = escrow_task_id(&context.harness, &escrow_id);
+    let (response, projection) = query_projection(&context.harness, &task_id, 184);
+    assert_settlement_projection(&response, &projection, &released);
+    assert_failed_intent_is_rejected(
+        &context.harness.snapshot,
+        context.harness.bind_addr.as_str(),
+        context.harness.state_file.as_path(),
+        &task_id,
+        &escrow_id,
+    );
+}
+
+fn projection_context() -> LiveSolanaAssetMovementContext {
+    build_live_solana_asset_movement_context(LiveSolanaAssetMovementParams {
         state_file_prefix: "kamn-projection-settlement-state",
         caller_did: ACTOR,
         api_bind: "127.0.0.1:34251",
@@ -22,30 +37,37 @@ fn integration_participant_projection_uses_persisted_settlement_evidence() {
         lamports_env: LAMPORTS_ENV,
         live_rpc_env: RPC_URL,
         amount_lamports: 31,
-    });
-    let (escrow_id, released) = fund_and_release_live_escrow(&context.harness, 181, 183, 31);
-    let state = read_state_json(context.harness.state_file.as_path());
-    let task_id = state["escrows"][&escrow_id]["task_id"]
-        .as_str()
-        .expect("task id");
-    let path = format!("/v1/tasks/{task_id}/participant-view");
+    })
+}
 
+fn escrow_task_id(harness: &AssetMovementHarness, escrow_id: &str) -> String {
+    read_state_json(harness.state_file.as_path())["escrows"][escrow_id]["task_id"]
+        .as_str()
+        .expect("task id")
+        .to_owned()
+}
+
+fn query_projection(harness: &AssetMovementHarness, task_id: &str, nonce: u64) -> (String, Value) {
+    let path = format!("/v1/tasks/{task_id}/participant-view");
     let response = raw_signed_request(
-        &context.harness.snapshot,
-        context.harness.bind_addr.as_str(),
+        &harness.snapshot,
+        harness.bind_addr.as_str(),
         SignedRequest {
             max_requests: 1,
             method: "GET",
             path: path.as_str(),
             caller_did: ACTOR,
-            nonce: 184,
+            nonce,
             body: "",
             extra_headers: &[("X-KAMN-Authz-Scope", "tasks:read")],
         },
     );
     let projection: Value =
         parse_service_api_payload(extract_http_response_body(&response)).expect("projection");
+    (response, projection)
+}
 
+fn assert_settlement_projection(response: &str, projection: &Value, released: &Value) {
     assert!(response.contains("HTTP/1.1 200 OK"), "{response}");
     assert_eq!(projection["escrow_state"], "released");
     assert_eq!(projection["network"], "solana-devnet");
@@ -54,13 +76,6 @@ fn integration_participant_projection_uses_persisted_settlement_evidence() {
         released["settlement_tx_signature"]
     );
     assert_eq!(projection["settlement_commitment"], "finalized");
-    assert_failed_intent_is_rejected(
-        &context.harness.snapshot,
-        context.harness.bind_addr.as_str(),
-        context.harness.state_file.as_path(),
-        task_id,
-        &escrow_id,
-    );
 }
 
 fn assert_failed_intent_is_rejected(

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_projection_settlement_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_projection_settlement_contract_tests.rs
@@ -1,0 +1,57 @@
+use super::super::*;
+use super::support::*;
+
+const RPC_URL: &str = "https://api.devnet.solana.com";
+const KEYPAIR_ENV: &str = "KAMN_SERVICE_API_LIVE_SOLANA_SETTLEMENT_KEYPAIR_FILE";
+const RECIPIENT_ENV: &str = "KAMN_SERVICE_API_LIVE_SOLANA_SETTLEMENT_RECIPIENT_PUBKEY";
+const LAMPORTS_ENV: &str = "KAMN_SERVICE_API_LIVE_SOLANA_SETTLEMENT_LAMPORTS";
+const ACTOR: &str = "kamn:did:agent:projection-settlement";
+
+#[test]
+fn integration_participant_projection_uses_persisted_settlement_evidence() {
+    let _env = acquire_service_api_test_env();
+    let _override_guard =
+        crate::service_api_endpoint::set_test_live_solana_settlement_override(true);
+    let context = build_live_solana_asset_movement_context(LiveSolanaAssetMovementParams {
+        state_file_prefix: "kamn-projection-settlement-state",
+        caller_did: ACTOR,
+        api_bind: "127.0.0.1:34251",
+        keypair_prefix: "kamn-projection-settlement-keypair",
+        keypair_env: KEYPAIR_ENV,
+        recipient_env: RECIPIENT_ENV,
+        lamports_env: LAMPORTS_ENV,
+        live_rpc_env: RPC_URL,
+        amount_lamports: 31,
+    });
+    let (escrow_id, released) = fund_and_release_live_escrow(&context.harness, 181, 183, 31);
+    let state = read_state_json(context.harness.state_file.as_path());
+    let task_id = state["escrows"][&escrow_id]["task_id"]
+        .as_str()
+        .expect("task id");
+    let path = format!("/v1/tasks/{task_id}/participant-view");
+
+    let response = raw_signed_request(
+        &context.harness.snapshot,
+        context.harness.bind_addr.as_str(),
+        SignedRequest {
+            max_requests: 1,
+            method: "GET",
+            path: path.as_str(),
+            caller_did: ACTOR,
+            nonce: 184,
+            body: "",
+            extra_headers: &[("X-KAMN-Authz-Scope", "tasks:read")],
+        },
+    );
+    let projection: Value =
+        parse_service_api_payload(extract_http_response_body(&response)).expect("projection");
+
+    assert!(response.contains("HTTP/1.1 200 OK"), "{response}");
+    assert_eq!(projection["escrow_state"], "released");
+    assert_eq!(projection["network"], "solana-devnet");
+    assert_eq!(
+        projection["settlement_tx_signature"],
+        released["settlement_tx_signature"]
+    );
+    assert_eq!(projection["settlement_commitment"], "finalized");
+}

--- a/crates/kamn-node/src/service_api_endpoint.rs
+++ b/crates/kamn-node/src/service_api_endpoint.rs
@@ -8,6 +8,7 @@ mod message_store;
 mod middleware_impl;
 mod models;
 mod payload;
+mod projection_models;
 mod runtime_observability;
 mod scope_fixture;
 mod server;
@@ -74,6 +75,9 @@ pub(crate) use models::{
     ServiceApiTaskCreateBody, ServiceApiTaskGetBody, ServiceApiTaskTransitionBody,
     ServiceApiWebsocketStateTransitionBody,
 };
+pub(crate) use projection_models::{
+    ServiceApiParticipantTaskProjection, ServiceApiVerifierTaskProjection,
+};
 use runtime_observability::ServiceApiRuntimeObservability;
 pub(crate) use snapshot::ServiceApiSnapshot;
 pub(crate) use state_io::{
@@ -116,6 +120,8 @@ const ROUTE_CHANNELS_MESSAGES_SUFFIX: &str = "/messages";
 const ROUTE_TASKS_PREFIX: &str = "/v1/tasks/";
 const ROUTE_TASKS_ACCEPT_SUFFIX: &str = "/accept";
 const ROUTE_TASKS_COMPLETE_SUFFIX: &str = "/complete";
+const ROUTE_TASKS_PARTICIPANT_VIEW_SUFFIX: &str = "/participant-view";
+const ROUTE_TASKS_VERIFIER_VIEW_SUFFIX: &str = "/verifier-view";
 const ROUTE_ESCROW_PREFIX: &str = "/v1/escrow/";
 const ROUTE_ESCROW_RELEASE_SUFFIX: &str = "/release";
 const ROUTE_CONTENT_PREFIX: &str = "/v1/content/";

--- a/crates/kamn-node/src/service_api_endpoint/auth/grant_policy.rs
+++ b/crates/kamn-node/src/service_api_endpoint/auth/grant_policy.rs
@@ -53,6 +53,11 @@ fn route_target(
 
 fn dynamic_route_target(method: &str, path: &str) -> Option<(String, &'static str, &'static str)> {
     if method == "GET" {
+        if super::payload::task_participant_view_path_id(path).is_some()
+            || super::payload::task_verifier_view_path_id(path).is_some()
+        {
+            return None;
+        }
         return super::payload::task_path_id(path)
             .map(|id| (task_resource(id), "task:read", "participant"));
     }

--- a/crates/kamn-node/src/service_api_endpoint/auth/scope_policy.rs
+++ b/crates/kamn-node/src/service_api_endpoint/auth/scope_policy.rs
@@ -116,6 +116,12 @@ fn get_scope(method: &str, path: &str) -> Option<ServiceApiScope> {
             ServiceApiScope::ChannelsRead
         }
         _ if super::payload::task_path_id(path).is_some() => ServiceApiScope::TasksRead,
+        _ if super::payload::task_participant_view_path_id(path).is_some() => {
+            ServiceApiScope::TasksRead
+        }
+        _ if super::payload::task_verifier_view_path_id(path).is_some() => {
+            ServiceApiScope::TasksRead
+        }
         _ if super::payload::agent_balance_path_id(path).is_some() => ServiceApiScope::AgentsRead,
         _ if super::payload::agent_path_id(path).is_some() => ServiceApiScope::AgentsRead,
         _ => return None,

--- a/crates/kamn-node/src/service_api_endpoint/message_store.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store.rs
@@ -40,6 +40,7 @@ mod persistence;
 mod runtime_evidence;
 mod store;
 mod task_models;
+mod task_projection;
 #[cfg(test)]
 mod tests;
 
@@ -51,6 +52,7 @@ use models::*;
 use runtime_evidence::build_data_layer_runtime_evidence;
 pub(crate) use task_models::ServiceApiSettlementIntentRecord;
 use task_models::*;
+pub(crate) use task_projection::TaskProjectionError;
 
 pub(crate) use models::{
     ServiceApiAgentBalanceBody, ServiceApiAgentRegistrationStoreError, ServiceApiMessageStore,

--- a/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops.rs
@@ -19,6 +19,22 @@ pub(crate) use settlement_intent::settlement_signature_is_available;
 use tasks::{next_task_id, persist_task_created_audit_export};
 
 impl ServiceApiMessageStore {
+    pub(crate) fn participant_task_projection(
+        &mut self,
+        task_id: &str,
+        requester_did: &str,
+    ) -> Result<Option<ServiceApiParticipantTaskProjection>, TaskProjectionError> {
+        super::super::task_projection::participant(self, task_id, requester_did)
+    }
+
+    pub(crate) fn verifier_task_projection(
+        &mut self,
+        task_id: &str,
+        requester_did: &str,
+    ) -> Result<Option<ServiceApiVerifierTaskProjection>, TaskProjectionError> {
+        super::super::task_projection::verifier(self, task_id, requester_did)
+    }
+
     pub(crate) fn prepare_settlement_intent(
         &mut self,
         actor: &str,

--- a/crates/kamn-node/src/service_api_endpoint/message_store/task_projection.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/task_projection.rs
@@ -84,7 +84,7 @@ fn build_public_projection(
 ) -> Result<ServiceApiTaskPublicProjection, TaskProjectionError> {
     let escrow = bound_escrow(snapshot, task)?;
     let transaction_id = matching_transaction_id(task, escrow)?;
-    let mut projection = public_fields(task, escrow, transaction_id);
+    let mut projection = public_fields(task, escrow, transaction_id)?;
     projection.public_commitment = public_commitment(&projection);
     Ok(projection)
 }
@@ -123,20 +123,27 @@ fn public_fields(
     task: &ServiceApiPersistedTaskRecord,
     escrow: &ServiceApiPersistedEscrowRecord,
     transaction_id: &str,
-) -> ServiceApiTaskPublicProjection {
-    ServiceApiTaskPublicProjection {
+) -> Result<ServiceApiTaskPublicProjection, TaskProjectionError> {
+    let amount_lamports = escrow
+        .amount_lamports
+        .ok_or(TaskProjectionError::Inconsistent)?;
+    let network = escrow
+        .network
+        .clone()
+        .ok_or(TaskProjectionError::Inconsistent)?;
+    Ok(ServiceApiTaskPublicProjection {
         schema_version: TASK_PROJECTION_SCHEMA_VERSION.to_owned(),
         task_id: task.task_id.clone(),
         transaction_id: transaction_id.to_owned(),
         task_state: task.state.clone(),
         escrow_id: escrow.escrow_id.clone(),
         escrow_state: escrow.state.clone(),
-        amount_lamports: escrow.amount_lamports.unwrap_or_default(),
-        network: escrow.network.clone().unwrap_or_default(),
+        amount_lamports,
+        network,
         settlement_tx_signature: escrow.settlement.settlement_tx_signature.clone(),
         settlement_commitment: escrow.settlement.settlement_commitment.clone(),
         public_commitment: String::new(),
-    }
+    })
 }
 
 fn public_commitment(projection: &ServiceApiTaskPublicProjection) -> String {

--- a/crates/kamn-node/src/service_api_endpoint/message_store/task_projection.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/task_projection.rs
@@ -1,0 +1,171 @@
+use super::*;
+use crate::service_api_endpoint::projection_models::{
+    ServiceApiTaskPublicProjection, TASK_PROJECTION_SCHEMA_VERSION,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum TaskProjectionError {
+    Unregistered,
+    Forbidden,
+    EscrowBindingMissing,
+    Inconsistent,
+    Persistence(String),
+}
+
+pub(crate) fn participant(
+    store: &mut ServiceApiMessageStore,
+    task_id: &str,
+    requester_did: &str,
+) -> Result<Option<ServiceApiParticipantTaskProjection>, TaskProjectionError> {
+    store
+        .refresh_from_disk()
+        .map_err(TaskProjectionError::Persistence)?;
+    require_registered(&store.snapshot, requester_did)?;
+    let Some(task) = store.snapshot.tasks.get(task_id) else {
+        return Ok(None);
+    };
+    let role = participant_role(task, requester_did).ok_or(TaskProjectionError::Forbidden)?;
+    let public = build_public_projection(&store.snapshot, task)?;
+    let receipts = task_receipt_ids(&store.snapshot, task_id);
+    Ok(Some(ServiceApiParticipantTaskProjection {
+        view_scope: "participant-private".to_owned(),
+        participant_role: role.to_owned(),
+        public,
+        task_receipt_ids: receipts,
+        completion_evidence_digest: task.completion_evidence_digest.clone(),
+    }))
+}
+
+pub(crate) fn verifier(
+    store: &mut ServiceApiMessageStore,
+    task_id: &str,
+    requester_did: &str,
+) -> Result<Option<ServiceApiVerifierTaskProjection>, TaskProjectionError> {
+    store
+        .refresh_from_disk()
+        .map_err(TaskProjectionError::Persistence)?;
+    require_registered(&store.snapshot, requester_did)?;
+    let Some(task) = store.snapshot.tasks.get(task_id) else {
+        return Ok(None);
+    };
+    Ok(Some(ServiceApiVerifierTaskProjection {
+        view_scope: "restricted-public".to_owned(),
+        public: build_public_projection(&store.snapshot, task)?,
+    }))
+}
+
+fn require_registered(
+    snapshot: &ServiceApiPersistedMessageStoreSnapshot,
+    requester_did: &str,
+) -> Result<(), TaskProjectionError> {
+    if snapshot
+        .agents
+        .get(requester_did)
+        .is_some_and(|agent| agent.registered)
+    {
+        return Ok(());
+    }
+    Err(TaskProjectionError::Unregistered)
+}
+
+fn participant_role<'a>(
+    task: &'a ServiceApiPersistedTaskRecord,
+    requester: &str,
+) -> Option<&'a str> {
+    if task.creator_did.as_deref() == Some(requester) {
+        return Some("creator");
+    }
+    (task.provider_did.as_deref() == Some(requester)).then_some("provider")
+}
+
+fn build_public_projection(
+    snapshot: &ServiceApiPersistedMessageStoreSnapshot,
+    task: &ServiceApiPersistedTaskRecord,
+) -> Result<ServiceApiTaskPublicProjection, TaskProjectionError> {
+    let escrow = bound_escrow(snapshot, task)?;
+    let transaction_id = matching_transaction_id(task, escrow)?;
+    let mut projection = public_fields(task, escrow, transaction_id);
+    projection.public_commitment = public_commitment(&projection);
+    Ok(projection)
+}
+
+fn bound_escrow<'a>(
+    snapshot: &'a ServiceApiPersistedMessageStoreSnapshot,
+    task: &ServiceApiPersistedTaskRecord,
+) -> Result<&'a ServiceApiPersistedEscrowRecord, TaskProjectionError> {
+    let mut matches = snapshot
+        .escrows
+        .values()
+        .filter(|escrow| escrow.task_id.as_deref() == Some(task.task_id.as_str()));
+    let escrow = matches
+        .next()
+        .ok_or(TaskProjectionError::EscrowBindingMissing)?;
+    if matches.next().is_some() {
+        return Err(TaskProjectionError::Inconsistent);
+    }
+    Ok(escrow)
+}
+
+fn matching_transaction_id<'a>(
+    task: &'a ServiceApiPersistedTaskRecord,
+    escrow: &'a ServiceApiPersistedEscrowRecord,
+) -> Result<&'a str, TaskProjectionError> {
+    match (
+        task.transaction_id.as_deref(),
+        escrow.transaction_id.as_deref(),
+    ) {
+        (Some(task_id), Some(escrow_id)) if task_id == escrow_id => Ok(task_id),
+        _ => Err(TaskProjectionError::Inconsistent),
+    }
+}
+
+fn public_fields(
+    task: &ServiceApiPersistedTaskRecord,
+    escrow: &ServiceApiPersistedEscrowRecord,
+    transaction_id: &str,
+) -> ServiceApiTaskPublicProjection {
+    ServiceApiTaskPublicProjection {
+        schema_version: TASK_PROJECTION_SCHEMA_VERSION.to_owned(),
+        task_id: task.task_id.clone(),
+        transaction_id: transaction_id.to_owned(),
+        task_state: task.state.clone(),
+        escrow_id: escrow.escrow_id.clone(),
+        escrow_state: escrow.state.clone(),
+        amount_lamports: escrow.amount_lamports.unwrap_or_default(),
+        network: escrow.network.clone().unwrap_or_default(),
+        settlement_tx_signature: escrow.settlement.settlement_tx_signature.clone(),
+        settlement_commitment: escrow.settlement.settlement_commitment.clone(),
+        public_commitment: String::new(),
+    }
+}
+
+fn public_commitment(projection: &ServiceApiTaskPublicProjection) -> String {
+    let canonical = format!(
+        "{}|{}|{}|{}|{}|{}|{}|{}|{}",
+        projection.task_id,
+        projection.transaction_id,
+        projection.task_state,
+        projection.escrow_id,
+        projection.escrow_state,
+        projection.amount_lamports,
+        projection.network,
+        projection.settlement_tx_signature.as_deref().unwrap_or(""),
+        projection.settlement_commitment.as_deref().unwrap_or("")
+    );
+    format!(
+        "fnv1a64:{:016x}",
+        crate::service_api_endpoint::deterministic_body_tag(canonical.as_bytes())
+    )
+}
+
+fn task_receipt_ids(
+    snapshot: &ServiceApiPersistedMessageStoreSnapshot,
+    task_id: &str,
+) -> Vec<String> {
+    snapshot
+        .task_transition_receipts
+        .iter()
+        .filter(|receipt| receipt.task_id == task_id)
+        .map(|receipt| receipt.receipt_id.clone())
+        .collect()
+}

--- a/crates/kamn-node/src/service_api_endpoint/message_store/task_projection.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/task_projection.rs
@@ -3,6 +3,8 @@ use crate::service_api_endpoint::projection_models::{
     ServiceApiTaskPublicProjection, TASK_PROJECTION_SCHEMA_VERSION,
 };
 
+mod commitment;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum TaskProjectionError {
     Unregistered,
@@ -84,8 +86,9 @@ fn build_public_projection(
 ) -> Result<ServiceApiTaskPublicProjection, TaskProjectionError> {
     let escrow = bound_escrow(snapshot, task)?;
     let transaction_id = matching_transaction_id(task, escrow)?;
+    require_settlement_consistency(snapshot, escrow)?;
     let mut projection = public_fields(task, escrow, transaction_id)?;
-    projection.public_commitment = public_commitment(&projection);
+    projection.public_commitment = commitment::public_commitment(&projection);
     Ok(projection)
 }
 
@@ -119,6 +122,28 @@ fn matching_transaction_id<'a>(
     }
 }
 
+fn require_settlement_consistency(
+    snapshot: &ServiceApiPersistedMessageStoreSnapshot,
+    escrow: &ServiceApiPersistedEscrowRecord,
+) -> Result<(), TaskProjectionError> {
+    let Some(signature) = escrow.settlement.settlement_tx_signature.as_deref() else {
+        return Ok(());
+    };
+    let intent = snapshot
+        .settlement_intents
+        .get(&escrow.escrow_id)
+        .ok_or(TaskProjectionError::Inconsistent)?;
+    if intent.state == "confirmed"
+        && intent.expected_signature == signature
+        && Some(intent.amount_lamports) == escrow.amount_lamports
+        && intent.network == "solana:devnet"
+        && escrow.network.as_deref() == Some("solana-devnet")
+    {
+        return Ok(());
+    }
+    Err(TaskProjectionError::Inconsistent)
+}
+
 fn public_fields(
     task: &ServiceApiPersistedTaskRecord,
     escrow: &ServiceApiPersistedEscrowRecord,
@@ -144,25 +169,6 @@ fn public_fields(
         settlement_commitment: escrow.settlement.settlement_commitment.clone(),
         public_commitment: String::new(),
     })
-}
-
-fn public_commitment(projection: &ServiceApiTaskPublicProjection) -> String {
-    let canonical = format!(
-        "{}|{}|{}|{}|{}|{}|{}|{}|{}",
-        projection.task_id,
-        projection.transaction_id,
-        projection.task_state,
-        projection.escrow_id,
-        projection.escrow_state,
-        projection.amount_lamports,
-        projection.network,
-        projection.settlement_tx_signature.as_deref().unwrap_or(""),
-        projection.settlement_commitment.as_deref().unwrap_or("")
-    );
-    format!(
-        "fnv1a64:{:016x}",
-        crate::service_api_endpoint::deterministic_body_tag(canonical.as_bytes())
-    )
 }
 
 fn task_receipt_ids(

--- a/crates/kamn-node/src/service_api_endpoint/message_store/task_projection/commitment.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/task_projection/commitment.rs
@@ -1,0 +1,33 @@
+use crate::service_api_endpoint::projection_models::ServiceApiTaskPublicProjection;
+use k256::sha2::{Digest, Sha256};
+
+pub(super) fn public_commitment(projection: &ServiceApiTaskPublicProjection) -> String {
+    let amount = projection.amount_lamports.to_string();
+    let fields = [
+        projection.task_id.as_str(),
+        projection.transaction_id.as_str(),
+        projection.task_state.as_str(),
+        projection.escrow_id.as_str(),
+        projection.escrow_state.as_str(),
+        amount.as_str(),
+        projection.network.as_str(),
+        projection.settlement_tx_signature.as_deref().unwrap_or(""),
+        projection.settlement_commitment.as_deref().unwrap_or(""),
+    ];
+    let canonical = fields.map(length_frame).join("|");
+    format!("sha256:{}", hex_digest(Sha256::digest(canonical)))
+}
+
+fn length_frame(value: &str) -> String {
+    format!("{}:{value}", value.len())
+}
+
+fn hex_digest(digest: impl AsRef<[u8]>) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut output = String::with_capacity(64);
+    for byte in digest.as_ref() {
+        output.push(HEX[(byte >> 4) as usize] as char);
+        output.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    output
+}

--- a/crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/queries.rs
+++ b/crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/queries.rs
@@ -1,18 +1,13 @@
 use super::*;
 
+mod task_projection;
+
 pub(super) async fn handle_get_route(
     state: &Arc<ServiceApiRuntimeState>,
     context: &ServiceApiRequestContext,
 ) -> Option<Response> {
-    if let Some(task_id) =
-        super::payload::task_participant_view_path_id(context.parsed_request.path.as_str())
-    {
-        return Some(participant_task_projection(state, context, task_id).await);
-    }
-    if let Some(task_id) =
-        super::payload::task_verifier_view_path_id(context.parsed_request.path.as_str())
-    {
-        return Some(verifier_task_projection(state, context, task_id).await);
+    if let Some(response) = task_projection::handle_task_projection_query(state, context).await {
+        return Some(response);
     }
     if let Some(message_id) = super::payload::message_path_id(context.parsed_request.path.as_str())
     {
@@ -34,79 +29,6 @@ pub(super) async fn handle_get_route(
         return Some(bridge_query(state, bridge_id).await);
     }
     agent_like_query(state, context).await
-}
-
-async fn participant_task_projection(
-    state: &Arc<ServiceApiRuntimeState>,
-    context: &ServiceApiRequestContext,
-    task_id: &str,
-) -> Response {
-    let requester = requester_did(context);
-    let result = {
-        let mut store = state.message_store.lock().await;
-        if let Err(response) = super::revalidate_transaction_authorization(&mut store, context) {
-            return *response;
-        }
-        store.participant_task_projection(task_id, requester)
-    };
-    projection_response(result)
-}
-
-async fn verifier_task_projection(
-    state: &Arc<ServiceApiRuntimeState>,
-    context: &ServiceApiRequestContext,
-    task_id: &str,
-) -> Response {
-    let requester = requester_did(context);
-    let result = state
-        .message_store
-        .lock()
-        .await
-        .verifier_task_projection(task_id, requester);
-    projection_response(result)
-}
-
-fn requester_did(context: &ServiceApiRequestContext) -> &str {
-    super::auth::header_value(
-        &context.parsed_request.headers,
-        REQUEST_AUTH_SENDER_DID_HEADER,
-    )
-    .unwrap_or_default()
-}
-
-fn projection_response<T: Serialize>(
-    result: Result<Option<T>, message_store::TaskProjectionError>,
-) -> Response {
-    use message_store::TaskProjectionError::*;
-    match result {
-        Ok(Some(payload)) => contract_json(200, &payload),
-        Ok(None) => not_found(),
-        Err(Unregistered) => projection_error(
-            StatusCode::FORBIDDEN,
-            "AGENT_NOT_REGISTERED",
-            "requester is not a registered agent",
-        ),
-        Err(Forbidden) => projection_error(
-            StatusCode::FORBIDDEN,
-            "TASK_PARTICIPANT_VIEW_FORBIDDEN",
-            "requester is not a task participant",
-        ),
-        Err(EscrowBindingMissing) => projection_error(
-            StatusCode::CONFLICT,
-            "TASK_ESCROW_BINDING_MISSING",
-            "task has no bound escrow",
-        ),
-        Err(Inconsistent) => projection_error(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "TRANSACTION_PROJECTION_INCONSISTENT",
-            "durable transaction projection fields disagree",
-        ),
-        Err(Persistence(error)) => persistence_error("task projection persistence failed", error),
-    }
-}
-
-fn projection_error(status: StatusCode, code: &str, message: &str) -> Response {
-    super::payload::json_error_response(status, "task-projection", code, message)
 }
 
 async fn message_query(

--- a/crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/queries.rs
+++ b/crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/queries.rs
@@ -4,6 +4,16 @@ pub(super) async fn handle_get_route(
     state: &Arc<ServiceApiRuntimeState>,
     context: &ServiceApiRequestContext,
 ) -> Option<Response> {
+    if let Some(task_id) =
+        super::payload::task_participant_view_path_id(context.parsed_request.path.as_str())
+    {
+        return Some(participant_task_projection(state, context, task_id).await);
+    }
+    if let Some(task_id) =
+        super::payload::task_verifier_view_path_id(context.parsed_request.path.as_str())
+    {
+        return Some(verifier_task_projection(state, context, task_id).await);
+    }
     if let Some(message_id) = super::payload::message_path_id(context.parsed_request.path.as_str())
     {
         return Some(message_query(state, &context.parsed_request, message_id).await);
@@ -24,6 +34,79 @@ pub(super) async fn handle_get_route(
         return Some(bridge_query(state, bridge_id).await);
     }
     agent_like_query(state, context).await
+}
+
+async fn participant_task_projection(
+    state: &Arc<ServiceApiRuntimeState>,
+    context: &ServiceApiRequestContext,
+    task_id: &str,
+) -> Response {
+    let requester = requester_did(context);
+    let result = {
+        let mut store = state.message_store.lock().await;
+        if let Err(response) = super::revalidate_transaction_authorization(&mut store, context) {
+            return *response;
+        }
+        store.participant_task_projection(task_id, requester)
+    };
+    projection_response(result)
+}
+
+async fn verifier_task_projection(
+    state: &Arc<ServiceApiRuntimeState>,
+    context: &ServiceApiRequestContext,
+    task_id: &str,
+) -> Response {
+    let requester = requester_did(context);
+    let result = state
+        .message_store
+        .lock()
+        .await
+        .verifier_task_projection(task_id, requester);
+    projection_response(result)
+}
+
+fn requester_did(context: &ServiceApiRequestContext) -> &str {
+    super::auth::header_value(
+        &context.parsed_request.headers,
+        REQUEST_AUTH_SENDER_DID_HEADER,
+    )
+    .unwrap_or_default()
+}
+
+fn projection_response<T: Serialize>(
+    result: Result<Option<T>, message_store::TaskProjectionError>,
+) -> Response {
+    use message_store::TaskProjectionError::*;
+    match result {
+        Ok(Some(payload)) => contract_json(200, &payload),
+        Ok(None) => not_found(),
+        Err(Unregistered) => projection_error(
+            StatusCode::FORBIDDEN,
+            "AGENT_NOT_REGISTERED",
+            "requester is not a registered agent",
+        ),
+        Err(Forbidden) => projection_error(
+            StatusCode::FORBIDDEN,
+            "TASK_PARTICIPANT_VIEW_FORBIDDEN",
+            "requester is not a task participant",
+        ),
+        Err(EscrowBindingMissing) => projection_error(
+            StatusCode::CONFLICT,
+            "TASK_ESCROW_BINDING_MISSING",
+            "task has no bound escrow",
+        ),
+        Err(Inconsistent) => projection_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "TRANSACTION_PROJECTION_INCONSISTENT",
+            "durable transaction projection fields disagree",
+        ),
+        Err(Persistence(error)) => persistence_error("task projection persistence failed", error),
+    }
+}
+
+fn projection_error(status: StatusCode, code: &str, message: &str) -> Response {
+    super::payload::json_error_response(status, "task-projection", code, message)
 }
 
 async fn message_query(

--- a/crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/queries/task_projection.rs
+++ b/crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/queries/task_projection.rs
@@ -1,0 +1,87 @@
+use super::*;
+
+pub(super) async fn handle_task_projection_query(
+    state: &Arc<ServiceApiRuntimeState>,
+    context: &ServiceApiRequestContext,
+) -> Option<Response> {
+    let path = context.parsed_request.path.as_str();
+    if let Some(task_id) = super::super::payload::task_participant_view_path_id(path) {
+        return Some(participant_projection(state, context, task_id).await);
+    }
+    let task_id = super::super::payload::task_verifier_view_path_id(path)?;
+    Some(verifier_projection(state, context, task_id).await)
+}
+
+async fn participant_projection(
+    state: &Arc<ServiceApiRuntimeState>,
+    context: &ServiceApiRequestContext,
+    task_id: &str,
+) -> Response {
+    let requester = requester_did(context);
+    let result = state
+        .message_store
+        .lock()
+        .await
+        .participant_task_projection(task_id, requester);
+    projection_response(result)
+}
+
+async fn verifier_projection(
+    state: &Arc<ServiceApiRuntimeState>,
+    context: &ServiceApiRequestContext,
+    task_id: &str,
+) -> Response {
+    let requester = requester_did(context);
+    let result = state
+        .message_store
+        .lock()
+        .await
+        .verifier_task_projection(task_id, requester);
+    projection_response(result)
+}
+
+fn requester_did(context: &ServiceApiRequestContext) -> &str {
+    super::super::auth::header_value(
+        &context.parsed_request.headers,
+        REQUEST_AUTH_SENDER_DID_HEADER,
+    )
+    .unwrap_or_default()
+}
+
+fn projection_response<T: Serialize>(
+    result: Result<Option<T>, message_store::TaskProjectionError>,
+) -> Response {
+    match result {
+        Ok(Some(payload)) => super::contract_json(200, &payload),
+        Ok(None) => super::not_found(),
+        Err(error) => projection_contract_error(error),
+    }
+}
+
+fn projection_contract_error(error: message_store::TaskProjectionError) -> Response {
+    use message_store::TaskProjectionError::*;
+    let (status, code, message) = match error {
+        Unregistered => (
+            StatusCode::FORBIDDEN,
+            "AGENT_NOT_REGISTERED",
+            "agent not registered",
+        ),
+        Forbidden => (
+            StatusCode::FORBIDDEN,
+            "TASK_PARTICIPANT_VIEW_FORBIDDEN",
+            "not a participant",
+        ),
+        EscrowBindingMissing => (
+            StatusCode::CONFLICT,
+            "TASK_ESCROW_BINDING_MISSING",
+            "escrow missing",
+        ),
+        Inconsistent => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "TRANSACTION_PROJECTION_INCONSISTENT",
+            "projection inconsistent",
+        ),
+        Persistence(error) => return super::persistence_error("task projection failed", error),
+    };
+    super::super::payload::json_error_response(status, "task-projection", code, message)
+}

--- a/crates/kamn-node/src/service_api_endpoint/payload.rs
+++ b/crates/kamn-node/src/service_api_endpoint/payload.rs
@@ -459,6 +459,8 @@ pub(super) fn route_exists_for_other_method(path: &str) -> bool {
         || task_path_id(path).is_some()
         || task_accept_path_id(path).is_some()
         || task_complete_path_id(path).is_some()
+        || task_participant_view_path_id(path).is_some()
+        || task_verifier_view_path_id(path).is_some()
         || escrow_release_path_id(path).is_some()
         || content_path_id(path).is_some()
         || content_expire_path_id(path).is_some()
@@ -508,6 +510,23 @@ pub(super) fn task_accept_path_id(path: &str) -> Option<&str> {
 pub(super) fn task_complete_path_id(path: &str) -> Option<&str> {
     let task_path = path.strip_prefix(ROUTE_TASKS_PREFIX)?;
     let task_id = task_path.strip_suffix(ROUTE_TASKS_COMPLETE_SUFFIX)?;
+    if task_id.is_empty() || task_id == "create" || task_id.contains('/') {
+        return None;
+    }
+    Some(task_id)
+}
+
+pub(super) fn task_participant_view_path_id(path: &str) -> Option<&str> {
+    task_view_path_id(path, ROUTE_TASKS_PARTICIPANT_VIEW_SUFFIX)
+}
+
+pub(super) fn task_verifier_view_path_id(path: &str) -> Option<&str> {
+    task_view_path_id(path, ROUTE_TASKS_VERIFIER_VIEW_SUFFIX)
+}
+
+fn task_view_path_id<'a>(path: &'a str, suffix: &str) -> Option<&'a str> {
+    let task_path = path.strip_prefix(ROUTE_TASKS_PREFIX)?;
+    let task_id = task_path.strip_suffix(suffix)?;
     if task_id.is_empty() || task_id == "create" || task_id.contains('/') {
         return None;
     }

--- a/crates/kamn-node/src/service_api_endpoint/payload.rs
+++ b/crates/kamn-node/src/service_api_endpoint/payload.rs
@@ -753,9 +753,29 @@ pub(super) fn escape_metrics_label(input: &str) -> String {
 mod tests {
     use super::{
         bridge_forward_path_id, bridge_path_id, content_expire_path_id, content_path_id,
-        content_tombstone_path_id, route_exists_for_other_method, ROUTE_BRIDGE_SUBMIT,
-        ROUTE_CONTENT_REGISTER,
+        content_tombstone_path_id, route_exists_for_other_method, task_participant_view_path_id,
+        task_verifier_view_path_id, ROUTE_BRIDGE_SUBMIT, ROUTE_CONTENT_REGISTER,
     };
+
+    #[test]
+    fn unit_task_projection_paths_accept_only_canonical_shapes() {
+        assert_eq!(
+            task_participant_view_path_id("/v1/tasks/task-a/participant-view"),
+            Some("task-a")
+        );
+        assert_eq!(
+            task_verifier_view_path_id("/v1/tasks/task-a/verifier-view"),
+            Some("task-a")
+        );
+        assert_eq!(
+            task_participant_view_path_id("/v1/tasks//participant-view"),
+            None
+        );
+        assert_eq!(
+            task_verifier_view_path_id("/v1/tasks/task-a/extra/verifier-view"),
+            None
+        );
+    }
 
     #[test]
     fn unit_content_path_id_contract_accepts_and_rejects_expected_shapes() {

--- a/crates/kamn-node/src/service_api_endpoint/projection_models.rs
+++ b/crates/kamn-node/src/service_api_endpoint/projection_models.rs
@@ -1,0 +1,39 @@
+use super::*;
+
+pub(crate) const TASK_PROJECTION_SCHEMA_VERSION: &str =
+    "kamn.runtime.task-disclosure-projection.v1";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct ServiceApiTaskPublicProjection {
+    pub(crate) schema_version: String,
+    pub(crate) task_id: String,
+    pub(crate) transaction_id: String,
+    pub(crate) task_state: String,
+    pub(crate) escrow_id: String,
+    pub(crate) escrow_state: String,
+    pub(crate) amount_lamports: u64,
+    pub(crate) network: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) settlement_tx_signature: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) settlement_commitment: Option<String>,
+    pub(crate) public_commitment: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct ServiceApiParticipantTaskProjection {
+    pub(crate) view_scope: String,
+    pub(crate) participant_role: String,
+    #[serde(flatten)]
+    pub(crate) public: ServiceApiTaskPublicProjection,
+    pub(crate) task_receipt_ids: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) completion_evidence_digest: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct ServiceApiVerifierTaskProjection {
+    pub(crate) view_scope: String,
+    #[serde(flatten)]
+    pub(crate) public: ServiceApiTaskPublicProjection,
+}

--- a/crates/kamn-sdk/src/service_client.rs
+++ b/crates/kamn-sdk/src/service_client.rs
@@ -15,6 +15,8 @@ pub(crate) mod service_client_bridge_misc_routes;
 mod service_client_content_routes;
 #[path = "service_client_message_task_routes.rs"]
 mod service_client_message_task_routes;
+#[path = "service_client_projection_routes.rs"]
+mod service_client_projection_routes;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct HttpResponse {

--- a/crates/kamn-sdk/src/service_client_projection_routes.rs
+++ b/crates/kamn-sdk/src/service_client_projection_routes.rs
@@ -1,0 +1,36 @@
+use super::super::{expect_status, normalize_route_segment, ServiceRequestAuth};
+use super::ServiceApiClient;
+use crate::SdkError;
+
+impl ServiceApiClient {
+    /// Returns the server-generated participant-private task projection JSON.
+    pub fn get_task_participant_projection(
+        &self,
+        task_id: &str,
+        auth: &ServiceRequestAuth,
+    ) -> Result<String, SdkError> {
+        self.get_task_projection(task_id, "participant-view", auth)
+    }
+
+    /// Returns the server-generated restricted-public task projection JSON.
+    pub fn get_task_verifier_projection(
+        &self,
+        task_id: &str,
+        auth: &ServiceRequestAuth,
+    ) -> Result<String, SdkError> {
+        self.get_task_projection(task_id, "verifier-view", auth)
+    }
+
+    fn get_task_projection(
+        &self,
+        task_id: &str,
+        view: &str,
+        auth: &ServiceRequestAuth,
+    ) -> Result<String, SdkError> {
+        let task_id = normalize_route_segment("task_id", task_id)?;
+        let route = format!("/v1/tasks/{task_id}/{view}");
+        let response = self.request("GET", route.as_str(), "", Some(auth))?;
+        expect_status(response.status, 200)?;
+        Ok(response.body)
+    }
+}

--- a/crates/kamn-sdk/tests/live_transport_task_escrow.rs
+++ b/crates/kamn-sdk/tests/live_transport_task_escrow.rs
@@ -8,6 +8,57 @@ mod malformed_payload_contract_tests;
 mod support;
 
 #[test]
+fn projection_routes_preserve_server_generated_json() {
+    use kamn_sdk::{service_signature_for_fields, AgentDid, ServiceApiClient, ServiceRequestAuth};
+
+    support::ensure_live_test_env();
+    let participant = r#"{"view_scope":"participant-private","public_commitment":"fnv1a64:a","task_receipt_ids":["receipt-1"]}"#;
+    let verifier = r#"{"view_scope":"restricted-public","public_commitment":"fnv1a64:a"}"#;
+    let requests = vec![
+        projection_request("participant-view", participant),
+        projection_request("verifier-view", verifier),
+    ];
+    let (bind_addr, server) = support::spawn_expected_server(requests);
+    let client = ServiceApiClient::connect(format!("http://{bind_addr}").as_str()).expect("client");
+    let did = AgentDid::parse("kamn:did:agent:projection-contract").expect("did");
+    let participant_auth = projection_auth(&did, 1);
+    let verifier_auth = projection_auth(&did, 2);
+
+    assert_eq!(
+        client
+            .get_task_participant_projection("task-1", &participant_auth)
+            .expect("participant projection"),
+        participant
+    );
+    assert_eq!(
+        client
+            .get_task_verifier_projection("task-1", &verifier_auth)
+            .expect("verifier projection"),
+        verifier
+    );
+    server.join().expect("server").expect("request contract");
+
+    fn projection_request(view: &str, response_body: &str) -> support::ExpectedRequest {
+        support::ExpectedRequest {
+            method: "GET",
+            path: format!("/v1/tasks/task-1/{view}"),
+            body: String::new(),
+            sender_did: "kamn:did:agent:projection-contract".to_owned(),
+            scope: "tasks:read",
+            response_status: 200,
+            response_body: response_body.to_owned(),
+        }
+    }
+
+    fn projection_auth(did: &AgentDid, nonce: u64) -> ServiceRequestAuth {
+        let signature =
+            service_signature_for_fields(did, nonce, "kamn-sdk-live", "1", "").expect("signature");
+        ServiceRequestAuth::new_with_scope(did.clone(), nonce, signature, Some("tasks:read"))
+            .expect("auth")
+    }
+}
+
+#[test]
 fn transition_routes_preserve_canonical_payloads() {
     use kamn_sdk::{service_signature_for_fields, AgentDid, ServiceApiClient, ServiceRequestAuth};
 

--- a/specs/7097-server-generated-disclosure-projections.md
+++ b/specs/7097-server-generated-disclosure-projections.md
@@ -51,17 +51,17 @@ placeholder, client-provided commitment, or participant response.
 
 ## Acceptance Criteria
 
-- [ ] Participant and verifier response types and serializers are separate.
-- [ ] Participant membership is derived from authenticated server context.
-- [ ] Unrelated and unregistered agents cannot retrieve participant output.
-- [ ] Verifier output is built from an explicit allowlist of durable fields.
-- [ ] Participant output contains at least one real field absent from verifier
+- [x] Participant and verifier response types and serializers are separate.
+- [x] Participant membership is derived from authenticated server context.
+- [x] Unrelated and unregistered agents cannot retrieve participant output.
+- [x] Verifier output is built from an explicit allowlist of durable fields.
+- [x] Participant output contains at least one real field absent from verifier
       output.
-- [ ] Verifier output contains no participant receipt or private payload digest.
-- [ ] Shared fields and deterministic public commitment match across views.
-- [ ] Confirmed devnet settlement fields come from persisted settlement evidence.
-- [ ] Signed HTTP integration tests exercise both routes against durable state.
-- [ ] The E2E harness can consume runtime responses without synthesizing private
+- [x] Verifier output contains no participant receipt or private payload digest.
+- [x] Shared fields and deterministic public commitment match across views.
+- [x] Confirmed devnet settlement fields come from persisted settlement evidence.
+- [x] Signed HTTP integration tests exercise both routes against durable state.
+- [x] The E2E harness can consume runtime responses without synthesizing private
       or public digest labels.
 
 ## Files To Touch
@@ -112,3 +112,33 @@ INTEGRATION:
   `kamn-e2e-harness`, formatting, strict workspace clippy, and `make check`.
 - Run `make demo-mvp` and canonical verification. This issue proves server
   disclosure behavior; it does not claim independent Pi execution yet.
+
+## Completion Evidence
+
+- `make check` passed formatting and strict workspace clippy with all targets
+  and features.
+- `cargo test -p kamn-node` passed the full package suite: 677 unit tests and
+  all standalone contract binaries; one explicitly live-only devnet test was
+  ignored by its declared environment gate.
+- `cargo test -p kamn-e2e-harness` passed the full package suite, including 255
+  library tests and the MVP disclosure, receipt, transcript, and verifier
+  contract binaries. Explicit local-runtime live probes remained ignored.
+- `make demo-mvp` returned `GO` in optional mode, with local-only claims labeled
+  separately and production readiness left `NOT_CLAIMED`.
+- The funded required-mode run returned `GO`, transferred 1,000,000 lamports on
+  Solana devnet, observed finalized balance movement, and persisted the same
+  settlement signature reported by the live service API.
+- The required-mode run wrote separate runtime-owned
+  `runtime-agent-a-participant-view.json`,
+  `runtime-agent-b-participant-view.json`, and
+  `runtime-agent-c-verifier-view.json` artifacts.
+- Canonical verification passed against `.kamn/demo/latest/proof/report.json`
+  after both optional and required-mode runs.
+
+## Deferred Boundary
+
+The runtime-owned projection artifacts are additive in this issue. The legacy
+canonical three-agent narrative and its generated view artifacts remain in the
+proof bundle until the plan's dependent transcript-replacement issue. They do
+not replace or manufacture the runtime projection responses, and they must not
+be cited as proof that independent Pi actors executed the transaction.

--- a/specs/7097-server-generated-disclosure-projections.md
+++ b/specs/7097-server-generated-disclosure-projections.md
@@ -1,0 +1,114 @@
+# Add Server-Generated Disclosure Projections
+
+## Objective
+
+Generate participant-private and restricted-public transaction views from the
+authenticated KAMN service API. Replace harness-authored disclosure claims with
+runtime responses derived from the same durable task, escrow, and settlement
+records.
+
+## Inputs/Outputs
+
+Signed `GET /v1/tasks/{task_id}/participant-view` requests identify the caller
+from the verified sender DID. Only the task creator or assigned provider may
+receive a participant response. Signed
+`GET /v1/tasks/{task_id}/verifier-view` requests return an allowlisted public
+projection to a registered caller with task-read scope.
+
+Both outputs include a schema version, task ID, task state, escrow ID, escrow
+state, settlement network, settlement signature when confirmed, commitment,
+and one deterministic public commitment over those shared fields. Participant
+output additionally includes the caller role and one or more real private
+transaction fields, including the task transition receipt digest. Verifier
+output never serializes participant receipt digests or private payload fields.
+
+## Boundaries/Non-goals
+
+- Reuse the existing signed service API, durable message store, task ownership,
+  escrow agreement, and settlement intent records.
+- Server serializers own disclosure. The client and E2E harness must not redact
+  a participant response to construct verifier evidence.
+- No generalized policy engine, field-encryption scheme, anonymous access,
+  web UI, or new dependency.
+- No Pi orchestration changes in this issue; independent actors consume these
+  routes in the dependent issue.
+- No mainnet, custody, dispute, refund, or multi-chain claim.
+
+## Failure Modes
+
+- Missing task: existing route-not-found response.
+- Unregistered or invalidly authenticated caller: existing authentication
+  response.
+- Participant caller is neither creator nor assigned provider:
+  `TASK_PARTICIPANT_VIEW_FORBIDDEN` (403).
+- Task has no bound escrow: `TASK_ESCROW_BINDING_MISSING` (409).
+- Durable task, escrow, or settlement records disagree:
+  `TRANSACTION_PROJECTION_INCONSISTENT` (500).
+- Persistence failure: existing observable state-persistence error (500).
+
+All failures are hard failures. A verifier view cannot fall back to a generated
+placeholder, client-provided commitment, or participant response.
+
+## Acceptance Criteria
+
+- [ ] Participant and verifier response types and serializers are separate.
+- [ ] Participant membership is derived from authenticated server context.
+- [ ] Unrelated and unregistered agents cannot retrieve participant output.
+- [ ] Verifier output is built from an explicit allowlist of durable fields.
+- [ ] Participant output contains at least one real field absent from verifier
+      output.
+- [ ] Verifier output contains no participant receipt or private payload digest.
+- [ ] Shared fields and deterministic public commitment match across views.
+- [ ] Confirmed devnet settlement fields come from persisted settlement evidence.
+- [ ] Signed HTTP integration tests exercise both routes against durable state.
+- [ ] The E2E harness can consume runtime responses without synthesizing private
+      or public digest labels.
+
+## Files To Touch
+
+- `crates/kamn-node/src/service_api_endpoint/models.rs` or a focused projection
+  model module
+- `crates/kamn-node/src/service_api_endpoint/message_store/` projection reads
+- `crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/queries.rs`
+  and focused route helpers
+- service API task/escrow authorization integration contracts
+- `crates/kamn-e2e-harness/src/mvp_demo/three_agent_views.rs` only for runtime
+  response consumption and artifact persistence
+
+## Error Semantics
+
+Interior projection code returns structured reason codes with task ID and
+requester DID context. It does not log. The HTTP route catches once, logs via
+the existing request boundary, and returns the stable status/code pair. Missing
+or inconsistent durable state never produces a partial projection.
+
+## Test Plan
+
+RED:
+
+- An unrelated registered Agent C can retrieve participant-private output.
+- Participant and verifier routes return the same response shape.
+- Verifier output exposes a transition receipt or participant-private digest.
+- Shared public commitment differs between participant and verifier output.
+- Harness-generated view evidence passes without a runtime projection response.
+
+GREEN:
+
+- Add focused projection models and one deterministic shared-field commitment.
+- Add store reads that join task, bound escrow, and settlement evidence.
+- Add signed participant and verifier query routes with explicit authorization.
+- Feed runtime responses into the existing three-agent proof artifact boundary.
+
+REFACTOR:
+
+- Keep files below 200 lines and functions below 25 lines.
+- Centralize shared-field projection and commitment generation without merging
+  participant and verifier serializers.
+- Remove synthetic digest construction made obsolete by runtime responses.
+
+INTEGRATION:
+
+- Run signed HTTP participant/verifier contracts, full `kamn-node`, full
+  `kamn-e2e-harness`, formatting, strict workspace clippy, and `make check`.
+- Run `make demo-mvp` and canonical verification. This issue proves server
+  disclosure behavior; it does not claim independent Pi execution yet.


### PR DESCRIPTION
## Human Summary

- Adds authenticated participant-private and restricted verifier projections derived from durable task, escrow, and settlement state.
- Uses separate serializers and explicit verifier allowlisting so third-party verification excludes participant receipt details.
- Binds shared facts with a SHA-256 commitment and fails closed when settlement intent, network, amount, signature, or escrow state disagree.
- Captures the three runtime-owned disclosure responses in funded MVP devnet proof runs while preserving the legacy narrative replacement as a later issue.

Closes #7097

Spec: `specs/7097-server-generated-disclosure-projections.md`

## Testing

- `cargo test -p kamn-node projection -- --nocapture`
- `cargo test -p kamn-sdk projection -- --nocapture`
- `cargo test -p kamn-e2e-harness three_agent -- --nocapture`
- `cargo test -p kamn-node`
- `cargo test -p kamn-e2e-harness`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `make check`
- `make demo-mvp`
- Funded required-mode `make demo-mvp` against `https://api.devnet.solana.com`: GO, finalized 1,000,000-lamport movement, persisted signature parity
- `cargo run -p kamn-e2e-harness -- verify-mvp-demo --report .kamn/demo/latest/proof/report.json`

## Notes for Reviewers

The runtime projection artifacts are additive. Legacy generated three-agent narrative artifacts remain until the plan's transcript-replacement issue and are not claimed as independent Pi actor evidence.

Review focus: authorization boundaries, durable settlement consistency checks, verifier field allowlist, and public commitment framing.

## Post-Deploy Monitoring & Validation

- Re-run the signed participant/verifier route contracts after merge.
- Run the canonical optional-mode demo and verifier from a clean checkout.
- During funded rehearsals, require finalized devnet evidence and confirm all three runtime projection artifacts exist.
- Treat any missing projection, commitment mismatch, or settlement-state disagreement as a hard NO-GO.

## AI Agent Details

- Server routes: signed participant and verifier task projections.
- SDK/agent surfaces: typed projection queries preserving server response bodies.
- Harness: captures runtime Agent A/B participant views and Agent C verifier view during the live-service devnet path.
- Commitment: SHA-256 over length-framed shared projection fields.
- No dependency, schema, CI, or public route contract changes beyond the issue-scoped endpoints.
