### PR TITLE
[7101] Replace generated narrative with runtime receipt chain

### DIFF
--- a/.pi/extensions/kamn-mvp/mcp-provenance.ts
+++ b/.pi/extensions/kamn-mvp/mcp-provenance.ts
@@ -1,11 +1,16 @@
 import { createHash } from "node:crypto";
 
 type JsonObject = Record<string, unknown>;
+const PUBLIC_RESULT_FIELDS = new Set([
+	"did", "task_id", "state", "transaction_id", "escrow_id", "amount_lamports", "network",
+	"settlement_tx_signature", "settlement_commitment", "public_commitment", "view_scope", "participant_role",
+]);
 export type McpResponseReceipt = {
 	request_id: number;
 	tool: string;
 	outcome: "success" | "error";
 	digest: string;
+	public_result: JsonObject;
 };
 export type McpSessionProvenance = {
 	child_process_id: number;
@@ -21,7 +26,10 @@ export class McpProvenanceTracker {
 		const requestId = Number(id);
 		if (!Number.isSafeInteger(requestId) || requestId <= 0) throw new Error("KAMN live MCP request ID is invalid");
 		const digest = createHash("sha256").update(JSON.stringify(payload)).digest("hex");
-		this.receipts.push({ request_id: requestId, tool, outcome, digest: `sha256:${digest}` });
+		this.receipts.push({
+			request_id: requestId, tool, outcome, digest: `sha256:${digest}`,
+			public_result: outcome === "success" ? publicResult(payload) : {},
+		});
 	}
 	provenance(childProcessId: number): McpSessionProvenance {
 		const first = this.receipts[0];
@@ -35,4 +43,10 @@ export class McpProvenanceTracker {
 			runtime_response_receipts: this.receipts.map((receipt) => ({ ...receipt })),
 		};
 	}
+}
+
+function publicResult(payload: JsonObject): JsonObject {
+	return Object.fromEntries(Object.entries(payload).filter(([field, value]) =>
+		PUBLIC_RESULT_FIELDS.has(field) && ["string", "number", "boolean"].includes(typeof value),
+	));
 }

--- a/.pi/extensions/kamn-mvp/mcp-session.test.ts
+++ b/.pi/extensions/kamn-mvp/mcp-session.test.ts
@@ -37,8 +37,8 @@ test("session provenance binds child process, request range, and runtime respons
 		last_request_id: 2,
 		runtime_response_digests: [responseDigest(registered), responseDigest(queried)],
 		runtime_response_receipts: [
-			{ request_id: 1, tool: "register", outcome: "success", digest: responseDigest(registered) },
-			{ request_id: 2, tool: "query_agent_profile", outcome: "success", digest: responseDigest(queried) },
+			{ request_id: 1, tool: "register", outcome: "success", digest: responseDigest(registered), public_result: { did: registered.did } },
+			{ request_id: 2, tool: "query_agent_profile", outcome: "success", digest: responseDigest(queried), public_result: { did: queried.did } },
 		],
 	});
 	await session.shutdown();
@@ -61,9 +61,9 @@ test("session provenance keeps handled error responses in the contiguous request
 			responseDigest(queried),
 		],
 		runtime_response_receipts: [
-			{ request_id: 1, tool: "register", outcome: "success", digest: responseDigest(registered) },
-			{ request_id: 2, tool: "release_escrow", outcome: "error", digest: responseDigest({ kind: "backend_error", message: "forced backend failure" }) },
-			{ request_id: 3, tool: "query_agent_profile", outcome: "success", digest: responseDigest(queried) },
+			{ request_id: 1, tool: "register", outcome: "success", digest: responseDigest(registered), public_result: { did: registered.did } },
+			{ request_id: 2, tool: "release_escrow", outcome: "error", digest: responseDigest({ kind: "backend_error", message: "forced backend failure" }), public_result: {} },
+			{ request_id: 3, tool: "query_agent_profile", outcome: "success", digest: responseDigest(queried), public_result: { did: queried.did } },
 		],
 	});
 	await session.shutdown();

--- a/.pi/extensions/kamn-mvp/pi-transaction-evidence.test.ts
+++ b/.pi/extensions/kamn-mvp/pi-transaction-evidence.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp } from "node:fs/promises";
+import { mkdtemp, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { resolve } from "node:path";
 import test from "node:test";
@@ -95,6 +95,17 @@ test("actor evidence accepts interim and final successful projection reads", asy
 	await assert.doesNotReject(verifyPiTransactionActors(paths));
 });
 
+test("actor evidence preserves strict public runtime result projections", async () => {
+	const paths = await actorPaths();
+	await writePiTransactionActor(paths.agent_a, actor("agent_a"));
+	const written = JSON.parse(await readFile(paths.agent_a, "utf8"));
+
+	assert.deepEqual(written.runtime_response_receipts[1].public_result, {
+		task_id: "task-live-7099", state: "submitted", transaction_id: "transaction-live-7099",
+	});
+	assert.equal("private_receipt_digest" in written.runtime_response_receipts.at(-1).public_result, false);
+});
+
 type Role = "agent_a" | "agent_b" | "agent_c";
 type Overrides = Partial<Record<Role, Record<string, unknown>>>;
 
@@ -146,7 +157,19 @@ function runtimeReceipts(role: Role) {
 		tool,
 		outcome: "success",
 		digest: `sha256:${String(index + 1 === 5 ? { agent_a: 1, agent_b: 2, agent_c: 3 }[role] : index + 1).repeat(64)}`,
+		public_result: publicResult(role, tool),
 	}));
+}
+
+function publicResult(role: Role, tool: string): Record<string, unknown> {
+	if (tool === "register") return { did: `kamn:did:${({ agent_a: "a", agent_b: "b", agent_c: "c" })[role]}` };
+	if (tool === "create_task") return { task_id: "task-live-7099", state: "submitted", transaction_id: "transaction-live-7099" };
+	if (tool === "accept_task") return { task_id: "task-live-7099", state: "accepted", transaction_id: "transaction-live-7099" };
+	if (tool === "complete_task") return { task_id: "task-live-7099", state: "completed", transaction_id: "transaction-live-7099" };
+	if (tool === "fund_escrow") return { task_id: "task-live-7099", escrow_id: "escrow-live-7099", state: "funded", amount_lamports: 1000000, network: "solana-devnet" };
+	if (tool === "release_escrow") return { escrow_id: "escrow-live-7099", state: "released", settlement_tx_signature: "devnet-signature-7099", settlement_commitment: "finalized" };
+	if (tool.includes("projection")) return { task_id: "task-live-7099", escrow_id: "escrow-live-7099", settlement_tx_signature: "devnet-signature-7099", settlement_commitment: "finalized", public_commitment: `sha256:${"d".repeat(64)}`, view_scope: role === "agent_c" ? "restricted-public" : "participant-private", ...(role === "agent_c" ? {} : { participant_role: role === "agent_a" ? "creator" : "provider" }) };
+	return { task_id: "task-live-7099", state: "accepted" };
 }
 
 async function actorPaths(): Promise<Record<Role, string>> {

--- a/.pi/extensions/kamn-mvp/pi-transaction-evidence.test.ts
+++ b/.pi/extensions/kamn-mvp/pi-transaction-evidence.test.ts
@@ -83,6 +83,7 @@ test("actor evidence accepts interim and final successful projection reads", asy
 	const receipts = runtimeReceipts("agent_b");
 	receipts.splice(4, 0, {
 		request_id: 5, tool: "query_participant_task_projection", outcome: "success", digest: `sha256:${"8".repeat(64)}`,
+		public_result: publicResult("agent_b", "query_participant_task_projection"),
 	});
 	receipts[5] = { ...receipts[5], request_id: 6, digest: finalDigest };
 	await writeActors(paths, { agent_b: {

--- a/.pi/extensions/kamn-mvp/pi-transaction-runtime-receipts.ts
+++ b/.pi/extensions/kamn-mvp/pi-transaction-runtime-receipts.ts
@@ -1,5 +1,12 @@
 export type Role = "agent_a" | "agent_b" | "agent_c";
-export type RuntimeReceipt = { request_id: number; tool: string; outcome: "success" | "error"; digest: string };
+type PublicResult = Record<string, string | number>;
+const PUBLIC_STRING_FIELDS = new Set([
+	"did", "task_id", "state", "transaction_id", "escrow_id", "network", "settlement_tx_signature",
+	"settlement_commitment", "public_commitment", "view_scope", "participant_role",
+]);
+export type RuntimeReceipt = {
+	request_id: number; tool: string; outcome: "success" | "error"; digest: string; public_result: PublicResult;
+};
 
 export function normalizeRuntimeReceipts(value: unknown): RuntimeReceipt[] {
 	if (!Array.isArray(value) || value.length === 0) throw mismatch();
@@ -36,7 +43,23 @@ function normalizeReceipt(value: unknown): RuntimeReceipt {
 		tool: requiredString(value.tool),
 		outcome,
 		digest: shaDigest(value.digest),
+		public_result: normalizePublicResult(value.public_result, outcome),
 	};
+}
+
+function normalizePublicResult(value: unknown, outcome: RuntimeReceipt["outcome"]): PublicResult {
+	if (!isRecord(value)) throw mismatch();
+	if (outcome === "error") {
+		if (Object.keys(value).length !== 0) throw mismatch();
+		return {};
+	}
+	return Object.fromEntries(Object.entries(value).map(([field, entry]) => [field, publicValue(field, entry)]));
+}
+
+function publicValue(field: string, value: unknown): string | number {
+	if (field === "amount_lamports" && typeof value === "number" && Number.isSafeInteger(value) && value > 0) return value;
+	if (PUBLIC_STRING_FIELDS.has(field) && typeof value === "string" && value.trim()) return value;
+	throw mismatch();
 }
 
 function requiredMutationTools(role: Role): string[] {

--- a/crates/kamn-e2e-harness/src/lib.rs
+++ b/crates/kamn-e2e-harness/src/lib.rs
@@ -5,8 +5,9 @@ use std::collections::HashSet;
 use std::path::Path;
 
 pub use mvp_demo::{
-    execute_mvp_demo_contract, execute_verify_mvp_demo_contract, verify_pi_transaction_actor_paths,
-    LiveTaskEvidencePaths, MvpDemoCommandConfig, VerifyMvpDemoCommandConfig,
+    build_runtime_receipt_chain_from_actor_paths, execute_mvp_demo_contract,
+    execute_verify_mvp_demo_contract, verify_pi_transaction_actor_paths, LiveTaskEvidencePaths,
+    MvpDemoCommandConfig, VerifyMvpDemoCommandConfig,
 };
 
 /// Driver implementations for each execution mode.

--- a/crates/kamn-e2e-harness/src/lib.rs
+++ b/crates/kamn-e2e-harness/src/lib.rs
@@ -247,7 +247,7 @@ pub enum HarnessCommand {
     /// Verify an evidence bundle.
     Verify(VerifyCommandConfig),
     /// Generate the MVP evaluator demo proof report.
-    DemoMvp(MvpDemoCommandConfig),
+    DemoMvp(Box<MvpDemoCommandConfig>),
     /// Verify an MVP evaluator demo proof report.
     VerifyMvpDemo(VerifyMvpDemoCommandConfig),
 }
@@ -445,7 +445,7 @@ fn parse_demo_mvp_command(args: &[String]) -> Result<HarnessCommand, String> {
         }
         return Err(format!("unknown demo-mvp flag: {}", args[index]));
     }
-    Ok(HarnessCommand::DemoMvp(MvpDemoCommandConfig {
+    Ok(HarnessCommand::DemoMvp(Box::new(MvpDemoCommandConfig {
         output_root: output_root
             .unwrap_or_else(|| mvp_demo::DEFAULT_MVP_DEMO_OUTPUT_ROOT.to_owned()),
         devnet_mode: mvp_devnet_mode_from_env(),
@@ -457,7 +457,16 @@ fn parse_demo_mvp_command(args: &[String]) -> Result<HarnessCommand, String> {
         agent_harness_evidence_path: agent_harness_evidence_path
             .or_else(mvp_agent_harness_evidence_path_from_env),
         live_task_evidence: mvp_live_task_evidence_from_env()?,
-    }))
+        pi_transaction_actor_paths: mvp_pi_transaction_actor_paths_from_env()?,
+    })))
+}
+
+fn mvp_pi_transaction_actor_paths_from_env() -> Result<Option<[String; 3]>, String> {
+    complete_pi_actor_paths([
+        std::env::var("KAMN_MVP_PI_TRANSACTION_AGENT_A_FILE").ok(),
+        std::env::var("KAMN_MVP_PI_TRANSACTION_AGENT_B_FILE").ok(),
+        std::env::var("KAMN_MVP_PI_TRANSACTION_AGENT_C_FILE").ok(),
+    ])
 }
 
 fn parse_verify_mvp_demo_command(args: &[String]) -> Result<HarnessCommand, String> {

--- a/crates/kamn-e2e-harness/src/mvp_demo/command_config.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/command_config.rs
@@ -32,6 +32,8 @@ pub struct MvpDemoCommandConfig {
     pub agent_harness_evidence_path: Option<String>,
     /// Optional all-or-none independent live task evidence paths.
     pub live_task_evidence: Option<LiveTaskEvidencePaths>,
+    /// Optional complete Agent A, Agent B, and Agent C runtime evidence set.
+    pub pi_transaction_actor_paths: Option<[String; 3]>,
 }
 
 /// Parsed `verify-mvp-demo` command configuration.

--- a/crates/kamn-e2e-harness/src/mvp_demo/mod.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/mod.rs
@@ -37,6 +37,7 @@ mod report_writer;
 mod runner;
 mod runner_settlement;
 mod runtime_receipt_chain;
+mod runtime_receipt_chain_precheck;
 mod service_api_proof;
 mod three_agent_claim;
 mod three_agent_receipt_spec;

--- a/crates/kamn-e2e-harness/src/mvp_demo/mod.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/mod.rs
@@ -45,6 +45,7 @@ mod three_agent_receipt_verify;
 mod three_agent_receipt_verify_support;
 mod three_agent_receipt_write;
 mod three_agent_receipts;
+mod three_agent_runtime_chain;
 mod three_agent_transcript;
 mod three_agent_transcript_build;
 mod three_agent_verify;

--- a/crates/kamn-e2e-harness/src/mvp_demo/mod.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/mod.rs
@@ -36,6 +36,7 @@ mod report_markdown;
 mod report_writer;
 mod runner;
 mod runner_settlement;
+mod runtime_receipt_chain;
 mod service_api_proof;
 mod three_agent_claim;
 mod three_agent_receipt_spec;
@@ -59,6 +60,7 @@ pub use report::{
     CLAIM_LABEL_PLACEHOLDER, CLAIM_LABEL_REAL, CLAIM_LABEL_ROADMAP, MVP_DEMO_REPORT_SCHEMA_VERSION,
 };
 pub use runner::{execute_mvp_demo_contract, execute_verify_mvp_demo_contract};
+pub use runtime_receipt_chain::build_runtime_receipt_chain_from_actor_paths;
 pub use verify::verify_mvp_demo_report_json;
 
 pub(crate) const DEFAULT_MVP_DEMO_OUTPUT_ROOT: &str = ".kamn/demo";

--- a/crates/kamn-e2e-harness/src/mvp_demo/mod.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/mod.rs
@@ -28,6 +28,7 @@ mod local_artifacts;
 mod localhost_signed;
 mod pi_transaction_actor_model;
 mod pi_transaction_actor_verify;
+mod pi_transaction_public_result;
 mod report;
 mod report_artifacts;
 mod report_devnet;

--- a/crates/kamn-e2e-harness/src/mvp_demo/mod.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/mod.rs
@@ -37,6 +37,7 @@ mod report_writer;
 mod runner;
 mod runner_settlement;
 mod runtime_receipt_chain;
+mod runtime_receipt_chain_facts;
 mod runtime_receipt_chain_precheck;
 mod service_api_proof;
 mod three_agent_claim;

--- a/crates/kamn-e2e-harness/src/mvp_demo/pi_transaction_actor_model.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/pi_transaction_actor_model.rs
@@ -1,4 +1,4 @@
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use super::pi_transaction_public_result::{validate_public_result, PublicResult};
 
@@ -43,7 +43,7 @@ pub(super) struct RuntimeReceipt {
     pub(super) public_result: PublicResult,
 }
 
-#[derive(Deserialize, PartialEq, Eq)]
+#[derive(Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub(super) enum Outcome {
     Success,

--- a/crates/kamn-e2e-harness/src/mvp_demo/pi_transaction_actor_model.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/pi_transaction_actor_model.rs
@@ -1,19 +1,21 @@
 use serde::Deserialize;
 
+use super::pi_transaction_public_result::{validate_public_result, PublicResult};
+
 const SCHEMA: &str = "kamn.mvp.pi-transaction-actor.v1";
 
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(super) struct Actor {
     schema_version: String,
-    actor: String,
+    pub(super) actor: String,
     pub(super) pi_process_id: u64,
     pub(super) did: String,
     pub(super) mcp_child_process_id: u64,
     first_request_id: u64,
     last_request_id: u64,
     runtime_response_digests: Vec<String>,
-    runtime_response_receipts: Vec<RuntimeReceipt>,
+    pub(super) runtime_response_receipts: Vec<RuntimeReceipt>,
     runtime_projection_digest: String,
     pub(super) task_id: String,
     pub(super) transaction_id: String,
@@ -33,16 +35,17 @@ pub(super) struct Actor {
 
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
-struct RuntimeReceipt {
-    request_id: u64,
-    tool: String,
-    outcome: Outcome,
-    digest: String,
+pub(super) struct RuntimeReceipt {
+    pub(super) request_id: u64,
+    pub(super) tool: String,
+    pub(super) outcome: Outcome,
+    pub(super) digest: String,
+    pub(super) public_result: PublicResult,
 }
 
 #[derive(Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
-enum Outcome {
+pub(super) enum Outcome {
     Success,
     Error,
 }
@@ -86,6 +89,7 @@ fn validate_runtime_receipts(actor: &Actor) -> Result<(), String> {
         {
             return Err(mismatch());
         }
+        validate_public_result(&receipt.public_result, receipt.outcome == Outcome::Error)?;
     }
     require_operations(actor)?;
     validate_projection_receipt(actor)

--- a/crates/kamn-e2e-harness/src/mvp_demo/pi_transaction_actor_verify.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/pi_transaction_actor_verify.rs
@@ -6,15 +6,28 @@ const ROLES: [&str; 3] = ["agent_a", "agent_b", "agent_c"];
 
 /// Verifies three independent Pi actor artifacts and returns shared evidence.
 pub fn verify_pi_transaction_actor_paths(paths: &[String; 3]) -> Result<String, String> {
-    let actors = [
-        read_actor(paths[0].as_str(), ROLES[0])?,
-        read_actor(paths[1].as_str(), ROLES[1])?,
-        read_actor(paths[2].as_str(), ROLES[2])?,
-    ];
+    let actors = read_and_validate_actors(paths)?;
+    shared_summary(&actors)
+}
+
+pub(super) fn read_and_validate_actors(paths: &[String; 3]) -> Result<[Actor; 3], String> {
+    let actors = read_actors(paths)?;
     require_distinct_u64(&actors, |actor| actor.pi_process_id)?;
     require_distinct_u64(&actors, |actor| actor.mcp_child_process_id)?;
     require_distinct_dids(&actors)?;
     require_shared_facts(&actors)?;
+    Ok(actors)
+}
+
+fn read_actors(paths: &[String; 3]) -> Result<[Actor; 3], String> {
+    Ok([
+        read_actor(paths[0].as_str(), ROLES[0])?,
+        read_actor(paths[1].as_str(), ROLES[1])?,
+        read_actor(paths[2].as_str(), ROLES[2])?,
+    ])
+}
+
+fn shared_summary(actors: &[Actor; 3]) -> Result<String, String> {
     serde_json::to_string(&serde_json::json!({
         "task_id": actors[0].task_id,
         "escrow_id": actors[0].escrow_id,

--- a/crates/kamn-e2e-harness/src/mvp_demo/pi_transaction_public_result.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/pi_transaction_public_result.rs
@@ -1,0 +1,52 @@
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct PublicResult {
+    pub(super) did: Option<String>,
+    pub(super) task_id: Option<String>,
+    pub(super) state: Option<String>,
+    pub(super) transaction_id: Option<String>,
+    pub(super) escrow_id: Option<String>,
+    pub(super) amount_lamports: Option<u64>,
+    pub(super) network: Option<String>,
+    pub(super) settlement_tx_signature: Option<String>,
+    pub(super) settlement_commitment: Option<String>,
+    pub(super) public_commitment: Option<String>,
+    pub(super) view_scope: Option<String>,
+    pub(super) participant_role: Option<String>,
+}
+
+pub(super) fn validate_public_result(result: &PublicResult, is_error: bool) -> Result<(), String> {
+    let values = result.string_values();
+    if values.iter().flatten().any(|value| value.is_empty()) || result.amount_lamports == Some(0) {
+        return Err(invalid());
+    }
+    let is_empty = values.iter().all(|value| value.is_none()) && result.amount_lamports.is_none();
+    if is_error != is_empty {
+        return Err(invalid());
+    }
+    Ok(())
+}
+
+impl PublicResult {
+    fn string_values(&self) -> [Option<&str>; 11] {
+        [
+            self.did.as_deref(),
+            self.task_id.as_deref(),
+            self.state.as_deref(),
+            self.transaction_id.as_deref(),
+            self.escrow_id.as_deref(),
+            self.network.as_deref(),
+            self.settlement_tx_signature.as_deref(),
+            self.settlement_commitment.as_deref(),
+            self.public_commitment.as_deref(),
+            self.view_scope.as_deref(),
+            self.participant_role.as_deref(),
+        ]
+    }
+}
+
+fn invalid() -> String {
+    "RUNTIME_RECEIPT_CHAIN_PUBLIC_RESULT_INVALID".to_owned()
+}

--- a/crates/kamn-e2e-harness/src/mvp_demo/pi_transaction_public_result.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/pi_transaction_public_result.rs
@@ -1,6 +1,6 @@
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub(super) struct PublicResult {
     pub(super) did: Option<String>,

--- a/crates/kamn-e2e-harness/src/mvp_demo/runner.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/runner.rs
@@ -65,11 +65,11 @@ fn validate_direct_evidence(
     if let Some(path) = config.agent_harness_evidence_path.as_deref() {
         validate_agent_harness_evidence_path(report, config.report.as_str(), path)?;
     }
-    config
-        .pi_transaction_actor_paths
-        .as_ref()
-        .map(super::pi_transaction_actor_verify::verify_pi_transaction_actor_paths)
-        .transpose()
+    let Some(paths) = config.pi_transaction_actor_paths.as_ref() else {
+        return Ok(None);
+    };
+    super::three_agent_transcript::require_runtime_chain_source(report)?;
+    super::pi_transaction_actor_verify::verify_pi_transaction_actor_paths(paths).map(Some)
 }
 
 fn render_verify_output(config: &VerifyMvpDemoCommandConfig, summary: Option<String>) -> String {

--- a/crates/kamn-e2e-harness/src/mvp_demo/runner.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/runner.rs
@@ -68,7 +68,9 @@ fn validate_direct_evidence(
     let Some(paths) = config.pi_transaction_actor_paths.as_ref() else {
         return Ok(None);
     };
-    super::three_agent_transcript::require_runtime_chain_source(report)?;
+    let expected =
+        super::runtime_receipt_chain::build_runtime_receipt_chain_from_actor_paths(paths)?;
+    super::three_agent_transcript::require_runtime_chain_source(report, expected.as_str())?;
     super::pi_transaction_actor_verify::verify_pi_transaction_actor_paths(paths).map(Some)
 }
 

--- a/crates/kamn-e2e-harness/src/mvp_demo/runner_settlement.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/runner_settlement.rs
@@ -24,7 +24,7 @@ pub(super) fn create_bound_settlement(
     let binding = create_binding(config, run_dir)?;
     let settlement = create_settlement(config, run_dir, binding.as_ref())?;
     let artifact_digests =
-        create_three_agent_artifacts(run_id, &settlement, binding.as_ref(), run_dir)?;
+        create_three_agent_artifacts(config, run_id, &settlement, binding.as_ref(), run_dir)?;
     Ok(BoundSettlement {
         binding,
         settlement,
@@ -61,6 +61,7 @@ fn create_settlement(
 }
 
 fn create_three_agent_artifacts(
+    config: &MvpDemoCommandConfig,
     run_id: &str,
     settlement: &DevnetSettlementAttempt,
     binding: Option<&LiveTaskBinding>,
@@ -71,7 +72,14 @@ fn create_three_agent_artifacts(
     };
     let views = write_three_agent_views(run_id, evidence, binding, run_dir)?;
     let receipts = write_three_agent_receipts(run_id, evidence, binding, run_dir, &views)?;
-    let transcript = write_three_agent_transcript(run_id, evidence, binding, run_dir, &views)?;
+    let transcript = write_three_agent_transcript(
+        run_id,
+        evidence,
+        binding,
+        run_dir,
+        &views,
+        config.pi_transaction_actor_paths.as_ref(),
+    )?;
     Ok(Some(ThreeAgentArtifactDigests {
         transcript,
         views,

--- a/crates/kamn-e2e-harness/src/mvp_demo/runtime_receipt_chain.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/runtime_receipt_chain.rs
@@ -11,6 +11,14 @@ const SCHEMA: &str = "kamn.mvp.runtime-receipt-chain.v1";
 #[derive(Serialize)]
 struct Chain<'a> {
     schema_version: &'static str,
+    task_id: &'a str,
+    transaction_id: &'a str,
+    escrow_id: &'a str,
+    amount_lamports: u64,
+    network: &'a str,
+    settlement_tx_signature: &'a str,
+    settlement_commitment: &'a str,
+    public_commitment: &'a str,
     steps: Vec<Step<'a>>,
     chain_digest: &'static str,
 }
@@ -47,6 +55,14 @@ pub fn build_runtime_receipt_chain_from_actor_paths(paths: &[String; 3]) -> Resu
         .collect::<Result<Vec<_>, _>>()?;
     let raw = serde_json::to_string(&Chain {
         schema_version: SCHEMA,
+        task_id: actors[0].task_id.as_str(),
+        transaction_id: actors[0].transaction_id.as_str(),
+        escrow_id: actors[0].escrow_id.as_str(),
+        amount_lamports: actors[0].amount_lamports,
+        network: actors[0].network.as_str(),
+        settlement_tx_signature: actors[0].settlement_tx_signature.as_str(),
+        settlement_commitment: actors[0].settlement_commitment.as_str(),
+        public_commitment: actors[0].public_commitment.as_str(),
         steps,
         chain_digest: "",
     })

--- a/crates/kamn-e2e-harness/src/mvp_demo/runtime_receipt_chain.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/runtime_receipt_chain.rs
@@ -4,6 +4,7 @@ use super::artifact_digest::attach_json_digest;
 use super::pi_transaction_actor_model::{Actor, Outcome, RuntimeReceipt};
 use super::pi_transaction_actor_verify::read_and_validate_actors;
 use super::pi_transaction_public_result::PublicResult;
+use super::runtime_receipt_chain_facts::validate_step_public_result;
 use super::runtime_receipt_chain_precheck::precheck_required_operations;
 
 const SCHEMA: &str = "kamn.mvp.runtime-receipt-chain.v1";
@@ -73,6 +74,12 @@ pub fn build_runtime_receipt_chain_from_actor_paths(paths: &[String; 3]) -> Resu
 fn build_step<'a>(actors: &'a [Actor; 3], required: &RequiredStep) -> Result<Step<'a>, String> {
     let actor = &actors[required.actor_index];
     let receipt = select_receipt(actor, required)?;
+    validate_step_public_result(
+        actor,
+        required.action,
+        required.after,
+        &receipt.public_result,
+    )?;
     Ok(Step {
         actor: actor.actor.as_str(),
         action: required.action,

--- a/crates/kamn-e2e-harness/src/mvp_demo/runtime_receipt_chain.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/runtime_receipt_chain.rs
@@ -1,0 +1,150 @@
+use serde::Serialize;
+
+use super::artifact_digest::attach_json_digest;
+use super::pi_transaction_actor_model::{Actor, Outcome, RuntimeReceipt};
+use super::pi_transaction_actor_verify::read_and_validate_actors;
+use super::pi_transaction_public_result::PublicResult;
+
+const SCHEMA: &str = "kamn.mvp.runtime-receipt-chain.v1";
+
+#[derive(Serialize)]
+struct Chain<'a> {
+    schema_version: &'static str,
+    steps: Vec<Step<'a>>,
+    chain_digest: &'static str,
+}
+
+#[derive(Serialize)]
+struct Step<'a> {
+    actor: &'a str,
+    action: &'a str,
+    request_id: u64,
+    outcome: &'a Outcome,
+    response_digest: &'a str,
+    state_domain: &'static str,
+    before_state: &'static str,
+    after_state: &'static str,
+    public_result: &'a PublicResult,
+}
+
+struct RequiredStep {
+    actor_index: usize,
+    action: &'static str,
+    domain: &'static str,
+    before: &'static str,
+    after: &'static str,
+    final_match: bool,
+}
+
+/// Builds a digested transaction chain from three verified Pi actor artifacts.
+pub fn build_runtime_receipt_chain_from_actor_paths(paths: &[String; 3]) -> Result<String, String> {
+    let actors = read_and_validate_actors(paths)?;
+    let steps = required_steps()
+        .iter()
+        .map(|required| build_step(&actors, required))
+        .collect::<Result<Vec<_>, _>>()?;
+    let raw = serde_json::to_string(&Chain {
+        schema_version: SCHEMA,
+        steps,
+        chain_digest: "",
+    })
+    .map_err(|_| artifact_mismatch())?;
+    Ok(attach_json_digest(raw, "chain_digest")?.json)
+}
+
+fn build_step<'a>(actors: &'a [Actor; 3], required: &RequiredStep) -> Result<Step<'a>, String> {
+    let actor = &actors[required.actor_index];
+    let receipt = select_receipt(actor, required)?;
+    Ok(Step {
+        actor: actor.actor.as_str(),
+        action: required.action,
+        request_id: receipt.request_id,
+        outcome: &receipt.outcome,
+        response_digest: receipt.digest.as_str(),
+        state_domain: required.domain,
+        before_state: required.before,
+        after_state: required.after,
+        public_result: &receipt.public_result,
+    })
+}
+
+fn select_receipt<'a>(
+    actor: &'a Actor,
+    required: &RequiredStep,
+) -> Result<&'a RuntimeReceipt, String> {
+    let matches = actor
+        .runtime_response_receipts
+        .iter()
+        .filter(|receipt| receipt.tool == required.action && receipt.outcome == Outcome::Success)
+        .collect::<Vec<_>>();
+    if matches.is_empty() {
+        return Err("RUNTIME_RECEIPT_CHAIN_STEP_MISSING".to_owned());
+    }
+    if !required.final_match && matches.len() != 1 {
+        return Err("RUNTIME_RECEIPT_CHAIN_STEP_DUPLICATED".to_owned());
+    }
+    matches.last().copied().ok_or_else(missing)
+}
+
+fn required_steps() -> [RequiredStep; 11] {
+    [
+        required(0, "register", "identity", "none", "registered", false),
+        required(1, "register", "identity", "none", "registered", false),
+        required(2, "register", "identity", "none", "registered", false),
+        required(0, "create_task", "task", "none", "submitted", false),
+        required(1, "accept_task", "task", "submitted", "accepted", false),
+        required(0, "fund_escrow", "escrow", "none", "funded", false),
+        required(1, "complete_task", "task", "accepted", "completed", false),
+        required(0, "release_escrow", "escrow", "funded", "released", false),
+        required(
+            0,
+            "query_participant_task_projection",
+            "projection",
+            "completed",
+            "completed",
+            true,
+        ),
+        required(
+            1,
+            "query_participant_task_projection",
+            "projection",
+            "completed",
+            "completed",
+            true,
+        ),
+        required(
+            2,
+            "query_verifier_task_projection",
+            "projection",
+            "completed",
+            "completed",
+            true,
+        ),
+    ]
+}
+
+fn required(
+    actor_index: usize,
+    action: &'static str,
+    domain: &'static str,
+    before: &'static str,
+    after: &'static str,
+    final_match: bool,
+) -> RequiredStep {
+    RequiredStep {
+        actor_index,
+        action,
+        domain,
+        before,
+        after,
+        final_match,
+    }
+}
+
+fn missing() -> String {
+    "RUNTIME_RECEIPT_CHAIN_STEP_MISSING".to_owned()
+}
+
+fn artifact_mismatch() -> String {
+    "RUNTIME_RECEIPT_CHAIN_ARTIFACT_MISMATCH".to_owned()
+}

--- a/crates/kamn-e2e-harness/src/mvp_demo/runtime_receipt_chain.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/runtime_receipt_chain.rs
@@ -38,7 +38,7 @@ struct RequiredStep {
 
 /// Builds a digested transaction chain from three verified Pi actor artifacts.
 pub fn build_runtime_receipt_chain_from_actor_paths(paths: &[String; 3]) -> Result<String, String> {
-    let actors = read_and_validate_actors(paths)?;
+    let actors = read_and_validate_actors(paths).map_err(map_actor_error)?;
     let steps = required_steps()
         .iter()
         .map(|required| build_step(&actors, required))
@@ -147,4 +147,13 @@ fn missing() -> String {
 
 fn artifact_mismatch() -> String {
     "RUNTIME_RECEIPT_CHAIN_ARTIFACT_MISMATCH".to_owned()
+}
+
+fn map_actor_error(error: String) -> String {
+    match error.as_str() {
+        "PI_RUNTIME_RECEIPT_MISMATCH" => "RUNTIME_RECEIPT_CHAIN_STEP_MISSING".to_owned(),
+        "PI_TRANSACTION_FACT_MISMATCH" => "RUNTIME_RECEIPT_CHAIN_FACT_MISMATCH".to_owned(),
+        "PI_VERIFIER_PRIVATE_LEAK" => "RUNTIME_RECEIPT_CHAIN_VERIFIER_PRIVATE_LEAK".to_owned(),
+        _ => error,
+    }
 }

--- a/crates/kamn-e2e-harness/src/mvp_demo/runtime_receipt_chain.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/runtime_receipt_chain.rs
@@ -4,6 +4,7 @@ use super::artifact_digest::attach_json_digest;
 use super::pi_transaction_actor_model::{Actor, Outcome, RuntimeReceipt};
 use super::pi_transaction_actor_verify::read_and_validate_actors;
 use super::pi_transaction_public_result::PublicResult;
+use super::runtime_receipt_chain_precheck::precheck_required_operations;
 
 const SCHEMA: &str = "kamn.mvp.runtime-receipt-chain.v1";
 
@@ -38,6 +39,7 @@ struct RequiredStep {
 
 /// Builds a digested transaction chain from three verified Pi actor artifacts.
 pub fn build_runtime_receipt_chain_from_actor_paths(paths: &[String; 3]) -> Result<String, String> {
+    precheck_required_operations(paths)?;
     let actors = read_and_validate_actors(paths).map_err(map_actor_error)?;
     let steps = required_steps()
         .iter()

--- a/crates/kamn-e2e-harness/src/mvp_demo/runtime_receipt_chain_facts.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/runtime_receipt_chain_facts.rs
@@ -1,0 +1,158 @@
+use super::pi_transaction_actor_model::Actor;
+use super::pi_transaction_public_result::PublicResult;
+
+pub(super) fn validate_step_public_result(
+    actor: &Actor,
+    action: &str,
+    after_state: &str,
+    result: &PublicResult,
+) -> Result<(), String> {
+    validate_present_facts(actor, result)?;
+    if result
+        .state
+        .as_deref()
+        .is_some_and(|state| state != after_state)
+    {
+        return Err(fact_mismatch());
+    }
+    match action {
+        "register" => require_registration(actor, result),
+        "create_task" | "accept_task" | "complete_task" => require_task(result),
+        "fund_escrow" => require_funding(result),
+        "release_escrow" => require_release(result),
+        "query_participant_task_projection" => require_participant_projection(actor, result),
+        "query_verifier_task_projection" => require_verifier_projection(result),
+        _ => Err(invalid()),
+    }
+}
+
+fn validate_present_facts(actor: &Actor, result: &PublicResult) -> Result<(), String> {
+    validate_identity_facts(actor, result)?;
+    validate_settlement_facts(actor, result)?;
+    if result
+        .amount_lamports
+        .is_some_and(|amount| amount != actor.amount_lamports)
+    {
+        return Err(fact_mismatch());
+    }
+    Ok(())
+}
+
+fn validate_identity_facts(actor: &Actor, result: &PublicResult) -> Result<(), String> {
+    require_optional_match(result.task_id.as_deref(), actor.task_id.as_str())?;
+    require_optional_match(
+        result.transaction_id.as_deref(),
+        actor.transaction_id.as_str(),
+    )?;
+    require_optional_match(result.escrow_id.as_deref(), actor.escrow_id.as_str())?;
+    require_optional_match(result.network.as_deref(), actor.network.as_str())?;
+    Ok(())
+}
+
+fn validate_settlement_facts(actor: &Actor, result: &PublicResult) -> Result<(), String> {
+    require_optional_match(
+        result.settlement_tx_signature.as_deref(),
+        actor.settlement_tx_signature.as_str(),
+    )?;
+    require_optional_match(
+        result.settlement_commitment.as_deref(),
+        actor.settlement_commitment.as_str(),
+    )?;
+    require_optional_match(
+        result.public_commitment.as_deref(),
+        actor.public_commitment.as_str(),
+    )?;
+    Ok(())
+}
+
+fn require_optional_match(actual: Option<&str>, expected: &str) -> Result<(), String> {
+    if actual.is_some_and(|value| value != expected) {
+        return Err(fact_mismatch());
+    }
+    Ok(())
+}
+
+fn require_registration(actor: &Actor, result: &PublicResult) -> Result<(), String> {
+    if result.did.as_deref() == Some(actor.did.as_str()) {
+        return Ok(());
+    }
+    Err(fact_mismatch())
+}
+
+fn require_task(result: &PublicResult) -> Result<(), String> {
+    require_all([
+        result.task_id.is_some(),
+        result.transaction_id.is_some(),
+        result.state.is_some(),
+    ])
+}
+
+fn require_funding(result: &PublicResult) -> Result<(), String> {
+    require_all([
+        result.task_id.is_some(),
+        result.escrow_id.is_some(),
+        result.state.is_some(),
+        result.amount_lamports.is_some(),
+        result.network.is_some(),
+    ])
+}
+
+fn require_release(result: &PublicResult) -> Result<(), String> {
+    require_all([
+        result.escrow_id.is_some(),
+        result.state.is_some(),
+        result.settlement_tx_signature.is_some(),
+        result.settlement_commitment.is_some(),
+    ])
+}
+
+fn require_participant_projection(actor: &Actor, result: &PublicResult) -> Result<(), String> {
+    let expected_role = if actor.actor == "agent_a" {
+        "creator"
+    } else {
+        "provider"
+    };
+    require_projection(result)?;
+    if result.view_scope.as_deref() == Some("participant-private")
+        && result.participant_role.as_deref() == Some(expected_role)
+    {
+        return Ok(());
+    }
+    Err(fact_mismatch())
+}
+
+fn require_verifier_projection(result: &PublicResult) -> Result<(), String> {
+    require_projection(result)?;
+    if result.view_scope.as_deref() == Some("restricted-public")
+        && result.participant_role.is_none()
+    {
+        return Ok(());
+    }
+    Err("RUNTIME_RECEIPT_CHAIN_VERIFIER_PRIVATE_LEAK".to_owned())
+}
+
+fn require_projection(result: &PublicResult) -> Result<(), String> {
+    require_all([
+        result.task_id.is_some(),
+        result.escrow_id.is_some(),
+        result.settlement_tx_signature.is_some(),
+        result.settlement_commitment.is_some(),
+        result.public_commitment.is_some(),
+        result.view_scope.is_some(),
+    ])
+}
+
+fn require_all<const N: usize>(fields: [bool; N]) -> Result<(), String> {
+    if fields.into_iter().all(|present| present) {
+        return Ok(());
+    }
+    Err(invalid())
+}
+
+fn invalid() -> String {
+    "RUNTIME_RECEIPT_CHAIN_PUBLIC_RESULT_INVALID".to_owned()
+}
+
+fn fact_mismatch() -> String {
+    "RUNTIME_RECEIPT_CHAIN_FACT_MISMATCH".to_owned()
+}

--- a/crates/kamn-e2e-harness/src/mvp_demo/runtime_receipt_chain_precheck.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/runtime_receipt_chain_precheck.rs
@@ -1,0 +1,49 @@
+use serde_json::Value;
+
+const REQUIRED: [[&str; 4]; 3] = [
+    ["register", "create_task", "fund_escrow", "release_escrow"],
+    ["register", "accept_task", "complete_task", ""],
+    ["register", "", "", ""],
+];
+
+pub(super) fn precheck_required_operations(paths: &[String; 3]) -> Result<(), String> {
+    for (index, path) in paths.iter().enumerate() {
+        let Some(receipts) = read_receipts(path)? else {
+            continue;
+        };
+        for action in REQUIRED[index].iter().filter(|action| !action.is_empty()) {
+            classify_action(receipts.as_slice(), action)?;
+        }
+    }
+    Ok(())
+}
+
+fn read_receipts(path: &str) -> Result<Option<Vec<Value>>, String> {
+    let raw = std::fs::read_to_string(path)
+        .map_err(|error| format!("failed to read Pi transaction actor {path}: {error}"))?;
+    let Ok(value) = serde_json::from_str::<Value>(&raw) else {
+        return Ok(None);
+    };
+    Ok(value["runtime_response_receipts"].as_array().cloned())
+}
+
+fn classify_action(receipts: &[Value], action: &str) -> Result<(), String> {
+    let matching = receipts
+        .iter()
+        .filter(|receipt| receipt["tool"] == action)
+        .collect::<Vec<_>>();
+    let success_count = matching
+        .iter()
+        .filter(|receipt| receipt["outcome"] == "success")
+        .count();
+    if success_count > 1 {
+        return Err("RUNTIME_RECEIPT_CHAIN_STEP_DUPLICATED".to_owned());
+    }
+    if success_count == 1 {
+        return Ok(());
+    }
+    if matching.iter().any(|receipt| receipt["outcome"] == "error") {
+        return Err("RUNTIME_RECEIPT_CHAIN_OUTCOME_INVALID".to_owned());
+    }
+    Err("RUNTIME_RECEIPT_CHAIN_STEP_MISSING".to_owned())
+}

--- a/crates/kamn-e2e-harness/src/mvp_demo/runtime_receipt_chain_precheck.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/runtime_receipt_chain_precheck.rs
@@ -15,11 +15,37 @@ pub(super) fn precheck_required_operations(paths: &[String; 3]) -> Result<(), St
         let Some(receipts) = actor["runtime_response_receipts"].as_array() else {
             continue;
         };
-        for action in REQUIRED[index].iter().filter(|action| !action.is_empty()) {
+        let actions = REQUIRED[index]
+            .iter()
+            .filter(|action| !action.is_empty())
+            .copied()
+            .collect::<Vec<_>>();
+        for action in &actions {
             classify_action(receipts, action)?;
         }
+        precheck_action_order(receipts, actions.as_slice())?;
     }
     Ok(())
+}
+
+fn precheck_action_order(receipts: &[Value], actions: &[&str]) -> Result<(), String> {
+    let positions = actions
+        .iter()
+        .map(|action| success_position(receipts, action))
+        .collect::<Option<Vec<_>>>();
+    let Some(positions) = positions else {
+        return Ok(());
+    };
+    if positions.windows(2).all(|pair| pair[0] < pair[1]) {
+        return Ok(());
+    }
+    Err("RUNTIME_RECEIPT_CHAIN_ORDER_INVALID".to_owned())
+}
+
+fn success_position(receipts: &[Value], action: &str) -> Option<usize> {
+    receipts
+        .iter()
+        .position(|receipt| receipt["tool"] == action && receipt["outcome"] == "success")
 }
 
 fn read_actor_json(path: &str) -> Result<Option<Value>, String> {

--- a/crates/kamn-e2e-harness/src/mvp_demo/runtime_receipt_chain_precheck.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/runtime_receipt_chain_precheck.rs
@@ -8,23 +8,44 @@ const REQUIRED: [[&str; 4]; 3] = [
 
 pub(super) fn precheck_required_operations(paths: &[String; 3]) -> Result<(), String> {
     for (index, path) in paths.iter().enumerate() {
-        let Some(receipts) = read_receipts(path)? else {
+        let Some(actor) = read_actor_json(path)? else {
+            continue;
+        };
+        precheck_digest_stream(&actor)?;
+        let Some(receipts) = actor["runtime_response_receipts"].as_array() else {
             continue;
         };
         for action in REQUIRED[index].iter().filter(|action| !action.is_empty()) {
-            classify_action(receipts.as_slice(), action)?;
+            classify_action(receipts, action)?;
         }
     }
     Ok(())
 }
 
-fn read_receipts(path: &str) -> Result<Option<Vec<Value>>, String> {
+fn read_actor_json(path: &str) -> Result<Option<Value>, String> {
     let raw = std::fs::read_to_string(path)
         .map_err(|error| format!("failed to read Pi transaction actor {path}: {error}"))?;
     let Ok(value) = serde_json::from_str::<Value>(&raw) else {
         return Ok(None);
     };
-    Ok(value["runtime_response_receipts"].as_array().cloned())
+    Ok(Some(value))
+}
+
+fn precheck_digest_stream(actor: &Value) -> Result<(), String> {
+    let (Some(receipts), Some(digests)) = (
+        actor["runtime_response_receipts"].as_array(),
+        actor["runtime_response_digests"].as_array(),
+    ) else {
+        return Ok(());
+    };
+    let drifted = receipts
+        .iter()
+        .zip(digests)
+        .any(|(receipt, digest)| receipt["digest"] != *digest);
+    if drifted {
+        return Err("RUNTIME_RECEIPT_CHAIN_DIGEST_MISMATCH".to_owned());
+    }
+    Ok(())
 }
 
 fn classify_action(receipts: &[Value], action: &str) -> Result<(), String> {

--- a/crates/kamn-e2e-harness/src/mvp_demo/three_agent_runtime_chain.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/three_agent_runtime_chain.rs
@@ -1,0 +1,64 @@
+use std::path::Path;
+
+use super::artifact_digest::validate_json_digest;
+use super::runtime_receipt_chain::build_runtime_receipt_chain_from_actor_paths;
+use super::verify_support::{extract_string, extract_u64, ClaimView};
+
+pub(super) fn write_runtime_chain(
+    path: &Path,
+    actor_paths: &[String; 3],
+) -> Result<String, String> {
+    let raw = build_runtime_receipt_chain_from_actor_paths(actor_paths)?;
+    let digest = extract_string(raw.as_str(), "chain_digest")?;
+    std::fs::write(path, raw).map_err(|error| {
+        format!(
+            "failed to write runtime receipt chain artifact {}: {error}",
+            path.display()
+        )
+    })?;
+    Ok(digest)
+}
+
+pub(super) fn validate_runtime_chain(raw: &str, claim: &ClaimView<'_>) -> Result<(), String> {
+    if raw.contains("raw_private_payload") || raw.contains("private_receipt_digest") {
+        return Err("RUNTIME_RECEIPT_CHAIN_VERIFIER_PRIVATE_LEAK".to_owned());
+    }
+    for field in [
+        "transaction_id",
+        "escrow_id",
+        "settlement_tx_signature",
+        "settlement_commitment",
+    ] {
+        require_matching_string(raw, claim, field)?;
+    }
+    require_matching_u64(raw, claim, "amount_lamports")?;
+    validate_chain_digest(raw, claim)
+}
+
+fn validate_chain_digest(raw: &str, claim: &ClaimView<'_>) -> Result<(), String> {
+    let digest = extract_string(raw, "chain_digest")?;
+    let claimed = extract_string(claim.raw, "three_agent_transcript_digest")?;
+    if digest != claimed {
+        return Err("RUNTIME_RECEIPT_CHAIN_ARTIFACT_MISMATCH".to_owned());
+    }
+    validate_json_digest(
+        raw,
+        "chain_digest",
+        digest.as_str(),
+        "runtime receipt chain",
+    )
+}
+
+fn require_matching_string(raw: &str, claim: &ClaimView<'_>, field: &str) -> Result<(), String> {
+    if extract_string(raw, field)? == extract_string(claim.raw, field)? {
+        return Ok(());
+    }
+    Err("RUNTIME_RECEIPT_CHAIN_FACT_MISMATCH".to_owned())
+}
+
+fn require_matching_u64(raw: &str, claim: &ClaimView<'_>, field: &str) -> Result<(), String> {
+    if extract_u64(raw, field)? == extract_u64(claim.raw, field)? {
+        return Ok(());
+    }
+    Err("RUNTIME_RECEIPT_CHAIN_FACT_MISMATCH".to_owned())
+}

--- a/crates/kamn-e2e-harness/src/mvp_demo/three_agent_transcript.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/three_agent_transcript.rs
@@ -5,6 +5,7 @@ use super::devnet_settlement::DevnetSettlementEvidence;
 use super::live_task_binding::LiveTaskBinding;
 use super::report::DemoReportInput;
 use super::three_agent_receipts::validate_three_agent_receipt_files;
+use super::three_agent_runtime_chain::{validate_runtime_chain, write_runtime_chain};
 use super::three_agent_transcript_build::transcript_json;
 use super::three_agent_view_artifacts::validate_three_agent_view_files;
 use super::verify_support::{
@@ -29,8 +30,12 @@ pub(crate) fn write_three_agent_transcript(
     binding: &LiveTaskBinding,
     run_dir: &Path,
     view_digests: &ThreeAgentViewDigests,
+    actor_paths: Option<&[String; 3]>,
 ) -> Result<String, String> {
     let path = run_dir.join("proof").join(TRANSCRIPT_FILE);
+    if let Some(paths) = actor_paths {
+        return write_runtime_chain(path.as_path(), paths);
+    }
     let artifact = transcript_json(run_id, evidence, binding, run_dir, view_digests)?;
     std::fs::write(path.as_path(), artifact.json.as_str()).map_err(|error| {
         format!(
@@ -78,6 +83,9 @@ fn validate_artifact_entry(report_json: &str, artifact: &str) -> Result<(), Stri
 
 fn validate_transcript(raw: &str, claim: &ClaimView<'_>) -> Result<(), String> {
     validate_json_delimiters(raw)?;
+    if raw.contains("\"schema_version\":\"kamn.mvp.runtime-receipt-chain.v1\"") {
+        return validate_runtime_chain(raw, claim);
+    }
     reject_raw_private_payload(raw)?;
     validate_required_markers(raw)?;
     validate_transcript_fields(raw, claim)?;

--- a/crates/kamn-e2e-harness/src/mvp_demo/three_agent_transcript.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/three_agent_transcript.rs
@@ -68,6 +68,19 @@ pub(crate) fn validate_three_agent_transcript_claim(claim: &ClaimView<'_>) -> Re
     Ok(())
 }
 
+pub(crate) fn require_runtime_chain_source(report_json: &str) -> Result<(), String> {
+    let claims = parse_claims(report_json)?;
+    let claim = three_agent_claim(claims.as_slice())
+        .ok_or_else(|| "RUNTIME_RECEIPT_CHAIN_SOURCE_INVALID".to_owned())?;
+    let artifact = extract_string(claim.raw, "three_agent_transcript_artifact")?;
+    let raw = std::fs::read_to_string(artifact)
+        .map_err(|_| "RUNTIME_RECEIPT_CHAIN_SOURCE_INVALID".to_owned())?;
+    if raw.contains("\"schema_version\":\"kamn.mvp.runtime-receipt-chain.v1\"") {
+        return Ok(());
+    }
+    Err("RUNTIME_RECEIPT_CHAIN_SOURCE_INVALID".to_owned())
+}
+
 fn three_agent_claim<'a>(claims: &'a [ClaimView<'a>]) -> Option<&'a ClaimView<'a>> {
     claims.iter().find(|claim| claim.id == CLAIM_ID)
 }

--- a/crates/kamn-e2e-harness/src/mvp_demo/three_agent_transcript.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/three_agent_transcript.rs
@@ -68,15 +68,21 @@ pub(crate) fn validate_three_agent_transcript_claim(claim: &ClaimView<'_>) -> Re
     Ok(())
 }
 
-pub(crate) fn require_runtime_chain_source(report_json: &str) -> Result<(), String> {
+pub(crate) fn require_runtime_chain_source(
+    report_json: &str,
+    expected_chain: &str,
+) -> Result<(), String> {
     let claims = parse_claims(report_json)?;
     let claim = three_agent_claim(claims.as_slice())
         .ok_or_else(|| "RUNTIME_RECEIPT_CHAIN_SOURCE_INVALID".to_owned())?;
     let artifact = extract_string(claim.raw, "three_agent_transcript_artifact")?;
     let raw = std::fs::read_to_string(artifact)
         .map_err(|_| "RUNTIME_RECEIPT_CHAIN_SOURCE_INVALID".to_owned())?;
-    if raw.contains("\"schema_version\":\"kamn.mvp.runtime-receipt-chain.v1\"") {
+    if raw == expected_chain {
         return Ok(());
+    }
+    if raw.contains("\"schema_version\":\"kamn.mvp.runtime-receipt-chain.v1\"") {
+        return Err("RUNTIME_RECEIPT_CHAIN_ARTIFACT_MISMATCH".to_owned());
     }
     Err("RUNTIME_RECEIPT_CHAIN_SOURCE_INVALID".to_owned())
 }

--- a/crates/kamn-e2e-harness/src/mvp_demo/three_agent_view_artifacts.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/three_agent_view_artifacts.rs
@@ -57,6 +57,9 @@ fn read_view(
 }
 
 fn validate_transcript_bindings(transcript: &str, claim: &ClaimView<'_>) -> Result<(), String> {
+    if transcript.contains("\"schema_version\":\"kamn.mvp.runtime-receipt-chain.v1\"") {
+        return Ok(());
+    }
     for field in view_claim_fields() {
         let transcript_value = extract_string(transcript, field)?;
         if transcript_value != extract_string(claim.raw, field)? {

--- a/crates/kamn-e2e-harness/tests/mvp_demo_agent_harness_claim_contract/support.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_demo_agent_harness_claim_contract/support.rs
@@ -61,6 +61,7 @@ pub(crate) fn demo_config(root: &Path, artifact: &Path) -> MvpDemoCommandConfig 
         service_api_websocket_command: Some(stub_service_command("integration_service_api_endpoint_websocket_upgrade_streams_state_transition_event")),
         agent_harness_evidence_path: Some(artifact.display().to_string()),
         live_task_evidence: None,
+        pi_transaction_actor_paths: None,
     }
 }
 

--- a/crates/kamn-e2e-harness/tests/mvp_demo_command_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_demo_command_contract.rs
@@ -9,6 +9,9 @@ use kamn_e2e_harness::{
 
 #[path = "support/mvp_demo_command.rs"]
 mod mvp_demo_command;
+#[path = "support/pi_transaction_actor_fixture.rs"]
+mod pi_transaction_actor_fixture;
+use pi_transaction_actor_fixture::{ActorFixture, Overrides};
 
 #[test]
 fn spec_c01_parser_accepts_demo_mvp_with_output_root() {
@@ -148,6 +151,23 @@ fn spec_c06_demo_mvp_devnet_required_records_settlement_evidence() {
         assert!(report.contains(marker), "missing report marker: {marker}");
     }
     let _ = std::fs::remove_dir_all(&temp);
+}
+
+#[test]
+fn spec_c10_demo_consumes_runtime_actor_chain_when_configured() {
+    let temp = temp_dir("mvp-demo-runtime-chain");
+    let actors = ActorFixture::new();
+    actors.write_all(Overrides::default());
+    let mut config = mvp_demo_command::devnet_required_demo_config(&temp);
+    config.pi_transaction_actor_paths = Some(actors.paths());
+
+    execute_mvp_demo_contract(&config).expect("runtime-backed demo should pass");
+    let transcript = std::fs::read_to_string(
+        run_directories(&temp)[0].join("proof/three-agent-transcript.json"),
+    )
+    .expect("canonical transaction proof");
+    assert!(transcript.contains("kamn.mvp.runtime-receipt-chain.v1"));
+    assert!(!transcript.contains("agent_a_registered"));
 }
 
 fn devnet_settlement_markers() -> [&'static str; 6] {

--- a/crates/kamn-e2e-harness/tests/mvp_demo_command_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_demo_command_contract.rs
@@ -8,6 +8,7 @@ use kamn_e2e_harness::{
 };
 
 #[path = "support/artifact_digest.rs"]
+#[allow(dead_code)]
 mod artifact_digest;
 #[path = "support/mvp_demo_command.rs"]
 mod mvp_demo_command;

--- a/crates/kamn-e2e-harness/tests/mvp_demo_command_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_demo_command_contract.rs
@@ -17,7 +17,7 @@ use pi_transaction_actor_fixture::{ActorFixture, Overrides};
 fn spec_c01_parser_accepts_demo_mvp_with_output_root() {
     let parsed = parse_command_args(["demo-mvp", "--output-root", "/tmp/kamn-demo"])
         .expect("demo-mvp command should parse");
-    let expected = HarnessCommand::DemoMvp(MvpDemoCommandConfig {
+    let expected = HarnessCommand::DemoMvp(Box::new(MvpDemoCommandConfig {
         output_root: "/tmp/kamn-demo".to_owned(),
         devnet_mode: "optional".to_owned(),
         solana_rpc_url: None,
@@ -27,7 +27,8 @@ fn spec_c01_parser_accepts_demo_mvp_with_output_root() {
         service_api_websocket_command: None,
         agent_harness_evidence_path: None,
         live_task_evidence: None,
-    });
+        pi_transaction_actor_paths: None,
+    }));
     assert_eq!(parsed, expected);
 }
 
@@ -158,6 +159,7 @@ fn spec_c10_demo_consumes_runtime_actor_chain_when_configured() {
     let temp = temp_dir("mvp-demo-runtime-chain");
     let actors = ActorFixture::new();
     actors.write_all(Overrides::default());
+    actors.rebind_shared_facts();
     let mut config = mvp_demo_command::devnet_required_demo_config(&temp);
     config.pi_transaction_actor_paths = Some(actors.paths());
 

--- a/crates/kamn-e2e-harness/tests/mvp_demo_command_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_demo_command_contract.rs
@@ -7,6 +7,8 @@ use kamn_e2e_harness::{
     HarnessCommand, MvpDemoCommandConfig, VerifyMvpDemoCommandConfig,
 };
 
+#[path = "support/artifact_digest.rs"]
+mod artifact_digest;
 #[path = "support/mvp_demo_command.rs"]
 mod mvp_demo_command;
 #[path = "support/pi_transaction_actor_fixture.rs"]
@@ -188,6 +190,43 @@ fn spec_c11_verifier_rejects_legacy_transcript_with_runtime_actors() {
     })
     .expect_err("runtime actors must not validate a generated transcript");
     assert_eq!(error, "RUNTIME_RECEIPT_CHAIN_SOURCE_INVALID");
+}
+
+#[test]
+fn spec_c12_verifier_rebuilds_chain_from_actor_receipts() {
+    let temp = temp_dir("mvp-demo-rebuilt-chain");
+    let actors = ActorFixture::new();
+    actors.write_all(Overrides::default());
+    actors.rebind_shared_facts();
+    let mut config = mvp_demo_command::devnet_required_demo_config(&temp);
+    config.pi_transaction_actor_paths = Some(actors.paths());
+    execute_mvp_demo_contract(&config).expect("runtime-backed report");
+
+    rewrite_chain_and_claim(&temp);
+    let error = execute_verify_mvp_demo_contract(&VerifyMvpDemoCommandConfig {
+        report: temp.join("latest/proof/report.json").display().to_string(),
+        agent_harness_evidence_path: None,
+        pi_transaction_actor_paths: Some(actors.paths()),
+    })
+    .expect_err("self-consistent forged chain must not pass");
+    assert_eq!(error, "RUNTIME_RECEIPT_CHAIN_ARTIFACT_MISMATCH");
+}
+
+fn rewrite_chain_and_claim(root: &Path) {
+    let chain_path = run_directories(root)[0].join("proof/three-agent-transcript.json");
+    let raw = std::fs::read_to_string(&chain_path).expect("runtime chain");
+    let old_digest = artifact_digest::digest_field(raw.as_str(), "chain_digest");
+    let changed = raw.replacen(
+        r#""after_state":"submitted""#,
+        r#""after_state":"forged""#,
+        1,
+    );
+    let changed = artifact_digest::with_digest(changed, "chain_digest");
+    let new_digest = artifact_digest::digest_field(changed.as_str(), "chain_digest");
+    std::fs::write(chain_path, changed).expect("forged chain");
+    let report_path = root.join("latest/proof/report.json");
+    let report = std::fs::read_to_string(&report_path).expect("report");
+    std::fs::write(report_path, report.replace(&old_digest, &new_digest)).expect("forged claim");
 }
 
 fn devnet_settlement_markers() -> [&'static str; 6] {

--- a/crates/kamn-e2e-harness/tests/mvp_demo_command_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_demo_command_contract.rs
@@ -172,6 +172,24 @@ fn spec_c10_demo_consumes_runtime_actor_chain_when_configured() {
     assert!(!transcript.contains("agent_a_registered"));
 }
 
+#[test]
+fn spec_c11_verifier_rejects_legacy_transcript_with_runtime_actors() {
+    let temp = temp_dir("mvp-demo-legacy-source");
+    let actors = ActorFixture::new();
+    actors.write_all(Overrides::default());
+    actors.rebind_shared_facts();
+    execute_mvp_demo_contract(&mvp_demo_command::devnet_required_demo_config(&temp))
+        .expect("legacy fixture report");
+
+    let error = execute_verify_mvp_demo_contract(&VerifyMvpDemoCommandConfig {
+        report: temp.join("latest/proof/report.json").display().to_string(),
+        agent_harness_evidence_path: None,
+        pi_transaction_actor_paths: Some(actors.paths()),
+    })
+    .expect_err("runtime actors must not validate a generated transcript");
+    assert_eq!(error, "RUNTIME_RECEIPT_CHAIN_SOURCE_INVALID");
+}
+
 fn devnet_settlement_markers() -> [&'static str; 6] {
     [
         r#""settlement_tx_signature":"devnet-signature-111""#,

--- a/crates/kamn-e2e-harness/tests/mvp_demo_runtime_receipt_chain_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_demo_runtime_receipt_chain_contract.rs
@@ -54,6 +54,28 @@ fn spec_c04_verifier_private_data_fails_with_chain_reason() {
     assert_chain_error(&fixture, "RUNTIME_RECEIPT_CHAIN_VERIFIER_PRIVATE_LEAK");
 }
 
+#[test]
+fn spec_c05_duplicate_successful_mutation_fails_closed() {
+    let fixture = ActorFixture::new();
+    fixture.write_all(Overrides {
+        agent_a_duplicate_fund: true,
+        ..Overrides::default()
+    });
+
+    assert_chain_error(&fixture, "RUNTIME_RECEIPT_CHAIN_STEP_DUPLICATED");
+}
+
+#[test]
+fn spec_c06_failed_release_cannot_satisfy_success_step() {
+    let fixture = ActorFixture::new();
+    fixture.write_all(Overrides {
+        agent_a_release_error: true,
+        ..Overrides::default()
+    });
+
+    assert_chain_error(&fixture, "RUNTIME_RECEIPT_CHAIN_OUTCOME_INVALID");
+}
+
 fn assert_chain_error(fixture: &ActorFixture, code: &str) {
     let error = build_runtime_receipt_chain_from_actor_paths(&fixture.paths())
         .expect_err("tampered runtime evidence must fail");

--- a/crates/kamn-e2e-harness/tests/mvp_demo_runtime_receipt_chain_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_demo_runtime_receipt_chain_contract.rs
@@ -87,6 +87,17 @@ fn spec_c07_receipt_digest_drift_fails_closed() {
     assert_chain_error(&fixture, "RUNTIME_RECEIPT_CHAIN_DIGEST_MISMATCH");
 }
 
+#[test]
+fn spec_c08_public_receipt_fact_drift_fails_closed() {
+    let fixture = ActorFixture::new();
+    fixture.write_all(Overrides {
+        agent_a_public_fact_drift: true,
+        ..Overrides::default()
+    });
+
+    assert_chain_error(&fixture, "RUNTIME_RECEIPT_CHAIN_FACT_MISMATCH");
+}
+
 fn assert_chain_error(fixture: &ActorFixture, code: &str) {
     let error = build_runtime_receipt_chain_from_actor_paths(&fixture.paths())
         .expect_err("tampered runtime evidence must fail");

--- a/crates/kamn-e2e-harness/tests/mvp_demo_runtime_receipt_chain_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_demo_runtime_receipt_chain_contract.rs
@@ -98,6 +98,15 @@ fn spec_c08_public_receipt_fact_drift_fails_closed() {
     assert_chain_error(&fixture, "RUNTIME_RECEIPT_CHAIN_FACT_MISMATCH");
 }
 
+#[test]
+fn spec_c09_actor_local_mutation_order_fails_closed() {
+    let fixture = ActorFixture::new();
+    fixture.write_all(Overrides::default());
+    fixture.reorder_agent_a_mutations();
+
+    assert_chain_error(&fixture, "RUNTIME_RECEIPT_CHAIN_ORDER_INVALID");
+}
+
 fn assert_chain_error(fixture: &ActorFixture, code: &str) {
     let error = build_runtime_receipt_chain_from_actor_paths(&fixture.paths())
         .expect_err("tampered runtime evidence must fail");

--- a/crates/kamn-e2e-harness/tests/mvp_demo_runtime_receipt_chain_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_demo_runtime_receipt_chain_contract.rs
@@ -76,6 +76,17 @@ fn spec_c06_failed_release_cannot_satisfy_success_step() {
     assert_chain_error(&fixture, "RUNTIME_RECEIPT_CHAIN_OUTCOME_INVALID");
 }
 
+#[test]
+fn spec_c07_receipt_digest_drift_fails_closed() {
+    let fixture = ActorFixture::new();
+    fixture.write_all(Overrides {
+        agent_a_receipt_digest_mismatch: true,
+        ..Overrides::default()
+    });
+
+    assert_chain_error(&fixture, "RUNTIME_RECEIPT_CHAIN_DIGEST_MISMATCH");
+}
+
 fn assert_chain_error(fixture: &ActorFixture, code: &str) {
     let error = build_runtime_receipt_chain_from_actor_paths(&fixture.paths())
         .expect_err("tampered runtime evidence must fail");

--- a/crates/kamn-e2e-harness/tests/mvp_demo_runtime_receipt_chain_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_demo_runtime_receipt_chain_contract.rs
@@ -3,7 +3,7 @@ use serde_json::Value;
 
 #[path = "support/pi_transaction_actor_fixture.rs"]
 mod pi_transaction_actor_fixture;
-use pi_transaction_actor_fixture::{ActorFixture, Overrides};
+use pi_transaction_actor_fixture::{sha, ActorFixture, Overrides};
 
 #[test]
 fn spec_c01_builds_ordered_chain_from_exact_runtime_receipts() {
@@ -19,6 +19,45 @@ fn spec_c01_builds_ordered_chain_from_exact_runtime_receipts() {
     assert!(steps(&chain).iter().all(has_runtime_source));
     assert!(!raw.contains("agent_a_registered"));
     assert!(!raw.contains("private_receipt_digest"));
+}
+
+#[test]
+fn spec_c02_missing_runtime_step_fails_with_chain_reason() {
+    let fixture = ActorFixture::new();
+    fixture.write_all(Overrides {
+        agent_a_include_release: false,
+        ..Overrides::default()
+    });
+
+    assert_chain_error(&fixture, "RUNTIME_RECEIPT_CHAIN_STEP_MISSING");
+}
+
+#[test]
+fn spec_c03_shared_fact_drift_fails_with_chain_reason() {
+    let fixture = ActorFixture::new();
+    fixture.write_all(Overrides {
+        agent_b_escrow: "escrow-other",
+        ..Overrides::default()
+    });
+
+    assert_chain_error(&fixture, "RUNTIME_RECEIPT_CHAIN_FACT_MISMATCH");
+}
+
+#[test]
+fn spec_c04_verifier_private_data_fails_with_chain_reason() {
+    let fixture = ActorFixture::new();
+    fixture.write_all(Overrides {
+        agent_c_private: Some(sha('e')),
+        ..Overrides::default()
+    });
+
+    assert_chain_error(&fixture, "RUNTIME_RECEIPT_CHAIN_VERIFIER_PRIVATE_LEAK");
+}
+
+fn assert_chain_error(fixture: &ActorFixture, code: &str) {
+    let error = build_runtime_receipt_chain_from_actor_paths(&fixture.paths())
+        .expect_err("tampered runtime evidence must fail");
+    assert_eq!(error, code);
 }
 
 fn actions(chain: &Value) -> Vec<&str> {

--- a/crates/kamn-e2e-harness/tests/mvp_demo_runtime_receipt_chain_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_demo_runtime_receipt_chain_contract.rs
@@ -1,0 +1,57 @@
+use kamn_e2e_harness::build_runtime_receipt_chain_from_actor_paths;
+use serde_json::Value;
+
+#[path = "support/pi_transaction_actor_fixture.rs"]
+mod pi_transaction_actor_fixture;
+use pi_transaction_actor_fixture::{ActorFixture, Overrides};
+
+#[test]
+fn spec_c01_builds_ordered_chain_from_exact_runtime_receipts() {
+    let fixture = ActorFixture::new();
+    fixture.write_all(Overrides::default());
+
+    let raw = build_runtime_receipt_chain_from_actor_paths(&fixture.paths())
+        .expect("valid actor receipts should build a runtime chain");
+    let chain: Value = serde_json::from_str(&raw).expect("strict chain JSON");
+
+    assert_eq!(chain["schema_version"], "kamn.mvp.runtime-receipt-chain.v1");
+    assert_eq!(actions(&chain), expected_actions());
+    assert!(steps(&chain).iter().all(has_runtime_source));
+    assert!(!raw.contains("agent_a_registered"));
+    assert!(!raw.contains("private_receipt_digest"));
+}
+
+fn actions(chain: &Value) -> Vec<&str> {
+    steps(chain)
+        .iter()
+        .map(|step| step["action"].as_str().expect("action"))
+        .collect()
+}
+
+fn steps(chain: &Value) -> &[Value] {
+    chain["steps"].as_array().expect("steps")
+}
+
+fn has_runtime_source(step: &Value) -> bool {
+    step["request_id"].as_u64().is_some()
+        && step["response_digest"]
+            .as_str()
+            .is_some_and(|digest| digest.starts_with("sha256:"))
+        && step["outcome"] == "success"
+}
+
+fn expected_actions() -> Vec<&'static str> {
+    vec![
+        "register",
+        "register",
+        "register",
+        "create_task",
+        "accept_task",
+        "fund_escrow",
+        "complete_task",
+        "release_escrow",
+        "query_participant_task_projection",
+        "query_participant_task_projection",
+        "query_verifier_task_projection",
+    ]
+}

--- a/crates/kamn-e2e-harness/tests/support/mvp_demo_command.rs
+++ b/crates/kamn-e2e-harness/tests/support/mvp_demo_command.rs
@@ -20,6 +20,7 @@ pub(crate) fn local_demo_config(temp: &Path) -> MvpDemoCommandConfig {
         )),
         agent_harness_evidence_path: None,
         live_task_evidence: None,
+        pi_transaction_actor_paths: None,
     }
 }
 

--- a/crates/kamn-e2e-harness/tests/support/pi_transaction_actor_fixture.rs
+++ b/crates/kamn-e2e-harness/tests/support/pi_transaction_actor_fixture.rs
@@ -1,4 +1,5 @@
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use sha2::{Digest, Sha256};
@@ -39,13 +40,16 @@ pub(crate) struct ActorFixture {
     root: PathBuf,
 }
 
+static FIXTURE_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
 impl ActorFixture {
     pub(crate) fn new() -> Self {
         let nanos = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("clock")
             .as_nanos();
-        let root = std::env::temp_dir().join(format!("kamn-pi-actors-{nanos}"));
+        let sequence = FIXTURE_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+        let root = std::env::temp_dir().join(format!("kamn-pi-actors-{nanos}-{sequence}"));
         std::fs::create_dir_all(&root).expect("fixture directory");
         Self { root }
     }

--- a/crates/kamn-e2e-harness/tests/support/pi_transaction_actor_fixture.rs
+++ b/crates/kamn-e2e-harness/tests/support/pi_transaction_actor_fixture.rs
@@ -22,6 +22,7 @@ pub(crate) struct Overrides {
     pub(crate) agent_a_duplicate_fund: bool,
     pub(crate) agent_a_release_error: bool,
     pub(crate) agent_a_receipt_digest_mismatch: bool,
+    pub(crate) agent_a_public_fact_drift: bool,
 }
 
 impl Default for Overrides {
@@ -38,6 +39,7 @@ impl Default for Overrides {
             agent_a_duplicate_fund: false,
             agent_a_release_error: false,
             agent_a_receipt_digest_mismatch: false,
+            agent_a_public_fact_drift: false,
         }
     }
 }
@@ -86,7 +88,8 @@ impl ActorFixture {
             .with_release(overrides.agent_a_include_release)
             .with_duplicate_fund(overrides.agent_a_duplicate_fund)
             .with_release_error(overrides.agent_a_release_error)
-            .with_receipt_digest_mismatch(overrides.agent_a_receipt_digest_mismatch);
+            .with_receipt_digest_mismatch(overrides.agent_a_receipt_digest_mismatch)
+            .with_public_fact_drift(overrides.agent_a_public_fact_drift);
         write_actor(&self.root.join("agent-a.json"), input);
     }
 

--- a/crates/kamn-e2e-harness/tests/support/pi_transaction_actor_fixture.rs
+++ b/crates/kamn-e2e-harness/tests/support/pi_transaction_actor_fixture.rs
@@ -19,6 +19,8 @@ pub(crate) struct Overrides {
     pub(crate) agent_a_handoff_authorized: bool,
     pub(crate) agent_a_handoff_as_string: bool,
     pub(crate) agent_a_include_release: bool,
+    pub(crate) agent_a_duplicate_fund: bool,
+    pub(crate) agent_a_release_error: bool,
 }
 
 impl Default for Overrides {
@@ -32,6 +34,8 @@ impl Default for Overrides {
             agent_a_handoff_authorized: false,
             agent_a_handoff_as_string: false,
             agent_a_include_release: true,
+            agent_a_duplicate_fund: false,
+            agent_a_release_error: false,
         }
     }
 }
@@ -70,7 +74,9 @@ impl ActorFixture {
             .with_private(sha('e'))
             .with_handoff_authorized(overrides.agent_a_handoff_authorized)
             .with_handoff_as_string(overrides.agent_a_handoff_as_string)
-            .with_release(overrides.agent_a_include_release);
+            .with_release(overrides.agent_a_include_release)
+            .with_duplicate_fund(overrides.agent_a_duplicate_fund)
+            .with_release_error(overrides.agent_a_release_error);
         write_actor(&self.root.join("agent-a.json"), input);
     }
 

--- a/crates/kamn-e2e-harness/tests/support/pi_transaction_actor_fixture.rs
+++ b/crates/kamn-e2e-harness/tests/support/pi_transaction_actor_fixture.rs
@@ -217,14 +217,46 @@ fn runtime_receipts(input: &ActorInput<'_>) -> String {
         .enumerate()
         .map(|(index, tool)| {
             format!(
-                r#"{{"request_id":{},"tool":"{}","outcome":"success","digest":"{}"}}"#,
+                r#"{{"request_id":{},"tool":"{}","outcome":"success","digest":"{}","public_result":{}}}"#,
                 index + 1,
                 tool,
-                response_digests(input)[index]
+                response_digests(input)[index],
+                public_result_json(input.role, tool),
             )
         })
         .collect::<Vec<_>>()
         .join(",")
+}
+
+fn public_result_json(role: &str, tool: &str) -> String {
+    match tool {
+        "register" => format!(r#"{{"did":"kamn:did:{}"}}"#, role_suffix(role)),
+        "create_task" => task_result("submitted"),
+        "accept_task" => task_result("accepted"),
+        "complete_task" => task_result("completed"),
+        "fund_escrow" => r#"{"task_id":"task-live-7099","escrow_id":"escrow-live-7099","state":"funded","amount_lamports":1000000,"network":"solana-devnet"}"#.to_owned(),
+        "release_escrow" => r#"{"escrow_id":"escrow-live-7099","state":"released","settlement_tx_signature":"devnet-signature-7099","settlement_commitment":"finalized"}"#.to_owned(),
+        "query_participant_task_projection" => projection_result(role, "participant-private"),
+        "query_verifier_task_projection" => projection_result(role, "restricted-public"),
+        _ => r#"{"task_id":"task-live-7099","state":"accepted"}"#.to_owned(),
+    }
+}
+
+fn task_result(state: &str) -> String {
+    format!(r#"{{"task_id":"task-live-7099","state":"{state}","transaction_id":"transaction-live-7099"}}"#)
+}
+
+fn projection_result(role: &str, scope: &str) -> String {
+    let participant = match role {
+        "agent_a" => r#", "participant_role":"creator""#,
+        "agent_b" => r#", "participant_role":"provider""#,
+        _ => "",
+    };
+    format!(r#"{{"task_id":"task-live-7099","escrow_id":"escrow-live-7099","settlement_tx_signature":"devnet-signature-7099","settlement_commitment":"finalized","public_commitment":"{}","view_scope":"{scope}"{participant}}}"#, sha('d'))
+}
+
+fn role_suffix(role: &str) -> char {
+    match role { "agent_a" => 'a', "agent_b" => 'b', _ => 'c' }
 }
 
 fn response_digests(input: &ActorInput<'_>) -> [String; 5] {

--- a/crates/kamn-e2e-harness/tests/support/pi_transaction_actor_fixture.rs
+++ b/crates/kamn-e2e-harness/tests/support/pi_transaction_actor_fixture.rs
@@ -83,6 +83,7 @@ impl ActorFixture {
         }
     }
 
+    #[allow(dead_code)]
     pub(crate) fn reorder_agent_a_mutations(&self) {
         reorder_actor_mutations(&self.root.join("agent-a.json"));
     }

--- a/crates/kamn-e2e-harness/tests/support/pi_transaction_actor_fixture.rs
+++ b/crates/kamn-e2e-harness/tests/support/pi_transaction_actor_fixture.rs
@@ -71,6 +71,13 @@ impl ActorFixture {
         self.write_c(overrides);
     }
 
+    #[allow(dead_code)]
+    pub(crate) fn rebind_shared_facts(&self) {
+        for path in self.paths() {
+            rebind_actor(Path::new(path.as_str()));
+        }
+    }
+
     fn write_a(&self, overrides: &Overrides) {
         let input = ActorInput::new("agent_a", 101, "kamn:did:a", "escrow-live-7099", '1')
             .with_private(sha('e'))
@@ -111,6 +118,23 @@ fn write_actor(path: &Path, input: ActorInput<'_>) {
         &unsigned[..unsigned.len() - 1]
     );
     std::fs::write(path, artifact).expect("write actor fixture");
+}
+
+#[allow(dead_code)]
+fn rebind_actor(path: &Path) {
+    let raw = std::fs::read_to_string(path).expect("actor fixture");
+    let marker = raw.rfind(",\"artifact_digest\":").expect("artifact digest");
+    let unsigned = format!("{}}}", &raw[..marker])
+        .replace("task-live-7099", "task-local-bound-7086")
+        .replace("transaction-live-7099", "task-local-bound-7086")
+        .replace("escrow-live-7099", "escrow-local-bound-7086")
+        .replace("devnet-signature-7099", "devnet-signature-111");
+    let digest = format!("sha256:{:x}", Sha256::digest(unsigned.as_bytes()));
+    let artifact = format!(
+        "{},\"artifact_digest\":\"{digest}\"}}",
+        &unsigned[..unsigned.len() - 1]
+    );
+    std::fs::write(path, artifact).expect("rebind actor fixture");
 }
 
 fn actor_json(input: &ActorInput<'_>) -> String {

--- a/crates/kamn-e2e-harness/tests/support/pi_transaction_actor_fixture.rs
+++ b/crates/kamn-e2e-harness/tests/support/pi_transaction_actor_fixture.rs
@@ -3,6 +3,11 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use sha2::{Digest, Sha256};
 
+#[path = "pi_transaction_receipt_fixture.rs"]
+mod receipt_fixture;
+pub(crate) use receipt_fixture::sha;
+use receipt_fixture::{response_digests, runtime_receipts, ActorInput};
+
 #[derive(Clone)]
 pub(crate) struct Overrides {
     pub(crate) agent_c_pid: u64,
@@ -85,54 +90,6 @@ impl ActorFixture {
     }
 }
 
-struct ActorInput<'a> {
-    role: &'a str,
-    pid: u64,
-    did: &'a str,
-    escrow: &'a str,
-    projection: String,
-    private: Option<String>,
-    handoff_authorized: bool,
-    handoff_as_string: bool,
-    include_release: bool,
-}
-
-impl<'a> ActorInput<'a> {
-    fn new(role: &'a str, pid: u64, did: &'a str, escrow: &'a str, projection: char) -> Self {
-        Self {
-            role,
-            pid,
-            did,
-            escrow,
-            projection: sha(projection),
-            private: None,
-            handoff_authorized: false,
-            handoff_as_string: false,
-            include_release: true,
-        }
-    }
-
-    fn with_private(mut self, value: String) -> Self {
-        self.private = Some(value);
-        self
-    }
-
-    fn with_handoff_authorized(mut self, value: bool) -> Self {
-        self.handoff_authorized = value;
-        self
-    }
-
-    fn with_handoff_as_string(mut self, value: bool) -> Self {
-        self.handoff_as_string = value;
-        self
-    }
-
-    fn with_release(mut self, value: bool) -> Self {
-        self.include_release = value;
-        self
-    }
-}
-
 fn write_actor(path: &Path, input: ActorInput<'_>) {
     let unsigned = actor_json(&input);
     let digest = format!("sha256:{:x}", Sha256::digest(unsigned.as_bytes()));
@@ -182,92 +139,4 @@ fn actor_json(input: &ActorInput<'_>) -> String {
         sha('d'),
         sha('b'),
     )
-}
-
-fn runtime_receipts(input: &ActorInput<'_>) -> String {
-    let tools = match input.role {
-        "agent_a" => [
-            "register",
-            "create_task",
-            "fund_escrow",
-            if input.include_release {
-                "release_escrow"
-            } else {
-                "query_task"
-            },
-            "query_participant_task_projection",
-        ],
-        "agent_b" => [
-            "register",
-            "accept_task",
-            "complete_task",
-            "query_task",
-            "query_participant_task_projection",
-        ],
-        _ => [
-            "register",
-            "query_task",
-            "query_task",
-            "query_task",
-            "query_verifier_task_projection",
-        ],
-    };
-    tools
-        .iter()
-        .enumerate()
-        .map(|(index, tool)| {
-            format!(
-                r#"{{"request_id":{},"tool":"{}","outcome":"success","digest":"{}","public_result":{}}}"#,
-                index + 1,
-                tool,
-                response_digests(input)[index],
-                public_result_json(input.role, tool),
-            )
-        })
-        .collect::<Vec<_>>()
-        .join(",")
-}
-
-fn public_result_json(role: &str, tool: &str) -> String {
-    match tool {
-        "register" => format!(r#"{{"did":"kamn:did:{}"}}"#, role_suffix(role)),
-        "create_task" => task_result("submitted"),
-        "accept_task" => task_result("accepted"),
-        "complete_task" => task_result("completed"),
-        "fund_escrow" => r#"{"task_id":"task-live-7099","escrow_id":"escrow-live-7099","state":"funded","amount_lamports":1000000,"network":"solana-devnet"}"#.to_owned(),
-        "release_escrow" => r#"{"escrow_id":"escrow-live-7099","state":"released","settlement_tx_signature":"devnet-signature-7099","settlement_commitment":"finalized"}"#.to_owned(),
-        "query_participant_task_projection" => projection_result(role, "participant-private"),
-        "query_verifier_task_projection" => projection_result(role, "restricted-public"),
-        _ => r#"{"task_id":"task-live-7099","state":"accepted"}"#.to_owned(),
-    }
-}
-
-fn task_result(state: &str) -> String {
-    format!(r#"{{"task_id":"task-live-7099","state":"{state}","transaction_id":"transaction-live-7099"}}"#)
-}
-
-fn projection_result(role: &str, scope: &str) -> String {
-    let participant = match role {
-        "agent_a" => r#", "participant_role":"creator""#,
-        "agent_b" => r#", "participant_role":"provider""#,
-        _ => "",
-    };
-    format!(r#"{{"task_id":"task-live-7099","escrow_id":"escrow-live-7099","settlement_tx_signature":"devnet-signature-7099","settlement_commitment":"finalized","public_commitment":"{}","view_scope":"{scope}"{participant}}}"#, sha('d'))
-}
-
-fn role_suffix(role: &str) -> char {
-    match role { "agent_a" => 'a', "agent_b" => 'b', _ => 'c' }
-}
-
-fn response_digests(input: &ActorInput<'_>) -> [String; 5] {
-    let projection = if input.projection == sha('f') {
-        sha('3')
-    } else {
-        input.projection.clone()
-    };
-    [sha('a'), sha('b'), sha('c'), sha('d'), projection]
-}
-
-pub(crate) fn sha(character: char) -> String {
-    format!("sha256:{}", character.to_string().repeat(64))
 }

--- a/crates/kamn-e2e-harness/tests/support/pi_transaction_actor_fixture.rs
+++ b/crates/kamn-e2e-harness/tests/support/pi_transaction_actor_fixture.rs
@@ -21,6 +21,7 @@ pub(crate) struct Overrides {
     pub(crate) agent_a_include_release: bool,
     pub(crate) agent_a_duplicate_fund: bool,
     pub(crate) agent_a_release_error: bool,
+    pub(crate) agent_a_receipt_digest_mismatch: bool,
 }
 
 impl Default for Overrides {
@@ -36,6 +37,7 @@ impl Default for Overrides {
             agent_a_include_release: true,
             agent_a_duplicate_fund: false,
             agent_a_release_error: false,
+            agent_a_receipt_digest_mismatch: false,
         }
     }
 }
@@ -76,7 +78,8 @@ impl ActorFixture {
             .with_handoff_as_string(overrides.agent_a_handoff_as_string)
             .with_release(overrides.agent_a_include_release)
             .with_duplicate_fund(overrides.agent_a_duplicate_fund)
-            .with_release_error(overrides.agent_a_release_error);
+            .with_release_error(overrides.agent_a_release_error)
+            .with_receipt_digest_mismatch(overrides.agent_a_receipt_digest_mismatch);
         write_actor(&self.root.join("agent-a.json"), input);
     }
 

--- a/crates/kamn-e2e-harness/tests/support/pi_transaction_actor_fixture.rs
+++ b/crates/kamn-e2e-harness/tests/support/pi_transaction_actor_fixture.rs
@@ -4,8 +4,11 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use sha2::{Digest, Sha256};
 
+#[path = "pi_transaction_actor_rewrite.rs"]
+mod actor_rewrite;
 #[path = "pi_transaction_receipt_fixture.rs"]
 mod receipt_fixture;
+use actor_rewrite::{rebind_actor, reorder_actor_mutations};
 pub(crate) use receipt_fixture::sha;
 use receipt_fixture::{response_digests, runtime_receipts, ActorInput};
 
@@ -80,6 +83,10 @@ impl ActorFixture {
         }
     }
 
+    pub(crate) fn reorder_agent_a_mutations(&self) {
+        reorder_actor_mutations(&self.root.join("agent-a.json"));
+    }
+
     fn write_a(&self, overrides: &Overrides) {
         let input = ActorInput::new("agent_a", 101, "kamn:did:a", "escrow-live-7099", '1')
             .with_private(sha('e'))
@@ -121,23 +128,6 @@ fn write_actor(path: &Path, input: ActorInput<'_>) {
         &unsigned[..unsigned.len() - 1]
     );
     std::fs::write(path, artifact).expect("write actor fixture");
-}
-
-#[allow(dead_code)]
-fn rebind_actor(path: &Path) {
-    let raw = std::fs::read_to_string(path).expect("actor fixture");
-    let marker = raw.rfind(",\"artifact_digest\":").expect("artifact digest");
-    let unsigned = format!("{}}}", &raw[..marker])
-        .replace("task-live-7099", "task-local-bound-7086")
-        .replace("transaction-live-7099", "task-local-bound-7086")
-        .replace("escrow-live-7099", "escrow-local-bound-7086")
-        .replace("devnet-signature-7099", "devnet-signature-111");
-    let digest = format!("sha256:{:x}", Sha256::digest(unsigned.as_bytes()));
-    let artifact = format!(
-        "{},\"artifact_digest\":\"{digest}\"}}",
-        &unsigned[..unsigned.len() - 1]
-    );
-    std::fs::write(path, artifact).expect("rebind actor fixture");
 }
 
 fn actor_json(input: &ActorInput<'_>) -> String {

--- a/crates/kamn-e2e-harness/tests/support/pi_transaction_actor_rewrite.rs
+++ b/crates/kamn-e2e-harness/tests/support/pi_transaction_actor_rewrite.rs
@@ -14,6 +14,7 @@ pub(super) fn rebind_actor(path: &Path) {
     );
 }
 
+#[allow(dead_code)]
 pub(super) fn reorder_actor_mutations(path: &Path) {
     rewrite_actor(
         path,

--- a/crates/kamn-e2e-harness/tests/support/pi_transaction_actor_rewrite.rs
+++ b/crates/kamn-e2e-harness/tests/support/pi_transaction_actor_rewrite.rs
@@ -1,0 +1,41 @@
+use std::path::Path;
+
+use sha2::{Digest, Sha256};
+
+pub(super) fn rebind_actor(path: &Path) {
+    rewrite_actor(
+        path,
+        &[
+            ("task-live-7099", "task-local-bound-7086"),
+            ("transaction-live-7099", "task-local-bound-7086"),
+            ("escrow-live-7099", "escrow-local-bound-7086"),
+            ("devnet-signature-7099", "devnet-signature-111"),
+        ],
+    );
+}
+
+pub(super) fn reorder_actor_mutations(path: &Path) {
+    rewrite_actor(
+        path,
+        &[
+            ("\"tool\":\"create_task\"", "\"tool\":\"swap_task\""),
+            ("\"tool\":\"fund_escrow\"", "\"tool\":\"create_task\""),
+            ("\"tool\":\"swap_task\"", "\"tool\":\"fund_escrow\""),
+        ],
+    );
+}
+
+fn rewrite_actor(path: &Path, replacements: &[(&str, &str)]) {
+    let raw = std::fs::read_to_string(path).expect("actor fixture");
+    let marker = raw.rfind(",\"artifact_digest\":").expect("artifact digest");
+    let mut unsigned = format!("{}}}", &raw[..marker]);
+    for (from, to) in replacements {
+        unsigned = unsigned.replace(from, to);
+    }
+    let digest = format!("sha256:{:x}", Sha256::digest(unsigned.as_bytes()));
+    let artifact = format!(
+        "{},\"artifact_digest\":\"{digest}\"}}",
+        &unsigned[..unsigned.len() - 1]
+    );
+    std::fs::write(path, artifact).expect("rewrite actor fixture");
+}

--- a/crates/kamn-e2e-harness/tests/support/pi_transaction_receipt_fixture.rs
+++ b/crates/kamn-e2e-harness/tests/support/pi_transaction_receipt_fixture.rs
@@ -1,0 +1,155 @@
+pub(crate) struct ActorInput<'a> {
+    pub(crate) role: &'a str,
+    pub(crate) pid: u64,
+    pub(crate) did: &'a str,
+    pub(crate) escrow: &'a str,
+    pub(crate) projection: String,
+    pub(crate) private: Option<String>,
+    pub(crate) handoff_authorized: bool,
+    pub(crate) handoff_as_string: bool,
+    pub(crate) include_release: bool,
+}
+
+impl<'a> ActorInput<'a> {
+    pub(crate) fn new(
+        role: &'a str,
+        pid: u64,
+        did: &'a str,
+        escrow: &'a str,
+        projection: char,
+    ) -> Self {
+        Self {
+            role,
+            pid,
+            did,
+            escrow,
+            projection: sha(projection),
+            private: None,
+            handoff_authorized: false,
+            handoff_as_string: false,
+            include_release: true,
+        }
+    }
+
+    pub(crate) fn with_private(mut self, value: String) -> Self {
+        self.private = Some(value);
+        self
+    }
+
+    pub(crate) fn with_handoff_authorized(mut self, value: bool) -> Self {
+        self.handoff_authorized = value;
+        self
+    }
+
+    pub(crate) fn with_handoff_as_string(mut self, value: bool) -> Self {
+        self.handoff_as_string = value;
+        self
+    }
+
+    pub(crate) fn with_release(mut self, value: bool) -> Self {
+        self.include_release = value;
+        self
+    }
+}
+
+pub(crate) fn runtime_receipts(input: &ActorInput<'_>) -> String {
+    tools(input)
+        .iter()
+        .enumerate()
+        .map(|(index, tool)| receipt_json(input, index, tool))
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+fn tools(input: &ActorInput<'_>) -> [&'static str; 5] {
+    match input.role {
+        "agent_a" => [
+            "register",
+            "create_task",
+            "fund_escrow",
+            if input.include_release {
+                "release_escrow"
+            } else {
+                "query_task"
+            },
+            "query_participant_task_projection",
+        ],
+        "agent_b" => [
+            "register",
+            "accept_task",
+            "complete_task",
+            "query_task",
+            "query_participant_task_projection",
+        ],
+        _ => [
+            "register",
+            "query_task",
+            "query_task",
+            "query_task",
+            "query_verifier_task_projection",
+        ],
+    }
+}
+
+fn receipt_json(input: &ActorInput<'_>, index: usize, tool: &str) -> String {
+    format!(
+        r#"{{"request_id":{},"tool":"{}","outcome":"success","digest":"{}","public_result":{}}}"#,
+        index + 1,
+        tool,
+        response_digests(input)[index],
+        public_result_json(input.role, tool),
+    )
+}
+
+fn public_result_json(role: &str, tool: &str) -> String {
+    match tool {
+        "register" => format!(r#"{{"did":"kamn:did:{}"}}"#, role_suffix(role)),
+        "create_task" => task_result("submitted"),
+        "accept_task" => task_result("accepted"),
+        "complete_task" => task_result("completed"),
+        "fund_escrow" => r#"{"task_id":"task-live-7099","escrow_id":"escrow-live-7099","state":"funded","amount_lamports":1000000,"network":"solana-devnet"}"#.to_owned(),
+        "release_escrow" => r#"{"escrow_id":"escrow-live-7099","state":"released","settlement_tx_signature":"devnet-signature-7099","settlement_commitment":"finalized"}"#.to_owned(),
+        "query_participant_task_projection" => projection_result(role, "participant-private"),
+        "query_verifier_task_projection" => projection_result(role, "restricted-public"),
+        _ => r#"{"task_id":"task-live-7099","state":"accepted"}"#.to_owned(),
+    }
+}
+
+fn task_result(state: &str) -> String {
+    format!(
+        r#"{{"task_id":"task-live-7099","state":"{state}","transaction_id":"transaction-live-7099"}}"#
+    )
+}
+
+fn projection_result(role: &str, scope: &str) -> String {
+    let participant = match role {
+        "agent_a" => r#", "participant_role":"creator""#,
+        "agent_b" => r#", "participant_role":"provider""#,
+        _ => "",
+    };
+    format!(
+        r#"{{"task_id":"task-live-7099","escrow_id":"escrow-live-7099","settlement_tx_signature":"devnet-signature-7099","settlement_commitment":"finalized","public_commitment":"{}","view_scope":"{scope}"{participant}}}"#,
+        sha('d')
+    )
+}
+
+fn role_suffix(role: &str) -> char {
+    match role {
+        "agent_a" => 'a',
+        "agent_b" => 'b',
+        _ => 'c',
+    }
+}
+
+pub(crate) fn response_digests(input: &ActorInput<'_>) -> [String; 5] {
+    let projection = if input.projection == sha('f') {
+        sha('3')
+    } else {
+        input.projection.clone()
+    };
+    [sha('a'), sha('b'), sha('c'), sha('d'), projection]
+}
+
+pub(crate) fn sha(character: char) -> String {
+    format!("sha256:{}", character.to_string().repeat(64))
+}

--- a/crates/kamn-e2e-harness/tests/support/pi_transaction_receipt_fixture.rs
+++ b/crates/kamn-e2e-harness/tests/support/pi_transaction_receipt_fixture.rs
@@ -8,6 +8,8 @@ pub(crate) struct ActorInput<'a> {
     pub(crate) handoff_authorized: bool,
     pub(crate) handoff_as_string: bool,
     pub(crate) include_release: bool,
+    pub(crate) duplicate_fund: bool,
+    pub(crate) release_error: bool,
 }
 
 impl<'a> ActorInput<'a> {
@@ -28,6 +30,8 @@ impl<'a> ActorInput<'a> {
             handoff_authorized: false,
             handoff_as_string: false,
             include_release: true,
+            duplicate_fund: false,
+            release_error: false,
         }
     }
 
@@ -50,6 +54,16 @@ impl<'a> ActorInput<'a> {
         self.include_release = value;
         self
     }
+
+    pub(crate) fn with_duplicate_fund(mut self, value: bool) -> Self {
+        self.duplicate_fund = value;
+        self
+    }
+
+    pub(crate) fn with_release_error(mut self, value: bool) -> Self {
+        self.release_error = value;
+        self
+    }
 }
 
 pub(crate) fn runtime_receipts(input: &ActorInput<'_>) -> String {
@@ -67,7 +81,9 @@ fn tools(input: &ActorInput<'_>) -> [&'static str; 5] {
             "register",
             "create_task",
             "fund_escrow",
-            if input.include_release {
+            if input.duplicate_fund {
+                "fund_escrow"
+            } else if input.include_release {
                 "release_escrow"
             } else {
                 "query_task"
@@ -92,12 +108,18 @@ fn tools(input: &ActorInput<'_>) -> [&'static str; 5] {
 }
 
 fn receipt_json(input: &ActorInput<'_>, index: usize, tool: &str) -> String {
+    let is_error = input.release_error && tool == "release_escrow";
+    let outcome = if is_error { "error" } else { "success" };
+    let public_result = if is_error {
+        "{}".to_owned()
+    } else {
+        public_result_json(input.role, tool)
+    };
     format!(
-        r#"{{"request_id":{},"tool":"{}","outcome":"success","digest":"{}","public_result":{}}}"#,
+        r#"{{"request_id":{},"tool":"{}","outcome":"{outcome}","digest":"{}","public_result":{public_result}}}"#,
         index + 1,
         tool,
         response_digests(input)[index],
-        public_result_json(input.role, tool),
     )
 }
 

--- a/crates/kamn-e2e-harness/tests/support/pi_transaction_receipt_fixture.rs
+++ b/crates/kamn-e2e-harness/tests/support/pi_transaction_receipt_fixture.rs
@@ -10,6 +10,7 @@ pub(crate) struct ActorInput<'a> {
     pub(crate) include_release: bool,
     pub(crate) duplicate_fund: bool,
     pub(crate) release_error: bool,
+    pub(crate) receipt_digest_mismatch: bool,
 }
 
 impl<'a> ActorInput<'a> {
@@ -32,6 +33,7 @@ impl<'a> ActorInput<'a> {
             include_release: true,
             duplicate_fund: false,
             release_error: false,
+            receipt_digest_mismatch: false,
         }
     }
 
@@ -62,6 +64,11 @@ impl<'a> ActorInput<'a> {
 
     pub(crate) fn with_release_error(mut self, value: bool) -> Self {
         self.release_error = value;
+        self
+    }
+
+    pub(crate) fn with_receipt_digest_mismatch(mut self, value: bool) -> Self {
+        self.receipt_digest_mismatch = value;
         self
     }
 }
@@ -115,11 +122,16 @@ fn receipt_json(input: &ActorInput<'_>, index: usize, tool: &str) -> String {
     } else {
         public_result_json(input.role, tool)
     };
+    let digest = if input.receipt_digest_mismatch && tool == "release_escrow" {
+        sha('f')
+    } else {
+        response_digests(input)[index].clone()
+    };
     format!(
         r#"{{"request_id":{},"tool":"{}","outcome":"{outcome}","digest":"{}","public_result":{public_result}}}"#,
         index + 1,
         tool,
-        response_digests(input)[index],
+        digest,
     )
 }
 

--- a/crates/kamn-e2e-harness/tests/support/pi_transaction_receipt_fixture.rs
+++ b/crates/kamn-e2e-harness/tests/support/pi_transaction_receipt_fixture.rs
@@ -11,6 +11,7 @@ pub(crate) struct ActorInput<'a> {
     pub(crate) duplicate_fund: bool,
     pub(crate) release_error: bool,
     pub(crate) receipt_digest_mismatch: bool,
+    pub(crate) public_fact_drift: bool,
 }
 
 impl<'a> ActorInput<'a> {
@@ -34,6 +35,7 @@ impl<'a> ActorInput<'a> {
             duplicate_fund: false,
             release_error: false,
             receipt_digest_mismatch: false,
+            public_fact_drift: false,
         }
     }
 
@@ -69,6 +71,11 @@ impl<'a> ActorInput<'a> {
 
     pub(crate) fn with_receipt_digest_mismatch(mut self, value: bool) -> Self {
         self.receipt_digest_mismatch = value;
+        self
+    }
+
+    pub(crate) fn with_public_fact_drift(mut self, value: bool) -> Self {
+        self.public_fact_drift = value;
         self
     }
 }
@@ -117,11 +124,14 @@ fn tools(input: &ActorInput<'_>) -> [&'static str; 5] {
 fn receipt_json(input: &ActorInput<'_>, index: usize, tool: &str) -> String {
     let is_error = input.release_error && tool == "release_escrow";
     let outcome = if is_error { "error" } else { "success" };
-    let public_result = if is_error {
+    let mut public_result = if is_error {
         "{}".to_owned()
     } else {
         public_result_json(input.role, tool)
     };
+    if input.public_fact_drift && tool == "fund_escrow" {
+        public_result = public_result.replace("escrow-live-7099", "escrow-other");
+    }
     let digest = if input.receipt_digest_mismatch && tool == "release_escrow" {
         sha('f')
     } else {

--- a/specs/7101-runtime-receipt-chain.md
+++ b/specs/7101-runtime-receipt-chain.md
@@ -1,0 +1,145 @@
+# Replace Generated Narrative With A Runtime Receipt Chain
+
+## Objective
+
+Build the canonical three-agent transcript from the strict Agent A, Agent B,
+and Agent C runtime receipt artifacts merged under #7099. A generated label,
+handoff identifier, copied settlement field, or harness-authored view body must
+not satisfy any successful transaction step.
+
+## Inputs/Outputs
+
+Inputs are the three `kamn.mvp.pi-transaction-actor.v1` artifacts already
+accepted by `verify_pi_transaction_actor_paths`, the task-bound settlement
+claim, and runtime-owned participant/restricted projection artifacts.
+
+Output is `kamn.mvp.runtime-receipt-chain.v1`, referenced by the canonical
+three-agent claim. Each ordered step records actor, action, request ID, outcome,
+runtime response digest, before/after state, and the shared public transaction
+facts required for that step. The chain has its own recomputed artifact digest.
+
+## Boundaries/Non-goals
+
+- Reuse the strict actor decoder and canonical report verifier.
+- Do not add another agent framework, runtime state machine, or settlement path.
+- Identifier-only handoffs may identify a task but never become chain steps.
+- Failed and ambiguous receipts remain provenance but never satisfy a success
+  step.
+- Legacy generated transcript v1 may remain readable for old local-only reports,
+  but it cannot satisfy the runtime-receipt-chain success claim.
+- One-command orchestration is #7102; evaluator explorer UX is #7103.
+- Do not commit live artifacts, keys, OAuth state, or private participant data.
+
+## Receipt Chain Contract
+
+The canonical successful order is:
+
+1. Agent A registration.
+2. Agent B registration.
+3. Agent C registration.
+4. Agent A task creation (`none -> submitted`).
+5. Agent B task acceptance (`submitted -> accepted`).
+6. Agent A escrow funding (`none -> funded`).
+7. Agent B task completion (`accepted -> completed`).
+8. Agent A escrow release authorization and finalized settlement
+   (`funded -> released`).
+9. Agent A participant projection.
+10. Agent B participant projection.
+11. Agent C restricted verifier projection.
+
+Per-actor request IDs remain monotonic within their independent streams; the
+cross-actor ordering above is the business-state order, not a claim that nonce
+values share one global clock. Every step digest must exist in the matching
+actor artifact. Mutation steps require exactly one successful receipt. Repeated
+projection reads are allowed, but only the final successful projection receipt
+can satisfy the corresponding chain step.
+
+All steps carry one task ID, transaction ID, escrow ID, amount, network,
+settlement signature, settlement commitment, and public commitment where those
+facts exist. Earlier steps may use explicit `not-yet-created` state markers,
+never invented IDs. Agent C carries restricted-public scope and no participant
+private receipt digest.
+
+## Failure Modes
+
+- Missing required receipt: `RUNTIME_RECEIPT_CHAIN_STEP_MISSING`.
+- Duplicate successful mutation: `RUNTIME_RECEIPT_CHAIN_STEP_DUPLICATED`.
+- Invalid business-state order: `RUNTIME_RECEIPT_CHAIN_ORDER_INVALID`.
+- Receipt/digest mismatch: `RUNTIME_RECEIPT_CHAIN_DIGEST_MISMATCH`.
+- Cross-transaction/task/escrow facts: `RUNTIME_RECEIPT_CHAIN_FACT_MISMATCH`.
+- Error receipt used as success: `RUNTIME_RECEIPT_CHAIN_OUTCOME_INVALID`.
+- Handoff/generated narrative used as proof: `RUNTIME_RECEIPT_CHAIN_SOURCE_INVALID`.
+- Verifier private disclosure: `RUNTIME_RECEIPT_CHAIN_VERIFIER_PRIVATE_LEAK`.
+- Artifact digest mismatch: `RUNTIME_RECEIPT_CHAIN_ARTIFACT_MISMATCH`.
+
+All failures hard-fail report generation or verification. There is no fallback
+from a configured runtime chain to generated transcript strings.
+
+## Acceptance Criteria
+
+- [ ] Every required chain step references one exact actor runtime receipt and digest.
+- [ ] Missing, reordered, duplicated, skipped, or cross-transaction receipts fail closed.
+- [ ] Business-state order covers registration, create, accept, fund, complete,
+      release/finalization, participant projections, and restricted verification.
+- [ ] Before/after state and all shared facts remain consistent across the chain.
+- [ ] Failed/ambiguous responses remain provenance but cannot satisfy success.
+- [ ] Handoff artifacts and generated step labels cannot satisfy chain steps.
+- [ ] Agent C is sourced from the final restricted server projection and exposes
+      no participant-private field or digest.
+- [ ] Canonical report generation consumes the verified runtime chain.
+- [ ] Legacy v1 generated transcripts cannot satisfy the runtime-chain claim.
+- [ ] Positive/negative contracts, integration wiring, formatting, strict
+      clippy, and `make check` pass.
+
+## Files To Touch
+
+- `crates/kamn-e2e-harness/src/mvp_demo/pi_transaction_actor_*.rs`
+- `crates/kamn-e2e-harness/src/mvp_demo/three_agent_transcript*.rs`
+- focused runtime-chain modules under `crates/kamn-e2e-harness/src/mvp_demo/`
+- `crates/kamn-e2e-harness/src/mvp_demo/runner*.rs`
+- `crates/kamn-e2e-harness/tests/mvp_demo_runtime_receipt_chain_contract.rs`
+- focused shared fixtures under `crates/kamn-e2e-harness/tests/support/`
+
+## Error Semantics
+
+Interior decoding and validation return stable reason-code-prefixed `String`
+errors without logging. Runner/report entrypoints surface the error once and do
+not emit a PASS claim or partial chain artifact after failure.
+
+## Test Plan
+
+RED:
+
+- A generated v1 transcript plus valid labels passes without actor receipts.
+- Remove one required actor receipt while retaining the generated step string.
+- Reorder accept/fund or complete/release business steps.
+- Duplicate release success or use an ambiguous release response as success.
+- Copy one receipt digest or settlement fact from another transaction.
+- Replace Agent C projection receipt with a handoff digest.
+
+GREEN:
+
+- Expose strict decoded actor receipts to a focused chain builder.
+- Select exactly-once successful mutation receipts and final projection receipts.
+- Build and digest the ordered v1 runtime chain.
+- Wire report generation and verification to require the chain when actor
+  evidence paths are configured.
+
+REFACTOR:
+
+- Keep actor decoding, receipt selection, order/fact validation, serialization,
+  and report wiring separate.
+- Keep files below 200 lines and functions below 25 lines.
+- Reuse existing digest and strict JSON helpers.
+
+INTEGRATION:
+
+- Build a report from the verified #7099 actor fixture set.
+- Reject every negative fixture through the public verifier entrypoint.
+- Run focused tests, formatting, strict workspace clippy, and `make check`.
+
+## Rollback
+
+Preserve spec, RED, GREEN, REFACTOR, and INTEGRATION commits independently.
+Runtime-chain report wiring can be reverted without changing task, escrow,
+settlement, Pi, or MCP runtime behavior.

--- a/specs/7101-runtime-receipt-chain.md
+++ b/specs/7101-runtime-receipt-chain.md
@@ -92,21 +92,34 @@ from a configured runtime chain to generated transcript strings.
 
 ## Acceptance Criteria
 
-- [ ] Every required chain step references one exact actor runtime receipt and digest.
-- [ ] Every successful chain receipt exposes only strict typed public fields
+- [x] Every required chain step references one exact actor runtime receipt and digest.
+- [x] Every successful chain receipt exposes only strict typed public fields
       needed to prove state and shared facts.
-- [ ] Missing, reordered, duplicated, skipped, or cross-transaction receipts fail closed.
-- [ ] Business-state order covers registration, create, accept, fund, complete,
+- [x] Missing, reordered, duplicated, skipped, or cross-transaction receipts fail closed.
+- [x] Business-state order covers registration, create, accept, fund, complete,
       release/finalization, participant projections, and restricted verification.
-- [ ] Before/after state and all shared facts remain consistent across the chain.
-- [ ] Failed/ambiguous responses remain provenance but cannot satisfy success.
-- [ ] Handoff artifacts and generated step labels cannot satisfy chain steps.
-- [ ] Agent C is sourced from the final restricted server projection and exposes
+- [x] Before/after state and all shared facts remain consistent across the chain.
+- [x] Failed/ambiguous responses remain provenance but cannot satisfy success.
+- [x] Handoff artifacts and generated step labels cannot satisfy chain steps.
+- [x] Agent C is sourced from the final restricted server projection and exposes
       no participant-private field or digest.
-- [ ] Canonical report generation consumes the verified runtime chain.
-- [ ] Legacy v1 generated transcripts cannot satisfy the runtime-chain claim.
-- [ ] Positive/negative contracts, integration wiring, formatting, strict
+- [x] Canonical report generation consumes the verified runtime chain.
+- [x] Legacy v1 generated transcripts cannot satisfy the runtime-chain claim.
+- [x] Positive/negative contracts, integration wiring, formatting, strict
       clippy, and `make check` pass.
+
+## Delivered Compatibility Boundary
+
+`demo-mvp` consumes the existing all-or-none
+`KAMN_MVP_PI_TRANSACTION_AGENT_{A,B,C}_FILE` environment contract. When those
+paths are configured, the canonical `three-agent-transcript.json` artifact is
+the runtime receipt chain and generation has no narrative fallback. The
+verifier rebuilds that chain from the supplied actor artifacts and requires an
+exact artifact match.
+
+Legacy generated transcript v1 remains readable only when no runtime actor set
+is asserted. It cannot satisfy verification with configured actor evidence.
+One-command production of fresh actor artifacts remains scoped to #7102.
 
 ## Files To Touch
 

--- a/specs/7101-runtime-receipt-chain.md
+++ b/specs/7101-runtime-receipt-chain.md
@@ -13,6 +13,15 @@ Inputs are the three `kamn.mvp.pi-transaction-actor.v1` artifacts already
 accepted by `verify_pi_transaction_actor_paths`, the task-bound settlement
 claim, and runtime-owned participant/restricted projection artifacts.
 
+The #7099 receipt shape currently carries request ID, tool, outcome, and exact
+response digest. That proves provenance but is insufficient to prove state
+transitions. This issue extends each receipt with a strict allowlisted
+`public_result` projection containing only applicable public fields: task ID,
+task state, transaction ID, escrow ID, escrow state, amount, network,
+settlement signature/commitment, public commitment, view scope, and participant
+role. Raw response bodies, private receipt digests, payloads, auth material, and
+completion evidence remain excluded.
+
 Output is `kamn.mvp.runtime-receipt-chain.v1`, referenced by the canonical
 three-agent claim. Each ordered step records actor, action, request ID, outcome,
 runtime response digest, before/after state, and the shared public transaction
@@ -54,6 +63,11 @@ actor artifact. Mutation steps require exactly one successful receipt. Repeated
 projection reads are allowed, but only the final successful projection receipt
 can satisfy the corresponding chain step.
 
+The response digest continues to bind the exact full runtime response observed
+by Pi; `public_result` supplies independently typed fields for chain semantics.
+Unknown public fields, type confusion, missing required operation fields, and
+private-field markers fail closed.
+
 All steps carry one task ID, transaction ID, escrow ID, amount, network,
 settlement signature, settlement commitment, and public commitment where those
 facts exist. Earlier steps may use explicit `not-yet-created` state markers,
@@ -66,6 +80,7 @@ private receipt digest.
 - Duplicate successful mutation: `RUNTIME_RECEIPT_CHAIN_STEP_DUPLICATED`.
 - Invalid business-state order: `RUNTIME_RECEIPT_CHAIN_ORDER_INVALID`.
 - Receipt/digest mismatch: `RUNTIME_RECEIPT_CHAIN_DIGEST_MISMATCH`.
+- Missing/invalid public receipt projection: `RUNTIME_RECEIPT_CHAIN_PUBLIC_RESULT_INVALID`.
 - Cross-transaction/task/escrow facts: `RUNTIME_RECEIPT_CHAIN_FACT_MISMATCH`.
 - Error receipt used as success: `RUNTIME_RECEIPT_CHAIN_OUTCOME_INVALID`.
 - Handoff/generated narrative used as proof: `RUNTIME_RECEIPT_CHAIN_SOURCE_INVALID`.
@@ -78,6 +93,8 @@ from a configured runtime chain to generated transcript strings.
 ## Acceptance Criteria
 
 - [ ] Every required chain step references one exact actor runtime receipt and digest.
+- [ ] Every successful chain receipt exposes only strict typed public fields
+      needed to prove state and shared facts.
 - [ ] Missing, reordered, duplicated, skipped, or cross-transaction receipts fail closed.
 - [ ] Business-state order covers registration, create, accept, fund, complete,
       release/finalization, participant projections, and restricted verification.

--- a/specs/7101-runtime-receipt-chain.md
+++ b/specs/7101-runtime-receipt-chain.md
@@ -16,7 +16,7 @@ claim, and runtime-owned participant/restricted projection artifacts.
 The #7099 receipt shape currently carries request ID, tool, outcome, and exact
 response digest. That proves provenance but is insufficient to prove state
 transitions. This issue extends each receipt with a strict allowlisted
-`public_result` projection containing only applicable public fields: task ID,
+`public_result` projection containing only applicable public fields: actor DID, task ID,
 task state, transaction ID, escrow ID, escrow state, amount, network,
 settlement signature/commitment, public commitment, view scope, and participant
 role. Raw response bodies, private receipt digests, payloads, auth material, and


### PR DESCRIPTION
## Human Summary

- Replaces the configured demo transaction narrative with an ordered, digested chain built from exact Pi runtime receipts.
- Adds strict typed public-result projections and validates task, escrow, settlement, state, identity, scope, and privacy facts per step.
- Makes `verify-mvp-demo` rebuild the canonical chain from supplied actor artifacts, rejecting legacy/mixed sources and self-consistent forged chains.
- Keeps legacy transcript v1 readable only when no runtime actor evidence is asserted.

Closes #7101

Spec: [`specs/7101-runtime-receipt-chain.md`](https://github.com/njfio/kamn/blob/7101-runtime-receipt-chain/specs/7101-runtime-receipt-chain.md)

## Testing

- `cargo fmt --check`
- `CARGO_TARGET_DIR=target/mvp-demo-proof CARGO_BUILD_JOBS=1 cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `CARGO_TARGET_DIR=target/mvp-demo-proof CARGO_BUILD_JOBS=1 make check`
- 44 focused Rust command, actor, chain, transcript, receipt, and view contracts
- `node --test .pi/extensions/kamn-mvp/pi-transaction-evidence.test.ts .pi/extensions/kamn-mvp/live-task-workflow.test.ts` (25 tests)

## Notes for Reviewers

Review the source-coupling boundary in `runner.rs` and `three_agent_transcript.rs`: when actor paths are configured there is intentionally no fallback to the generated transcript. One-command creation of fresh actor artifacts remains #7102.

## AI Agent Details

- Public runtime projections are deny-unknown and contain no raw responses, auth data, completion evidence, or private receipt digests.
- Per-actor request order is validated independently; cross-actor chain order represents business-state order, not a global clock.
- The verifier compares the report artifact byte-for-byte with a deterministic rebuild from actor receipts after strict actor and artifact validation.
- shell_loc_delta_actual: 0
- rust_loc_delta_actual: 0
- shell_to_rust_ratio_delta_actual: 0.0
- shell_surface_ratio_target_status: neutral