### PR TITLE
feat: add the canonical three-agent transaction demo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2168,6 +2168,7 @@ dependencies = [
  "kamn-agent-lib",
  "kamn-cli",
  "kamn-mcp-server",
+ "kamn-sdk",
  "serde",
  "serde_json",
  "sha2",

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ PRE_PUSH_WORKSPACE_TIMEOUT_SECONDS ?= 14400
 LOCAL_GATE_ENV = PATH="$(PRE_PUSH_PYTHON3_DIR):$(LOCAL_GATE_BASH_DIR):$(PATH)"
 PRE_PUSH_ENV = PATH="$(PRE_PUSH_PYTHON3_DIR):$(LOCAL_GATE_BASH_DIR):$(PATH)"
 
-.PHONY: help check test pre-push smoke-live-network deep-live-network demo demo-mvp demo-localhost-transport ci-tools kolme-local-heavy kolme-fork-rust-tests-local
+.PHONY: help check test pre-push smoke-live-network deep-live-network demo demo-mvp demo-agent-transaction demo-localhost-transport ci-tools kolme-local-heavy kolme-fork-rust-tests-local
 
 help:
 	@echo "KAMN developer lanes"
@@ -21,6 +21,7 @@ help:
 	@echo "  make deep-live-network - scheduled/manual pilot deep lane summary report"
 	@echo "  make demo   - two-process localhost signed-message demo"
 	@echo "  make demo-mvp - evaluator MVP demo proof report"
+	@echo "  make demo-agent-transaction - canonical three-agent devnet transaction demo"
 	@echo "  make demo-localhost-transport - explicit localhost sender/listener transport demo"
 	@echo "  make ci-tools - CI helper regression suite"
 	@echo "  make kolme-local-heavy - local-only Kolme heavy validation matrix (requires explicit opt-in for run mode)"
@@ -69,6 +70,9 @@ demo:
 
 demo-mvp:
 	CARGO_TARGET_DIR=target/mvp-demo-proof cargo run -p kamn-e2e-harness -- demo-mvp
+
+demo-agent-transaction:
+	CARGO_TARGET_DIR=target/mvp-demo-proof cargo run -p kamn-e2e-harness -- demo-agent-transaction
 
 demo-localhost-transport:
 	bash scripts/sdk/run_localhost_signed_demo.sh

--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,9 @@ demo-mvp:
 	CARGO_TARGET_DIR=target/mvp-demo-proof cargo run -p kamn-e2e-harness -- demo-mvp
 
 demo-agent-transaction:
+	CARGO_TARGET_DIR=target/mvp-demo-proof cargo build -p kamn-node -p kamn-mcp-server
+	KAMN_MVP_LOCAL_NODE_BINARY="$${KAMN_MVP_LOCAL_NODE_BINARY:-target/mvp-demo-proof/debug/kamn-node}" \
+	KAMN_MVP_LIVE_MCP_BINARY="$${KAMN_MVP_LIVE_MCP_BINARY:-target/mvp-demo-proof/debug/kamn-mcp-server}" \
 	CARGO_TARGET_DIR=target/mvp-demo-proof cargo run -p kamn-e2e-harness -- demo-agent-transaction
 
 demo-localhost-transport:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Prerequisites:
 - Python 3
 - Solana CLI only for independently confirming devnet transactions
 
-Run the local-only MVP demo:
+Run the bounded local proof demo without autonomous Pi actors:
 
 ```bash
 make demo-mvp
@@ -50,6 +50,44 @@ Expected top-level artifacts:
 
 The report links to the concrete run directory under `.kamn/demo/<run-id>/`, including local signed-flow, service API, websocket, audit, and settlement proof files where applicable.
 
+### Canonical three-agent transaction demo
+
+The evaluator-facing product demo is `make demo-agent-transaction`. It starts
+the local KAMN node, launches three independent persistent Pi processes using
+existing Codex OAuth and `gpt-5.5`, drives the task and escrow lifecycle, makes
+one Solana devnet transfer on release, verifies all three actor views, and
+writes the canonical report.
+
+Create three local KAMN identity keys in an ignored directory once:
+
+```bash
+mkdir -p .kamn/devnet
+openssl rand -hex 32 > .kamn/devnet/mvp-agent-a.key
+openssl rand -hex 32 > .kamn/devnet/mvp-agent-b.key
+openssl rand -hex 32 > .kamn/devnet/mvp-agent-c.key
+chmod 600 .kamn/devnet/mvp-agent-*.key
+```
+
+Then run with a funded Solana devnet payer and recipient:
+
+```bash
+KAMN_MVP_AGENT_DRIVER=pi \
+KAMN_MVP_DEVNET_MODE=required \
+KAMN_MVP_SOLANA_RPC_URL=https://api.devnet.solana.com \
+KAMN_SERVICE_API_LIVE_SOLANA_BRIDGE_RPC_URL=https://api.devnet.solana.com \
+KAMN_SERVICE_API_LIVE_SOLANA_SETTLEMENT_KEYPAIR_FILE=/absolute/path/to/devnet-payer.json \
+KAMN_SERVICE_API_LIVE_SOLANA_SETTLEMENT_RECIPIENT_PUBKEY=<devnet-recipient-pubkey> \
+KAMN_SERVICE_API_LIVE_SOLANA_SETTLEMENT_LAMPORTS=1000000 \
+KAMN_SERVICE_API_LIVE_SOLANA_SETTLEMENT_COMMITMENT=finalized \
+KAMN_MVP_LIVE_MCP_AGENT_A_KEY_FILE="$PWD/.kamn/devnet/mvp-agent-a.key" \
+KAMN_MVP_LIVE_MCP_AGENT_B_KEY_FILE="$PWD/.kamn/devnet/mvp-agent-b.key" \
+KAMN_MVP_LIVE_MCP_AGENT_C_KEY_FILE="$PWD/.kamn/devnet/mvp-agent-c.key" \
+make demo-agent-transaction
+```
+
+The command returns `GO` only after the standalone report verifier passes. A
+failure returns a stable reason and writes `.kamn/demo/latest/NO-GO.txt`.
+
 For the funded Solana devnet-backed path:
 
 ```bash
@@ -65,13 +103,12 @@ make demo-mvp
 
 If the devnet path is fully configured and funded, the report can return `GO` with a `devnet_settlement_asset_movement` claim labelled `devnet-backed`. If devnet evidence is unavailable, the honest result is `NO-GO`, not a local-only settlement pass.
 
-To produce the full three-agent story, first create fresh independent Agent A,
-Agent B, and restricted Agent C artifacts using the evaluator runbook, then
-provide all four `KAMN_MVP_LIVE_TASK_*_FILE` variables to the funded command.
-KAMN validates those sources, places their task ID and binding digest in the
-live service escrow request, and propagates the request-derived `escrow-local-*`
-ID through the transcript, participant views, restricted verifier view, and
-receipts. A settlement-only run does not claim three-agent verification.
+In the canonical transaction report, `execution_surface:"command-override"`
+describes the bounded report adapter, not a simulated transfer. The transfer is
+initiated by Agent A through the live local KAMN service. The adapter confirms
+that exact actor signature with `solana confirm`, verifies finalized payer and
+recipient balance movement, and reuses the evidence without submitting a
+second transaction.
 
 Detailed evaluator runbook:
 

--- a/crates/kamn-e2e-harness/Cargo.toml
+++ b/crates/kamn-e2e-harness/Cargo.toml
@@ -8,6 +8,7 @@ license = "Apache-2.0"
 kamn-agent-lib = { path = "../kamn-agent-lib" }
 kamn-cli = { path = "../kamn-cli" }
 kamn-mcp-server = { path = "../kamn-mcp-server" }
+kamn-sdk = { path = "../kamn-sdk" }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 sha2.workspace = true

--- a/crates/kamn-e2e-harness/src/agent_transaction_demo.rs
+++ b/crates/kamn-e2e-harness/src/agent_transaction_demo.rs
@@ -29,6 +29,8 @@ pub struct AgentTransactionDemoConfig {
     pub pi_model: String,
     /// Explicit project-local Pi extension path.
     pub pi_extension: String,
+    /// Canonical proof output root.
+    pub output_root: String,
 }
 
 /// Parses and validates canonical demo configuration without performing work.
@@ -55,6 +57,7 @@ pub fn parse_agent_transaction_demo_config(
             "KAMN_MVP_PI_EXTENSION",
             ".pi/extensions/kamn-mvp/index.ts",
         ),
+        output_root: optional(env, "KAMN_MVP_AGENT_TRANSACTION_OUTPUT_ROOT", ".kamn/demo"),
     };
     validate_config(&config)?;
     Ok(config)
@@ -64,8 +67,15 @@ pub fn parse_agent_transaction_demo_config(
 pub fn execute_agent_transaction_demo_contract() -> Result<String, String> {
     let env = std::env::vars().collect::<BTreeMap<_, _>>();
     let config = parse_agent_transaction_demo_config(&env)?;
-    super::agent_transaction_preflight::validate_agent_transaction_preflight(&config)?;
-    Err("AGENT_TRANSACTION_CHILD_FAILED: supervisor unavailable".to_owned())
+    execute_agent_transaction_demo_with_config(&config)
+}
+
+/// Executes the canonical demo from an already parsed configuration.
+pub fn execute_agent_transaction_demo_with_config(
+    config: &AgentTransactionDemoConfig,
+) -> Result<String, String> {
+    super::agent_transaction_preflight::validate_agent_transaction_preflight(config)?;
+    super::agent_transaction_supervisor::run_supervised_registration(config)
 }
 
 fn agent_keys(env: &BTreeMap<String, String>) -> Result<[String; 3], String> {

--- a/crates/kamn-e2e-harness/src/agent_transaction_demo.rs
+++ b/crates/kamn-e2e-harness/src/agent_transaction_demo.rs
@@ -44,6 +44,13 @@ pub fn parse_agent_transaction_demo_config(
     Ok(config)
 }
 
+/// Validates canonical process configuration before supervisor execution.
+pub fn execute_agent_transaction_demo_contract() -> Result<String, String> {
+    let env = std::env::vars().collect::<BTreeMap<_, _>>();
+    parse_agent_transaction_demo_config(&env)?;
+    Err("AGENT_TRANSACTION_CHILD_FAILED: supervisor unavailable".to_owned())
+}
+
 fn agent_keys(env: &BTreeMap<String, String>) -> Result<[String; 3], String> {
     Ok([
         required(env, "KAMN_MVP_LIVE_MCP_AGENT_A_KEY_FILE")?,

--- a/crates/kamn-e2e-harness/src/agent_transaction_demo.rs
+++ b/crates/kamn-e2e-harness/src/agent_transaction_demo.rs
@@ -31,6 +31,8 @@ pub struct AgentTransactionDemoConfig {
     pub pi_extension: String,
     /// Canonical proof output root.
     pub output_root: String,
+    /// Maximum wait for one Pi RPC phase.
+    pub rpc_timeout_ms: u64,
 }
 
 /// Parses and validates canonical demo configuration without performing work.
@@ -58,6 +60,11 @@ pub fn parse_agent_transaction_demo_config(
             ".pi/extensions/kamn-mvp/index.ts",
         ),
         output_root: optional(env, "KAMN_MVP_AGENT_TRANSACTION_OUTPUT_ROOT", ".kamn/demo"),
+        rpc_timeout_ms: optional_positive_u64(
+            env,
+            "KAMN_MVP_AGENT_TRANSACTION_RPC_TIMEOUT_MS",
+            180_000,
+        )?,
     };
     validate_config(&config)?;
     Ok(config)
@@ -109,6 +116,17 @@ fn positive_u64(env: &BTreeMap<String, String>, name: &str) -> Result<u64, Strin
         .ok()
         .filter(|parsed| *parsed > 0)
         .ok_or_else(|| config_error(format!("{name} must be a positive integer")))
+}
+
+fn optional_positive_u64(
+    env: &BTreeMap<String, String>,
+    name: &str,
+    default: u64,
+) -> Result<u64, String> {
+    match env.get(name) {
+        Some(_) => positive_u64(env, name),
+        None => Ok(default),
+    }
 }
 
 fn validate_config(config: &AgentTransactionDemoConfig) -> Result<(), String> {

--- a/crates/kamn-e2e-harness/src/agent_transaction_demo.rs
+++ b/crates/kamn-e2e-harness/src/agent_transaction_demo.rs
@@ -29,6 +29,12 @@ pub struct AgentTransactionDemoConfig {
     pub pi_model: String,
     /// Explicit project-local Pi extension path.
     pub pi_extension: String,
+    /// Local KAMN node executable path.
+    pub local_node_binary: String,
+    /// Local KAMN MCP server executable path exposed to Pi tools.
+    pub mcp_binary: String,
+    /// Local KAMN service API endpoint used by the MCP server.
+    pub mcp_endpoint: String,
     /// Canonical proof output root.
     pub output_root: String,
     /// Maximum wait for one Pi RPC phase.
@@ -69,6 +75,13 @@ pub fn parse_agent_transaction_demo_config(
             "KAMN_MVP_PI_EXTENSION",
             ".pi/extensions/kamn-mvp/index.ts",
         ),
+        local_node_binary: optional(env, "KAMN_MVP_LOCAL_NODE_BINARY", "target/debug/kamn-node"),
+        mcp_binary: optional(
+            env,
+            "KAMN_MVP_LIVE_MCP_BINARY",
+            "target/debug/kamn-mcp-server",
+        ),
+        mcp_endpoint: optional(env, "KAMN_MVP_LIVE_MCP_ENDPOINT", "http://127.0.0.1:18278"),
         output_root: optional(env, "KAMN_MVP_AGENT_TRANSACTION_OUTPUT_ROOT", ".kamn/demo"),
         rpc_timeout_ms: optional_positive_u64(
             env,

--- a/crates/kamn-e2e-harness/src/agent_transaction_demo.rs
+++ b/crates/kamn-e2e-harness/src/agent_transaction_demo.rs
@@ -33,6 +33,16 @@ pub struct AgentTransactionDemoConfig {
     pub output_root: String,
     /// Maximum wait for one Pi RPC phase.
     pub rpc_timeout_ms: u64,
+    /// Non-proof staging root for coordination and actor artifacts.
+    pub staging_root: String,
+    /// Optional devnet settlement command override at the external test boundary.
+    pub devnet_settlement_command: Option<Vec<String>>,
+    /// Optional localhost proof command override at the external test boundary.
+    pub localhost_signed_demo_command: Option<Vec<String>>,
+    /// Optional service API proof command override at the external test boundary.
+    pub service_api_vertical_slice_command: Option<Vec<String>>,
+    /// Optional websocket proof command override at the external test boundary.
+    pub service_api_websocket_command: Option<Vec<String>>,
 }
 
 /// Parses and validates canonical demo configuration without performing work.
@@ -65,6 +75,11 @@ pub fn parse_agent_transaction_demo_config(
             "KAMN_MVP_AGENT_TRANSACTION_RPC_TIMEOUT_MS",
             180_000,
         )?,
+        staging_root: staging_root(env),
+        devnet_settlement_command: None,
+        localhost_signed_demo_command: None,
+        service_api_vertical_slice_command: None,
+        service_api_websocket_command: None,
     };
     validate_config(&config)?;
     Ok(config)
@@ -107,6 +122,19 @@ fn optional(env: &BTreeMap<String, String>, name: &str, default: &str) -> String
         .filter(|value| !value.is_empty())
         .unwrap_or(default)
         .to_owned()
+}
+
+fn staging_root(env: &BTreeMap<String, String>) -> String {
+    env.get("KAMN_MVP_AGENT_TRANSACTION_STAGING_ROOT")
+        .map(|value| value.trim())
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+        .unwrap_or_else(|| {
+            std::env::temp_dir()
+                .join(format!("kamn-agent-transaction-{}", std::process::id()))
+                .display()
+                .to_string()
+        })
 }
 
 fn positive_u64(env: &BTreeMap<String, String>, name: &str) -> Result<u64, String> {

--- a/crates/kamn-e2e-harness/src/agent_transaction_demo.rs
+++ b/crates/kamn-e2e-harness/src/agent_transaction_demo.rs
@@ -1,0 +1,98 @@
+use std::collections::{BTreeMap, HashSet};
+
+const CONFIG_ERROR: &str = "AGENT_TRANSACTION_DEVNET_CONFIG_INVALID";
+
+/// Validated configuration for the canonical three-agent transaction demo.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentTransactionDemoConfig {
+    /// Agent runtime driver. The MVP supports only `pi`.
+    pub agent_driver: String,
+    /// Settlement mode. The canonical transaction requires `required`.
+    pub devnet_mode: String,
+    /// Solana devnet RPC URL.
+    pub solana_rpc_url: String,
+    /// Three external KAMN agent key-file paths.
+    pub agent_key_files: [String; 3],
+    /// External Solana payer keypair path.
+    pub solana_keypair_file: String,
+    /// Solana devnet recipient pubkey.
+    pub solana_recipient_pubkey: String,
+    /// Positive transfer amount in lamports.
+    pub solana_lamports: u64,
+    /// Required settlement commitment.
+    pub solana_commitment: String,
+}
+
+/// Parses and validates canonical demo configuration without performing work.
+pub fn parse_agent_transaction_demo_config(
+    env: &BTreeMap<String, String>,
+) -> Result<AgentTransactionDemoConfig, String> {
+    let config = AgentTransactionDemoConfig {
+        agent_driver: required(env, "KAMN_MVP_AGENT_DRIVER")?,
+        devnet_mode: required(env, "KAMN_MVP_DEVNET_MODE")?,
+        solana_rpc_url: required(env, "KAMN_MVP_SOLANA_RPC_URL")?,
+        agent_key_files: agent_keys(env)?,
+        solana_keypair_file: required(env, "KAMN_SERVICE_API_LIVE_SOLANA_SETTLEMENT_KEYPAIR_FILE")?,
+        solana_recipient_pubkey: required(
+            env,
+            "KAMN_SERVICE_API_LIVE_SOLANA_SETTLEMENT_RECIPIENT_PUBKEY",
+        )?,
+        solana_lamports: positive_u64(env, "KAMN_SERVICE_API_LIVE_SOLANA_SETTLEMENT_LAMPORTS")?,
+        solana_commitment: required(env, "KAMN_SERVICE_API_LIVE_SOLANA_SETTLEMENT_COMMITMENT")?,
+    };
+    validate_config(&config)?;
+    Ok(config)
+}
+
+fn agent_keys(env: &BTreeMap<String, String>) -> Result<[String; 3], String> {
+    Ok([
+        required(env, "KAMN_MVP_LIVE_MCP_AGENT_A_KEY_FILE")?,
+        required(env, "KAMN_MVP_LIVE_MCP_AGENT_B_KEY_FILE")?,
+        required(env, "KAMN_MVP_LIVE_MCP_AGENT_C_KEY_FILE")?,
+    ])
+}
+
+fn required(env: &BTreeMap<String, String>, name: &str) -> Result<String, String> {
+    env.get(name)
+        .map(|value| value.trim())
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+        .ok_or_else(|| config_error(format!("missing {name}")))
+}
+
+fn positive_u64(env: &BTreeMap<String, String>, name: &str) -> Result<u64, String> {
+    let value = required(env, name)?;
+    value
+        .parse::<u64>()
+        .ok()
+        .filter(|parsed| *parsed > 0)
+        .ok_or_else(|| config_error(format!("{name} must be a positive integer")))
+}
+
+fn validate_config(config: &AgentTransactionDemoConfig) -> Result<(), String> {
+    if config.agent_driver != "pi" {
+        return Err("AGENT_TRANSACTION_DRIVER_INVALID: expected pi".to_owned());
+    }
+    if config.devnet_mode != "required"
+        || !config.solana_rpc_url.starts_with("https://")
+        || !config.solana_rpc_url.contains("devnet")
+        || config.solana_commitment != "finalized"
+    {
+        return Err(config_error(
+            "required finalized Solana devnet configuration",
+        ));
+    }
+    require_distinct_agent_keys(&config.agent_key_files)
+}
+
+fn require_distinct_agent_keys(paths: &[String; 3]) -> Result<(), String> {
+    let unique = paths.iter().collect::<HashSet<_>>();
+    if unique.len() == paths.len() {
+        return Ok(());
+    }
+    Err("AGENT_TRANSACTION_AGENT_CONFIG_INVALID: agent key paths must be distinct".to_owned())
+}
+
+fn config_error(message: impl AsRef<str>) -> String {
+    format!("{CONFIG_ERROR}: {}", message.as_ref())
+}

--- a/crates/kamn-e2e-harness/src/agent_transaction_demo.rs
+++ b/crates/kamn-e2e-harness/src/agent_transaction_demo.rs
@@ -21,6 +21,14 @@ pub struct AgentTransactionDemoConfig {
     pub solana_lamports: u64,
     /// Required settlement commitment.
     pub solana_commitment: String,
+    /// Pi executable path or command name.
+    pub pi_binary: String,
+    /// Pi OAuth-backed provider name.
+    pub pi_provider: String,
+    /// Pi model identifier.
+    pub pi_model: String,
+    /// Explicit project-local Pi extension path.
+    pub pi_extension: String,
 }
 
 /// Parses and validates canonical demo configuration without performing work.
@@ -39,6 +47,14 @@ pub fn parse_agent_transaction_demo_config(
         )?,
         solana_lamports: positive_u64(env, "KAMN_SERVICE_API_LIVE_SOLANA_SETTLEMENT_LAMPORTS")?,
         solana_commitment: required(env, "KAMN_SERVICE_API_LIVE_SOLANA_SETTLEMENT_COMMITMENT")?,
+        pi_binary: optional(env, "KAMN_MVP_PI_BINARY", "pi"),
+        pi_provider: optional(env, "KAMN_MVP_PI_PROVIDER", "openai-codex"),
+        pi_model: optional(env, "KAMN_MVP_PI_MODEL", "gpt-5.5"),
+        pi_extension: optional(
+            env,
+            "KAMN_MVP_PI_EXTENSION",
+            ".pi/extensions/kamn-mvp/index.ts",
+        ),
     };
     validate_config(&config)?;
     Ok(config)
@@ -65,6 +81,14 @@ fn required(env: &BTreeMap<String, String>, name: &str) -> Result<String, String
         .filter(|value| !value.is_empty())
         .map(str::to_owned)
         .ok_or_else(|| config_error(format!("missing {name}")))
+}
+
+fn optional(env: &BTreeMap<String, String>, name: &str, default: &str) -> String {
+    env.get(name)
+        .map(|value| value.trim())
+        .filter(|value| !value.is_empty())
+        .unwrap_or(default)
+        .to_owned()
 }
 
 fn positive_u64(env: &BTreeMap<String, String>, name: &str) -> Result<u64, String> {

--- a/crates/kamn-e2e-harness/src/agent_transaction_demo.rs
+++ b/crates/kamn-e2e-harness/src/agent_transaction_demo.rs
@@ -63,7 +63,8 @@ pub fn parse_agent_transaction_demo_config(
 /// Validates canonical process configuration before supervisor execution.
 pub fn execute_agent_transaction_demo_contract() -> Result<String, String> {
     let env = std::env::vars().collect::<BTreeMap<_, _>>();
-    parse_agent_transaction_demo_config(&env)?;
+    let config = parse_agent_transaction_demo_config(&env)?;
+    super::agent_transaction_preflight::validate_agent_transaction_preflight(&config)?;
     Err("AGENT_TRANSACTION_CHILD_FAILED: supervisor unavailable".to_owned())
 }
 

--- a/crates/kamn-e2e-harness/src/agent_transaction_devnet_evidence.rs
+++ b/crates/kamn-e2e-harness/src/agent_transaction_devnet_evidence.rs
@@ -1,0 +1,191 @@
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::Value;
+
+use super::agent_transaction_evidence::AgentTransactionEvidencePaths;
+use super::AgentTransactionDemoConfig;
+
+const EVIDENCE_ERROR: &str = "AGENT_TRANSACTION_SETTLEMENT_INVALID";
+
+pub(super) fn collect_actor_settlement_evidence(
+    config: &AgentTransactionDemoConfig,
+    paths: &AgentTransactionEvidencePaths,
+) -> Result<PathBuf, String> {
+    let actor = read_actor(paths.actors[0].as_str())?;
+    let payer = payer_pubkey(config.solana_keypair_file.as_str())?;
+    let confirmation = confirm(config, actor.signature.as_str())?;
+    let balances = transaction_balances(&confirmation, payer.as_str(), config)?;
+    let evidence = evidence_json(config, &actor, payer.as_str(), &balances);
+    let path = Path::new(config.staging_root.as_str()).join("actor-devnet-evidence.json");
+    std::fs::write(&path, evidence)
+        .map_err(|error| settlement_error(format!("evidence write failed: {error}")))?;
+    Ok(path)
+}
+
+struct ActorSettlement {
+    signature: String,
+    escrow_id: String,
+    lamports: u64,
+}
+
+struct TransactionBalances {
+    payer_before: u64,
+    payer_after: u64,
+    recipient_before: u64,
+    recipient_after: u64,
+}
+
+fn read_actor(path: &str) -> Result<ActorSettlement, String> {
+    let raw = std::fs::read_to_string(path)
+        .map_err(|error| settlement_error(format!("actor read failed: {error}")))?;
+    let value: Value = serde_json::from_str(raw.as_str())
+        .map_err(|error| settlement_error(format!("actor JSON failed: {error}")))?;
+    Ok(ActorSettlement {
+        signature: string_field(&value, "settlement_tx_signature")?,
+        escrow_id: string_field(&value, "escrow_id")?,
+        lamports: u64_field(&value, "amount_lamports")?,
+    })
+}
+
+fn payer_pubkey(keypair: &str) -> Result<String, String> {
+    let output = Command::new("solana-keygen")
+        .args(["pubkey", keypair])
+        .output()
+        .map_err(|error| settlement_error(format!("solana-keygen failed: {error}")))?;
+    if !output.status.success() {
+        return Err(settlement_error("solana-keygen rejected payer"));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_owned())
+}
+
+fn confirm(config: &AgentTransactionDemoConfig, signature: &str) -> Result<Value, String> {
+    let output = Command::new("solana")
+        .args([
+            "confirm",
+            "--url",
+            config.solana_rpc_url.as_str(),
+            "--commitment",
+            "finalized",
+            "--verbose",
+            "--output",
+            "json",
+            signature,
+        ])
+        .output()
+        .map_err(|error| settlement_error(format!("solana confirm failed: {error}")))?;
+    if !output.status.success() {
+        return Err(settlement_error("Solana did not confirm actor settlement"));
+    }
+    serde_json::from_slice(&output.stdout)
+        .map_err(|error| settlement_error(format!("confirmation JSON failed: {error}")))
+}
+
+fn transaction_balances(
+    value: &Value,
+    payer: &str,
+    config: &AgentTransactionDemoConfig,
+) -> Result<TransactionBalances, String> {
+    require_finalized(value)?;
+    let keys = value["transaction"]["message"]["accountKeys"]
+        .as_array()
+        .ok_or_else(|| settlement_error("confirmation account keys missing"))?;
+    let payer_index = account_index(keys, payer)?;
+    let recipient_index = account_index(keys, config.solana_recipient_pubkey.as_str())?;
+    let pre = balance_array(value, "preBalances")?;
+    let post = balance_array(value, "postBalances")?;
+    let balances = balances(pre, post, payer_index, recipient_index)?;
+    validate_movement(&balances, config.solana_lamports)?;
+    Ok(balances)
+}
+
+fn require_finalized(value: &Value) -> Result<(), String> {
+    if value["confirmationStatus"] == "finalized" && value["meta"]["err"].is_null() {
+        return Ok(());
+    }
+    Err(settlement_error(
+        "actor transaction is not finalized success",
+    ))
+}
+
+fn account_index(keys: &[Value], expected: &str) -> Result<usize, String> {
+    keys.iter()
+        .position(|key| key.as_str() == Some(expected))
+        .ok_or_else(|| settlement_error(format!("transaction account missing: {expected}")))
+}
+
+fn balance_array<'a>(value: &'a Value, field: &str) -> Result<&'a [Value], String> {
+    value["meta"][field]
+        .as_array()
+        .map(Vec::as_slice)
+        .ok_or_else(|| settlement_error(format!("confirmation {field} missing")))
+}
+
+fn balances(
+    pre: &[Value],
+    post: &[Value],
+    payer: usize,
+    recipient: usize,
+) -> Result<TransactionBalances, String> {
+    Ok(TransactionBalances {
+        payer_before: indexed_balance(pre, payer)?,
+        payer_after: indexed_balance(post, payer)?,
+        recipient_before: indexed_balance(pre, recipient)?,
+        recipient_after: indexed_balance(post, recipient)?,
+    })
+}
+
+fn indexed_balance(values: &[Value], index: usize) -> Result<u64, String> {
+    values
+        .get(index)
+        .and_then(Value::as_u64)
+        .ok_or_else(|| settlement_error("transaction balance missing"))
+}
+
+fn validate_movement(found: &TransactionBalances, lamports: u64) -> Result<(), String> {
+    let recipient_moved = found.recipient_after >= found.recipient_before.saturating_add(lamports);
+    if recipient_moved && found.payer_after < found.payer_before {
+        return Ok(());
+    }
+    Err(settlement_error(
+        "actor transaction balance movement invalid",
+    ))
+}
+
+fn evidence_json(
+    config: &AgentTransactionDemoConfig,
+    actor: &ActorSettlement,
+    payer: &str,
+    balances: &TransactionBalances,
+) -> String {
+    serde_json::json!({
+        "network": "solana:devnet", "rpc_url": config.solana_rpc_url,
+        "payer_pubkey": payer, "recipient_pubkey": config.solana_recipient_pubkey,
+        "lamports": actor.lamports, "escrow_id": actor.escrow_id,
+        "settlement_tx_signature": actor.signature, "settlement_commitment": "finalized",
+        "payer_balance_before": balances.payer_before, "payer_balance_after": balances.payer_after,
+        "recipient_balance_before": balances.recipient_before,
+        "recipient_balance_after": balances.recipient_after,
+        "persisted_settlement_tx_signature": actor.signature,
+    })
+    .to_string()
+}
+
+fn string_field(value: &Value, field: &str) -> Result<String, String> {
+    value[field]
+        .as_str()
+        .filter(|found| !found.is_empty())
+        .map(str::to_owned)
+        .ok_or_else(|| settlement_error(format!("actor {field} missing")))
+}
+
+fn u64_field(value: &Value, field: &str) -> Result<u64, String> {
+    value[field]
+        .as_u64()
+        .filter(|found| *found > 0)
+        .ok_or_else(|| settlement_error(format!("actor {field} missing")))
+}
+
+fn settlement_error(message: impl AsRef<str>) -> String {
+    format!("{EVIDENCE_ERROR}: {}", message.as_ref())
+}

--- a/crates/kamn-e2e-harness/src/agent_transaction_evidence.rs
+++ b/crates/kamn-e2e-harness/src/agent_transaction_evidence.rs
@@ -1,0 +1,82 @@
+use std::path::Path;
+
+use super::AgentTransactionDemoConfig;
+
+pub(super) struct AgentTransactionEvidencePaths {
+    pub(super) handoff: String,
+    pub(super) agent_a_receipt: String,
+    pub(super) agent_b_receipt: String,
+    pub(super) agent_c_observation: String,
+    pub(super) actors: [String; 3],
+    pub(super) run_id: String,
+}
+
+impl AgentTransactionEvidencePaths {
+    pub(super) fn prepare(config: &AgentTransactionDemoConfig) -> Result<Self, String> {
+        let root = Path::new(config.staging_root.as_str());
+        reject_existing_artifacts(root)?;
+        std::fs::create_dir_all(root)
+            .map_err(|_| "AGENT_TRANSACTION_OUTPUT_CONFLICT: staging root failed".to_owned())?;
+        Ok(Self {
+            handoff: path(root, "handoff.json"),
+            agent_a_receipt: path(root, "task-agent-a.json"),
+            agent_b_receipt: path(root, "task-agent-b.json"),
+            agent_c_observation: path(root, "task-agent-c.json"),
+            actors: [
+                path(root, "agent-a.json"),
+                path(root, "agent-b.json"),
+                path(root, "agent-c.json"),
+            ],
+            run_id: format!("agent-transaction-{}", std::process::id()),
+        })
+    }
+
+    pub(super) fn environment(&self) -> Vec<(&'static str, String)> {
+        vec![
+            ("KAMN_MVP_LIVE_TASK_HANDOFF_FILE", self.handoff.clone()),
+            (
+                "KAMN_MVP_LIVE_TASK_AGENT_A_RECEIPT_FILE",
+                self.agent_a_receipt.clone(),
+            ),
+            (
+                "KAMN_MVP_LIVE_TASK_AGENT_B_RECEIPT_FILE",
+                self.agent_b_receipt.clone(),
+            ),
+            (
+                "KAMN_MVP_LIVE_TASK_AGENT_C_OBSERVATION_FILE",
+                self.agent_c_observation.clone(),
+            ),
+            (
+                "KAMN_MVP_PI_TRANSACTION_AGENT_A_FILE",
+                self.actors[0].clone(),
+            ),
+            (
+                "KAMN_MVP_PI_TRANSACTION_AGENT_B_FILE",
+                self.actors[1].clone(),
+            ),
+            (
+                "KAMN_MVP_PI_TRANSACTION_AGENT_C_FILE",
+                self.actors[2].clone(),
+            ),
+            ("KAMN_MVP_PI_RUN_ID", self.run_id.clone()),
+        ]
+    }
+}
+
+fn reject_existing_artifacts(root: &Path) -> Result<(), String> {
+    if !root.exists() {
+        return Ok(());
+    }
+    let occupied = std::fs::read_dir(root)
+        .map_err(|_| "AGENT_TRANSACTION_OUTPUT_CONFLICT: staging root unreadable".to_owned())?
+        .next()
+        .is_some();
+    if occupied {
+        return Err("AGENT_TRANSACTION_OUTPUT_CONFLICT: staging root is not empty".to_owned());
+    }
+    Ok(())
+}
+
+fn path(root: &Path, name: &str) -> String {
+    root.join(name).display().to_string()
+}

--- a/crates/kamn-e2e-harness/src/agent_transaction_evidence.rs
+++ b/crates/kamn-e2e-harness/src/agent_transaction_evidence.rs
@@ -31,8 +31,11 @@ impl AgentTransactionEvidencePaths {
         })
     }
 
-    pub(super) fn environment(&self) -> Vec<(&'static str, String)> {
-        vec![
+    pub(super) fn environment(
+        &self,
+        config: &AgentTransactionDemoConfig,
+    ) -> Vec<(&'static str, String)> {
+        let mut environment = vec![
             ("KAMN_MVP_LIVE_TASK_HANDOFF_FILE", self.handoff.clone()),
             (
                 "KAMN_MVP_LIVE_TASK_AGENT_A_RECEIPT_FILE",
@@ -59,8 +62,45 @@ impl AgentTransactionEvidencePaths {
                 self.actors[2].clone(),
             ),
             ("KAMN_MVP_PI_RUN_ID", self.run_id.clone()),
-        ]
+        ];
+        environment.extend(runtime_environment(config));
+        environment
     }
+}
+
+fn runtime_environment(config: &AgentTransactionDemoConfig) -> Vec<(&'static str, String)> {
+    vec![
+        ("KAMN_MVP_LIVE_MCP_BINARY", config.mcp_binary.clone()),
+        ("KAMN_MVP_LIVE_MCP_ENDPOINT", config.mcp_endpoint.clone()),
+        (
+            "KAMN_MVP_LIVE_MCP_AGENT_A_NAME",
+            "kamn-mvp-agent-a".to_owned(),
+        ),
+        (
+            "KAMN_MVP_LIVE_MCP_AGENT_B_NAME",
+            "kamn-mvp-agent-b".to_owned(),
+        ),
+        (
+            "KAMN_MVP_LIVE_MCP_AGENT_C_NAME",
+            "kamn-mvp-agent-c".to_owned(),
+        ),
+        (
+            "KAMN_MVP_LIVE_MCP_AGENT_A_KEY_FILE",
+            config.agent_key_files[0].clone(),
+        ),
+        (
+            "KAMN_MVP_LIVE_MCP_AGENT_B_KEY_FILE",
+            config.agent_key_files[1].clone(),
+        ),
+        (
+            "KAMN_MVP_LIVE_MCP_AGENT_C_KEY_FILE",
+            config.agent_key_files[2].clone(),
+        ),
+        (
+            "KAMN_SERVICE_API_LIVE_SOLANA_SETTLEMENT_LAMPORTS",
+            config.solana_lamports.to_string(),
+        ),
+    ]
 }
 
 fn reject_existing_artifacts(root: &Path) -> Result<(), String> {

--- a/crates/kamn-e2e-harness/src/agent_transaction_finalize.rs
+++ b/crates/kamn-e2e-harness/src/agent_transaction_finalize.rs
@@ -1,0 +1,45 @@
+use super::agent_transaction_evidence::AgentTransactionEvidencePaths;
+use super::{
+    build_runtime_receipt_chain_from_actor_paths, execute_mvp_demo_contract,
+    execute_verify_mvp_demo_contract, AgentTransactionDemoConfig, LiveTaskEvidencePaths,
+    MvpDemoCommandConfig, VerifyMvpDemoCommandConfig,
+};
+
+pub(super) fn finalize(
+    config: &AgentTransactionDemoConfig,
+    paths: &AgentTransactionEvidencePaths,
+) -> Result<String, String> {
+    build_runtime_receipt_chain_from_actor_paths(&paths.actors)?;
+    let report = execute_mvp_demo_contract(&demo_config(config, paths))?;
+    execute_verify_mvp_demo_contract(&VerifyMvpDemoCommandConfig {
+        report: format!("{}/latest/proof/report.json", config.output_root),
+        agent_harness_evidence_path: None,
+        pi_transaction_actor_paths: Some(paths.actors.clone()),
+    })?;
+    Ok(format!(
+        "{{\"decision\":\"GO\",\"proof_schema\":\"kamn.mvp.runtime-receipt-chain.v1\",\"report\":{report}}}"
+    ))
+}
+
+fn demo_config(
+    config: &AgentTransactionDemoConfig,
+    paths: &AgentTransactionEvidencePaths,
+) -> MvpDemoCommandConfig {
+    MvpDemoCommandConfig {
+        output_root: config.output_root.clone(),
+        devnet_mode: config.devnet_mode.clone(),
+        solana_rpc_url: Some(config.solana_rpc_url.clone()),
+        devnet_settlement_command: config.devnet_settlement_command.clone(),
+        localhost_signed_demo_command: config.localhost_signed_demo_command.clone(),
+        service_api_vertical_slice_command: config.service_api_vertical_slice_command.clone(),
+        service_api_websocket_command: config.service_api_websocket_command.clone(),
+        agent_harness_evidence_path: None,
+        live_task_evidence: Some(LiveTaskEvidencePaths {
+            handoff: paths.handoff.clone(),
+            agent_a_receipt: paths.agent_a_receipt.clone(),
+            agent_b_receipt: paths.agent_b_receipt.clone(),
+            agent_c_observation: paths.agent_c_observation.clone(),
+        }),
+        pi_transaction_actor_paths: Some(paths.actors.clone()),
+    }
+}

--- a/crates/kamn-e2e-harness/src/agent_transaction_finalize.rs
+++ b/crates/kamn-e2e-harness/src/agent_transaction_finalize.rs
@@ -1,3 +1,4 @@
+use super::agent_transaction_devnet_evidence::collect_actor_settlement_evidence;
 use super::agent_transaction_evidence::AgentTransactionEvidencePaths;
 use super::{
     build_runtime_receipt_chain_from_actor_paths, execute_mvp_demo_contract,
@@ -10,7 +11,13 @@ pub(super) fn finalize(
     paths: &AgentTransactionEvidencePaths,
 ) -> Result<String, String> {
     build_runtime_receipt_chain_from_actor_paths(&paths.actors)?;
-    let report = execute_mvp_demo_contract(&demo_config(config, paths))?;
+    let mut demo = demo_config(config, paths);
+    if demo.devnet_settlement_command.is_none() {
+        let evidence = collect_actor_settlement_evidence(config, paths)?;
+        demo.devnet_settlement_command =
+            Some(vec!["cat".to_owned(), evidence.display().to_string()]);
+    }
+    let report = execute_mvp_demo_contract(&demo)?;
     execute_verify_mvp_demo_contract(&VerifyMvpDemoCommandConfig {
         report: format!("{}/latest/proof/report.json", config.output_root),
         agent_harness_evidence_path: None,

--- a/crates/kamn-e2e-harness/src/agent_transaction_pi_command.rs
+++ b/crates/kamn-e2e-harness/src/agent_transaction_pi_command.rs
@@ -76,6 +76,7 @@ const AGENT_B_TOOLS: &[&str] = &[
     "kamn_live_agent_b_register",
     "kamn_live_agent_b_receive_task_handoff",
     "kamn_live_agent_b_accept_task",
+    "kamn_live_agent_b_query_task",
     "kamn_live_agent_b_write_task_receipt",
     "kamn_live_agent_b_wait_for_escrow_funding",
     "kamn_live_agent_b_complete_task",

--- a/crates/kamn-e2e-harness/src/agent_transaction_pi_command.rs
+++ b/crates/kamn-e2e-harness/src/agent_transaction_pi_command.rs
@@ -87,6 +87,7 @@ const AGENT_C_TOOLS: &[&str] = &[
     "kamn_live_agent_c_register",
     "kamn_live_agent_c_receive_task_handoff",
     "kamn_live_agent_c_query_verifier_projection",
+    "kamn_live_agent_c_verify_restricted_task_observation",
     "kamn_live_agent_c_write_transaction_evidence",
     "kamn_live_verify_pi_transaction_actors",
 ];

--- a/crates/kamn-e2e-harness/src/agent_transaction_pi_command.rs
+++ b/crates/kamn-e2e-harness/src/agent_transaction_pi_command.rs
@@ -1,0 +1,100 @@
+use super::AgentTransactionDemoConfig;
+
+/// Role assigned to one independent Pi transaction process.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AgentTransactionRole {
+    /// Task creator, escrow funder, and release authorizer.
+    AgentA,
+    /// Task provider and completion author.
+    AgentB,
+    /// Restricted independent verifier.
+    AgentC,
+}
+
+/// Builds one persistent, role-bounded Pi RPC command.
+pub fn build_pi_actor_command(
+    config: &AgentTransactionDemoConfig,
+    role: AgentTransactionRole,
+) -> Vec<String> {
+    let mut command = base_command(config);
+    command.extend([
+        "--tools".to_owned(),
+        role_tools(role).join(","),
+        "--name".to_owned(),
+        role_name(role).to_owned(),
+    ]);
+    command
+}
+
+fn base_command(config: &AgentTransactionDemoConfig) -> Vec<String> {
+    [
+        config.pi_binary.as_str(),
+        "--mode",
+        "rpc",
+        "--provider",
+        config.pi_provider.as_str(),
+        "--model",
+        config.pi_model.as_str(),
+        "--thinking",
+        "high",
+        "--no-session",
+        "--approve",
+        "--no-extensions",
+        "--extension",
+        config.pi_extension.as_str(),
+        "--no-skills",
+        "--no-prompt-templates",
+        "--no-context-files",
+        "--no-builtin-tools",
+    ]
+    .into_iter()
+    .map(str::to_owned)
+    .collect()
+}
+
+fn role_tools(role: AgentTransactionRole) -> &'static [&'static str] {
+    match role {
+        AgentTransactionRole::AgentA => AGENT_A_TOOLS,
+        AgentTransactionRole::AgentB => AGENT_B_TOOLS,
+        AgentTransactionRole::AgentC => AGENT_C_TOOLS,
+    }
+}
+
+const AGENT_A_TOOLS: &[&str] = &[
+    "kamn_live_agent_a_register",
+    "kamn_live_agent_a_create_task",
+    "kamn_live_agent_a_publish_task_handoff",
+    "kamn_live_agent_a_wait_for_task_acceptance",
+    "kamn_live_agent_a_fund_escrow",
+    "kamn_live_agent_a_wait_for_task_completion",
+    "kamn_live_agent_a_release_escrow",
+    "kamn_live_agent_a_query_participant_projection",
+    "kamn_live_agent_a_write_transaction_evidence",
+];
+
+const AGENT_B_TOOLS: &[&str] = &[
+    "kamn_live_agent_b_register",
+    "kamn_live_agent_b_receive_task_handoff",
+    "kamn_live_agent_b_accept_task",
+    "kamn_live_agent_b_write_task_receipt",
+    "kamn_live_agent_b_wait_for_escrow_funding",
+    "kamn_live_agent_b_complete_task",
+    "kamn_live_agent_b_query_participant_projection",
+    "kamn_live_agent_b_write_transaction_evidence",
+];
+
+const AGENT_C_TOOLS: &[&str] = &[
+    "kamn_live_agent_c_register",
+    "kamn_live_agent_c_receive_task_handoff",
+    "kamn_live_agent_c_query_verifier_projection",
+    "kamn_live_agent_c_write_transaction_evidence",
+    "kamn_live_verify_pi_transaction_actors",
+];
+
+fn role_name(role: AgentTransactionRole) -> &'static str {
+    match role {
+        AgentTransactionRole::AgentA => "kamn-mvp-agent-a",
+        AgentTransactionRole::AgentB => "kamn-mvp-agent-b",
+        AgentTransactionRole::AgentC => "kamn-mvp-agent-c",
+    }
+}

--- a/crates/kamn-e2e-harness/src/agent_transaction_preflight.rs
+++ b/crates/kamn-e2e-harness/src/agent_transaction_preflight.rs
@@ -18,8 +18,26 @@ pub fn validate_agent_transaction_preflight(
     }
     validate_payer_keypair(config.solana_keypair_file.as_str())?;
     require_nonempty_file(config.pi_extension.as_str(), PI_ERROR)?;
+    require_executable(config.local_node_binary.as_str())?;
+    require_nonempty_file(config.mcp_binary.as_str(), AGENT_ERROR)?;
     validate_recipient(config.solana_recipient_pubkey.as_str())?;
     probe_pi_auth(config)
+}
+
+fn require_executable(path: &str) -> Result<(), String> {
+    require_nonempty_file(path, AGENT_ERROR)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mode = std::fs::metadata(path)
+            .map_err(|_| format!("{AGENT_ERROR}: local node metadata unavailable"))?
+            .permissions()
+            .mode();
+        if mode & 0o111 == 0 {
+            return Err(format!("{AGENT_ERROR}: local node is not executable"));
+        }
+    }
+    Ok(())
 }
 
 fn require_nonempty_file(path: &str, code: &str) -> Result<(), String> {

--- a/crates/kamn-e2e-harness/src/agent_transaction_preflight.rs
+++ b/crates/kamn-e2e-harness/src/agent_transaction_preflight.rs
@@ -1,0 +1,87 @@
+use std::path::Path;
+use std::process::Command;
+
+use serde_json::Value;
+
+use super::AgentTransactionDemoConfig;
+
+const PI_ERROR: &str = "AGENT_TRANSACTION_PI_PREFLIGHT_FAILED";
+const AGENT_ERROR: &str = "AGENT_TRANSACTION_AGENT_CONFIG_INVALID";
+const DEVNET_ERROR: &str = "AGENT_TRANSACTION_DEVNET_CONFIG_INVALID";
+
+/// Proves external files and current Pi OAuth/model readiness before execution.
+pub fn validate_agent_transaction_preflight(
+    config: &AgentTransactionDemoConfig,
+) -> Result<(), String> {
+    for path in &config.agent_key_files {
+        require_nonempty_file(path, AGENT_ERROR)?;
+    }
+    validate_payer_keypair(config.solana_keypair_file.as_str())?;
+    require_nonempty_file(config.pi_extension.as_str(), PI_ERROR)?;
+    validate_recipient(config.solana_recipient_pubkey.as_str())?;
+    probe_pi_auth(config)
+}
+
+fn require_nonempty_file(path: &str, code: &str) -> Result<(), String> {
+    let metadata = std::fs::metadata(path)
+        .map_err(|_| format!("{code}: required external file is unavailable"))?;
+    if metadata.is_file() && metadata.len() > 0 {
+        return Ok(());
+    }
+    Err(format!("{code}: required external file is empty"))
+}
+
+fn validate_payer_keypair(path: &str) -> Result<(), String> {
+    require_nonempty_file(path, DEVNET_ERROR)?;
+    let raw = std::fs::read_to_string(path)
+        .map_err(|_| format!("{DEVNET_ERROR}: payer keypair is unreadable"))?;
+    let value: Value = serde_json::from_str(raw.as_str())
+        .map_err(|_| format!("{DEVNET_ERROR}: payer keypair JSON is invalid"))?;
+    let valid = value.as_array().is_some_and(|items| {
+        items.len() == 64
+            && items
+                .iter()
+                .all(|item| item.as_u64().is_some_and(|byte| byte <= u8::MAX as u64))
+    });
+    if valid {
+        return Ok(());
+    }
+    Err(format!(
+        "{DEVNET_ERROR}: payer keypair must contain 64 bytes"
+    ))
+}
+
+fn validate_recipient(value: &str) -> Result<(), String> {
+    let valid_length = (32..=44).contains(&value.len());
+    let valid_chars = value
+        .bytes()
+        .all(|byte| byte.is_ascii_alphanumeric() && !matches!(byte, b'0' | b'O' | b'I' | b'l'));
+    if valid_length && valid_chars {
+        return Ok(());
+    }
+    Err(format!("{DEVNET_ERROR}: recipient pubkey is invalid"))
+}
+
+fn probe_pi_auth(config: &AgentTransactionDemoConfig) -> Result<(), String> {
+    let output = Command::new(Path::new(config.pi_binary.as_str()))
+        .args([
+            "--provider",
+            config.pi_provider.as_str(),
+            "--model",
+            config.pi_model.as_str(),
+            "--no-tools",
+            "--no-session",
+            "--no-extensions",
+            "--no-skills",
+            "--no-context-files",
+            "--print",
+            "Reply exactly KAMN_PI_PREFLIGHT_OK",
+        ])
+        .output()
+        .map_err(|_| format!("{PI_ERROR}: Pi executable is unavailable"))?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    if output.status.success() && stdout.contains("KAMN_PI_PREFLIGHT_OK") {
+        return Ok(());
+    }
+    Err(format!("{PI_ERROR}: OAuth/model probe failed"))
+}

--- a/crates/kamn-e2e-harness/src/agent_transaction_process.rs
+++ b/crates/kamn-e2e-harness/src/agent_transaction_process.rs
@@ -47,13 +47,47 @@ pub(super) fn wait_or_kill(child: &mut Child, timeout_ms: u64) {
     let _ = child.wait();
 }
 
+pub(super) fn terminate_process_group(child: &mut Child) {
+    if child.try_wait().ok().flatten().is_some() {
+        return;
+    }
+    signal_process_group(child.id(), "-TERM");
+    wait_after_signal(child);
+}
+
+pub(super) fn terminate_process(child: &mut Child) {
+    if child.try_wait().ok().flatten().is_some() {
+        return;
+    }
+    let pid = child.id().to_string();
+    let _ = Command::new("kill").args(["-TERM", pid.as_str()]).status();
+    wait_after_signal(child);
+}
+
+fn wait_after_signal(child: &mut Child) {
+    let deadline = Instant::now() + Duration::from_millis(50);
+    while Instant::now() < deadline {
+        if child.try_wait().ok().flatten().is_some() {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    wait_or_kill(child, 0);
+}
+
 #[cfg(unix)]
 fn kill_process_group(pid: u32) {
-    let group = format!("-{pid}");
-    let _ = Command::new("kill")
-        .args(["-KILL", group.as_str()])
-        .status();
+    signal_process_group(pid, "-KILL");
 }
+
+#[cfg(unix)]
+fn signal_process_group(pid: u32, signal: &str) {
+    let group = format!("-{pid}");
+    let _ = Command::new("kill").args([signal, group.as_str()]).status();
+}
+
+#[cfg(not(unix))]
+fn signal_process_group(_pid: u32, _signal: &str) {}
 
 #[cfg(not(unix))]
 fn kill_process_group(_pid: u32) {}

--- a/crates/kamn-e2e-harness/src/agent_transaction_process.rs
+++ b/crates/kamn-e2e-harness/src/agent_transaction_process.rs
@@ -4,13 +4,17 @@ use std::time::{Duration, Instant};
 #[cfg(unix)]
 use std::os::unix::process::CommandExt;
 
-pub(super) fn start_process(command: &[String]) -> Result<Child, String> {
+pub(super) fn start_process(
+    command: &[String],
+    environment: &[(&'static str, String)],
+) -> Result<Child, String> {
     let mut process = Command::new(&command[0]);
     process
         .args(&command[1..])
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
-        .stderr(Stdio::null());
+        .stderr(Stdio::null())
+        .envs(environment.iter().cloned());
     #[cfg(unix)]
     process.process_group(0);
     process

--- a/crates/kamn-e2e-harness/src/agent_transaction_process.rs
+++ b/crates/kamn-e2e-harness/src/agent_transaction_process.rs
@@ -1,0 +1,59 @@
+use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+use std::time::{Duration, Instant};
+
+#[cfg(unix)]
+use std::os::unix::process::CommandExt;
+
+pub(super) fn start_process(command: &[String]) -> Result<Child, String> {
+    let mut process = Command::new(&command[0]);
+    process
+        .args(&command[1..])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null());
+    #[cfg(unix)]
+    process.process_group(0);
+    process
+        .spawn()
+        .map_err(|_| child_error("failed to spawn Pi actor"))
+}
+
+pub(super) fn take_pipes(child: &mut Child) -> Result<(ChildStdin, ChildStdout), String> {
+    let stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| child_error("missing Pi stdin"))?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| child_error("missing Pi stdout"))?;
+    Ok((stdin, stdout))
+}
+
+pub(super) fn wait_or_kill(child: &mut Child, timeout_ms: u64) {
+    let deadline = Instant::now() + Duration::from_millis(timeout_ms.min(2_000));
+    while Instant::now() < deadline {
+        if child.try_wait().ok().flatten().is_some() {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    kill_process_group(child.id());
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+#[cfg(unix)]
+fn kill_process_group(pid: u32) {
+    let group = format!("-{pid}");
+    let _ = Command::new("kill")
+        .args(["-KILL", group.as_str()])
+        .status();
+}
+
+#[cfg(not(unix))]
+fn kill_process_group(_pid: u32) {}
+
+fn child_error(detail: &str) -> String {
+    format!("AGENT_TRANSACTION_CHILD_FAILED: {detail}")
+}

--- a/crates/kamn-e2e-harness/src/agent_transaction_process.rs
+++ b/crates/kamn-e2e-harness/src/agent_transaction_process.rs
@@ -83,7 +83,10 @@ fn kill_process_group(pid: u32) {
 #[cfg(unix)]
 fn signal_process_group(pid: u32, signal: &str) {
     let group = format!("-{pid}");
-    let _ = Command::new("kill").args([signal, group.as_str()]).status();
+    let _ = Command::new("kill")
+        .args([signal, group.as_str()])
+        .stderr(Stdio::null())
+        .status();
 }
 
 #[cfg(not(unix))]

--- a/crates/kamn-e2e-harness/src/agent_transaction_rpc.rs
+++ b/crates/kamn-e2e-harness/src/agent_transaction_rpc.rs
@@ -76,7 +76,8 @@ fn spawn_child(
     role: AgentTransactionRole,
 ) -> Result<RpcChild, String> {
     let command = build_pi_actor_command(config, role);
-    let mut child = start_process(command.as_slice(), paths.environment().as_slice())?;
+    let environment = paths.environment(config);
+    let mut child = start_process(command.as_slice(), environment.as_slice())?;
     let (stdin, stdout) = take_pipes(&mut child)?;
     let (events, reader) = spawn_reader(stdout);
     Ok(RpcChild {

--- a/crates/kamn-e2e-harness/src/agent_transaction_rpc.rs
+++ b/crates/kamn-e2e-harness/src/agent_transaction_rpc.rs
@@ -1,0 +1,157 @@
+use std::io::{BufRead, BufReader, Write};
+use std::process::{Child, ChildStdin, ChildStdout};
+use std::sync::mpsc::{self, Receiver, RecvTimeoutError};
+use std::thread::JoinHandle;
+use std::time::Duration;
+
+use serde_json::Value;
+
+use super::agent_transaction_process::{start_process, take_pipes, wait_or_kill};
+use super::{build_pi_actor_command, AgentTransactionDemoConfig, AgentTransactionRole};
+
+const CHILD_ERROR: &str = "AGENT_TRANSACTION_CHILD_FAILED";
+
+struct RpcChild {
+    child: Child,
+    stdin: Option<ChildStdin>,
+    events: Receiver<Result<Value, String>>,
+    reader: Option<JoinHandle<()>>,
+}
+
+pub(super) struct RpcGroup {
+    children: Vec<RpcChild>,
+    timeout_ms: u64,
+    cleaned: bool,
+}
+
+impl RpcGroup {
+    pub(super) fn spawn(config: &AgentTransactionDemoConfig) -> Result<Self, String> {
+        let mut children = Vec::with_capacity(3);
+        for role in [
+            AgentTransactionRole::AgentA,
+            AgentTransactionRole::AgentB,
+            AgentTransactionRole::AgentC,
+        ] {
+            match spawn_child(config, role) {
+                Ok(child) => children.push(child),
+                Err(error) => {
+                    cleanup_children(children.as_mut_slice(), config.rpc_timeout_ms);
+                    return Err(error);
+                }
+            }
+        }
+        Ok(Self {
+            children,
+            timeout_ms: config.rpc_timeout_ms,
+            cleaned: false,
+        })
+    }
+
+    pub(super) fn prompt(&mut self, index: usize, message: &str) -> Result<Value, String> {
+        prompt(&mut self.children[index], message, self.timeout_ms)
+    }
+
+    pub(super) fn cleanup(&mut self) {
+        if self.cleaned {
+            return;
+        }
+        self.cleaned = true;
+        cleanup_children(self.children.as_mut_slice(), self.timeout_ms);
+    }
+}
+
+impl Drop for RpcGroup {
+    fn drop(&mut self) {
+        self.cleanup();
+    }
+}
+
+fn spawn_child(
+    config: &AgentTransactionDemoConfig,
+    role: AgentTransactionRole,
+) -> Result<RpcChild, String> {
+    let command = build_pi_actor_command(config, role);
+    let mut child = start_process(command.as_slice())?;
+    let (stdin, stdout) = take_pipes(&mut child)?;
+    let (events, reader) = spawn_reader(stdout);
+    Ok(RpcChild {
+        child,
+        stdin: Some(stdin),
+        events,
+        reader: Some(reader),
+    })
+}
+
+fn prompt(child: &mut RpcChild, message: &str, timeout_ms: u64) -> Result<Value, String> {
+    let request = serde_json::json!({"id":"phase","type":"prompt","message":message});
+    let stdin = child
+        .stdin
+        .as_mut()
+        .ok_or_else(|| child_error("Pi stdin closed"))?;
+    writeln!(stdin, "{request}").map_err(|_| child_error("Pi prompt write failed"))?;
+    stdin
+        .flush()
+        .map_err(|_| child_error("Pi prompt flush failed"))?;
+    read_agent_end(child, timeout_ms)
+}
+
+fn read_agent_end(child: &mut RpcChild, timeout_ms: u64) -> Result<Value, String> {
+    let timeout = Duration::from_millis(timeout_ms);
+    loop {
+        let event = receive_event(child, timeout)?;
+        if event["type"] == "extension_error" {
+            return Err(child_error("Pi extension failed"));
+        }
+        if event["type"] == "agent_end" {
+            return Ok(event);
+        }
+    }
+}
+
+fn receive_event(child: &RpcChild, timeout: Duration) -> Result<Value, String> {
+    match child.events.recv_timeout(timeout) {
+        Ok(result) => result,
+        Err(RecvTimeoutError::Timeout) => Err(child_error("Pi RPC phase timed out")),
+        Err(RecvTimeoutError::Disconnected) => Err(child_error("Pi actor exited before agent_end")),
+    }
+}
+
+fn spawn_reader(stdout: ChildStdout) -> (Receiver<Result<Value, String>>, JoinHandle<()>) {
+    let (sender, receiver) = mpsc::channel();
+    let handle = std::thread::spawn(move || read_events(stdout, sender));
+    (receiver, handle)
+}
+
+fn read_events(stdout: ChildStdout, sender: mpsc::Sender<Result<Value, String>>) {
+    let mut reader = BufReader::new(stdout);
+    let mut line = String::new();
+    loop {
+        line.clear();
+        match reader.read_line(&mut line) {
+            Ok(0) | Err(_) => break,
+            Ok(_) => {
+                let event = serde_json::from_str(line.trim())
+                    .map_err(|_| child_error("Pi RPC emitted malformed JSON"));
+                if sender.send(event).is_err() {
+                    break;
+                }
+            }
+        }
+    }
+}
+
+fn cleanup_children(children: &mut [RpcChild], timeout_ms: u64) {
+    for child in children.iter_mut() {
+        child.stdin.take();
+    }
+    for child in children.iter_mut() {
+        wait_or_kill(&mut child.child, timeout_ms);
+        if let Some(reader) = child.reader.take() {
+            let _ = reader.join();
+        }
+    }
+}
+
+fn child_error(detail: &str) -> String {
+    format!("{CHILD_ERROR}: {detail}")
+}

--- a/crates/kamn-e2e-harness/src/agent_transaction_rpc.rs
+++ b/crates/kamn-e2e-harness/src/agent_transaction_rpc.rs
@@ -1,6 +1,6 @@
-use std::io::{BufRead, BufReader, Write};
-use std::process::{Child, ChildStdin, ChildStdout};
-use std::sync::mpsc::{self, Receiver, RecvTimeoutError};
+use std::io::Write;
+use std::process::{Child, ChildStdin};
+use std::sync::mpsc::{Receiver, RecvTimeoutError};
 use std::thread::JoinHandle;
 use std::time::Duration;
 
@@ -8,6 +8,7 @@ use serde_json::Value;
 
 use super::agent_transaction_evidence::AgentTransactionEvidencePaths;
 use super::agent_transaction_process::{start_process, take_pipes, terminate_process_group};
+use super::agent_transaction_rpc_events::spawn_reader;
 use super::{build_pi_actor_command, AgentTransactionDemoConfig, AgentTransactionRole};
 
 const CHILD_ERROR: &str = "AGENT_TRANSACTION_CHILD_FAILED";
@@ -51,8 +52,18 @@ impl RpcGroup {
         })
     }
 
-    pub(super) fn prompt(&mut self, index: usize, message: &str) -> Result<Value, String> {
-        prompt(&mut self.children[index], message, self.timeout_ms)
+    pub(super) fn prompt(
+        &mut self,
+        index: usize,
+        message: &str,
+        terminal_tool: &str,
+    ) -> Result<Value, String> {
+        prompt(
+            &mut self.children[index],
+            message,
+            terminal_tool,
+            self.timeout_ms,
+        )
     }
 
     pub(super) fn cleanup(&mut self) {
@@ -88,7 +99,12 @@ fn spawn_child(
     })
 }
 
-fn prompt(child: &mut RpcChild, message: &str, timeout_ms: u64) -> Result<Value, String> {
+fn prompt(
+    child: &mut RpcChild,
+    message: &str,
+    terminal_tool: &str,
+    timeout_ms: u64,
+) -> Result<Value, String> {
     let request = serde_json::json!({"id":"phase","type":"prompt","message":message});
     let stdin = child
         .stdin
@@ -98,10 +114,14 @@ fn prompt(child: &mut RpcChild, message: &str, timeout_ms: u64) -> Result<Value,
     stdin
         .flush()
         .map_err(|_| child_error("Pi prompt flush failed"))?;
-    read_agent_end(child, timeout_ms)
+    read_agent_end(child, terminal_tool, timeout_ms)
 }
 
-fn read_agent_end(child: &mut RpcChild, timeout_ms: u64) -> Result<Value, String> {
+fn read_agent_end(
+    child: &mut RpcChild,
+    terminal_tool: &str,
+    timeout_ms: u64,
+) -> Result<Value, String> {
     let timeout = Duration::from_millis(timeout_ms);
     let mut tool_result = None;
     loop {
@@ -114,11 +134,25 @@ fn read_agent_end(child: &mut RpcChild, timeout_ms: u64) -> Result<Value, String
         }
         if event["type"] == "tool_execution_end" {
             tool_result = Some(event.clone());
+            if event["toolName"] == terminal_tool {
+                abort_turn(child)?;
+            }
         }
         if event["type"] == "agent_end" {
             return Ok(tool_result.unwrap_or(event));
         }
     }
+}
+
+fn abort_turn(child: &mut RpcChild) -> Result<(), String> {
+    let stdin = child
+        .stdin
+        .as_mut()
+        .ok_or_else(|| child_error("Pi stdin closed before abort"))?;
+    writeln!(stdin, r#"{{"type":"abort"}}"#).map_err(|_| child_error("Pi abort write failed"))?;
+    stdin
+        .flush()
+        .map_err(|_| child_error("Pi abort flush failed"))
 }
 
 fn failed_tool_error(event: &Value) -> Option<String> {
@@ -139,30 +173,6 @@ fn receive_event(child: &RpcChild, timeout: Duration) -> Result<Value, String> {
         Ok(result) => result,
         Err(RecvTimeoutError::Timeout) => Err(child_error("Pi RPC phase timed out")),
         Err(RecvTimeoutError::Disconnected) => Err(child_error("Pi actor exited before agent_end")),
-    }
-}
-
-fn spawn_reader(stdout: ChildStdout) -> (Receiver<Result<Value, String>>, JoinHandle<()>) {
-    let (sender, receiver) = mpsc::channel();
-    let handle = std::thread::spawn(move || read_events(stdout, sender));
-    (receiver, handle)
-}
-
-fn read_events(stdout: ChildStdout, sender: mpsc::Sender<Result<Value, String>>) {
-    let mut reader = BufReader::new(stdout);
-    let mut line = String::new();
-    loop {
-        line.clear();
-        match reader.read_line(&mut line) {
-            Ok(0) | Err(_) => break,
-            Ok(_) => {
-                let event = serde_json::from_str(line.trim())
-                    .map_err(|_| child_error("Pi RPC emitted malformed JSON"));
-                if sender.send(event).is_err() {
-                    break;
-                }
-            }
-        }
     }
 }
 

--- a/crates/kamn-e2e-harness/src/agent_transaction_rpc.rs
+++ b/crates/kamn-e2e-harness/src/agent_transaction_rpc.rs
@@ -108,10 +108,19 @@ fn read_agent_end(child: &mut RpcChild, timeout_ms: u64) -> Result<Value, String
         if event["type"] == "extension_error" {
             return Err(child_error("Pi extension failed"));
         }
+        if let Some(tool) = failed_tool(&event) {
+            return Err(child_error(format!("Pi tool failed: {tool}").as_str()));
+        }
         if event["type"] == "agent_end" {
             return Ok(event);
         }
     }
+}
+
+fn failed_tool(event: &Value) -> Option<&str> {
+    let failed =
+        event["type"] == "tool_execution_end" && event["result"]["isError"].as_bool() == Some(true);
+    failed.then(|| event["toolName"].as_str()).flatten()
 }
 
 fn receive_event(child: &RpcChild, timeout: Duration) -> Result<Value, String> {

--- a/crates/kamn-e2e-harness/src/agent_transaction_rpc.rs
+++ b/crates/kamn-e2e-harness/src/agent_transaction_rpc.rs
@@ -103,6 +103,7 @@ fn prompt(child: &mut RpcChild, message: &str, timeout_ms: u64) -> Result<Value,
 
 fn read_agent_end(child: &mut RpcChild, timeout_ms: u64) -> Result<Value, String> {
     let timeout = Duration::from_millis(timeout_ms);
+    let mut tool_result = None;
     loop {
         let event = receive_event(child, timeout)?;
         if event["type"] == "extension_error" {
@@ -111,8 +112,11 @@ fn read_agent_end(child: &mut RpcChild, timeout_ms: u64) -> Result<Value, String
         if let Some(tool) = failed_tool(&event) {
             return Err(child_error(format!("Pi tool failed: {tool}").as_str()));
         }
+        if event["type"] == "tool_execution_end" {
+            tool_result = Some(event.clone());
+        }
         if event["type"] == "agent_end" {
-            return Ok(event);
+            return Ok(tool_result.unwrap_or(event));
         }
     }
 }

--- a/crates/kamn-e2e-harness/src/agent_transaction_rpc.rs
+++ b/crates/kamn-e2e-harness/src/agent_transaction_rpc.rs
@@ -109,8 +109,8 @@ fn read_agent_end(child: &mut RpcChild, timeout_ms: u64) -> Result<Value, String
         if event["type"] == "extension_error" {
             return Err(child_error("Pi extension failed"));
         }
-        if let Some(tool) = failed_tool(&event) {
-            return Err(child_error(format!("Pi tool failed: {tool}").as_str()));
+        if let Some(error) = failed_tool_error(&event) {
+            return Err(child_error(error.as_str()));
         }
         if event["type"] == "tool_execution_end" {
             tool_result = Some(event.clone());
@@ -121,11 +121,17 @@ fn read_agent_end(child: &mut RpcChild, timeout_ms: u64) -> Result<Value, String
     }
 }
 
-fn failed_tool(event: &Value) -> Option<&str> {
+fn failed_tool_error(event: &Value) -> Option<String> {
     let failed = event["type"] == "tool_execution_end"
         && (event["isError"].as_bool() == Some(true)
             || event["result"]["isError"].as_bool() == Some(true));
-    failed.then(|| event["toolName"].as_str()).flatten()
+    failed.then(|| {
+        format!(
+            "Pi tool failed: {}: {}",
+            event["toolName"].as_str().unwrap_or("unknown"),
+            event["result"]
+        )
+    })
 }
 
 fn receive_event(child: &RpcChild, timeout: Duration) -> Result<Value, String> {

--- a/crates/kamn-e2e-harness/src/agent_transaction_rpc.rs
+++ b/crates/kamn-e2e-harness/src/agent_transaction_rpc.rs
@@ -122,8 +122,9 @@ fn read_agent_end(child: &mut RpcChild, timeout_ms: u64) -> Result<Value, String
 }
 
 fn failed_tool(event: &Value) -> Option<&str> {
-    let failed =
-        event["type"] == "tool_execution_end" && event["result"]["isError"].as_bool() == Some(true);
+    let failed = event["type"] == "tool_execution_end"
+        && (event["isError"].as_bool() == Some(true)
+            || event["result"]["isError"].as_bool() == Some(true));
     failed.then(|| event["toolName"].as_str()).flatten()
 }
 

--- a/crates/kamn-e2e-harness/src/agent_transaction_rpc.rs
+++ b/crates/kamn-e2e-harness/src/agent_transaction_rpc.rs
@@ -6,6 +6,7 @@ use std::time::Duration;
 
 use serde_json::Value;
 
+use super::agent_transaction_evidence::AgentTransactionEvidencePaths;
 use super::agent_transaction_process::{start_process, take_pipes, wait_or_kill};
 use super::{build_pi_actor_command, AgentTransactionDemoConfig, AgentTransactionRole};
 
@@ -25,14 +26,17 @@ pub(super) struct RpcGroup {
 }
 
 impl RpcGroup {
-    pub(super) fn spawn(config: &AgentTransactionDemoConfig) -> Result<Self, String> {
+    pub(super) fn spawn(
+        config: &AgentTransactionDemoConfig,
+        paths: &AgentTransactionEvidencePaths,
+    ) -> Result<Self, String> {
         let mut children = Vec::with_capacity(3);
         for role in [
             AgentTransactionRole::AgentA,
             AgentTransactionRole::AgentB,
             AgentTransactionRole::AgentC,
         ] {
-            match spawn_child(config, role) {
+            match spawn_child(config, paths, role) {
                 Ok(child) => children.push(child),
                 Err(error) => {
                     cleanup_children(children.as_mut_slice(), config.rpc_timeout_ms);
@@ -68,10 +72,11 @@ impl Drop for RpcGroup {
 
 fn spawn_child(
     config: &AgentTransactionDemoConfig,
+    paths: &AgentTransactionEvidencePaths,
     role: AgentTransactionRole,
 ) -> Result<RpcChild, String> {
     let command = build_pi_actor_command(config, role);
-    let mut child = start_process(command.as_slice())?;
+    let mut child = start_process(command.as_slice(), paths.environment().as_slice())?;
     let (stdin, stdout) = take_pipes(&mut child)?;
     let (events, reader) = spawn_reader(stdout);
     Ok(RpcChild {

--- a/crates/kamn-e2e-harness/src/agent_transaction_rpc.rs
+++ b/crates/kamn-e2e-harness/src/agent_transaction_rpc.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 use serde_json::Value;
 
 use super::agent_transaction_evidence::AgentTransactionEvidencePaths;
-use super::agent_transaction_process::{start_process, take_pipes, wait_or_kill};
+use super::agent_transaction_process::{start_process, take_pipes, terminate_process_group};
 use super::{build_pi_actor_command, AgentTransactionDemoConfig, AgentTransactionRole};
 
 const CHILD_ERROR: &str = "AGENT_TRANSACTION_CHILD_FAILED";
@@ -39,7 +39,7 @@ impl RpcGroup {
             match spawn_child(config, paths, role) {
                 Ok(child) => children.push(child),
                 Err(error) => {
-                    cleanup_children(children.as_mut_slice(), config.rpc_timeout_ms);
+                    cleanup_children(children.as_mut_slice());
                     return Err(error);
                 }
             }
@@ -60,7 +60,7 @@ impl RpcGroup {
             return;
         }
         self.cleaned = true;
-        cleanup_children(self.children.as_mut_slice(), self.timeout_ms);
+        cleanup_children(self.children.as_mut_slice());
     }
 }
 
@@ -145,12 +145,12 @@ fn read_events(stdout: ChildStdout, sender: mpsc::Sender<Result<Value, String>>)
     }
 }
 
-fn cleanup_children(children: &mut [RpcChild], timeout_ms: u64) {
+fn cleanup_children(children: &mut [RpcChild]) {
     for child in children.iter_mut() {
         child.stdin.take();
     }
     for child in children.iter_mut() {
-        wait_or_kill(&mut child.child, timeout_ms);
+        terminate_process_group(&mut child.child);
         if let Some(reader) = child.reader.take() {
             let _ = reader.join();
         }

--- a/crates/kamn-e2e-harness/src/agent_transaction_rpc_events.rs
+++ b/crates/kamn-e2e-harness/src/agent_transaction_rpc_events.rs
@@ -1,0 +1,33 @@
+use std::io::{BufRead, BufReader};
+use std::process::ChildStdout;
+use std::sync::mpsc::{self, Receiver};
+use std::thread::JoinHandle;
+
+use serde_json::Value;
+
+pub(super) fn spawn_reader(
+    stdout: ChildStdout,
+) -> (Receiver<Result<Value, String>>, JoinHandle<()>) {
+    let (sender, receiver) = mpsc::channel();
+    let handle = std::thread::spawn(move || read_events(stdout, sender));
+    (receiver, handle)
+}
+
+fn read_events(stdout: ChildStdout, sender: mpsc::Sender<Result<Value, String>>) {
+    let mut reader = BufReader::new(stdout);
+    let mut line = String::new();
+    loop {
+        line.clear();
+        match reader.read_line(&mut line) {
+            Ok(0) | Err(_) => break,
+            Ok(_) if send_event(line.as_str(), &sender).is_err() => break,
+            Ok(_) => {}
+        }
+    }
+}
+
+fn send_event(line: &str, sender: &mpsc::Sender<Result<Value, String>>) -> Result<(), ()> {
+    let event = serde_json::from_str(line.trim())
+        .map_err(|_| "AGENT_TRANSACTION_CHILD_FAILED: Pi RPC emitted malformed JSON".to_owned());
+    sender.send(event).map_err(|_| ())
+}

--- a/crates/kamn-e2e-harness/src/agent_transaction_runtime.rs
+++ b/crates/kamn-e2e-harness/src/agent_transaction_runtime.rs
@@ -43,7 +43,21 @@ impl Drop for LocalRuntime {
 fn runtime_command(config: &AgentTransactionDemoConfig, address: &str) -> Command {
     let storage = std::path::Path::new(config.staging_root.as_str()).join("node-state");
     let mut command = Command::new(config.local_node_binary.as_str());
-    command.args([
+    command.args(runtime_args(address));
+    command
+        .arg(storage)
+        .env("KAMN_SERVICE_API_TLS_MODE", "disabled");
+    command
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    #[cfg(unix)]
+    command.process_group(0);
+    command
+}
+
+fn runtime_args(address: &str) -> [&str; 11] {
+    [
         "--runtime-mode",
         "api",
         "--role",
@@ -55,17 +69,7 @@ fn runtime_command(config: &AgentTransactionDemoConfig, address: &str) -> Comman
         "--api-idle-timeout-ms",
         "600000",
         "--storage-dir",
-    ]);
-    command
-        .arg(storage)
-        .env("KAMN_SERVICE_API_TLS_MODE", "disabled");
-    command
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null());
-    #[cfg(unix)]
-    command.process_group(0);
-    command
+    ]
 }
 
 fn endpoint_address(endpoint: &str) -> Result<String, String> {

--- a/crates/kamn-e2e-harness/src/agent_transaction_runtime.rs
+++ b/crates/kamn-e2e-harness/src/agent_transaction_runtime.rs
@@ -1,4 +1,5 @@
 use std::net::TcpStream;
+use std::path::Path;
 use std::process::{Child, Command, Stdio};
 use std::time::{Duration, Instant};
 
@@ -6,6 +7,7 @@ use std::time::{Duration, Instant};
 use std::os::unix::process::CommandExt;
 
 use super::agent_transaction_process::terminate_process;
+use super::agent_transaction_runtime_grant::write_task_creation_grant;
 use super::AgentTransactionDemoConfig;
 
 const RUNTIME_ERROR: &str = "AGENT_TRANSACTION_RUNTIME_FAILED";
@@ -18,7 +20,8 @@ impl LocalRuntime {
     pub(super) fn start(config: &AgentTransactionDemoConfig) -> Result<Self, String> {
         let address = endpoint_address(config.mcp_endpoint.as_str())?;
         reject_occupied_endpoint(address.as_str())?;
-        let mut command = runtime_command(config, address.as_str());
+        let state_file = write_task_creation_grant(config)?;
+        let mut command = runtime_command(config, address.as_str(), &state_file);
         let child = command
             .spawn()
             .map_err(|error| format!("{RUNTIME_ERROR}: node spawn failed: {error}"))?;
@@ -48,13 +51,14 @@ impl Drop for LocalRuntime {
     }
 }
 
-fn runtime_command(config: &AgentTransactionDemoConfig, address: &str) -> Command {
+fn runtime_command(config: &AgentTransactionDemoConfig, address: &str, state: &Path) -> Command {
     let storage = std::path::Path::new(config.staging_root.as_str()).join("node-state");
     let mut command = Command::new(config.local_node_binary.as_str());
     command.args(runtime_args(address));
     command
         .arg(storage)
-        .env("KAMN_SERVICE_API_TLS_MODE", "disabled");
+        .env("KAMN_SERVICE_API_TLS_MODE", "disabled")
+        .env("KAMN_SERVICE_API_STATE_FILE", state);
     command
         .stdin(Stdio::null())
         .stdout(Stdio::null())

--- a/crates/kamn-e2e-harness/src/agent_transaction_runtime.rs
+++ b/crates/kamn-e2e-harness/src/agent_transaction_runtime.rs
@@ -17,6 +17,7 @@ pub(super) struct LocalRuntime {
 impl LocalRuntime {
     pub(super) fn start(config: &AgentTransactionDemoConfig) -> Result<Self, String> {
         let address = endpoint_address(config.mcp_endpoint.as_str())?;
+        reject_occupied_endpoint(address.as_str())?;
         let mut command = runtime_command(config, address.as_str());
         let child = command
             .spawn()
@@ -32,6 +33,13 @@ impl LocalRuntime {
     pub(super) fn cleanup(&mut self) {
         terminate_process(&mut self.child);
     }
+}
+
+fn reject_occupied_endpoint(address: &str) -> Result<(), String> {
+    if TcpStream::connect(address).is_ok() {
+        return Err(format!("{RUNTIME_ERROR}: endpoint already occupied"));
+    }
+    Ok(())
 }
 
 impl Drop for LocalRuntime {

--- a/crates/kamn-e2e-harness/src/agent_transaction_runtime.rs
+++ b/crates/kamn-e2e-harness/src/agent_transaction_runtime.rs
@@ -1,0 +1,97 @@
+use std::net::TcpStream;
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+#[cfg(unix)]
+use std::os::unix::process::CommandExt;
+
+use super::agent_transaction_process::terminate_process;
+use super::AgentTransactionDemoConfig;
+
+const RUNTIME_ERROR: &str = "AGENT_TRANSACTION_RUNTIME_FAILED";
+
+pub(super) struct LocalRuntime {
+    child: Child,
+}
+
+impl LocalRuntime {
+    pub(super) fn start(config: &AgentTransactionDemoConfig) -> Result<Self, String> {
+        let address = endpoint_address(config.mcp_endpoint.as_str())?;
+        let mut command = runtime_command(config, address.as_str());
+        let child = command
+            .spawn()
+            .map_err(|error| format!("{RUNTIME_ERROR}: node spawn failed: {error}"))?;
+        let mut runtime = Self { child };
+        if let Err(error) = wait_until_ready(&mut runtime.child, address.as_str()) {
+            runtime.cleanup();
+            return Err(error);
+        }
+        Ok(runtime)
+    }
+
+    pub(super) fn cleanup(&mut self) {
+        terminate_process(&mut self.child);
+    }
+}
+
+impl Drop for LocalRuntime {
+    fn drop(&mut self) {
+        self.cleanup();
+    }
+}
+
+fn runtime_command(config: &AgentTransactionDemoConfig, address: &str) -> Command {
+    let storage = std::path::Path::new(config.staging_root.as_str()).join("node-state");
+    let mut command = Command::new(config.local_node_binary.as_str());
+    command.args([
+        "--runtime-mode",
+        "api",
+        "--role",
+        "processor",
+        "--api-bind",
+        address,
+        "--api-max-requests",
+        "1000",
+        "--api-idle-timeout-ms",
+        "600000",
+        "--storage-dir",
+    ]);
+    command
+        .arg(storage)
+        .env("KAMN_SERVICE_API_TLS_MODE", "disabled");
+    command
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    #[cfg(unix)]
+    command.process_group(0);
+    command
+}
+
+fn endpoint_address(endpoint: &str) -> Result<String, String> {
+    let address = endpoint
+        .strip_prefix("http://")
+        .filter(|value| value.starts_with("127.0.0.1:") || value.starts_with("localhost:"));
+    match address {
+        Some(value) if value.rsplit_once(':').is_some() => Ok(value.to_owned()),
+        _ => Err(format!("{RUNTIME_ERROR}: endpoint must be loopback HTTP")),
+    }
+}
+
+fn wait_until_ready(child: &mut Child, address: &str) -> Result<(), String> {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while Instant::now() < deadline {
+        if TcpStream::connect(address).is_ok() {
+            return Ok(());
+        }
+        if let Some(status) = child.try_wait().map_err(runtime_wait_error)? {
+            return Err(format!("{RUNTIME_ERROR}: node exited with {status}"));
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+    Err(format!("{RUNTIME_ERROR}: node readiness timed out"))
+}
+
+fn runtime_wait_error(error: std::io::Error) -> String {
+    format!("{RUNTIME_ERROR}: node status failed: {error}")
+}

--- a/crates/kamn-e2e-harness/src/agent_transaction_runtime_grant.rs
+++ b/crates/kamn-e2e-harness/src/agent_transaction_runtime_grant.rs
@@ -1,0 +1,33 @@
+use std::path::{Path, PathBuf};
+
+use kamn_sdk::{service_public_key_for_private_key, AgentDid};
+
+use super::AgentTransactionDemoConfig;
+
+const RUNTIME_ERROR: &str = "AGENT_TRANSACTION_RUNTIME_FAILED";
+const AGENT_A_NAME: &str = "kamn-mvp-agent-a";
+
+pub(super) fn write_task_creation_grant(
+    config: &AgentTransactionDemoConfig,
+) -> Result<PathBuf, String> {
+    let signing_key = std::fs::read_to_string(config.agent_key_files[0].as_str())
+        .map_err(|error| runtime_error("Agent A key read", error))?;
+    let public_key = service_public_key_for_private_key(signing_key.trim())
+        .map_err(|error| format!("{RUNTIME_ERROR}: Agent A key invalid: {error}"))?;
+    let did = AgentDid::with_public_key_hex_binding(AGENT_A_NAME, public_key.as_str())
+        .map_err(|error| format!("{RUNTIME_ERROR}: Agent A DID invalid: {error}"))?;
+    let path = Path::new(config.staging_root.as_str()).join("service-api-state.json");
+    std::fs::write(&path, state_json(did.as_str()))
+        .map_err(|error| runtime_error("grant bootstrap write", error))?;
+    Ok(path)
+}
+
+fn state_json(did: &str) -> String {
+    format!(
+        r#"{{"schema_version":"kamn.runtime.service-api-message-store.v4","messages":{{}},"channel_messages":{{}},"agent_grants":{{"agent-a-task-create":{{"did":"{did}","resource":"transaction:new","role":"initiator","action":"task:create","status":"active","idempotency_key":"agent-a-task-create"}}}}}}"#
+    )
+}
+
+fn runtime_error(context: &str, error: std::io::Error) -> String {
+    format!("{RUNTIME_ERROR}: {context} failed: {error}")
+}

--- a/crates/kamn-e2e-harness/src/agent_transaction_supervisor.rs
+++ b/crates/kamn-e2e-harness/src/agent_transaction_supervisor.rs
@@ -5,6 +5,7 @@ use serde_json::Value;
 use super::agent_transaction_evidence::AgentTransactionEvidencePaths;
 use super::agent_transaction_finalize::finalize;
 use super::agent_transaction_rpc::RpcGroup;
+use super::agent_transaction_runtime::LocalRuntime;
 use super::AgentTransactionDemoConfig;
 
 const PROOF_ERROR: &str = "AGENT_TRANSACTION_PROOF_INVALID";
@@ -16,12 +17,20 @@ pub(super) fn run_supervised_registration(
         Ok(paths) => paths,
         Err(error) => return fail_no_go(config, error.as_str()),
     };
+    let mut runtime = match LocalRuntime::start(config) {
+        Ok(runtime) => runtime,
+        Err(error) => return fail_no_go(config, error.as_str()),
+    };
     let mut group = match RpcGroup::spawn(config, &paths) {
         Ok(group) => group,
-        Err(error) => return fail_no_go(config, error.as_str()),
+        Err(error) => {
+            runtime.cleanup();
+            return fail_no_go(config, error.as_str());
+        }
     };
     let result = run_phases(&mut group);
     group.cleanup();
+    runtime.cleanup();
     match result {
         Ok(()) => match finalize(config, &paths) {
             Ok(output) => Ok(output),

--- a/crates/kamn-e2e-harness/src/agent_transaction_supervisor.rs
+++ b/crates/kamn-e2e-harness/src/agent_transaction_supervisor.rs
@@ -48,19 +48,34 @@ fn execute_with_paths(
 }
 
 fn run_phases(group: &mut RpcGroup) -> Result<(), String> {
+    let provider_did = register_provider(group)?;
+    run_mutations(group, provider_did.as_str())?;
+    run_final_evidence(group)
+}
+
+fn register_provider(group: &mut RpcGroup) -> Result<String, String> {
     let registration = group.prompt(
         1,
         "Call kamn_live_agent_b_register exactly once, then stop.",
         "kamn_live_agent_b_register",
     )?;
-    let provider_did = find_string(&registration, "did").ok_or_else(|| {
-        format!("AGENT_TRANSACTION_CHILD_FAILED: Agent B omitted DID: {registration}")
-    })?;
+    find_string(&registration, "did")
+        .map(str::to_owned)
+        .ok_or_else(|| {
+            format!("AGENT_TRANSACTION_CHILD_FAILED: Agent B omitted DID: {registration}")
+        })
+}
+
+fn run_mutations(group: &mut RpcGroup, provider_did: &str) -> Result<(), String> {
     group.prompt(
         0,
         agent_a_create_prompt(provider_did).as_str(),
         "kamn_live_agent_a_publish_task_handoff",
     )?;
+    run_state_transitions(group)
+}
+
+fn run_state_transitions(group: &mut RpcGroup) -> Result<(), String> {
     group.prompt(
         1,
         AGENT_B_ACCEPT_PROMPT,
@@ -70,12 +85,21 @@ fn run_phases(group: &mut RpcGroup) -> Result<(), String> {
     group.prompt(
         1,
         AGENT_B_COMPLETE_PROMPT,
-        "kamn_live_agent_b_write_transaction_evidence",
+        "kamn_live_agent_b_complete_task",
     )?;
     group.prompt(
         0,
         AGENT_A_RELEASE_PROMPT,
         "kamn_live_agent_a_write_transaction_evidence",
+    )?;
+    Ok(())
+}
+
+fn run_final_evidence(group: &mut RpcGroup) -> Result<(), String> {
+    group.prompt(
+        1,
+        AGENT_B_EVIDENCE_PROMPT,
+        "kamn_live_agent_b_write_transaction_evidence",
     )?;
     group.prompt(
         2,
@@ -102,14 +126,17 @@ const AGENT_A_FUND_PROMPT: &str = "Call these tools exactly once in order: \
 kamn_live_agent_a_wait_for_task_acceptance; kamn_live_agent_a_fund_escrow. Then stop.";
 
 const AGENT_B_COMPLETE_PROMPT: &str = "Call these tools exactly once in order: \
-kamn_live_agent_b_wait_for_escrow_funding; kamn_live_agent_b_complete_task; \
-kamn_live_agent_b_query_participant_projection; \
-kamn_live_agent_b_write_transaction_evidence. Then stop.";
+kamn_live_agent_b_wait_for_escrow_funding; kamn_live_agent_b_complete_task. \
+Then stop.";
 
 const AGENT_A_RELEASE_PROMPT: &str = "Call these tools exactly once in order: \
 kamn_live_agent_a_wait_for_task_completion; kamn_live_agent_a_release_escrow; \
 kamn_live_agent_a_query_participant_projection; \
 kamn_live_agent_a_write_transaction_evidence. Then stop.";
+
+const AGENT_B_EVIDENCE_PROMPT: &str = "Call these tools exactly once in order: \
+kamn_live_agent_b_query_participant_projection; \
+kamn_live_agent_b_write_transaction_evidence. Then stop.";
 
 const AGENT_C_VERIFY_PROMPT: &str = "Call these tools exactly once in order: \
 kamn_live_agent_c_register; kamn_live_agent_c_receive_task_handoff; \

--- a/crates/kamn-e2e-harness/src/agent_transaction_supervisor.rs
+++ b/crates/kamn-e2e-harness/src/agent_transaction_supervisor.rs
@@ -17,11 +17,18 @@ pub(super) fn run_supervised_registration(
         Ok(paths) => paths,
         Err(error) => return fail_no_go(config, error.as_str()),
     };
+    execute_with_paths(config, &paths)
+}
+
+fn execute_with_paths(
+    config: &AgentTransactionDemoConfig,
+    paths: &AgentTransactionEvidencePaths,
+) -> Result<String, String> {
     let mut runtime = match LocalRuntime::start(config) {
         Ok(runtime) => runtime,
         Err(error) => return fail_no_go(config, error.as_str()),
     };
-    let mut group = match RpcGroup::spawn(config, &paths) {
+    let mut group = match RpcGroup::spawn(config, paths) {
         Ok(group) => group,
         Err(error) => {
             runtime.cleanup();
@@ -32,7 +39,7 @@ pub(super) fn run_supervised_registration(
     group.cleanup();
     runtime.cleanup();
     match result {
-        Ok(()) => match finalize(config, &paths) {
+        Ok(()) => match finalize(config, paths) {
             Ok(output) => Ok(output),
             Err(error) => fail_no_go(config, format!("{PROOF_ERROR}: {error}").as_str()),
         },

--- a/crates/kamn-e2e-harness/src/agent_transaction_supervisor.rs
+++ b/crates/kamn-e2e-harness/src/agent_transaction_supervisor.rs
@@ -52,8 +52,9 @@ fn run_phases(group: &mut RpcGroup) -> Result<(), String> {
         1,
         "Call kamn_live_agent_b_register exactly once, then stop.",
     )?;
-    let provider_did = find_string(&registration, "did")
-        .ok_or_else(|| "AGENT_TRANSACTION_CHILD_FAILED: Agent B omitted DID".to_owned())?;
+    let provider_did = find_string(&registration, "did").ok_or_else(|| {
+        format!("AGENT_TRANSACTION_CHILD_FAILED: Agent B omitted DID: {registration}")
+    })?;
     group.prompt(0, agent_a_create_prompt(provider_did).as_str())?;
     group.prompt(1, AGENT_B_ACCEPT_PROMPT)?;
     group.prompt(0, AGENT_A_FUND_PROMPT)?;

--- a/crates/kamn-e2e-harness/src/agent_transaction_supervisor.rs
+++ b/crates/kamn-e2e-harness/src/agent_transaction_supervisor.rs
@@ -1,7 +1,12 @@
 use std::io::{BufRead, BufReader, Write};
 use std::path::Path;
 use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+use std::sync::mpsc::{self, Receiver, RecvTimeoutError};
+use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
+
+#[cfg(unix)]
+use std::os::unix::process::CommandExt;
 
 use serde_json::Value;
 
@@ -12,7 +17,8 @@ const CHILD_ERROR: &str = "AGENT_TRANSACTION_CHILD_FAILED";
 struct RpcChild {
     child: Child,
     stdin: Option<ChildStdin>,
-    stdout: BufReader<ChildStdout>,
+    events: Receiver<Result<Value, String>>,
+    reader: Option<JoinHandle<()>>,
 }
 
 pub(super) fn run_supervised_registration(
@@ -22,8 +28,9 @@ pub(super) fn run_supervised_registration(
     let result = prompt(
         &mut children[1],
         "Register Agent B using the only registration tool.",
+        config.rpc_timeout_ms,
     );
-    cleanup_all(&mut children);
+    cleanup_all(&mut children, config.rpc_timeout_ms);
     match result {
         Ok(()) => fail_no_go(config, "scenario orchestration incomplete"),
         Err(error) => fail_no_go(config, error.as_str()),
@@ -43,13 +50,32 @@ fn spawn_child(
     role: AgentTransactionRole,
 ) -> Result<RpcChild, String> {
     let command = build_pi_actor_command(config, role);
-    let mut child = Command::new(&command[0])
+    let mut child = start_process(command.as_slice())?;
+    let (stdin, stdout) = take_pipes(&mut child)?;
+    let (events, reader) = spawn_reader(stdout);
+    Ok(RpcChild {
+        child,
+        stdin: Some(stdin),
+        events,
+        reader: Some(reader),
+    })
+}
+
+fn start_process(command: &[String]) -> Result<Child, String> {
+    let mut process = Command::new(&command[0]);
+    process
         .args(&command[1..])
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
-        .stderr(Stdio::null())
+        .stderr(Stdio::null());
+    #[cfg(unix)]
+    process.process_group(0);
+    process
         .spawn()
-        .map_err(|_| child_error("failed to spawn Pi actor"))?;
+        .map_err(|_| child_error("failed to spawn Pi actor"))
+}
+
+fn take_pipes(child: &mut Child) -> Result<(ChildStdin, ChildStdout), String> {
     let stdin = child
         .stdin
         .take()
@@ -58,14 +84,10 @@ fn spawn_child(
         .stdout
         .take()
         .ok_or_else(|| child_error("missing Pi stdout"))?;
-    Ok(RpcChild {
-        child,
-        stdin: Some(stdin),
-        stdout: BufReader::new(stdout),
-    })
+    Ok((stdin, stdout))
 }
 
-fn prompt(child: &mut RpcChild, message: &str) -> Result<(), String> {
+fn prompt(child: &mut RpcChild, message: &str, timeout_ms: u64) -> Result<(), String> {
     let request = serde_json::json!({"id":"phase","type":"prompt","message":message});
     let stdin = child
         .stdin
@@ -75,23 +97,13 @@ fn prompt(child: &mut RpcChild, message: &str) -> Result<(), String> {
     stdin
         .flush()
         .map_err(|_| child_error("Pi prompt flush failed"))?;
-    read_agent_end(child)
+    read_agent_end(child, timeout_ms)
 }
 
-fn read_agent_end(child: &mut RpcChild) -> Result<(), String> {
-    let mut line = String::new();
+fn read_agent_end(child: &mut RpcChild, timeout_ms: u64) -> Result<(), String> {
+    let timeout = Duration::from_millis(timeout_ms);
     loop {
-        line.clear();
-        if child
-            .stdout
-            .read_line(&mut line)
-            .map_err(|_| child_error("Pi RPC read failed"))?
-            == 0
-        {
-            return Err(child_error("Pi actor exited before agent_end"));
-        }
-        let event: Value = serde_json::from_str(line.trim())
-            .map_err(|_| child_error("Pi RPC emitted malformed JSON"))?;
+        let event = receive_event(child, timeout)?;
         if event["type"] == "extension_error" {
             return Err(child_error("Pi extension failed"));
         }
@@ -101,26 +113,73 @@ fn read_agent_end(child: &mut RpcChild) -> Result<(), String> {
     }
 }
 
-fn cleanup_all(children: &mut [RpcChild; 3]) {
+fn receive_event(child: &RpcChild, timeout: Duration) -> Result<Value, String> {
+    match child.events.recv_timeout(timeout) {
+        Ok(result) => result,
+        Err(RecvTimeoutError::Timeout) => Err(child_error("Pi RPC phase timed out")),
+        Err(RecvTimeoutError::Disconnected) => Err(child_error("Pi actor exited before agent_end")),
+    }
+}
+
+fn spawn_reader(stdout: ChildStdout) -> (Receiver<Result<Value, String>>, JoinHandle<()>) {
+    let (sender, receiver) = mpsc::channel();
+    let handle = std::thread::spawn(move || {
+        let mut reader = BufReader::new(stdout);
+        let mut line = String::new();
+        loop {
+            line.clear();
+            match reader.read_line(&mut line) {
+                Ok(0) => break,
+                Ok(_) => {
+                    let event = serde_json::from_str(line.trim())
+                        .map_err(|_| child_error("Pi RPC emitted malformed JSON"));
+                    if sender.send(event).is_err() {
+                        break;
+                    }
+                }
+                Err(_) => break,
+            }
+        }
+    });
+    (receiver, handle)
+}
+
+fn cleanup_all(children: &mut [RpcChild; 3], timeout_ms: u64) {
     for child in children.iter_mut() {
         child.stdin.take();
     }
     for child in children.iter_mut() {
-        wait_or_kill(&mut child.child);
+        wait_or_kill(&mut child.child, timeout_ms);
+        if let Some(reader) = child.reader.take() {
+            let _ = reader.join();
+        }
     }
 }
 
-fn wait_or_kill(child: &mut Child) {
-    let deadline = Instant::now() + Duration::from_secs(2);
+fn wait_or_kill(child: &mut Child, timeout_ms: u64) {
+    let grace = Duration::from_millis(timeout_ms.min(2_000));
+    let deadline = Instant::now() + grace;
     while Instant::now() < deadline {
         if child.try_wait().ok().flatten().is_some() {
             return;
         }
         std::thread::sleep(Duration::from_millis(10));
     }
+    kill_process_group(child.id());
     let _ = child.kill();
     let _ = child.wait();
 }
+
+#[cfg(unix)]
+fn kill_process_group(pid: u32) {
+    let group = format!("-{pid}");
+    let _ = Command::new("kill")
+        .args(["-KILL", group.as_str()])
+        .status();
+}
+
+#[cfg(not(unix))]
+fn kill_process_group(_pid: u32) {}
 
 fn fail_no_go(config: &AgentTransactionDemoConfig, detail: &str) -> Result<String, String> {
     let error = child_error(detail);

--- a/crates/kamn-e2e-harness/src/agent_transaction_supervisor.rs
+++ b/crates/kamn-e2e-harness/src/agent_transaction_supervisor.rs
@@ -75,7 +75,7 @@ kamn_live_agent_a_publish_task_handoff. Then stop."
 
 const AGENT_B_ACCEPT_PROMPT: &str = "Call these tools exactly once in order: \
 kamn_live_agent_b_receive_task_handoff; kamn_live_agent_b_accept_task; \
-kamn_live_agent_b_write_task_receipt. Then stop.";
+kamn_live_agent_b_query_task; kamn_live_agent_b_write_task_receipt. Then stop.";
 
 const AGENT_A_FUND_PROMPT: &str = "Call these tools exactly once in order: \
 kamn_live_agent_a_wait_for_task_acceptance; kamn_live_agent_a_fund_escrow. Then stop.";

--- a/crates/kamn-e2e-harness/src/agent_transaction_supervisor.rs
+++ b/crates/kamn-e2e-harness/src/agent_transaction_supervisor.rs
@@ -1,0 +1,140 @@
+use std::io::{BufRead, BufReader, Write};
+use std::path::Path;
+use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+use std::time::{Duration, Instant};
+
+use serde_json::Value;
+
+use super::{build_pi_actor_command, AgentTransactionDemoConfig, AgentTransactionRole};
+
+const CHILD_ERROR: &str = "AGENT_TRANSACTION_CHILD_FAILED";
+
+struct RpcChild {
+    child: Child,
+    stdin: Option<ChildStdin>,
+    stdout: BufReader<ChildStdout>,
+}
+
+pub(super) fn run_supervised_registration(
+    config: &AgentTransactionDemoConfig,
+) -> Result<String, String> {
+    let mut children = spawn_children(config)?;
+    let result = prompt(
+        &mut children[1],
+        "Register Agent B using the only registration tool.",
+    );
+    cleanup_all(&mut children);
+    match result {
+        Ok(()) => fail_no_go(config, "scenario orchestration incomplete"),
+        Err(error) => fail_no_go(config, error.as_str()),
+    }
+}
+
+fn spawn_children(config: &AgentTransactionDemoConfig) -> Result<[RpcChild; 3], String> {
+    Ok([
+        spawn_child(config, AgentTransactionRole::AgentA)?,
+        spawn_child(config, AgentTransactionRole::AgentB)?,
+        spawn_child(config, AgentTransactionRole::AgentC)?,
+    ])
+}
+
+fn spawn_child(
+    config: &AgentTransactionDemoConfig,
+    role: AgentTransactionRole,
+) -> Result<RpcChild, String> {
+    let command = build_pi_actor_command(config, role);
+    let mut child = Command::new(&command[0])
+        .args(&command[1..])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|_| child_error("failed to spawn Pi actor"))?;
+    let stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| child_error("missing Pi stdin"))?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| child_error("missing Pi stdout"))?;
+    Ok(RpcChild {
+        child,
+        stdin: Some(stdin),
+        stdout: BufReader::new(stdout),
+    })
+}
+
+fn prompt(child: &mut RpcChild, message: &str) -> Result<(), String> {
+    let request = serde_json::json!({"id":"phase","type":"prompt","message":message});
+    let stdin = child
+        .stdin
+        .as_mut()
+        .ok_or_else(|| child_error("Pi stdin closed"))?;
+    writeln!(stdin, "{request}").map_err(|_| child_error("Pi prompt write failed"))?;
+    stdin
+        .flush()
+        .map_err(|_| child_error("Pi prompt flush failed"))?;
+    read_agent_end(child)
+}
+
+fn read_agent_end(child: &mut RpcChild) -> Result<(), String> {
+    let mut line = String::new();
+    loop {
+        line.clear();
+        if child
+            .stdout
+            .read_line(&mut line)
+            .map_err(|_| child_error("Pi RPC read failed"))?
+            == 0
+        {
+            return Err(child_error("Pi actor exited before agent_end"));
+        }
+        let event: Value = serde_json::from_str(line.trim())
+            .map_err(|_| child_error("Pi RPC emitted malformed JSON"))?;
+        if event["type"] == "extension_error" {
+            return Err(child_error("Pi extension failed"));
+        }
+        if event["type"] == "agent_end" {
+            return Ok(());
+        }
+    }
+}
+
+fn cleanup_all(children: &mut [RpcChild; 3]) {
+    for child in children.iter_mut() {
+        child.stdin.take();
+    }
+    for child in children.iter_mut() {
+        wait_or_kill(&mut child.child);
+    }
+}
+
+fn wait_or_kill(child: &mut Child) {
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while Instant::now() < deadline {
+        if child.try_wait().ok().flatten().is_some() {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+fn fail_no_go(config: &AgentTransactionDemoConfig, detail: &str) -> Result<String, String> {
+    let error = child_error(detail);
+    let latest = Path::new(config.output_root.as_str()).join("latest");
+    std::fs::create_dir_all(&latest)
+        .map_err(|_| child_error("failed to create NO-GO output directory"))?;
+    std::fs::write(
+        latest.join("NO-GO.txt"),
+        format!("decision=NO-GO\nreason={error}\n"),
+    )
+    .map_err(|_| child_error("failed to write NO-GO report"))?;
+    Err(error)
+}
+
+fn child_error(detail: &str) -> String {
+    format!("{CHILD_ERROR}: {detail}")
+}

--- a/crates/kamn-e2e-harness/src/agent_transaction_supervisor.rs
+++ b/crates/kamn-e2e-harness/src/agent_transaction_supervisor.rs
@@ -2,6 +2,8 @@ use std::path::Path;
 
 use serde_json::Value;
 
+use super::agent_transaction_evidence::AgentTransactionEvidencePaths;
+use super::agent_transaction_finalize::finalize;
 use super::agent_transaction_rpc::RpcGroup;
 use super::AgentTransactionDemoConfig;
 
@@ -10,17 +12,21 @@ const PROOF_ERROR: &str = "AGENT_TRANSACTION_PROOF_INVALID";
 pub(super) fn run_supervised_registration(
     config: &AgentTransactionDemoConfig,
 ) -> Result<String, String> {
-    let mut group = match RpcGroup::spawn(config) {
+    let paths = match AgentTransactionEvidencePaths::prepare(config) {
+        Ok(paths) => paths,
+        Err(error) => return fail_no_go(config, error.as_str()),
+    };
+    let mut group = match RpcGroup::spawn(config, &paths) {
         Ok(group) => group,
         Err(error) => return fail_no_go(config, error.as_str()),
     };
     let result = run_phases(&mut group);
     group.cleanup();
     match result {
-        Ok(()) => fail_no_go(
-            config,
-            format!("{PROOF_ERROR}: actor evidence is missing").as_str(),
-        ),
+        Ok(()) => match finalize(config, &paths) {
+            Ok(output) => Ok(output),
+            Err(error) => fail_no_go(config, format!("{PROOF_ERROR}: {error}").as_str()),
+        },
         Err(error) => fail_no_go(config, error.as_str()),
     }
 }

--- a/crates/kamn-e2e-harness/src/agent_transaction_supervisor.rs
+++ b/crates/kamn-e2e-harness/src/agent_transaction_supervisor.rs
@@ -51,16 +51,37 @@ fn run_phases(group: &mut RpcGroup) -> Result<(), String> {
     let registration = group.prompt(
         1,
         "Call kamn_live_agent_b_register exactly once, then stop.",
+        "kamn_live_agent_b_register",
     )?;
     let provider_did = find_string(&registration, "did").ok_or_else(|| {
         format!("AGENT_TRANSACTION_CHILD_FAILED: Agent B omitted DID: {registration}")
     })?;
-    group.prompt(0, agent_a_create_prompt(provider_did).as_str())?;
-    group.prompt(1, AGENT_B_ACCEPT_PROMPT)?;
-    group.prompt(0, AGENT_A_FUND_PROMPT)?;
-    group.prompt(1, AGENT_B_COMPLETE_PROMPT)?;
-    group.prompt(0, AGENT_A_RELEASE_PROMPT)?;
-    group.prompt(2, AGENT_C_VERIFY_PROMPT)?;
+    group.prompt(
+        0,
+        agent_a_create_prompt(provider_did).as_str(),
+        "kamn_live_agent_a_publish_task_handoff",
+    )?;
+    group.prompt(
+        1,
+        AGENT_B_ACCEPT_PROMPT,
+        "kamn_live_agent_b_write_task_receipt",
+    )?;
+    group.prompt(0, AGENT_A_FUND_PROMPT, "kamn_live_agent_a_fund_escrow")?;
+    group.prompt(
+        1,
+        AGENT_B_COMPLETE_PROMPT,
+        "kamn_live_agent_b_write_transaction_evidence",
+    )?;
+    group.prompt(
+        0,
+        AGENT_A_RELEASE_PROMPT,
+        "kamn_live_agent_a_write_transaction_evidence",
+    )?;
+    group.prompt(
+        2,
+        AGENT_C_VERIFY_PROMPT,
+        "kamn_live_verify_pi_transaction_actors",
+    )?;
     Ok(())
 }
 

--- a/crates/kamn-e2e-harness/src/agent_transaction_supervisor.rs
+++ b/crates/kamn-e2e-harness/src/agent_transaction_supervisor.rs
@@ -1,199 +1,98 @@
-use std::io::{BufRead, BufReader, Write};
 use std::path::Path;
-use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
-use std::sync::mpsc::{self, Receiver, RecvTimeoutError};
-use std::thread::JoinHandle;
-use std::time::{Duration, Instant};
-
-#[cfg(unix)]
-use std::os::unix::process::CommandExt;
 
 use serde_json::Value;
 
-use super::{build_pi_actor_command, AgentTransactionDemoConfig, AgentTransactionRole};
+use super::agent_transaction_rpc::RpcGroup;
+use super::AgentTransactionDemoConfig;
 
-const CHILD_ERROR: &str = "AGENT_TRANSACTION_CHILD_FAILED";
-
-struct RpcChild {
-    child: Child,
-    stdin: Option<ChildStdin>,
-    events: Receiver<Result<Value, String>>,
-    reader: Option<JoinHandle<()>>,
-}
+const PROOF_ERROR: &str = "AGENT_TRANSACTION_PROOF_INVALID";
 
 pub(super) fn run_supervised_registration(
     config: &AgentTransactionDemoConfig,
 ) -> Result<String, String> {
-    let mut children = spawn_children(config)?;
-    let result = prompt(
-        &mut children[1],
-        "Register Agent B using the only registration tool.",
-        config.rpc_timeout_ms,
-    );
-    cleanup_all(&mut children, config.rpc_timeout_ms);
+    let mut group = match RpcGroup::spawn(config) {
+        Ok(group) => group,
+        Err(error) => return fail_no_go(config, error.as_str()),
+    };
+    let result = run_phases(&mut group);
+    group.cleanup();
     match result {
-        Ok(()) => fail_no_go(config, "scenario orchestration incomplete"),
+        Ok(()) => fail_no_go(
+            config,
+            format!("{PROOF_ERROR}: actor evidence is missing").as_str(),
+        ),
         Err(error) => fail_no_go(config, error.as_str()),
     }
 }
 
-fn spawn_children(config: &AgentTransactionDemoConfig) -> Result<[RpcChild; 3], String> {
-    Ok([
-        spawn_child(config, AgentTransactionRole::AgentA)?,
-        spawn_child(config, AgentTransactionRole::AgentB)?,
-        spawn_child(config, AgentTransactionRole::AgentC)?,
-    ])
+fn run_phases(group: &mut RpcGroup) -> Result<(), String> {
+    let registration = group.prompt(
+        1,
+        "Call kamn_live_agent_b_register exactly once, then stop.",
+    )?;
+    let provider_did = find_string(&registration, "did")
+        .ok_or_else(|| "AGENT_TRANSACTION_CHILD_FAILED: Agent B omitted DID".to_owned())?;
+    group.prompt(0, agent_a_create_prompt(provider_did).as_str())?;
+    group.prompt(1, AGENT_B_ACCEPT_PROMPT)?;
+    group.prompt(0, AGENT_A_FUND_PROMPT)?;
+    group.prompt(1, AGENT_B_COMPLETE_PROMPT)?;
+    group.prompt(0, AGENT_A_RELEASE_PROMPT)?;
+    group.prompt(2, AGENT_C_VERIFY_PROMPT)?;
+    Ok(())
 }
 
-fn spawn_child(
-    config: &AgentTransactionDemoConfig,
-    role: AgentTransactionRole,
-) -> Result<RpcChild, String> {
-    let command = build_pi_actor_command(config, role);
-    let mut child = start_process(command.as_slice())?;
-    let (stdin, stdout) = take_pipes(&mut child)?;
-    let (events, reader) = spawn_reader(stdout);
-    Ok(RpcChild {
-        child,
-        stdin: Some(stdin),
-        events,
-        reader: Some(reader),
-    })
+fn agent_a_create_prompt(provider_did: &str) -> String {
+    format!(
+        "Call these tools exactly once in order: kamn_live_agent_a_register; \
+kamn_live_agent_a_create_task with title 'KAMN evaluator transaction', description \
+'Runtime-backed agent transaction', and provider_did '{provider_did}'; \
+kamn_live_agent_a_publish_task_handoff. Then stop."
+    )
 }
 
-fn start_process(command: &[String]) -> Result<Child, String> {
-    let mut process = Command::new(&command[0]);
-    process
-        .args(&command[1..])
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::null());
-    #[cfg(unix)]
-    process.process_group(0);
-    process
-        .spawn()
-        .map_err(|_| child_error("failed to spawn Pi actor"))
-}
+const AGENT_B_ACCEPT_PROMPT: &str = "Call these tools exactly once in order: \
+kamn_live_agent_b_receive_task_handoff; kamn_live_agent_b_accept_task; \
+kamn_live_agent_b_write_task_receipt. Then stop.";
 
-fn take_pipes(child: &mut Child) -> Result<(ChildStdin, ChildStdout), String> {
-    let stdin = child
-        .stdin
-        .take()
-        .ok_or_else(|| child_error("missing Pi stdin"))?;
-    let stdout = child
-        .stdout
-        .take()
-        .ok_or_else(|| child_error("missing Pi stdout"))?;
-    Ok((stdin, stdout))
-}
+const AGENT_A_FUND_PROMPT: &str = "Call these tools exactly once in order: \
+kamn_live_agent_a_wait_for_task_acceptance; kamn_live_agent_a_fund_escrow. Then stop.";
 
-fn prompt(child: &mut RpcChild, message: &str, timeout_ms: u64) -> Result<(), String> {
-    let request = serde_json::json!({"id":"phase","type":"prompt","message":message});
-    let stdin = child
-        .stdin
-        .as_mut()
-        .ok_or_else(|| child_error("Pi stdin closed"))?;
-    writeln!(stdin, "{request}").map_err(|_| child_error("Pi prompt write failed"))?;
-    stdin
-        .flush()
-        .map_err(|_| child_error("Pi prompt flush failed"))?;
-    read_agent_end(child, timeout_ms)
-}
+const AGENT_B_COMPLETE_PROMPT: &str = "Call these tools exactly once in order: \
+kamn_live_agent_b_wait_for_escrow_funding; kamn_live_agent_b_complete_task; \
+kamn_live_agent_b_query_participant_projection; \
+kamn_live_agent_b_write_transaction_evidence. Then stop.";
 
-fn read_agent_end(child: &mut RpcChild, timeout_ms: u64) -> Result<(), String> {
-    let timeout = Duration::from_millis(timeout_ms);
-    loop {
-        let event = receive_event(child, timeout)?;
-        if event["type"] == "extension_error" {
-            return Err(child_error("Pi extension failed"));
-        }
-        if event["type"] == "agent_end" {
-            return Ok(());
-        }
+const AGENT_A_RELEASE_PROMPT: &str = "Call these tools exactly once in order: \
+kamn_live_agent_a_wait_for_task_completion; kamn_live_agent_a_release_escrow; \
+kamn_live_agent_a_query_participant_projection; \
+kamn_live_agent_a_write_transaction_evidence. Then stop.";
+
+const AGENT_C_VERIFY_PROMPT: &str = "Call these tools exactly once in order: \
+kamn_live_agent_c_register; kamn_live_agent_c_receive_task_handoff; \
+kamn_live_agent_c_query_verifier_projection; \
+kamn_live_agent_c_verify_restricted_task_observation; \
+kamn_live_agent_c_write_transaction_evidence; \
+kamn_live_verify_pi_transaction_actors. Then stop.";
+
+fn find_string<'a>(value: &'a Value, field: &str) -> Option<&'a str> {
+    match value {
+        Value::Object(map) => map
+            .get(field)
+            .and_then(Value::as_str)
+            .or_else(|| map.values().find_map(|item| find_string(item, field))),
+        Value::Array(items) => items.iter().find_map(|item| find_string(item, field)),
+        _ => None,
     }
 }
 
-fn receive_event(child: &RpcChild, timeout: Duration) -> Result<Value, String> {
-    match child.events.recv_timeout(timeout) {
-        Ok(result) => result,
-        Err(RecvTimeoutError::Timeout) => Err(child_error("Pi RPC phase timed out")),
-        Err(RecvTimeoutError::Disconnected) => Err(child_error("Pi actor exited before agent_end")),
-    }
-}
-
-fn spawn_reader(stdout: ChildStdout) -> (Receiver<Result<Value, String>>, JoinHandle<()>) {
-    let (sender, receiver) = mpsc::channel();
-    let handle = std::thread::spawn(move || {
-        let mut reader = BufReader::new(stdout);
-        let mut line = String::new();
-        loop {
-            line.clear();
-            match reader.read_line(&mut line) {
-                Ok(0) => break,
-                Ok(_) => {
-                    let event = serde_json::from_str(line.trim())
-                        .map_err(|_| child_error("Pi RPC emitted malformed JSON"));
-                    if sender.send(event).is_err() {
-                        break;
-                    }
-                }
-                Err(_) => break,
-            }
-        }
-    });
-    (receiver, handle)
-}
-
-fn cleanup_all(children: &mut [RpcChild; 3], timeout_ms: u64) {
-    for child in children.iter_mut() {
-        child.stdin.take();
-    }
-    for child in children.iter_mut() {
-        wait_or_kill(&mut child.child, timeout_ms);
-        if let Some(reader) = child.reader.take() {
-            let _ = reader.join();
-        }
-    }
-}
-
-fn wait_or_kill(child: &mut Child, timeout_ms: u64) {
-    let grace = Duration::from_millis(timeout_ms.min(2_000));
-    let deadline = Instant::now() + grace;
-    while Instant::now() < deadline {
-        if child.try_wait().ok().flatten().is_some() {
-            return;
-        }
-        std::thread::sleep(Duration::from_millis(10));
-    }
-    kill_process_group(child.id());
-    let _ = child.kill();
-    let _ = child.wait();
-}
-
-#[cfg(unix)]
-fn kill_process_group(pid: u32) {
-    let group = format!("-{pid}");
-    let _ = Command::new("kill")
-        .args(["-KILL", group.as_str()])
-        .status();
-}
-
-#[cfg(not(unix))]
-fn kill_process_group(_pid: u32) {}
-
-fn fail_no_go(config: &AgentTransactionDemoConfig, detail: &str) -> Result<String, String> {
-    let error = child_error(detail);
+fn fail_no_go(config: &AgentTransactionDemoConfig, error: &str) -> Result<String, String> {
     let latest = Path::new(config.output_root.as_str()).join("latest");
     std::fs::create_dir_all(&latest)
-        .map_err(|_| child_error("failed to create NO-GO output directory"))?;
+        .map_err(|_| "AGENT_TRANSACTION_PROOF_INVALID: NO-GO directory failed".to_owned())?;
     std::fs::write(
         latest.join("NO-GO.txt"),
         format!("decision=NO-GO\nreason={error}\n"),
     )
-    .map_err(|_| child_error("failed to write NO-GO report"))?;
-    Err(error)
-}
-
-fn child_error(detail: &str) -> String {
-    format!("{CHILD_ERROR}: {detail}")
+    .map_err(|_| "AGENT_TRANSACTION_PROOF_INVALID: NO-GO report failed".to_owned())?;
+    Err(error.to_owned())
 }

--- a/crates/kamn-e2e-harness/src/lib.rs
+++ b/crates/kamn-e2e-harness/src/lib.rs
@@ -24,6 +24,7 @@ mod agent_transaction_preflight;
 mod agent_transaction_process;
 mod agent_transaction_rpc;
 mod agent_transaction_runtime;
+mod agent_transaction_runtime_grant;
 mod agent_transaction_supervisor;
 
 /// Driver implementations for each execution mode.

--- a/crates/kamn-e2e-harness/src/lib.rs
+++ b/crates/kamn-e2e-harness/src/lib.rs
@@ -19,6 +19,8 @@ pub use mvp_demo::{
 mod agent_transaction_demo;
 mod agent_transaction_pi_command;
 mod agent_transaction_preflight;
+mod agent_transaction_process;
+mod agent_transaction_rpc;
 mod agent_transaction_supervisor;
 
 /// Driver implementations for each execution mode.

--- a/crates/kamn-e2e-harness/src/lib.rs
+++ b/crates/kamn-e2e-harness/src/lib.rs
@@ -4,7 +4,10 @@
 use std::collections::HashSet;
 use std::path::Path;
 
-pub use agent_transaction_demo::{parse_agent_transaction_demo_config, AgentTransactionDemoConfig};
+pub use agent_transaction_demo::{
+    execute_agent_transaction_demo_contract, parse_agent_transaction_demo_config,
+    AgentTransactionDemoConfig,
+};
 pub use mvp_demo::{
     build_runtime_receipt_chain_from_actor_paths, execute_mvp_demo_contract,
     execute_verify_mvp_demo_contract, verify_pi_transaction_actor_paths, LiveTaskEvidencePaths,
@@ -253,6 +256,8 @@ pub enum HarnessCommand {
     DemoMvp(Box<MvpDemoCommandConfig>),
     /// Verify an MVP evaluator demo proof report.
     VerifyMvpDemo(VerifyMvpDemoCommandConfig),
+    /// Run the canonical three-agent devnet transaction demo.
+    DemoAgentTransaction,
 }
 
 /// Parses a comma-delimited list of scenario IDs.
@@ -312,6 +317,12 @@ where
     }
     match args[0].as_str() {
         "demo-mvp" => parse_demo_mvp_command(args.as_slice()),
+        "demo-agent-transaction" => {
+            if args.len() != 1 {
+                return Err("demo-agent-transaction does not accept flags".to_owned());
+            }
+            Ok(HarnessCommand::DemoAgentTransaction)
+        }
         "verify-mvp-demo" => parse_verify_mvp_demo_command(args.as_slice()),
         "run" => {
             let mut mode = None;

--- a/crates/kamn-e2e-harness/src/lib.rs
+++ b/crates/kamn-e2e-harness/src/lib.rs
@@ -23,6 +23,7 @@ mod agent_transaction_pi_command;
 mod agent_transaction_preflight;
 mod agent_transaction_process;
 mod agent_transaction_rpc;
+mod agent_transaction_rpc_events;
 mod agent_transaction_runtime;
 mod agent_transaction_runtime_grant;
 mod agent_transaction_supervisor;

--- a/crates/kamn-e2e-harness/src/lib.rs
+++ b/crates/kamn-e2e-harness/src/lib.rs
@@ -23,6 +23,7 @@ mod agent_transaction_pi_command;
 mod agent_transaction_preflight;
 mod agent_transaction_process;
 mod agent_transaction_rpc;
+mod agent_transaction_runtime;
 mod agent_transaction_supervisor;
 
 /// Driver implementations for each execution mode.

--- a/crates/kamn-e2e-harness/src/lib.rs
+++ b/crates/kamn-e2e-harness/src/lib.rs
@@ -8,6 +8,7 @@ pub use agent_transaction_demo::{
     execute_agent_transaction_demo_contract, parse_agent_transaction_demo_config,
     AgentTransactionDemoConfig,
 };
+pub use agent_transaction_pi_command::{build_pi_actor_command, AgentTransactionRole};
 pub use mvp_demo::{
     build_runtime_receipt_chain_from_actor_paths, execute_mvp_demo_contract,
     execute_verify_mvp_demo_contract, verify_pi_transaction_actor_paths, LiveTaskEvidencePaths,
@@ -15,6 +16,7 @@ pub use mvp_demo::{
 };
 
 mod agent_transaction_demo;
+mod agent_transaction_pi_command;
 
 /// Driver implementations for each execution mode.
 pub mod drivers;

--- a/crates/kamn-e2e-harness/src/lib.rs
+++ b/crates/kamn-e2e-harness/src/lib.rs
@@ -17,6 +17,8 @@ pub use mvp_demo::{
 };
 
 mod agent_transaction_demo;
+mod agent_transaction_evidence;
+mod agent_transaction_finalize;
 mod agent_transaction_pi_command;
 mod agent_transaction_preflight;
 mod agent_transaction_process;

--- a/crates/kamn-e2e-harness/src/lib.rs
+++ b/crates/kamn-e2e-harness/src/lib.rs
@@ -5,8 +5,8 @@ use std::collections::HashSet;
 use std::path::Path;
 
 pub use agent_transaction_demo::{
-    execute_agent_transaction_demo_contract, parse_agent_transaction_demo_config,
-    AgentTransactionDemoConfig,
+    execute_agent_transaction_demo_contract, execute_agent_transaction_demo_with_config,
+    parse_agent_transaction_demo_config, AgentTransactionDemoConfig,
 };
 pub use agent_transaction_pi_command::{build_pi_actor_command, AgentTransactionRole};
 pub use agent_transaction_preflight::validate_agent_transaction_preflight;
@@ -19,6 +19,7 @@ pub use mvp_demo::{
 mod agent_transaction_demo;
 mod agent_transaction_pi_command;
 mod agent_transaction_preflight;
+mod agent_transaction_supervisor;
 
 /// Driver implementations for each execution mode.
 pub mod drivers;

--- a/crates/kamn-e2e-harness/src/lib.rs
+++ b/crates/kamn-e2e-harness/src/lib.rs
@@ -17,6 +17,7 @@ pub use mvp_demo::{
 };
 
 mod agent_transaction_demo;
+mod agent_transaction_devnet_evidence;
 mod agent_transaction_evidence;
 mod agent_transaction_finalize;
 mod agent_transaction_pi_command;

--- a/crates/kamn-e2e-harness/src/lib.rs
+++ b/crates/kamn-e2e-harness/src/lib.rs
@@ -9,6 +9,7 @@ pub use agent_transaction_demo::{
     AgentTransactionDemoConfig,
 };
 pub use agent_transaction_pi_command::{build_pi_actor_command, AgentTransactionRole};
+pub use agent_transaction_preflight::validate_agent_transaction_preflight;
 pub use mvp_demo::{
     build_runtime_receipt_chain_from_actor_paths, execute_mvp_demo_contract,
     execute_verify_mvp_demo_contract, verify_pi_transaction_actor_paths, LiveTaskEvidencePaths,
@@ -17,6 +18,7 @@ pub use mvp_demo::{
 
 mod agent_transaction_demo;
 mod agent_transaction_pi_command;
+mod agent_transaction_preflight;
 
 /// Driver implementations for each execution mode.
 pub mod drivers;

--- a/crates/kamn-e2e-harness/src/lib.rs
+++ b/crates/kamn-e2e-harness/src/lib.rs
@@ -4,11 +4,14 @@
 use std::collections::HashSet;
 use std::path::Path;
 
+pub use agent_transaction_demo::{parse_agent_transaction_demo_config, AgentTransactionDemoConfig};
 pub use mvp_demo::{
     build_runtime_receipt_chain_from_actor_paths, execute_mvp_demo_contract,
     execute_verify_mvp_demo_contract, verify_pi_transaction_actor_paths, LiveTaskEvidencePaths,
     MvpDemoCommandConfig, VerifyMvpDemoCommandConfig,
 };
+
+mod agent_transaction_demo;
 
 /// Driver implementations for each execution mode.
 pub mod drivers;

--- a/crates/kamn-e2e-harness/src/main.rs
+++ b/crates/kamn-e2e-harness/src/main.rs
@@ -1,6 +1,6 @@
 use kamn_e2e_harness::{
-    execute_mvp_demo_contract, execute_run_contract, execute_verify_contract,
-    execute_verify_mvp_demo_contract, parse_command_args, HarnessCommand,
+    execute_agent_transaction_demo_contract, execute_mvp_demo_contract, execute_run_contract,
+    execute_verify_contract, execute_verify_mvp_demo_contract, parse_command_args, HarnessCommand,
 };
 
 fn main() {
@@ -18,6 +18,7 @@ fn main() {
         HarnessCommand::Verify(config) => execute_verify_contract(&config),
         HarnessCommand::DemoMvp(config) => execute_mvp_demo_contract(&config),
         HarnessCommand::VerifyMvpDemo(config) => execute_verify_mvp_demo_contract(&config),
+        HarnessCommand::DemoAgentTransaction => execute_agent_transaction_demo_contract(),
     };
     match output {
         Ok(rendered) => println!("{rendered}"),

--- a/crates/kamn-e2e-harness/src/mvp_demo/devnet_settlement_service_tests.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/devnet_settlement_service_tests.rs
@@ -7,6 +7,8 @@ fn funded_rehearsal_payload_carries_canonical_task_agreement() {
         artifact_path: "binding.json".to_owned(),
         digest: "a".repeat(64),
         task_id: "task-external".to_owned(),
+        transaction_id: "task-external".to_owned(),
+        terms_digest: "a".repeat(64),
         agent_a_pid: 1,
         agent_b_pid: 2,
         agent_c_pid: 3,

--- a/crates/kamn-e2e-harness/src/mvp_demo/live_task_binding.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/live_task_binding.rs
@@ -12,6 +12,8 @@ pub(crate) struct LiveTaskBinding {
     pub(crate) artifact_path: String,
     pub(crate) digest: String,
     pub(crate) task_id: String,
+    pub(crate) transaction_id: String,
+    pub(crate) terms_digest: String,
     pub(crate) agent_a_pid: u64,
     pub(crate) agent_b_pid: u64,
     pub(crate) agent_c_pid: u64,
@@ -32,10 +34,16 @@ pub(crate) fn create_live_task_binding(
 }
 
 fn binding(path: PathBuf, digest: String, found: ValidatedSources) -> LiveTaskBinding {
+    let transaction_id = found
+        .transaction_id
+        .unwrap_or_else(|| found.task_id.clone());
+    let terms_digest = found.terms_digest.unwrap_or_else(|| digest.clone());
     LiveTaskBinding {
         artifact_path: path.display().to_string(),
         digest,
         task_id: found.task_id,
+        transaction_id,
+        terms_digest,
         agent_a_pid: found.agent_a_pid,
         agent_b_pid: found.agent_b_pid,
         agent_c_pid: found.agent_c_pid,

--- a/crates/kamn-e2e-harness/src/mvp_demo/live_task_binding_verify.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/live_task_binding_verify.rs
@@ -107,8 +107,13 @@ fn validate_claim_fields(
     sources: &ValidatedSources,
     digest: &str,
 ) -> Result<(), String> {
-    require_string(claim.raw, "transaction_id", sources.task_id.as_str())?;
-    require_string(claim.raw, "terms_digest", digest)?;
+    let transaction_id = sources
+        .transaction_id
+        .as_deref()
+        .unwrap_or(&sources.task_id);
+    let terms_digest = sources.terms_digest.as_deref().unwrap_or(digest);
+    require_string(claim.raw, "transaction_id", transaction_id)?;
+    require_string(claim.raw, "terms_digest", terms_digest)?;
     require_string(claim.raw, "task_binding_digest", digest)?;
     let devnet = devnet_claim(report)?;
     require_string(devnet.raw, "task_id", sources.task_id.as_str())?;

--- a/crates/kamn-e2e-harness/src/mvp_demo/live_task_sources.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/live_task_sources.rs
@@ -61,7 +61,7 @@ pub(super) fn validate_sources(sources: &Sources) -> Result<ValidatedSources, St
 }
 
 fn validate_source_shapes(sources: &Sources) -> Result<(), String> {
-    validate_shape(&sources.handoff, "kamn.mvp.live-task-handoff.v1", 3)?;
+    validate_handoff_shape(&sources.handoff)?;
     validate_shape(&sources.agent_a, "kamn.mvp.live-task-actor-receipt.v1", 6)?;
     validate_shape(&sources.agent_b, "kamn.mvp.live-task-actor-receipt.v1", 6)?;
     validate_shape(
@@ -69,6 +69,28 @@ fn validate_source_shapes(sources: &Sources) -> Result<(), String> {
         "kamn.mvp.live-task-restricted-observation.v1",
         12,
     )
+}
+
+fn validate_handoff_shape(raw: &str) -> Result<(), String> {
+    match extract_string(raw, "schema_version")?.as_str() {
+        "kamn.mvp.live-task-handoff.v1" => validate_shape(raw, "kamn.mvp.live-task-handoff.v1", 3),
+        "kamn.mvp.live-task-handoff.v2" => validate_handoff_v2(raw),
+        _ => Err("live task evidence schema_version mismatch".to_owned()),
+    }
+}
+
+fn validate_handoff_v2(raw: &str) -> Result<(), String> {
+    validate_shape(raw, "kamn.mvp.live-task-handoff.v2", 6)?;
+    let transaction = extract_string(raw, "transaction_id")?;
+    let terms = extract_string(raw, "terms_digest")?;
+    let provider = extract_string(raw, "provider_did")?;
+    let valid = !transaction.is_empty()
+        && terms.len() == 64
+        && terms.bytes().all(|byte| byte.is_ascii_hexdigit())
+        && provider.starts_with("kamn:did:agent:");
+    valid
+        .then_some(())
+        .ok_or_else(|| "live task handoff v2 fields invalid".to_owned())
 }
 
 fn source_fields(sources: &Sources, task_id: String) -> Result<ValidatedSources, String> {

--- a/crates/kamn-e2e-harness/src/mvp_demo/live_task_sources.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/live_task_sources.rs
@@ -20,6 +20,8 @@ impl Sources {
 
 pub(crate) struct ValidatedSources {
     pub(crate) task_id: String,
+    pub(crate) transaction_id: Option<String>,
+    pub(crate) terms_digest: Option<String>,
     pub(crate) agent_a_pid: u64,
     pub(crate) agent_b_pid: u64,
     pub(crate) agent_c_pid: u64,
@@ -94,8 +96,12 @@ fn validate_handoff_v2(raw: &str) -> Result<(), String> {
 }
 
 fn source_fields(sources: &Sources, task_id: String) -> Result<ValidatedSources, String> {
+    let version_two =
+        extract_string(&sources.handoff, "schema_version")? == "kamn.mvp.live-task-handoff.v2";
     Ok(ValidatedSources {
         task_id,
+        transaction_id: optional_v2_field(&sources.handoff, "transaction_id", version_two)?,
+        terms_digest: optional_v2_field(&sources.handoff, "terms_digest", version_two)?,
         agent_a_pid: receipt_pid(&sources.agent_a, "agent_a")?,
         agent_b_pid: receipt_pid(&sources.agent_b, "agent_b")?,
         agent_c_pid: extract_u64(&sources.agent_c, "agent_c_pi_process_id")?,
@@ -105,6 +111,10 @@ fn source_fields(sources: &Sources, task_id: String) -> Result<ValidatedSources,
         agent_c_digest: artifact_digest(&sources.agent_c)?,
         public_commitment: extract_string(&sources.agent_c, "public_commitment")?,
     })
+}
+
+fn optional_v2_field(raw: &str, field: &str, version_two: bool) -> Result<Option<String>, String> {
+    version_two.then(|| extract_string(raw, field)).transpose()
 }
 
 fn validate_source_agreement(sources: &Sources, found: &ValidatedSources) -> Result<(), String> {

--- a/crates/kamn-e2e-harness/src/mvp_demo/runtime_receipt_chain_facts.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/runtime_receipt_chain_facts.rs
@@ -80,21 +80,11 @@ fn require_registration(actor: &Actor, result: &PublicResult) -> Result<(), Stri
 }
 
 fn require_task(result: &PublicResult) -> Result<(), String> {
-    require_all([
-        result.task_id.is_some(),
-        result.transaction_id.is_some(),
-        result.state.is_some(),
-    ])
+    require_all([result.task_id.is_some(), result.state.is_some()])
 }
 
 fn require_funding(result: &PublicResult) -> Result<(), String> {
-    require_all([
-        result.task_id.is_some(),
-        result.escrow_id.is_some(),
-        result.state.is_some(),
-        result.amount_lamports.is_some(),
-        result.network.is_some(),
-    ])
+    require_all([result.escrow_id.is_some(), result.state.is_some()])
 }
 
 fn require_release(result: &PublicResult) -> Result<(), String> {

--- a/crates/kamn-e2e-harness/src/mvp_demo/runtime_receipt_chain_facts.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/runtime_receipt_chain_facts.rs
@@ -98,12 +98,7 @@ fn require_funding(result: &PublicResult) -> Result<(), String> {
 }
 
 fn require_release(result: &PublicResult) -> Result<(), String> {
-    require_all([
-        result.escrow_id.is_some(),
-        result.state.is_some(),
-        result.settlement_tx_signature.is_some(),
-        result.settlement_commitment.is_some(),
-    ])
+    require_all([result.escrow_id.is_some(), result.state.is_some()])
 }
 
 fn require_participant_projection(actor: &Actor, result: &PublicResult) -> Result<(), String> {

--- a/crates/kamn-e2e-harness/src/mvp_demo/three_agent_claim.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/three_agent_claim.rs
@@ -15,8 +15,8 @@ pub(crate) fn three_agent_escrow_claim_json(
     receipt_paths: [&str; 3],
     artifact_digests: &ThreeAgentArtifactDigests,
 ) -> String {
-    let transaction_id = binding.task_id.as_str();
-    let terms_digest = binding.digest.as_str();
+    let transaction_id = binding.transaction_id.as_str();
+    let terms_digest = binding.terms_digest.as_str();
     let escrow_id = evidence.escrow_id.as_str();
     format!(
         "{{{},{},{},{},{},{},{},{},{},{}}}",

--- a/crates/kamn-e2e-harness/src/mvp_demo/three_agent_receipt_write.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/three_agent_receipt_write.rs
@@ -89,7 +89,7 @@ fn verifier_receipt(
 fn shared_fields(evidence: &DevnetSettlementEvidence, binding: &LiveTaskBinding) -> String {
     format!(
         "\"transaction_id\":\"{}\",\"escrow_id\":\"{}\",\"task_binding_digest\":\"{}\",\"settlement_tx_signature\":\"{}\",\"amount_lamports\":{},\"payer_pubkey\":\"{}\",\"recipient_pubkey\":\"{}\",\"settlement_commitment\":\"{}\"",
-        escape_json(binding.task_id.as_str()),
+        escape_json(binding.transaction_id.as_str()),
         escape_json(evidence.escrow_id.as_str()),
         escape_json(binding.digest.as_str()),
         escape_json(evidence.settlement_tx_signature.as_str()),

--- a/crates/kamn-e2e-harness/src/mvp_demo/three_agent_transcript_build.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/three_agent_transcript_build.rs
@@ -15,7 +15,7 @@ pub(crate) fn transcript_json(
     attach_json_digest(
         format!(
             "{{\"schema_version\":\"kamn.mvp.three-agent-transcript.v1\",\"proof_label\":\"local-only\",\"devnet_settlement_linked\":true,\"transaction_id\":\"{}\",\"escrow_id\":\"{}\",\"task_binding_digest\":\"{}\",{},\"views\":{},\"agent_a_private_field_count\":3,\"agent_b_private_field_count\":3,\"verifier_private_field_count\":0,\"private_payload_redacted\":true,{},\"transcript_digest\":\"\",{}}}",
-            escape_json(binding.task_id.as_str()),
+            escape_json(binding.transaction_id.as_str()),
             escape_json(evidence.escrow_id.as_str()),
             escape_json(binding.digest.as_str()),
             steps_json(),

--- a/crates/kamn-e2e-harness/src/mvp_demo/three_agent_views.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/three_agent_views.rs
@@ -119,7 +119,7 @@ fn verifier_view_json(
 fn shared_view_fields(evidence: &DevnetSettlementEvidence, binding: &LiveTaskBinding) -> String {
     format!(
         "\"transaction_id\":\"{}\",\"escrow_id\":\"{}\",\"task_binding_digest\":\"{}\",\"settlement_tx_signature\":\"{}\",\"amount_lamports\":{},\"payer_pubkey\":\"{}\",\"recipient_pubkey\":\"{}\",\"settlement_commitment\":\"{}\"",
-        escape_json(binding.task_id.as_str()),
+        escape_json(binding.transaction_id.as_str()),
         escape_json(evidence.escrow_id.as_str()),
         escape_json(binding.digest.as_str()),
         escape_json(evidence.settlement_tx_signature.as_str()),

--- a/crates/kamn-e2e-harness/tests/agent_transaction_demo_config_contract.rs
+++ b/crates/kamn-e2e-harness/tests/agent_transaction_demo_config_contract.rs
@@ -2,7 +2,10 @@ use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::process::Command;
 
-use kamn_e2e_harness::{parse_agent_transaction_demo_config, parse_command_args, HarnessCommand};
+use kamn_e2e_harness::{
+    build_pi_actor_command, parse_agent_transaction_demo_config, parse_command_args,
+    AgentTransactionRole, HarnessCommand,
+};
 
 #[test]
 fn spec_c00_parser_routes_canonical_agent_transaction_command() {
@@ -44,6 +47,51 @@ fn spec_c03_partial_devnet_configuration_fails_before_execution() {
     let error = parse_agent_transaction_demo_config(&env)
         .expect_err("partial devnet configuration must fail");
     assert!(error.starts_with("AGENT_TRANSACTION_DEVNET_CONFIG_INVALID"));
+}
+
+#[test]
+fn spec_c04_pi_rpc_commands_are_role_bounded_and_persistent() {
+    let config = parse_agent_transaction_demo_config(&complete_env()).expect("configuration");
+    let agent_a = build_pi_actor_command(&config, AgentTransactionRole::AgentA);
+    let agent_b = build_pi_actor_command(&config, AgentTransactionRole::AgentB);
+    let agent_c = build_pi_actor_command(&config, AgentTransactionRole::AgentC);
+
+    for command in [&agent_a, &agent_b, &agent_c] {
+        assert!(contains_pair(command, "--mode", "rpc"));
+        assert!(contains_pair(command, "--provider", "openai-codex"));
+        assert!(contains_pair(command, "--model", "gpt-5.5"));
+        for flag in [
+            "--no-session",
+            "--approve",
+            "--no-extensions",
+            "--no-builtin-tools",
+            "--no-skills",
+            "--no-prompt-templates",
+            "--no-context-files",
+        ] {
+            assert!(command.contains(&flag.to_owned()), "missing {flag}");
+        }
+    }
+    assert!(tools(&agent_a).contains("kamn_live_agent_a_release_escrow"));
+    assert!(!tools(&agent_a).contains("kamn_live_agent_b_complete_task"));
+    assert!(tools(&agent_b).contains("kamn_live_agent_b_complete_task"));
+    assert!(!tools(&agent_b).contains("kamn_live_agent_a_release_escrow"));
+    assert!(tools(&agent_c).contains("kamn_live_agent_c_query_verifier_projection"));
+    assert!(!tools(&agent_c).contains("kamn_live_agent_a_fund_escrow"));
+}
+
+fn contains_pair(command: &[String], flag: &str, value: &str) -> bool {
+    command
+        .windows(2)
+        .any(|pair| pair == [flag.to_owned(), value.to_owned()])
+}
+
+fn tools(command: &[String]) -> &str {
+    let index = command
+        .iter()
+        .position(|value| value == "--tools")
+        .expect("tools flag");
+    command[index + 1].as_str()
 }
 
 fn complete_env() -> BTreeMap<String, String> {

--- a/crates/kamn-e2e-harness/tests/agent_transaction_demo_config_contract.rs
+++ b/crates/kamn-e2e-harness/tests/agent_transaction_demo_config_contract.rs
@@ -76,6 +76,7 @@ fn spec_c04_pi_rpc_commands_are_role_bounded_and_persistent() {
     assert!(tools(&agent_a).contains("kamn_live_agent_a_release_escrow"));
     assert!(!tools(&agent_a).contains("kamn_live_agent_b_complete_task"));
     assert!(tools(&agent_b).contains("kamn_live_agent_b_complete_task"));
+    assert!(tools(&agent_b).contains("kamn_live_agent_b_query_task"));
     assert!(!tools(&agent_b).contains("kamn_live_agent_a_release_escrow"));
     assert!(tools(&agent_c).contains("kamn_live_agent_c_query_verifier_projection"));
     assert!(!tools(&agent_c).contains("kamn_live_agent_a_fund_escrow"));

--- a/crates/kamn-e2e-harness/tests/agent_transaction_demo_config_contract.rs
+++ b/crates/kamn-e2e-harness/tests/agent_transaction_demo_config_contract.rs
@@ -1,0 +1,74 @@
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use std::process::Command;
+
+use kamn_e2e_harness::parse_agent_transaction_demo_config;
+
+#[test]
+fn spec_c01_canonical_make_target_invokes_rust_supervisor() {
+    let output = Command::new("make")
+        .args(["-n", "demo-agent-transaction"])
+        .current_dir(repo_root())
+        .output()
+        .expect("make dry run");
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("kamn-e2e-harness -- demo-agent-transaction"));
+}
+
+#[test]
+fn spec_c02_preflight_parses_complete_pi_devnet_configuration() {
+    let config = parse_agent_transaction_demo_config(&complete_env())
+        .expect("complete canonical configuration");
+
+    assert_eq!(config.agent_driver, "pi");
+    assert_eq!(config.devnet_mode, "required");
+    assert_eq!(config.solana_rpc_url, "https://api.devnet.solana.com");
+    assert_eq!(config.solana_lamports, 1_000_000);
+    assert_eq!(config.solana_commitment, "finalized");
+    assert_eq!(config.agent_key_files.len(), 3);
+}
+
+#[test]
+fn spec_c03_partial_devnet_configuration_fails_before_execution() {
+    let mut env = complete_env();
+    env.remove("KAMN_SERVICE_API_LIVE_SOLANA_SETTLEMENT_RECIPIENT_PUBKEY");
+
+    let error = parse_agent_transaction_demo_config(&env)
+        .expect_err("partial devnet configuration must fail");
+    assert!(error.starts_with("AGENT_TRANSACTION_DEVNET_CONFIG_INVALID"));
+}
+
+fn complete_env() -> BTreeMap<String, String> {
+    [
+        ("KAMN_MVP_AGENT_DRIVER", "pi"),
+        ("KAMN_MVP_DEVNET_MODE", "required"),
+        ("KAMN_MVP_SOLANA_RPC_URL", "https://api.devnet.solana.com"),
+        ("KAMN_MVP_LIVE_MCP_AGENT_A_KEY_FILE", "/tmp/agent-a.key"),
+        ("KAMN_MVP_LIVE_MCP_AGENT_B_KEY_FILE", "/tmp/agent-b.key"),
+        ("KAMN_MVP_LIVE_MCP_AGENT_C_KEY_FILE", "/tmp/agent-c.key"),
+        (
+            "KAMN_SERVICE_API_LIVE_SOLANA_SETTLEMENT_KEYPAIR_FILE",
+            "/tmp/devnet-payer.json",
+        ),
+        (
+            "KAMN_SERVICE_API_LIVE_SOLANA_SETTLEMENT_RECIPIENT_PUBKEY",
+            "recipient111111111111111111111111111111111111111",
+        ),
+        (
+            "KAMN_SERVICE_API_LIVE_SOLANA_SETTLEMENT_LAMPORTS",
+            "1000000",
+        ),
+        (
+            "KAMN_SERVICE_API_LIVE_SOLANA_SETTLEMENT_COMMITMENT",
+            "finalized",
+        ),
+    ]
+    .into_iter()
+    .map(|(key, value)| (key.to_owned(), value.to_owned()))
+    .collect()
+}
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..")
+}

--- a/crates/kamn-e2e-harness/tests/agent_transaction_demo_config_contract.rs
+++ b/crates/kamn-e2e-harness/tests/agent_transaction_demo_config_contract.rs
@@ -23,6 +23,7 @@ fn spec_c01_canonical_make_target_invokes_rust_supervisor() {
         .expect("make dry run");
     assert!(output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("cargo build -p kamn-node -p kamn-mcp-server"));
     assert!(stdout.contains("kamn-e2e-harness -- demo-agent-transaction"));
 }
 

--- a/crates/kamn-e2e-harness/tests/agent_transaction_demo_config_contract.rs
+++ b/crates/kamn-e2e-harness/tests/agent_transaction_demo_config_contract.rs
@@ -2,7 +2,14 @@ use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::process::Command;
 
-use kamn_e2e_harness::parse_agent_transaction_demo_config;
+use kamn_e2e_harness::{parse_agent_transaction_demo_config, parse_command_args, HarnessCommand};
+
+#[test]
+fn spec_c00_parser_routes_canonical_agent_transaction_command() {
+    let parsed = parse_command_args(["demo-agent-transaction"])
+        .expect("canonical agent transaction command should parse");
+    assert_eq!(parsed, HarnessCommand::DemoAgentTransaction);
+}
 
 #[test]
 fn spec_c01_canonical_make_target_invokes_rust_supervisor() {

--- a/crates/kamn-e2e-harness/tests/agent_transaction_demo_preflight_contract.rs
+++ b/crates/kamn-e2e-harness/tests/agent_transaction_demo_preflight_contract.rs
@@ -54,6 +54,8 @@ impl PreflightFixture {
         )
         .expect("extension");
         write_fake_pi(root.join("pi"), pi_mode);
+        write_fake_pi(root.join("kamn-node"), "pass");
+        std::fs::write(root.join("kamn-mcp-server"), "stub").expect("MCP binary");
         Self { root }
     }
 
@@ -69,6 +71,8 @@ impl PreflightFixture {
             ),
             ("KAMN_MVP_PI_BINARY", "pi"),
             ("KAMN_MVP_PI_EXTENSION", ".pi/extensions/kamn-mvp/index.ts"),
+            ("KAMN_MVP_LOCAL_NODE_BINARY", "kamn-node"),
+            ("KAMN_MVP_LIVE_MCP_BINARY", "kamn-mcp-server"),
         ] {
             env.insert(name.to_owned(), self.root.join(file).display().to_string());
         }

--- a/crates/kamn-e2e-harness/tests/agent_transaction_demo_preflight_contract.rs
+++ b/crates/kamn-e2e-harness/tests/agent_transaction_demo_preflight_contract.rs
@@ -1,0 +1,123 @@
+use std::collections::BTreeMap;
+use std::os::unix::fs::PermissionsExt;
+use std::path::PathBuf;
+
+use kamn_e2e_harness::{parse_agent_transaction_demo_config, validate_agent_transaction_preflight};
+
+#[test]
+fn spec_c01_preflight_proves_files_and_pi_oauth_before_execution() {
+    let fixture = PreflightFixture::new("pass");
+    let config = parse_agent_transaction_demo_config(&fixture.env()).expect("configuration");
+
+    validate_agent_transaction_preflight(&config).expect("complete preflight should pass");
+}
+
+#[test]
+fn spec_c02_missing_agent_key_fails_closed() {
+    let fixture = PreflightFixture::new("pass");
+    std::fs::remove_file(fixture.root.join("agent-b.key")).expect("remove key");
+    let config = parse_agent_transaction_demo_config(&fixture.env()).expect("configuration");
+
+    let error = validate_agent_transaction_preflight(&config).expect_err("missing key must fail");
+    assert!(error.starts_with("AGENT_TRANSACTION_AGENT_CONFIG_INVALID"));
+}
+
+#[test]
+fn spec_c03_failed_pi_oauth_probe_fails_closed() {
+    let fixture = PreflightFixture::new("fail");
+    let config = parse_agent_transaction_demo_config(&fixture.env()).expect("configuration");
+
+    let error = validate_agent_transaction_preflight(&config).expect_err("Pi auth must fail");
+    assert!(error.starts_with("AGENT_TRANSACTION_PI_PREFLIGHT_FAILED"));
+}
+
+struct PreflightFixture {
+    root: PathBuf,
+}
+
+impl PreflightFixture {
+    fn new(pi_mode: &str) -> Self {
+        let root = unique_root();
+        std::fs::create_dir_all(root.join(".pi/extensions/kamn-mvp")).expect("fixture root");
+        for name in ["agent-a.key", "agent-b.key", "agent-c.key"] {
+            std::fs::write(root.join(name), format!("private-{name}")).expect("agent key");
+        }
+        let keypair = (0_u8..64).collect::<Vec<_>>();
+        std::fs::write(
+            root.join("payer.json"),
+            serde_json::to_string(&keypair).expect("keypair JSON"),
+        )
+        .expect("payer keypair");
+        std::fs::write(
+            root.join(".pi/extensions/kamn-mvp/index.ts"),
+            "export default {}",
+        )
+        .expect("extension");
+        write_fake_pi(root.join("pi"), pi_mode);
+        Self { root }
+    }
+
+    fn env(&self) -> BTreeMap<String, String> {
+        let mut env = base_env();
+        for (name, file) in [
+            ("KAMN_MVP_LIVE_MCP_AGENT_A_KEY_FILE", "agent-a.key"),
+            ("KAMN_MVP_LIVE_MCP_AGENT_B_KEY_FILE", "agent-b.key"),
+            ("KAMN_MVP_LIVE_MCP_AGENT_C_KEY_FILE", "agent-c.key"),
+            (
+                "KAMN_SERVICE_API_LIVE_SOLANA_SETTLEMENT_KEYPAIR_FILE",
+                "payer.json",
+            ),
+            ("KAMN_MVP_PI_BINARY", "pi"),
+            ("KAMN_MVP_PI_EXTENSION", ".pi/extensions/kamn-mvp/index.ts"),
+        ] {
+            env.insert(name.to_owned(), self.root.join(file).display().to_string());
+        }
+        env
+    }
+}
+
+fn write_fake_pi(path: PathBuf, mode: &str) {
+    let body = if mode == "pass" {
+        "#!/bin/sh\necho KAMN_PI_PREFLIGHT_OK\n"
+    } else {
+        "#!/bin/sh\necho auth-failed >&2\nexit 1\n"
+    };
+    std::fs::write(&path, body).expect("fake Pi");
+    let mut permissions = std::fs::metadata(&path).expect("metadata").permissions();
+    permissions.set_mode(0o700);
+    std::fs::set_permissions(path, permissions).expect("permissions");
+}
+
+fn base_env() -> BTreeMap<String, String> {
+    [
+        ("KAMN_MVP_AGENT_DRIVER", "pi"),
+        ("KAMN_MVP_DEVNET_MODE", "required"),
+        ("KAMN_MVP_SOLANA_RPC_URL", "https://api.devnet.solana.com"),
+        (
+            "KAMN_SERVICE_API_LIVE_SOLANA_SETTLEMENT_RECIPIENT_PUBKEY",
+            "FV5LvudLjZQGCrPwXUY2JaVr26sQE15K25BGvsKWvyFe",
+        ),
+        (
+            "KAMN_SERVICE_API_LIVE_SOLANA_SETTLEMENT_LAMPORTS",
+            "1000000",
+        ),
+        (
+            "KAMN_SERVICE_API_LIVE_SOLANA_SETTLEMENT_COMMITMENT",
+            "finalized",
+        ),
+    ]
+    .into_iter()
+    .map(|(key, value)| (key.to_owned(), value.to_owned()))
+    .collect()
+}
+
+fn unique_root() -> PathBuf {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("clock")
+        .as_nanos();
+    std::env::temp_dir().join(format!(
+        "kamn-agent-preflight-{}-{nanos}",
+        std::process::id()
+    ))
+}

--- a/crates/kamn-e2e-harness/tests/agent_transaction_demo_success_contract.rs
+++ b/crates/kamn-e2e-harness/tests/agent_transaction_demo_success_contract.rs
@@ -1,0 +1,181 @@
+use std::collections::BTreeMap;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+
+use kamn_e2e_harness::{
+    execute_agent_transaction_demo_with_config, execute_verify_mvp_demo_contract,
+    parse_agent_transaction_demo_config, LiveTaskEvidencePaths, VerifyMvpDemoCommandConfig,
+};
+
+#[path = "support/mvp_demo_command.rs"]
+mod mvp_demo_command;
+#[path = "support/pi_transaction_actor_fixture.rs"]
+mod pi_transaction_actor_fixture;
+use pi_transaction_actor_fixture::{ActorFixture, Overrides};
+
+#[test]
+fn spec_c01_success_writes_one_runtime_chain_report_after_children_exit() {
+    let root = unique_root();
+    let actors = ActorFixture::new();
+    actors.write_all(Overrides::default());
+    actors.rebind_shared_facts();
+    let demo_stub = mvp_demo_command::devnet_required_demo_config(&root.join("stub"));
+    let live = demo_stub
+        .live_task_evidence
+        .as_ref()
+        .expect("live evidence");
+    let mut config = configured_fixture(&root, &actors.paths(), live);
+    config.devnet_settlement_command = demo_stub.devnet_settlement_command;
+    config.localhost_signed_demo_command = demo_stub.localhost_signed_demo_command;
+    config.service_api_vertical_slice_command = demo_stub.service_api_vertical_slice_command;
+    config.service_api_websocket_command = demo_stub.service_api_websocket_command;
+
+    let report = execute_agent_transaction_demo_with_config(&config)
+        .expect("canonical deterministic demo should pass");
+    assert!(report.contains("kamn.mvp.runtime-receipt-chain.v1"));
+    assert!(!report.contains("agent_a_registered"));
+    assert_eq!(run_directories(&root.join("demo")).len(), 1);
+    assert!(!root.join("demo/latest/NO-GO.txt").exists());
+    verify_latest(&root).expect("canonical verifier should pass after child exit");
+}
+
+fn configured_fixture(
+    root: &Path,
+    actor_sources: &[String; 3],
+    live: &LiveTaskEvidencePaths,
+) -> kamn_e2e_harness::AgentTransactionDemoConfig {
+    std::fs::create_dir_all(root.join("extension")).expect("fixture root");
+    for name in ["agent-a.key", "agent-b.key", "agent-c.key"] {
+        std::fs::write(root.join(name), name).expect("agent key");
+    }
+    let payer = (0_u8..64).collect::<Vec<_>>();
+    std::fs::write(
+        root.join("payer.json"),
+        serde_json::to_string(&payer).expect("payer"),
+    )
+    .expect("payer file");
+    std::fs::write(root.join("extension/index.ts"), "export default {}").expect("extension");
+    write_success_pi(root, actor_sources, live);
+    parse_agent_transaction_demo_config(&fixture_env(root)).expect("configuration")
+}
+
+fn fixture_env(root: &Path) -> BTreeMap<String, String> {
+    let mut env = base_env();
+    for (name, file) in [
+        ("KAMN_MVP_LIVE_MCP_AGENT_A_KEY_FILE", "agent-a.key"),
+        ("KAMN_MVP_LIVE_MCP_AGENT_B_KEY_FILE", "agent-b.key"),
+        ("KAMN_MVP_LIVE_MCP_AGENT_C_KEY_FILE", "agent-c.key"),
+        (
+            "KAMN_SERVICE_API_LIVE_SOLANA_SETTLEMENT_KEYPAIR_FILE",
+            "payer.json",
+        ),
+        ("KAMN_MVP_PI_BINARY", "pi"),
+        ("KAMN_MVP_PI_EXTENSION", "extension/index.ts"),
+        ("KAMN_MVP_AGENT_TRANSACTION_OUTPUT_ROOT", "demo"),
+        ("KAMN_MVP_AGENT_TRANSACTION_STAGING_ROOT", "staging"),
+    ] {
+        env.insert(name.to_owned(), root.join(file).display().to_string());
+    }
+    env
+}
+
+fn write_success_pi(root: &Path, actors: &[String; 3], live: &LiveTaskEvidencePaths) {
+    let script = format!(
+        r#"#!/bin/sh
+case " $* " in *" --print "*) echo KAMN_PI_PREFLIGHT_OK; exit 0;; esac
+role=""; previous=""
+for arg in "$@"; do
+  if [ "$previous" = "--name" ]; then role="$arg"; fi
+  previous="$arg"
+done
+while read line; do
+  mkdir -p "$(dirname "$KAMN_MVP_PI_TRANSACTION_AGENT_A_FILE")"
+  cp "{}" "$KAMN_MVP_PI_TRANSACTION_AGENT_A_FILE"
+  cp "{}" "$KAMN_MVP_PI_TRANSACTION_AGENT_B_FILE"
+  cp "{}" "$KAMN_MVP_PI_TRANSACTION_AGENT_C_FILE"
+  cp "{}" "$KAMN_MVP_LIVE_TASK_HANDOFF_FILE"
+  cp "{}" "$KAMN_MVP_LIVE_TASK_AGENT_A_RECEIPT_FILE"
+  cp "{}" "$KAMN_MVP_LIVE_TASK_AGENT_B_RECEIPT_FILE"
+  cp "{}" "$KAMN_MVP_LIVE_TASK_AGENT_C_OBSERVATION_FILE"
+  echo '{{"type":"response","command":"prompt","success":true}}'
+  if [ "$role" = "kamn-mvp-agent-b" ]; then
+    echo '{{"type":"agent_end","messages":[{{"did":"kamn:did:agent:b"}}]}}'
+  else
+    echo '{{"type":"agent_end","messages":[]}}'
+  fi
+done
+"#,
+        actors[0],
+        actors[1],
+        actors[2],
+        live.handoff,
+        live.agent_a_receipt,
+        live.agent_b_receipt,
+        live.agent_c_observation,
+    );
+    write_executable(root.join("pi"), script.as_str());
+}
+
+fn base_env() -> BTreeMap<String, String> {
+    [
+        ("KAMN_MVP_AGENT_DRIVER", "pi"),
+        ("KAMN_MVP_DEVNET_MODE", "required"),
+        ("KAMN_MVP_SOLANA_RPC_URL", "https://api.devnet.solana.com"),
+        (
+            "KAMN_SERVICE_API_LIVE_SOLANA_SETTLEMENT_RECIPIENT_PUBKEY",
+            "FV5LvudLjZQGCrPwXUY2JaVr26sQE15K25BGvsKWvyFe",
+        ),
+        (
+            "KAMN_SERVICE_API_LIVE_SOLANA_SETTLEMENT_LAMPORTS",
+            "1000000",
+        ),
+        (
+            "KAMN_SERVICE_API_LIVE_SOLANA_SETTLEMENT_COMMITMENT",
+            "finalized",
+        ),
+    ]
+    .into_iter()
+    .map(|(key, value)| (key.to_owned(), value.to_owned()))
+    .collect()
+}
+
+fn write_executable(path: PathBuf, body: &str) {
+    std::fs::write(&path, body).expect("fake Pi");
+    let mut permissions = std::fs::metadata(&path).expect("metadata").permissions();
+    permissions.set_mode(0o700);
+    std::fs::set_permissions(path, permissions).expect("permissions");
+}
+
+fn run_directories(root: &Path) -> Vec<PathBuf> {
+    std::fs::read_dir(root)
+        .expect("output root")
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| {
+            path.is_dir() && path.file_name().and_then(|name| name.to_str()) != Some("latest")
+        })
+        .collect()
+}
+
+fn verify_latest(root: &Path) -> Result<String, String> {
+    execute_verify_mvp_demo_contract(&VerifyMvpDemoCommandConfig {
+        report: root
+            .join("demo/latest/proof/report.json")
+            .display()
+            .to_string(),
+        agent_harness_evidence_path: None,
+        pi_transaction_actor_paths: Some([
+            root.join("staging/agent-a.json").display().to_string(),
+            root.join("staging/agent-b.json").display().to_string(),
+            root.join("staging/agent-c.json").display().to_string(),
+        ]),
+    })
+}
+
+fn unique_root() -> PathBuf {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("clock")
+        .as_nanos();
+    std::env::temp_dir().join(format!("kamn-agent-success-{}-{nanos}", std::process::id()))
+}

--- a/crates/kamn-e2e-harness/tests/agent_transaction_demo_success_contract.rs
+++ b/crates/kamn-e2e-harness/tests/agent_transaction_demo_success_contract.rs
@@ -51,8 +51,12 @@ fn configured_fixture(
     live: &LiveTaskEvidencePaths,
 ) -> kamn_e2e_harness::AgentTransactionDemoConfig {
     std::fs::create_dir_all(root.join("extension")).expect("fixture root");
-    for name in ["agent-a.key", "agent-b.key", "agent-c.key"] {
-        std::fs::write(root.join(name), name).expect("agent key");
+    for (name, byte) in [
+        ("agent-a.key", "11"),
+        ("agent-b.key", "22"),
+        ("agent-c.key", "33"),
+    ] {
+        std::fs::write(root.join(name), byte.repeat(32)).expect("agent key");
     }
     let payer = (0_u8..64).collect::<Vec<_>>();
     std::fs::write(

--- a/crates/kamn-e2e-harness/tests/agent_transaction_demo_success_contract.rs
+++ b/crates/kamn-e2e-harness/tests/agent_transaction_demo_success_contract.rs
@@ -7,6 +7,8 @@ use kamn_e2e_harness::{
     parse_agent_transaction_demo_config, LiveTaskEvidencePaths, VerifyMvpDemoCommandConfig,
 };
 
+#[path = "support/fake_local_runtime.rs"]
+mod fake_local_runtime;
 #[path = "support/mvp_demo_command.rs"]
 mod mvp_demo_command;
 #[path = "support/pi_transaction_actor_fixture.rs"]
@@ -76,6 +78,7 @@ fn fixture_env(root: &Path) -> BTreeMap<String, String> {
     ] {
         env.insert(name.to_owned(), root.join(file).display().to_string());
     }
+    fake_local_runtime::configure(root, &mut env);
     env
 }
 

--- a/crates/kamn-e2e-harness/tests/agent_transaction_demo_success_contract.rs
+++ b/crates/kamn-e2e-harness/tests/agent_transaction_demo_success_contract.rs
@@ -91,6 +91,11 @@ for arg in "$@"; do
   if [ "$previous" = "--name" ]; then role="$arg"; fi
   previous="$arg"
 done
+test -n "$KAMN_MVP_LIVE_MCP_BINARY" || exit 41
+test -n "$KAMN_MVP_LIVE_MCP_ENDPOINT" || exit 42
+test -n "$KAMN_MVP_LIVE_MCP_AGENT_A_NAME" || exit 43
+test -n "$KAMN_MVP_LIVE_MCP_AGENT_B_NAME" || exit 44
+test -n "$KAMN_MVP_LIVE_MCP_AGENT_C_NAME" || exit 45
 while read line; do
   mkdir -p "$(dirname "$KAMN_MVP_PI_TRANSACTION_AGENT_A_FILE")"
   cp "{}" "$KAMN_MVP_PI_TRANSACTION_AGENT_A_FILE"

--- a/crates/kamn-e2e-harness/tests/agent_transaction_demo_success_contract.rs
+++ b/crates/kamn-e2e-harness/tests/agent_transaction_demo_success_contract.rs
@@ -105,6 +105,7 @@ test -n "$KAMN_MVP_LIVE_MCP_AGENT_A_NAME" || exit 43
 test -n "$KAMN_MVP_LIVE_MCP_AGENT_B_NAME" || exit 44
 test -n "$KAMN_MVP_LIVE_MCP_AGENT_C_NAME" || exit 45
 while read line; do
+  case "$line" in *'"type":"abort"'*) continue;; esac
   mkdir -p "$(dirname "$KAMN_MVP_PI_TRANSACTION_AGENT_A_FILE")"
   cp "{}" "$KAMN_MVP_PI_TRANSACTION_AGENT_A_FILE"
   cp "{}" "$KAMN_MVP_PI_TRANSACTION_AGENT_B_FILE"

--- a/crates/kamn-e2e-harness/tests/agent_transaction_demo_success_contract.rs
+++ b/crates/kamn-e2e-harness/tests/agent_transaction_demo_success_contract.rs
@@ -38,6 +38,10 @@ fn spec_c01_success_writes_one_runtime_chain_report_after_children_exit() {
     assert!(!report.contains("agent_a_registered"));
     assert_eq!(run_directories(&root.join("demo")).len(), 1);
     assert!(!root.join("demo/latest/NO-GO.txt").exists());
+    let bootstrap = std::fs::read_to_string(root.join("staging/service-api-state.json"))
+        .expect("local authorization bootstrap");
+    assert!(bootstrap.contains(r#""action":"task:create""#));
+    assert!(!bootstrap.contains(r#""action":"escrow:release""#));
     verify_latest(&root).expect("canonical verifier should pass after child exit");
 }
 

--- a/crates/kamn-e2e-harness/tests/agent_transaction_demo_supervisor_contract.rs
+++ b/crates/kamn-e2e-harness/tests/agent_transaction_demo_supervisor_contract.rs
@@ -40,6 +40,30 @@ fn spec_c02_unresponsive_actor_times_out_and_cleans_every_child() {
     assert_no_processes(&fixture.root);
 }
 
+#[test]
+fn spec_c03_successful_rpc_children_run_the_canonical_phase_order() {
+    let fixture = SupervisorFixture::new("success");
+    let config = parse_agent_transaction_demo_config(&fixture.env()).expect("configuration");
+
+    let error = execute_agent_transaction_demo_with_config(&config)
+        .expect_err("missing proof artifacts must fail after actor phases");
+    assert!(error.starts_with("AGENT_TRANSACTION_PROOF_INVALID"));
+    let phases = std::fs::read_to_string(fixture.root.join("prompts.log")).expect("phase log");
+    assert_eq!(
+        phases.lines().collect::<Vec<_>>(),
+        [
+            "kamn-mvp-agent-b",
+            "kamn-mvp-agent-a",
+            "kamn-mvp-agent-b",
+            "kamn-mvp-agent-a",
+            "kamn-mvp-agent-b",
+            "kamn-mvp-agent-a",
+            "kamn-mvp-agent-c",
+        ]
+    );
+    assert_no_processes(&fixture.root);
+}
+
 struct SupervisorFixture {
     root: PathBuf,
 }
@@ -87,10 +111,10 @@ impl SupervisorFixture {
 }
 
 fn write_fake_pi(root: &std::path::Path, mode: &str) {
-    let b_action = if mode == "hang" {
-        "sleep 2; exit 9"
-    } else {
-        "exit 9"
+    let b_action = match mode {
+        "hang" => "sleep 2; exit 9",
+        "fail" => "exit 9",
+        _ => "",
     };
     let script = format!(
         r#"#!/bin/sh
@@ -103,13 +127,19 @@ for arg in "$@"; do
 done
 echo $$ > "{}/$role.pid"
 trap 'echo cleaned > "{}/$role.cleaned"; exit 0' TERM INT
-if [ "$role" = "kamn-mvp-agent-b" ]; then read line; {b_action}; fi
+if [ "$role" = "kamn-mvp-agent-b" ] && [ -n "{b_action}" ]; then read line; {b_action}; fi
 while read line; do
+  echo "$role" >> "{}/prompts.log"
   echo '{{"type":"response","command":"prompt","success":true}}'
-  echo '{{"type":"agent_end","messages":[]}}'
+  if [ "$role" = "kamn-mvp-agent-b" ]; then
+    echo '{{"type":"agent_end","messages":[{{"did":"kamn:did:agent:b"}}]}}'
+  else
+    echo '{{"type":"agent_end","messages":[]}}'
+  fi
 done
 echo cleaned > "{}/$role.cleaned"
 "#,
+        root.display(),
         root.display(),
         root.display(),
         root.display()

--- a/crates/kamn-e2e-harness/tests/agent_transaction_demo_supervisor_contract.rs
+++ b/crates/kamn-e2e-harness/tests/agent_transaction_demo_supervisor_contract.rs
@@ -70,6 +70,7 @@ fn spec_c03_successful_rpc_children_run_the_canonical_phase_order() {
             "kamn-mvp-agent-a",
             "kamn-mvp-agent-b",
             "kamn-mvp-agent-a",
+            "kamn-mvp-agent-b",
             "kamn-mvp-agent-c",
         ]
     );

--- a/crates/kamn-e2e-harness/tests/agent_transaction_demo_supervisor_contract.rs
+++ b/crates/kamn-e2e-harness/tests/agent_transaction_demo_supervisor_contract.rs
@@ -85,7 +85,7 @@ fn spec_c04_tool_execution_failure_stops_the_transaction_immediately() {
     let error = execute_agent_transaction_demo_with_config(&config)
         .expect_err("failed tool execution must fail the actor phase");
     assert!(error.starts_with("AGENT_TRANSACTION_CHILD_FAILED"));
-    assert!(error.contains("kamn_live_agent_b_register"));
+    assert!(error.contains("Pi tool failed: kamn_live_agent_b_register"));
     assert!(!fixture.root.join("demo/latest/proof/report.json").exists());
 }
 

--- a/crates/kamn-e2e-harness/tests/agent_transaction_demo_supervisor_contract.rs
+++ b/crates/kamn-e2e-harness/tests/agent_transaction_demo_supervisor_contract.rs
@@ -1,10 +1,14 @@
 use std::collections::BTreeMap;
-use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
 
 use kamn_e2e_harness::{
     execute_agent_transaction_demo_with_config, parse_agent_transaction_demo_config,
 };
+
+#[path = "support/fake_local_runtime.rs"]
+mod fake_local_runtime;
+#[path = "support/fake_supervisor_pi.rs"]
+mod fake_supervisor_pi;
 
 #[test]
 fn spec_c01_actor_failure_cleans_every_child_and_writes_no_go() {
@@ -74,7 +78,6 @@ fn spec_c03_successful_rpc_children_run_the_canonical_phase_order() {
 
 struct SupervisorFixture {
     root: PathBuf,
-    endpoint: String,
 }
 
 impl SupervisorFixture {
@@ -91,11 +94,8 @@ impl SupervisorFixture {
         )
         .expect("payer file");
         std::fs::write(root.join("extension/index.ts"), "export default {}").expect("extension");
-        write_fake_pi(&root, pi_mode);
-        let endpoint = format!("http://127.0.0.1:{}", free_port());
-        write_fake_runtime(&root);
-        std::fs::write(root.join("kamn-mcp-server"), "stub").expect("MCP binary");
-        Self { root, endpoint }
+        fake_supervisor_pi::write(&root, pi_mode);
+        Self { root }
     }
 
     fn env(&self) -> BTreeMap<String, String> {
@@ -118,87 +118,9 @@ impl SupervisorFixture {
             "KAMN_MVP_AGENT_TRANSACTION_RPC_TIMEOUT_MS".to_owned(),
             "100".to_owned(),
         );
-        env.insert(
-            "KAMN_MVP_LOCAL_NODE_BINARY".to_owned(),
-            self.root.join("kamn-node").display().to_string(),
-        );
-        env.insert(
-            "KAMN_MVP_LIVE_MCP_BINARY".to_owned(),
-            self.root.join("kamn-mcp-server").display().to_string(),
-        );
-        env.insert(
-            "KAMN_MVP_LIVE_MCP_ENDPOINT".to_owned(),
-            self.endpoint.clone(),
-        );
+        fake_local_runtime::configure(&self.root, &mut env);
         env
     }
-}
-
-fn write_fake_runtime(root: &std::path::Path) {
-    let script = format!(
-        r#"#!/bin/sh
-port=""
-previous=""
-for arg in "$@"; do
-  if [ "$previous" = "--api-bind" ]; then port="${{arg##*:}}"; fi
-  previous="$arg"
-done
-exec python3 -c 'import signal,socket,sys,time
-root=sys.argv[1]; port=int(sys.argv[2])
-open(root+"/runtime.started","w").write(str(__import__("os").getpid()))
-server=socket.socket(); server.setsockopt(socket.SOL_SOCKET,socket.SO_REUSEADDR,1); server.bind(("127.0.0.1",port)); server.listen()
-def stop(*_):
- open(root+"/runtime.stopped","w").write("stopped"); server.close(); sys.exit(0)
-signal.signal(signal.SIGTERM,stop)
-while True: time.sleep(.05)' "{}" "$port"
-"#,
-        root.display()
-    );
-    write_executable(root.join("kamn-node"), script.as_str());
-}
-
-fn write_fake_pi(root: &std::path::Path, mode: &str) {
-    let b_branch = match mode {
-        "hang" => "if [ \"$role\" = \"kamn-mvp-agent-b\" ]; then read line; sleep 2; exit 9; fi",
-        "fail" => "if [ \"$role\" = \"kamn-mvp-agent-b\" ]; then read line; exit 9; fi",
-        _ => "",
-    };
-    let script = format!(
-        r#"#!/bin/sh
-case " $* " in *" --print "*) echo KAMN_PI_PREFLIGHT_OK; exit 0;; esac
-role=""
-previous=""
-for arg in "$@"; do
-  if [ "$previous" = "--name" ]; then role="$arg"; fi
-  previous="$arg"
-done
-echo $$ > "{}/$role.pid"
-trap 'echo cleaned > "{}/$role.cleaned"; exit 0' TERM INT
-{b_branch}
-while read line; do
-  echo "$role" >> "{}/prompts.log"
-  echo '{{"type":"response","command":"prompt","success":true}}'
-  if [ "$role" = "kamn-mvp-agent-b" ]; then
-    echo '{{"type":"agent_end","messages":[{{"did":"kamn:did:agent:b"}}]}}'
-  else
-    echo '{{"type":"agent_end","messages":[]}}'
-  fi
-done
-echo cleaned > "{}/$role.cleaned"
-"#,
-        root.display(),
-        root.display(),
-        root.display(),
-        root.display()
-    );
-    write_executable(root.join("pi"), script.as_str());
-}
-
-fn write_executable(path: PathBuf, contents: &str) {
-    std::fs::write(&path, contents).expect("fake executable");
-    let mut permissions = std::fs::metadata(&path).expect("metadata").permissions();
-    permissions.set_mode(0o700);
-    std::fs::set_permissions(path, permissions).expect("permissions");
 }
 
 fn assert_no_processes(root: &std::path::Path) {
@@ -249,14 +171,6 @@ fn unique_root() -> PathBuf {
         "kamn-agent-supervisor-{}-{nanos}-{id}",
         std::process::id()
     ))
-}
-
-fn free_port() -> u16 {
-    std::net::TcpListener::bind("127.0.0.1:0")
-        .expect("free port")
-        .local_addr()
-        .expect("local address")
-        .port()
 }
 
 fn test_lock() -> std::sync::MutexGuard<'static, ()> {

--- a/crates/kamn-e2e-harness/tests/agent_transaction_demo_supervisor_contract.rs
+++ b/crates/kamn-e2e-harness/tests/agent_transaction_demo_supervisor_contract.rs
@@ -76,6 +76,19 @@ fn spec_c03_successful_rpc_children_run_the_canonical_phase_order() {
     assert_no_processes(&fixture.root);
 }
 
+#[test]
+fn spec_c04_tool_execution_failure_stops_the_transaction_immediately() {
+    let _guard = test_lock();
+    let fixture = SupervisorFixture::new("tool-error");
+    let config = parse_agent_transaction_demo_config(&fixture.env()).expect("configuration");
+
+    let error = execute_agent_transaction_demo_with_config(&config)
+        .expect_err("failed tool execution must fail the actor phase");
+    assert!(error.starts_with("AGENT_TRANSACTION_CHILD_FAILED"));
+    assert!(error.contains("kamn_live_agent_b_register"));
+    assert!(!fixture.root.join("demo/latest/proof/report.json").exists());
+}
+
 struct SupervisorFixture {
     root: PathBuf,
 }

--- a/crates/kamn-e2e-harness/tests/agent_transaction_demo_supervisor_contract.rs
+++ b/crates/kamn-e2e-harness/tests/agent_transaction_demo_supervisor_contract.rs
@@ -34,9 +34,10 @@ fn spec_c02_unresponsive_actor_times_out_and_cleans_every_child() {
         .expect_err("unresponsive actor must fail");
     assert!(error.starts_with("AGENT_TRANSACTION_CHILD_FAILED"));
     assert!(started.elapsed() < std::time::Duration::from_secs(1));
-    for role in ["kamn-mvp-agent-a", "kamn-mvp-agent-b", "kamn-mvp-agent-c"] {
+    for role in ["kamn-mvp-agent-a", "kamn-mvp-agent-c"] {
         assert!(fixture.root.join(format!("{role}.cleaned")).is_file());
     }
+    assert_no_processes(&fixture.root);
 }
 
 struct SupervisorFixture {
@@ -100,6 +101,7 @@ for arg in "$@"; do
   if [ "$previous" = "--name" ]; then role="$arg"; fi
   previous="$arg"
 done
+echo $$ > "{}/$role.pid"
 trap 'echo cleaned > "{}/$role.cleaned"; exit 0' TERM INT
 if [ "$role" = "kamn-mvp-agent-b" ]; then read line; {b_action}; fi
 while read line; do
@@ -109,6 +111,7 @@ done
 echo cleaned > "{}/$role.cleaned"
 "#,
         root.display(),
+        root.display(),
         root.display()
     );
     let path = root.join("pi");
@@ -116,6 +119,20 @@ echo cleaned > "{}/$role.cleaned"
     let mut permissions = std::fs::metadata(&path).expect("metadata").permissions();
     permissions.set_mode(0o700);
     std::fs::set_permissions(path, permissions).expect("permissions");
+}
+
+fn assert_no_processes(root: &std::path::Path) {
+    for role in ["kamn-mvp-agent-a", "kamn-mvp-agent-b", "kamn-mvp-agent-c"] {
+        let pid = std::fs::read_to_string(root.join(format!("{role}.pid")))
+            .expect("child pid")
+            .trim()
+            .to_owned();
+        let status = std::process::Command::new("kill")
+            .args(["-0", pid.as_str()])
+            .status()
+            .expect("kill probe");
+        assert!(!status.success(), "child {pid} survived cleanup");
+    }
 }
 
 fn base_env() -> BTreeMap<String, String> {

--- a/crates/kamn-e2e-harness/tests/agent_transaction_demo_supervisor_contract.rs
+++ b/crates/kamn-e2e-harness/tests/agent_transaction_demo_supervisor_contract.rs
@@ -47,7 +47,10 @@ fn spec_c03_successful_rpc_children_run_the_canonical_phase_order() {
 
     let error = execute_agent_transaction_demo_with_config(&config)
         .expect_err("missing proof artifacts must fail after actor phases");
-    assert!(error.starts_with("AGENT_TRANSACTION_PROOF_INVALID"));
+    assert!(
+        error.starts_with("AGENT_TRANSACTION_PROOF_INVALID"),
+        "unexpected error: {error}"
+    );
     let phases = std::fs::read_to_string(fixture.root.join("prompts.log")).expect("phase log");
     assert_eq!(
         phases.lines().collect::<Vec<_>>(),
@@ -111,9 +114,9 @@ impl SupervisorFixture {
 }
 
 fn write_fake_pi(root: &std::path::Path, mode: &str) {
-    let b_action = match mode {
-        "hang" => "sleep 2; exit 9",
-        "fail" => "exit 9",
+    let b_branch = match mode {
+        "hang" => "if [ \"$role\" = \"kamn-mvp-agent-b\" ]; then read line; sleep 2; exit 9; fi",
+        "fail" => "if [ \"$role\" = \"kamn-mvp-agent-b\" ]; then read line; exit 9; fi",
         _ => "",
     };
     let script = format!(
@@ -127,7 +130,7 @@ for arg in "$@"; do
 done
 echo $$ > "{}/$role.pid"
 trap 'echo cleaned > "{}/$role.cleaned"; exit 0' TERM INT
-if [ "$role" = "kamn-mvp-agent-b" ] && [ -n "{b_action}" ]; then read line; {b_action}; fi
+{b_branch}
 while read line; do
   echo "$role" >> "{}/prompts.log"
   echo '{{"type":"response","command":"prompt","success":true}}'

--- a/crates/kamn-e2e-harness/tests/agent_transaction_demo_supervisor_contract.rs
+++ b/crates/kamn-e2e-harness/tests/agent_transaction_demo_supervisor_contract.rs
@@ -1,0 +1,129 @@
+use std::collections::BTreeMap;
+use std::os::unix::fs::PermissionsExt;
+use std::path::PathBuf;
+
+use kamn_e2e_harness::{
+    execute_agent_transaction_demo_with_config, parse_agent_transaction_demo_config,
+};
+
+#[test]
+fn spec_c01_actor_failure_cleans_every_child_and_writes_no_go() {
+    let fixture = SupervisorFixture::new();
+    let config = parse_agent_transaction_demo_config(&fixture.env()).expect("configuration");
+
+    let error = execute_agent_transaction_demo_with_config(&config)
+        .expect_err("Agent B failure must fail the demo");
+    assert!(error.starts_with("AGENT_TRANSACTION_CHILD_FAILED"));
+    for role in ["kamn-mvp-agent-a", "kamn-mvp-agent-c"] {
+        assert!(fixture.root.join(format!("{role}.cleaned")).is_file());
+    }
+    let no_go =
+        std::fs::read_to_string(fixture.root.join("demo/latest/NO-GO.txt")).expect("NO-GO report");
+    assert!(no_go.contains("decision=NO-GO"));
+    assert!(no_go.contains("AGENT_TRANSACTION_CHILD_FAILED"));
+    assert!(!fixture.root.join("demo/latest/proof/report.json").exists());
+}
+
+struct SupervisorFixture {
+    root: PathBuf,
+}
+
+impl SupervisorFixture {
+    fn new() -> Self {
+        let root = unique_root();
+        std::fs::create_dir_all(root.join("extension")).expect("fixture root");
+        for name in ["agent-a.key", "agent-b.key", "agent-c.key"] {
+            std::fs::write(root.join(name), name).expect("agent key");
+        }
+        let payer = (0_u8..64).collect::<Vec<_>>();
+        std::fs::write(
+            root.join("payer.json"),
+            serde_json::to_string(&payer).expect("payer JSON"),
+        )
+        .expect("payer file");
+        std::fs::write(root.join("extension/index.ts"), "export default {}").expect("extension");
+        write_fake_pi(&root);
+        Self { root }
+    }
+
+    fn env(&self) -> BTreeMap<String, String> {
+        let mut env = base_env();
+        for (name, path) in [
+            ("KAMN_MVP_LIVE_MCP_AGENT_A_KEY_FILE", "agent-a.key"),
+            ("KAMN_MVP_LIVE_MCP_AGENT_B_KEY_FILE", "agent-b.key"),
+            ("KAMN_MVP_LIVE_MCP_AGENT_C_KEY_FILE", "agent-c.key"),
+            (
+                "KAMN_SERVICE_API_LIVE_SOLANA_SETTLEMENT_KEYPAIR_FILE",
+                "payer.json",
+            ),
+            ("KAMN_MVP_PI_BINARY", "pi"),
+            ("KAMN_MVP_PI_EXTENSION", "extension/index.ts"),
+            ("KAMN_MVP_AGENT_TRANSACTION_OUTPUT_ROOT", "demo"),
+        ] {
+            env.insert(name.to_owned(), self.root.join(path).display().to_string());
+        }
+        env
+    }
+}
+
+fn write_fake_pi(root: &std::path::Path) {
+    let script = format!(
+        r#"#!/bin/sh
+case " $* " in *" --print "*) echo KAMN_PI_PREFLIGHT_OK; exit 0;; esac
+role=""
+previous=""
+for arg in "$@"; do
+  if [ "$previous" = "--name" ]; then role="$arg"; fi
+  previous="$arg"
+done
+trap 'echo cleaned > "{}/$role.cleaned"; exit 0' TERM INT
+if [ "$role" = "kamn-mvp-agent-b" ]; then read line; exit 9; fi
+while read line; do
+  echo '{{"type":"response","command":"prompt","success":true}}'
+  echo '{{"type":"agent_end","messages":[]}}'
+done
+echo cleaned > "{}/$role.cleaned"
+"#,
+        root.display(),
+        root.display()
+    );
+    let path = root.join("pi");
+    std::fs::write(&path, script).expect("fake Pi");
+    let mut permissions = std::fs::metadata(&path).expect("metadata").permissions();
+    permissions.set_mode(0o700);
+    std::fs::set_permissions(path, permissions).expect("permissions");
+}
+
+fn base_env() -> BTreeMap<String, String> {
+    [
+        ("KAMN_MVP_AGENT_DRIVER", "pi"),
+        ("KAMN_MVP_DEVNET_MODE", "required"),
+        ("KAMN_MVP_SOLANA_RPC_URL", "https://api.devnet.solana.com"),
+        (
+            "KAMN_SERVICE_API_LIVE_SOLANA_SETTLEMENT_RECIPIENT_PUBKEY",
+            "FV5LvudLjZQGCrPwXUY2JaVr26sQE15K25BGvsKWvyFe",
+        ),
+        (
+            "KAMN_SERVICE_API_LIVE_SOLANA_SETTLEMENT_LAMPORTS",
+            "1000000",
+        ),
+        (
+            "KAMN_SERVICE_API_LIVE_SOLANA_SETTLEMENT_COMMITMENT",
+            "finalized",
+        ),
+    ]
+    .into_iter()
+    .map(|(key, value)| (key.to_owned(), value.to_owned()))
+    .collect()
+}
+
+fn unique_root() -> PathBuf {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("clock")
+        .as_nanos();
+    std::env::temp_dir().join(format!(
+        "kamn-agent-supervisor-{}-{nanos}",
+        std::process::id()
+    ))
+}

--- a/crates/kamn-e2e-harness/tests/agent_transaction_demo_supervisor_contract.rs
+++ b/crates/kamn-e2e-harness/tests/agent_transaction_demo_supervisor_contract.rs
@@ -8,6 +8,7 @@ use kamn_e2e_harness::{
 
 #[test]
 fn spec_c01_actor_failure_cleans_every_child_and_writes_no_go() {
+    let _guard = test_lock();
     let fixture = SupervisorFixture::new("fail");
     let config = parse_agent_transaction_demo_config(&fixture.env()).expect("configuration");
 
@@ -28,6 +29,7 @@ fn spec_c01_actor_failure_cleans_every_child_and_writes_no_go() {
 
 #[test]
 fn spec_c02_unresponsive_actor_times_out_and_cleans_every_child() {
+    let _guard = test_lock();
     let fixture = SupervisorFixture::new("hang");
     let config = parse_agent_transaction_demo_config(&fixture.env()).expect("configuration");
     let started = std::time::Instant::now();
@@ -44,6 +46,7 @@ fn spec_c02_unresponsive_actor_times_out_and_cleans_every_child() {
 
 #[test]
 fn spec_c03_successful_rpc_children_run_the_canonical_phase_order() {
+    let _guard = test_lock();
     let fixture = SupervisorFixture::new("success");
     let config = parse_agent_transaction_demo_config(&fixture.env()).expect("configuration");
 
@@ -123,7 +126,10 @@ impl SupervisorFixture {
             "KAMN_MVP_LIVE_MCP_BINARY".to_owned(),
             self.root.join("kamn-mcp-server").display().to_string(),
         );
-        env.insert("KAMN_MVP_LIVE_MCP_ENDPOINT".to_owned(), self.endpoint.clone());
+        env.insert(
+            "KAMN_MVP_LIVE_MCP_ENDPOINT".to_owned(),
+            self.endpoint.clone(),
+        );
         env
     }
 }
@@ -185,8 +191,11 @@ echo cleaned > "{}/$role.cleaned"
         root.display(),
         root.display()
     );
-    let path = root.join("pi");
-    std::fs::write(&path, script).expect("fake Pi");
+    write_executable(root.join("pi"), script.as_str());
+}
+
+fn write_executable(path: PathBuf, contents: &str) {
+    std::fs::write(&path, contents).expect("fake executable");
     let mut permissions = std::fs::metadata(&path).expect("metadata").permissions();
     permissions.set_mode(0o700);
     std::fs::set_permissions(path, permissions).expect("permissions");
@@ -230,12 +239,14 @@ fn base_env() -> BTreeMap<String, String> {
 }
 
 fn unique_root() -> PathBuf {
+    static NEXT_ID: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
     let nanos = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .expect("clock")
         .as_nanos();
+    let id = NEXT_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     std::env::temp_dir().join(format!(
-        "kamn-agent-supervisor-{}-{nanos}",
+        "kamn-agent-supervisor-{}-{nanos}-{id}",
         std::process::id()
     ))
 }
@@ -246,4 +257,9 @@ fn free_port() -> u16 {
         .local_addr()
         .expect("local address")
         .port()
+}
+
+fn test_lock() -> std::sync::MutexGuard<'static, ()> {
+    static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    LOCK.lock().expect("supervisor test lock")
 }

--- a/crates/kamn-e2e-harness/tests/agent_transaction_demo_supervisor_contract.rs
+++ b/crates/kamn-e2e-harness/tests/agent_transaction_demo_supervisor_contract.rs
@@ -22,6 +22,8 @@ fn spec_c01_actor_failure_cleans_every_child_and_writes_no_go() {
     assert!(no_go.contains("decision=NO-GO"));
     assert!(no_go.contains("AGENT_TRANSACTION_CHILD_FAILED"));
     assert!(!fixture.root.join("demo/latest/proof/report.json").exists());
+    assert!(fixture.root.join("runtime.started").is_file());
+    assert!(fixture.root.join("runtime.stopped").is_file());
 }
 
 #[test]
@@ -69,6 +71,7 @@ fn spec_c03_successful_rpc_children_run_the_canonical_phase_order() {
 
 struct SupervisorFixture {
     root: PathBuf,
+    endpoint: String,
 }
 
 impl SupervisorFixture {
@@ -86,7 +89,10 @@ impl SupervisorFixture {
         .expect("payer file");
         std::fs::write(root.join("extension/index.ts"), "export default {}").expect("extension");
         write_fake_pi(&root, pi_mode);
-        Self { root }
+        let endpoint = format!("http://127.0.0.1:{}", free_port());
+        write_fake_runtime(&root);
+        std::fs::write(root.join("kamn-mcp-server"), "stub").expect("MCP binary");
+        Self { root, endpoint }
     }
 
     fn env(&self) -> BTreeMap<String, String> {
@@ -109,8 +115,40 @@ impl SupervisorFixture {
             "KAMN_MVP_AGENT_TRANSACTION_RPC_TIMEOUT_MS".to_owned(),
             "100".to_owned(),
         );
+        env.insert(
+            "KAMN_MVP_LOCAL_NODE_BINARY".to_owned(),
+            self.root.join("kamn-node").display().to_string(),
+        );
+        env.insert(
+            "KAMN_MVP_LIVE_MCP_BINARY".to_owned(),
+            self.root.join("kamn-mcp-server").display().to_string(),
+        );
+        env.insert("KAMN_MVP_LIVE_MCP_ENDPOINT".to_owned(), self.endpoint.clone());
         env
     }
+}
+
+fn write_fake_runtime(root: &std::path::Path) {
+    let script = format!(
+        r#"#!/bin/sh
+port=""
+previous=""
+for arg in "$@"; do
+  if [ "$previous" = "--api-bind" ]; then port="${{arg##*:}}"; fi
+  previous="$arg"
+done
+exec python3 -c 'import signal,socket,sys,time
+root=sys.argv[1]; port=int(sys.argv[2])
+open(root+"/runtime.started","w").write(str(__import__("os").getpid()))
+server=socket.socket(); server.setsockopt(socket.SOL_SOCKET,socket.SO_REUSEADDR,1); server.bind(("127.0.0.1",port)); server.listen()
+def stop(*_):
+ open(root+"/runtime.stopped","w").write("stopped"); server.close(); sys.exit(0)
+signal.signal(signal.SIGTERM,stop)
+while True: time.sleep(.05)' "{}" "$port"
+"#,
+        root.display()
+    );
+    write_executable(root.join("kamn-node"), script.as_str());
 }
 
 fn write_fake_pi(root: &std::path::Path, mode: &str) {
@@ -200,4 +238,12 @@ fn unique_root() -> PathBuf {
         "kamn-agent-supervisor-{}-{nanos}",
         std::process::id()
     ))
+}
+
+fn free_port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .expect("free port")
+        .local_addr()
+        .expect("local address")
+        .port()
 }

--- a/crates/kamn-e2e-harness/tests/agent_transaction_demo_supervisor_contract.rs
+++ b/crates/kamn-e2e-harness/tests/agent_transaction_demo_supervisor_contract.rs
@@ -8,7 +8,7 @@ use kamn_e2e_harness::{
 
 #[test]
 fn spec_c01_actor_failure_cleans_every_child_and_writes_no_go() {
-    let fixture = SupervisorFixture::new();
+    let fixture = SupervisorFixture::new("fail");
     let config = parse_agent_transaction_demo_config(&fixture.env()).expect("configuration");
 
     let error = execute_agent_transaction_demo_with_config(&config)
@@ -24,12 +24,27 @@ fn spec_c01_actor_failure_cleans_every_child_and_writes_no_go() {
     assert!(!fixture.root.join("demo/latest/proof/report.json").exists());
 }
 
+#[test]
+fn spec_c02_unresponsive_actor_times_out_and_cleans_every_child() {
+    let fixture = SupervisorFixture::new("hang");
+    let config = parse_agent_transaction_demo_config(&fixture.env()).expect("configuration");
+    let started = std::time::Instant::now();
+
+    let error = execute_agent_transaction_demo_with_config(&config)
+        .expect_err("unresponsive actor must fail");
+    assert!(error.starts_with("AGENT_TRANSACTION_CHILD_FAILED"));
+    assert!(started.elapsed() < std::time::Duration::from_secs(1));
+    for role in ["kamn-mvp-agent-a", "kamn-mvp-agent-b", "kamn-mvp-agent-c"] {
+        assert!(fixture.root.join(format!("{role}.cleaned")).is_file());
+    }
+}
+
 struct SupervisorFixture {
     root: PathBuf,
 }
 
 impl SupervisorFixture {
-    fn new() -> Self {
+    fn new(pi_mode: &str) -> Self {
         let root = unique_root();
         std::fs::create_dir_all(root.join("extension")).expect("fixture root");
         for name in ["agent-a.key", "agent-b.key", "agent-c.key"] {
@@ -42,7 +57,7 @@ impl SupervisorFixture {
         )
         .expect("payer file");
         std::fs::write(root.join("extension/index.ts"), "export default {}").expect("extension");
-        write_fake_pi(&root);
+        write_fake_pi(&root, pi_mode);
         Self { root }
     }
 
@@ -62,11 +77,20 @@ impl SupervisorFixture {
         ] {
             env.insert(name.to_owned(), self.root.join(path).display().to_string());
         }
+        env.insert(
+            "KAMN_MVP_AGENT_TRANSACTION_RPC_TIMEOUT_MS".to_owned(),
+            "100".to_owned(),
+        );
         env
     }
 }
 
-fn write_fake_pi(root: &std::path::Path) {
+fn write_fake_pi(root: &std::path::Path, mode: &str) {
+    let b_action = if mode == "hang" {
+        "sleep 2; exit 9"
+    } else {
+        "exit 9"
+    };
     let script = format!(
         r#"#!/bin/sh
 case " $* " in *" --print "*) echo KAMN_PI_PREFLIGHT_OK; exit 0;; esac
@@ -77,7 +101,7 @@ for arg in "$@"; do
   previous="$arg"
 done
 trap 'echo cleaned > "{}/$role.cleaned"; exit 0' TERM INT
-if [ "$role" = "kamn-mvp-agent-b" ]; then read line; exit 9; fi
+if [ "$role" = "kamn-mvp-agent-b" ]; then read line; {b_action}; fi
 while read line; do
   echo '{{"type":"response","command":"prompt","success":true}}'
   echo '{{"type":"agent_end","messages":[]}}'

--- a/crates/kamn-e2e-harness/tests/agent_transaction_demo_supervisor_contract.rs
+++ b/crates/kamn-e2e-harness/tests/agent_transaction_demo_supervisor_contract.rs
@@ -97,8 +97,12 @@ impl SupervisorFixture {
     fn new(pi_mode: &str) -> Self {
         let root = unique_root();
         std::fs::create_dir_all(root.join("extension")).expect("fixture root");
-        for name in ["agent-a.key", "agent-b.key", "agent-c.key"] {
-            std::fs::write(root.join(name), name).expect("agent key");
+        for (name, byte) in [
+            ("agent-a.key", "11"),
+            ("agent-b.key", "22"),
+            ("agent-c.key", "33"),
+        ] {
+            std::fs::write(root.join(name), byte.repeat(32)).expect("agent key");
         }
         let payer = (0_u8..64).collect::<Vec<_>>();
         std::fs::write(
@@ -124,6 +128,7 @@ impl SupervisorFixture {
             ("KAMN_MVP_PI_BINARY", "pi"),
             ("KAMN_MVP_PI_EXTENSION", "extension/index.ts"),
             ("KAMN_MVP_AGENT_TRANSACTION_OUTPUT_ROOT", "demo"),
+            ("KAMN_MVP_AGENT_TRANSACTION_STAGING_ROOT", "staging"),
         ] {
             env.insert(name.to_owned(), self.root.join(path).display().to_string());
         }
@@ -188,5 +193,6 @@ fn unique_root() -> PathBuf {
 
 fn test_lock() -> std::sync::MutexGuard<'static, ()> {
     static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-    LOCK.lock().expect("supervisor test lock")
+    LOCK.lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
 }

--- a/crates/kamn-e2e-harness/tests/mvp_demo_live_task_settlement_binding_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_demo_live_task_settlement_binding_contract.rs
@@ -3,6 +3,8 @@ use kamn_e2e_harness::{
 };
 use std::path::{Path, PathBuf};
 
+#[path = "support/live_task_evidence.rs"]
+mod live_task_evidence;
 #[path = "support/mvp_demo_command.rs"]
 mod mvp_demo_command;
 
@@ -102,6 +104,15 @@ fn spec_c05_live_service_claim_requires_request_derived_escrow_id() {
 
     let err = verify_latest(&root).expect_err("request-derived escrow mismatch must fail");
     assert!(err.contains("devnet escrow funding request"), "{err}");
+}
+
+#[test]
+fn spec_c06_bound_demo_accepts_transaction_aware_handoff_v2() {
+    let root = temp_root("handoff-v2");
+    let mut config = mvp_demo_command::devnet_required_demo_config(&root);
+    config.live_task_evidence = Some(live_task_evidence::write_v2(&root.join("handoff-v2")));
+
+    execute_mvp_demo_contract(&config).expect("v2 handoff should bind to the demo");
 }
 
 fn relabel_report_as_live_service(root: &Path, request: Option<&Path>) {

--- a/crates/kamn-e2e-harness/tests/mvp_demo_live_task_settlement_binding_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_demo_live_task_settlement_binding_contract.rs
@@ -3,8 +3,6 @@ use kamn_e2e_harness::{
 };
 use std::path::{Path, PathBuf};
 
-#[path = "support/live_task_evidence.rs"]
-mod live_task_evidence;
 #[path = "support/mvp_demo_command.rs"]
 mod mvp_demo_command;
 
@@ -110,7 +108,9 @@ fn spec_c05_live_service_claim_requires_request_derived_escrow_id() {
 fn spec_c06_bound_demo_accepts_transaction_aware_handoff_v2() {
     let root = temp_root("handoff-v2");
     let mut config = mvp_demo_command::devnet_required_demo_config(&root);
-    config.live_task_evidence = Some(live_task_evidence::write_v2(&root.join("handoff-v2")));
+    config.live_task_evidence = Some(mvp_demo_command::live_task_evidence::write_v2(
+        &root.join("handoff-v2"),
+    ));
 
     execute_mvp_demo_contract(&config).expect("v2 handoff should bind to the demo");
 }

--- a/crates/kamn-e2e-harness/tests/support/fake_local_runtime.rs
+++ b/crates/kamn-e2e-harness/tests/support/fake_local_runtime.rs
@@ -1,0 +1,55 @@
+use std::collections::BTreeMap;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+
+pub fn configure(root: &Path, env: &mut BTreeMap<String, String>) {
+    write_runtime(root);
+    std::fs::write(root.join("kamn-mcp-server"), "stub").expect("MCP binary");
+    env.insert(
+        "KAMN_MVP_LOCAL_NODE_BINARY".to_owned(),
+        root.join("kamn-node").display().to_string(),
+    );
+    env.insert(
+        "KAMN_MVP_LIVE_MCP_BINARY".to_owned(),
+        root.join("kamn-mcp-server").display().to_string(),
+    );
+    env.insert(
+        "KAMN_MVP_LIVE_MCP_ENDPOINT".to_owned(),
+        format!("http://127.0.0.1:{}", free_port()),
+    );
+}
+
+fn write_runtime(root: &Path) {
+    let script = format!(
+        r#"#!/bin/sh
+port=""
+previous=""
+for arg in "$@"; do
+  if [ "$previous" = "--api-bind" ]; then port="${{arg##*:}}"; fi
+  previous="$arg"
+done
+exec python3 -c 'import signal,socket,sys,time
+root=sys.argv[1]; port=int(sys.argv[2])
+open(root+"/runtime.started","w").write(str(__import__("os").getpid()))
+server=socket.socket(); server.setsockopt(socket.SOL_SOCKET,socket.SO_REUSEADDR,1); server.bind(("127.0.0.1",port)); server.listen()
+def stop(*_):
+ open(root+"/runtime.stopped","w").write("stopped"); server.close(); sys.exit(0)
+signal.signal(signal.SIGTERM,stop)
+while True: time.sleep(.05)' "{}" "$port"
+"#,
+        root.display()
+    );
+    let path = root.join("kamn-node");
+    std::fs::write(&path, script).expect("fake runtime");
+    let mut permissions = std::fs::metadata(&path).expect("metadata").permissions();
+    permissions.set_mode(0o700);
+    std::fs::set_permissions(path, permissions).expect("permissions");
+}
+
+fn free_port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .expect("free port")
+        .local_addr()
+        .expect("local address")
+        .port()
+}

--- a/crates/kamn-e2e-harness/tests/support/fake_supervisor_pi.rs
+++ b/crates/kamn-e2e-harness/tests/support/fake_supervisor_pi.rs
@@ -1,0 +1,43 @@
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+
+pub fn write(root: &Path, mode: &str) {
+    let b_branch = match mode {
+        "hang" => "if [ \"$role\" = \"kamn-mvp-agent-b\" ]; then read line; sleep 2; exit 9; fi",
+        "fail" => "if [ \"$role\" = \"kamn-mvp-agent-b\" ]; then read line; exit 9; fi",
+        _ => "",
+    };
+    let script = format!(
+        r#"#!/bin/sh
+case " $* " in *" --print "*) echo KAMN_PI_PREFLIGHT_OK; exit 0;; esac
+role=""
+previous=""
+for arg in "$@"; do
+  if [ "$previous" = "--name" ]; then role="$arg"; fi
+  previous="$arg"
+done
+echo $$ > "{}/$role.pid"
+trap 'echo cleaned > "{}/$role.cleaned"; exit 0' TERM INT
+{b_branch}
+while read line; do
+  echo "$role" >> "{}/prompts.log"
+  echo '{{"type":"response","command":"prompt","success":true}}'
+  if [ "$role" = "kamn-mvp-agent-b" ]; then
+    echo '{{"type":"agent_end","messages":[{{"did":"kamn:did:agent:b"}}]}}'
+  else
+    echo '{{"type":"agent_end","messages":[]}}'
+  fi
+done
+echo cleaned > "{}/$role.cleaned"
+"#,
+        root.display(),
+        root.display(),
+        root.display(),
+        root.display()
+    );
+    let path = root.join("pi");
+    std::fs::write(&path, script).expect("fake Pi");
+    let mut permissions = std::fs::metadata(&path).expect("metadata").permissions();
+    permissions.set_mode(0o700);
+    std::fs::set_permissions(path, permissions).expect("permissions");
+}

--- a/crates/kamn-e2e-harness/tests/support/fake_supervisor_pi.rs
+++ b/crates/kamn-e2e-harness/tests/support/fake_supervisor_pi.rs
@@ -5,6 +5,7 @@ pub fn write(root: &Path, mode: &str) {
     let b_branch = match mode {
         "hang" => "if [ \"$role\" = \"kamn-mvp-agent-b\" ]; then read line; sleep 2; exit 9; fi",
         "fail" => "if [ \"$role\" = \"kamn-mvp-agent-b\" ]; then read line; exit 9; fi",
+        "tool-error" => "if [ \"$role\" = \"kamn-mvp-agent-b\" ]; then read line; echo '{\"type\":\"tool_execution_end\",\"toolName\":\"kamn_live_agent_b_register\",\"result\":{\"isError\":true}}'; echo '{\"type\":\"agent_end\",\"messages\":[]}'; fi",
         _ => "",
     };
     let script = format!(

--- a/crates/kamn-e2e-harness/tests/support/fake_supervisor_pi.rs
+++ b/crates/kamn-e2e-harness/tests/support/fake_supervisor_pi.rs
@@ -21,6 +21,7 @@ echo $$ > "{}/$role.pid"
 trap 'echo cleaned > "{}/$role.cleaned"; exit 0' TERM INT
 {b_branch}
 while read line; do
+  case "$line" in *'"type":"abort"'*) continue;; esac
   echo "$role" >> "{}/prompts.log"
   echo '{{"type":"response","command":"prompt","success":true}}'
   if [ "$role" = "kamn-mvp-agent-b" ]; then

--- a/crates/kamn-e2e-harness/tests/support/fake_supervisor_pi.rs
+++ b/crates/kamn-e2e-harness/tests/support/fake_supervisor_pi.rs
@@ -24,7 +24,8 @@ while read line; do
   echo "$role" >> "{}/prompts.log"
   echo '{{"type":"response","command":"prompt","success":true}}'
   if [ "$role" = "kamn-mvp-agent-b" ]; then
-    echo '{{"type":"agent_end","messages":[{{"did":"kamn:did:agent:b"}}]}}'
+    echo '{{"type":"tool_execution_end","toolName":"kamn_live_agent_b_register","result":{{"isError":false,"details":{{"result":{{"did":"kamn:did:agent:b"}}}}}}}}'
+    echo '{{"type":"agent_end","messages":[]}}'
   else
     echo '{{"type":"agent_end","messages":[]}}'
   fi

--- a/crates/kamn-e2e-harness/tests/support/fake_supervisor_pi.rs
+++ b/crates/kamn-e2e-harness/tests/support/fake_supervisor_pi.rs
@@ -5,7 +5,7 @@ pub fn write(root: &Path, mode: &str) {
     let b_branch = match mode {
         "hang" => "if [ \"$role\" = \"kamn-mvp-agent-b\" ]; then read line; sleep 2; exit 9; fi",
         "fail" => "if [ \"$role\" = \"kamn-mvp-agent-b\" ]; then read line; exit 9; fi",
-        "tool-error" => "if [ \"$role\" = \"kamn-mvp-agent-b\" ]; then read line; echo '{\"type\":\"tool_execution_end\",\"toolName\":\"kamn_live_agent_b_register\",\"result\":{\"isError\":true}}'; echo '{\"type\":\"agent_end\",\"messages\":[]}'; fi",
+        "tool-error" => "if [ \"$role\" = \"kamn-mvp-agent-b\" ]; then read line; echo '{\"type\":\"tool_execution_end\",\"toolName\":\"kamn_live_agent_b_register\",\"result\":{},\"isError\":true}'; echo '{\"type\":\"agent_end\",\"messages\":[]}'; fi",
         _ => "",
     };
     let script = format!(
@@ -24,7 +24,7 @@ while read line; do
   echo "$role" >> "{}/prompts.log"
   echo '{{"type":"response","command":"prompt","success":true}}'
   if [ "$role" = "kamn-mvp-agent-b" ]; then
-    echo '{{"type":"tool_execution_end","toolName":"kamn_live_agent_b_register","result":{{"isError":false,"details":{{"result":{{"did":"kamn:did:agent:b"}}}}}}}}'
+    echo '{{"type":"tool_execution_end","toolName":"kamn_live_agent_b_register","result":{{"details":{{"result":{{"did":"kamn:did:agent:b"}}}}}},"isError":false}}'
     echo '{{"type":"agent_end","messages":[]}}'
   else
     echo '{{"type":"agent_end","messages":[]}}'

--- a/crates/kamn-e2e-harness/tests/support/live_task_evidence.rs
+++ b/crates/kamn-e2e-harness/tests/support/live_task_evidence.rs
@@ -11,12 +11,21 @@ pub(crate) fn write(root: &Path) -> LiveTaskEvidencePaths {
 }
 
 pub(crate) fn write_for_task(root: &Path, task_id: &str) -> LiveTaskEvidencePaths {
+    write_for_task_version(root, task_id, false)
+}
+
+#[allow(dead_code)]
+pub(crate) fn write_v2(root: &Path) -> LiveTaskEvidencePaths {
+    write_for_task_version(root, TASK_ID, true)
+}
+
+fn write_for_task_version(root: &Path, task_id: &str, version_two: bool) -> LiveTaskEvidencePaths {
     std::fs::create_dir_all(root).expect("task evidence root should be created");
     let handoff = root.join("live-task-handoff.json");
     let agent_a = root.join("live-task-agent-a.json");
     let agent_b = root.join("live-task-agent-b.json");
     let agent_c = root.join("live-task-agent-c.json");
-    let handoff_digest = write_handoff(handoff.as_path(), task_id);
+    let handoff_digest = write_handoff(handoff.as_path(), task_id, version_two);
     let agent_a_digest = write_receipt(agent_a.as_path(), "agent_a", 101, task_id);
     let agent_b_digest = write_receipt(agent_b.as_path(), "agent_b", 202, task_id);
     write_observation(
@@ -34,9 +43,15 @@ pub(crate) fn write_for_task(root: &Path, task_id: &str) -> LiveTaskEvidencePath
     }
 }
 
-fn write_handoff(path: &Path, task_id: &str) -> String {
-    let raw =
-        format!(r#"{{"schema_version":"kamn.mvp.live-task-handoff.v1","task_id":"{task_id}"}}"#);
+fn write_handoff(path: &Path, task_id: &str, version_two: bool) -> String {
+    let raw = if version_two {
+        format!(
+            r#"{{"schema_version":"kamn.mvp.live-task-handoff.v2","task_id":"{task_id}","transaction_id":"transaction-live-7086","terms_digest":"{}","provider_did":"kamn:did:agent:provider"}}"#,
+            "a".repeat(64)
+        )
+    } else {
+        format!(r#"{{"schema_version":"kamn.mvp.live-task-handoff.v1","task_id":"{task_id}"}}"#)
+    };
     write_with_digest(path, raw)
 }
 

--- a/crates/kamn-e2e-harness/tests/support/pi_transaction_receipt_fixture.rs
+++ b/crates/kamn-e2e-harness/tests/support/pi_transaction_receipt_fixture.rs
@@ -152,7 +152,9 @@ fn public_result_json(role: &str, tool: &str) -> String {
         "accept_task" => task_result("accepted"),
         "complete_task" => task_result("completed"),
         "fund_escrow" => r#"{"task_id":"task-live-7099","escrow_id":"escrow-live-7099","state":"funded","amount_lamports":1000000,"network":"solana-devnet"}"#.to_owned(),
-        "release_escrow" => r#"{"escrow_id":"escrow-live-7099","state":"released","settlement_tx_signature":"devnet-signature-7099","settlement_commitment":"finalized"}"#.to_owned(),
+        "release_escrow" => {
+            r#"{"escrow_id":"escrow-live-7099","state":"released"}"#.to_owned()
+        }
         "query_participant_task_projection" => projection_result(role, "participant-private"),
         "query_verifier_task_projection" => projection_result(role, "restricted-public"),
         _ => r#"{"task_id":"task-live-7099","state":"accepted"}"#.to_owned(),

--- a/crates/kamn-e2e-harness/tests/support/pi_transaction_receipt_fixture.rs
+++ b/crates/kamn-e2e-harness/tests/support/pi_transaction_receipt_fixture.rs
@@ -151,10 +151,8 @@ fn public_result_json(role: &str, tool: &str) -> String {
         "create_task" => task_result("submitted"),
         "accept_task" => task_result("accepted"),
         "complete_task" => task_result("completed"),
-        "fund_escrow" => r#"{"task_id":"task-live-7099","escrow_id":"escrow-live-7099","state":"funded","amount_lamports":1000000,"network":"solana-devnet"}"#.to_owned(),
-        "release_escrow" => {
-            r#"{"escrow_id":"escrow-live-7099","state":"released"}"#.to_owned()
-        }
+        "fund_escrow" => r#"{"escrow_id":"escrow-live-7099","state":"funded"}"#.to_owned(),
+        "release_escrow" => r#"{"escrow_id":"escrow-live-7099","state":"released"}"#.to_owned(),
         "query_participant_task_projection" => projection_result(role, "participant-private"),
         "query_verifier_task_projection" => projection_result(role, "restricted-public"),
         _ => r#"{"task_id":"task-live-7099","state":"accepted"}"#.to_owned(),
@@ -162,9 +160,7 @@ fn public_result_json(role: &str, tool: &str) -> String {
 }
 
 fn task_result(state: &str) -> String {
-    format!(
-        r#"{{"task_id":"task-live-7099","state":"{state}","transaction_id":"transaction-live-7099"}}"#
-    )
+    format!(r#"{{"task_id":"task-live-7099","state":"{state}"}}"#)
 }
 
 fn projection_result(role: &str, scope: &str) -> String {

--- a/docs/validation/mvp-evaluator-demo.md
+++ b/docs/validation/mvp-evaluator-demo.md
@@ -54,6 +54,61 @@ cargo run -p kamn-e2e-harness -- verify-mvp-demo --report .kamn/demo/latest/proo
 
 The default demo is local-only for runtime, auth, message/task, state, relay, websocket, and audit proof. It does not claim settlement or asset movement success.
 
+## Canonical Three-Agent Devnet Demo
+
+Use this path for the complete evaluator story. It requires Pi `0.80.3` or
+compatible, an existing `openai-codex` OAuth login with `gpt-5.5`, three local
+KAMN identity keys, and a funded Solana devnet payer/recipient pair.
+
+```bash
+mkdir -p .kamn/devnet
+openssl rand -hex 32 > .kamn/devnet/mvp-agent-a.key
+openssl rand -hex 32 > .kamn/devnet/mvp-agent-b.key
+openssl rand -hex 32 > .kamn/devnet/mvp-agent-c.key
+chmod 600 .kamn/devnet/mvp-agent-*.key
+```
+
+```bash
+KAMN_MVP_AGENT_DRIVER=pi \
+KAMN_MVP_DEVNET_MODE=required \
+KAMN_MVP_SOLANA_RPC_URL=https://api.devnet.solana.com \
+KAMN_SERVICE_API_LIVE_SOLANA_BRIDGE_RPC_URL=https://api.devnet.solana.com \
+KAMN_SERVICE_API_LIVE_SOLANA_SETTLEMENT_KEYPAIR_FILE=/absolute/path/to/devnet-payer.json \
+KAMN_SERVICE_API_LIVE_SOLANA_SETTLEMENT_RECIPIENT_PUBKEY=<devnet-recipient-pubkey> \
+KAMN_SERVICE_API_LIVE_SOLANA_SETTLEMENT_LAMPORTS=1000000 \
+KAMN_SERVICE_API_LIVE_SOLANA_SETTLEMENT_COMMITMENT=finalized \
+KAMN_MVP_LIVE_MCP_AGENT_A_KEY_FILE="$PWD/.kamn/devnet/mvp-agent-a.key" \
+KAMN_MVP_LIVE_MCP_AGENT_B_KEY_FILE="$PWD/.kamn/devnet/mvp-agent-b.key" \
+KAMN_MVP_LIVE_MCP_AGENT_C_KEY_FILE="$PWD/.kamn/devnet/mvp-agent-c.key" \
+make demo-agent-transaction
+```
+
+The supervisor owns the local node and all Pi/MCP child lifecycles. Agent B
+registers first; Agent A creates and funds the task; Agent B accepts and
+completes it; Agent A releases escrow; Agent B records its final participant
+view; and Agent C verifies the restricted public view. The command then
+confirms the exact release signature and balance movement on Solana devnet,
+builds one runtime receipt chain, and runs the canonical verifier.
+
+The report may label settlement evidence `execution_surface:"command-override"`
+because a bounded adapter feeds already-confirmed actor evidence into the
+existing report collector. It does not execute or simulate settlement. The
+actual transfer is the live service release transaction named by all actor
+projections and independently confirmed by the adapter.
+
+Expected terminal result:
+
+```text
+{"decision":"GO","proof_schema":"kamn.mvp.runtime-receipt-chain.v1",...}
+```
+
+Re-run the verifier independently after all children exit:
+
+```bash
+cargo run -p kamn-e2e-harness -- \
+  verify-mvp-demo --report .kamn/demo/latest/proof/report.json
+```
+
 ## Optional Pi Agent Harness
 KAMN includes a project-local Pi extension at `.pi/extensions/kamn-mvp/index.ts`.
 It registers named local proof tools:

--- a/specs/7102-canonical-agent-transaction-demo.md
+++ b/specs/7102-canonical-agent-transaction-demo.md
@@ -61,7 +61,7 @@ registers and verifies the restricted projection. The exact tool sequence may
 be coordinated through existing identifier-only handoff files, never through
 authorization-bearing files.
 
-Each actor command uses `pi --print --no-session --approve --no-extensions`
+Each actor command uses persistent `pi --mode rpc --no-session --approve --no-extensions`
 with the explicit project extension, OpenAI provider/model from validated
 configuration, `--no-builtin-tools`, and a role-specific `--tools` allowlist.
 The supervisor accepts success only from process exit status plus strict actor,
@@ -106,24 +106,24 @@ and never reuses a prior GO report.
 
 ## Acceptance Criteria
 
-- [ ] The documented canonical environment plus `make demo-agent-transaction`
+- [x] The documented canonical environment plus `make demo-agent-transaction`
       invokes the Rust-owned supervisor.
-- [ ] Driver, Pi/auth/model/extension, agent keys, and devnet configuration are
+- [x] Driver, Pi/auth/model/extension, agent keys, and devnet configuration are
       validated before any task mutation.
-- [ ] Three independent bounded Pi processes and their MCP children start and
+- [x] Three independent bounded Pi processes and their MCP children start and
       stop automatically.
-- [ ] Actor role tool allowlists exclude built-in and cross-role capabilities.
-- [ ] Any child failure or signal writes NO-GO and leaves no known child alive.
-- [ ] Dry-run, placeholder, copied, missing, or non-finalized settlement cannot
+- [x] Actor role tool allowlists exclude built-in and cross-role capabilities.
+- [x] Any child failure or signal writes NO-GO and leaves no known child alive.
+- [x] Dry-run, placeholder, copied, missing, or non-finalized settlement cannot
       produce GO.
-- [ ] Success writes exactly one proof directory and one unambiguous latest
+- [x] Success writes exactly one proof directory and one unambiguous latest
       pointer containing reports, actors, receipts, projections, and devnet
       evidence.
-- [ ] The report labels local, devnet-backed, dry-run, placeholder, roadmap, and
+- [x] The report labels local, devnet-backed, dry-run, placeholder, roadmap, and
       not-claimed surfaces honestly.
-- [ ] Canonical verification passes after every demo process exits.
-- [ ] No secret value or mutable live artifact is committed or emitted.
-- [ ] Formatting, strict clippy, focused integration tests, and `make check`
+- [x] Canonical verification passes after every demo process exits.
+- [x] No secret value or mutable live artifact is committed or emitted.
+- [x] Formatting, strict clippy, focused integration tests, and `make check`
       pass.
 
 ## Files To Touch
@@ -136,7 +136,8 @@ and never reuses a prior GO report.
   cannot be invoked non-interactively
 - `docs/validation/mvp-evaluator-demo.md`
 
-No new dependency is expected. Shell LOC remains a thin Make alias; the issue
+The harness adds only the existing local `kamn-sdk` workspace crate for exact
+key-bound DID derivation. Shell LOC remains a thin Make alias; the issue
 estimate is revised toward Rust ownership rather than adding a shell supervisor.
 
 ## Error Semantics

--- a/specs/7102-canonical-agent-transaction-demo.md
+++ b/specs/7102-canonical-agent-transaction-demo.md
@@ -1,0 +1,191 @@
+# Add One Canonical Agent Transaction Demo Command
+
+## Objective
+
+Provide one evaluator command that validates prerequisites, starts the local
+KAMN transaction surface, launches three independent bounded Pi actors, drives
+the runtime receipt chain, requires finalized Solana devnet settlement, writes
+one proof directory with human and machine reports, verifies it after all child
+processes exit, and leaves no child process running on success or failure.
+
+## Inputs/Outputs
+
+The canonical input is:
+
+```bash
+KAMN_MVP_AGENT_DRIVER=pi \
+KAMN_MVP_DEVNET_MODE=required \
+KAMN_MVP_SOLANA_RPC_URL=https://api.devnet.solana.com \
+make demo-agent-transaction
+```
+
+Required external inputs are the installed `pi` CLI with existing OpenAI Codex
+OAuth, the project-local KAMN Pi extension, three external KAMN agent key files,
+a funded external Solana devnet payer keypair, recipient pubkey, positive
+lamport amount, devnet RPC URL, and finalized commitment. Secrets are referenced
+by path and never copied into command output, Pi prompts, child environments, or
+proof artifacts.
+
+Success outputs exactly one run directory below `.kamn/demo/`, one unambiguous
+`.kamn/demo/latest` pointer, `proof/report.json`, `proof/report.md`, three actor
+artifacts, runtime receipts/projections, runtime receipt chain, devnet evidence,
+and a concise terminal `GO` summary. Failure outputs one bounded NO-GO report
+with a stable reason code and no success claim.
+
+## Boundaries/Non-goals
+
+- Reuse the existing Rust harness, Pi extension, MCP sessions, local KAMN
+  service path, devnet settlement path, actor artifacts, runtime chain, report,
+  and verifier.
+- Make owns only a thin alias. Process supervision and report semantics are
+  Rust-owned; Pi owns bounded role decisions; existing tools own transaction
+  payloads and authorization.
+- Pi processes receive only their role-specific extension tool allowlist and no
+  built-in file, shell, edit, write, search, or arbitrary MCP tools.
+- Validate every prerequisite before launching actors or creating a task.
+- Keep `make demo-mvp` unchanged until three consecutive fresh canonical live
+  rehearsals pass.
+- Issue #7103 owns independent evaluator/explorer UX. Restart and duplicate-
+  transfer hardening beyond existing idempotency belongs to the next issue.
+- No mainnet, production custody, web UI, generalized orchestration framework,
+  multi-chain settlement, disputes, or committed mutable live artifacts.
+
+## Execution Contract
+
+The Rust supervisor creates one run root and fixed coordination/evidence paths,
+starts children in dependency order, captures stdout/stderr to role-specific
+logs, and records every child PID. Agent A registers and creates the task; Agent
+B registers, accepts, waits for funding, completes, and projects; Agent A waits
+for completion, releases finalized devnet settlement, and projects; Agent C
+registers and verifies the restricted projection. The exact tool sequence may
+be coordinated through existing identifier-only handoff files, never through
+authorization-bearing files.
+
+Each actor command uses `pi --print --no-session --approve --no-extensions`
+with the explicit project extension, OpenAI provider/model from validated
+configuration, `--no-builtin-tools`, and a role-specific `--tools` allowlist.
+The supervisor accepts success only from process exit status plus strict actor,
+chain, report, and canonical verifier evidence; Pi prose is diagnostic only.
+
+On any error or signal, the supervisor terminates all known Pi/MCP/runtime
+children, waits for them, writes NO-GO once, and exits non-zero. Cleanup is
+idempotent. A stale prior `latest` pointer is never reported as the current run.
+
+## Claim Labels
+
+- Local runtime identity, task, durable state, MCP receipts, projections,
+  websocket/event visibility, and audit export are `local` or `local-only`.
+- Confirmed Solana transfer and finalized signature evidence are
+  `devnet-backed`.
+- A dry-run is `dry-run` and can never produce GO.
+- Placeholder signatures, fixture-only commands, and in-memory-only value
+  movement are `placeholder` and can never produce GO.
+- Mainnet, custody, production availability, disputes, and generalized
+  marketplace behavior are `not-claimed`.
+
+## Failure Modes
+
+- Unsupported/missing agent driver: `AGENT_TRANSACTION_DRIVER_INVALID`.
+- Pi missing, auth unavailable, model unavailable, or extension missing:
+  `AGENT_TRANSACTION_PI_PREFLIGHT_FAILED`.
+- Partial/missing agent keys or unsafe secret path:
+  `AGENT_TRANSACTION_AGENT_CONFIG_INVALID`.
+- Missing/invalid devnet payer, recipient, amount, RPC, or commitment:
+  `AGENT_TRANSACTION_DEVNET_CONFIG_INVALID`.
+- Existing output/latest ambiguity: `AGENT_TRANSACTION_OUTPUT_CONFLICT`.
+- Child spawn, timeout, non-zero exit, or malformed output:
+  `AGENT_TRANSACTION_CHILD_FAILED`.
+- Child survives cleanup: `AGENT_TRANSACTION_CLEANUP_FAILED`.
+- Dry-run, placeholder, copied, non-finalized, or missing settlement evidence:
+  `AGENT_TRANSACTION_SETTLEMENT_INVALID`.
+- Missing/mismatched actor, chain, report, or verifier evidence:
+  `AGENT_TRANSACTION_PROOF_INVALID`.
+
+Every failure hard-fails, writes NO-GO when the output root is safely available,
+and never reuses a prior GO report.
+
+## Acceptance Criteria
+
+- [ ] The documented canonical environment plus `make demo-agent-transaction`
+      invokes the Rust-owned supervisor.
+- [ ] Driver, Pi/auth/model/extension, agent keys, and devnet configuration are
+      validated before any task mutation.
+- [ ] Three independent bounded Pi processes and their MCP children start and
+      stop automatically.
+- [ ] Actor role tool allowlists exclude built-in and cross-role capabilities.
+- [ ] Any child failure or signal writes NO-GO and leaves no known child alive.
+- [ ] Dry-run, placeholder, copied, missing, or non-finalized settlement cannot
+      produce GO.
+- [ ] Success writes exactly one proof directory and one unambiguous latest
+      pointer containing reports, actors, receipts, projections, and devnet
+      evidence.
+- [ ] The report labels local, devnet-backed, dry-run, placeholder, roadmap, and
+      not-claimed surfaces honestly.
+- [ ] Canonical verification passes after every demo process exits.
+- [ ] No secret value or mutable live artifact is committed or emitted.
+- [ ] Formatting, strict clippy, focused integration tests, and `make check`
+      pass.
+
+## Files To Touch
+
+- `Makefile`
+- `crates/kamn-e2e-harness/src/lib.rs`
+- focused `crates/kamn-e2e-harness/src/agent_transaction_demo*.rs`
+- focused `crates/kamn-e2e-harness/tests/agent_transaction_demo*.rs`
+- minimal `.pi/extensions/kamn-mvp/` surfaces only if an existing bounded tool
+  cannot be invoked non-interactively
+- `docs/validation/mvp-evaluator-demo.md`
+
+No new dependency is expected. Shell LOC remains a thin Make alias; the issue
+estimate is revised toward Rust ownership rather than adding a shell supervisor.
+
+## Error Semantics
+
+Interior Rust functions return stable reason-code-prefixed `String` errors and
+do not log. The command entrypoint catches once, writes the terminal/report
+decision once, performs cleanup, and exits non-zero on NO-GO. Child logs redact
+secret-bearing arguments and environments. Cleanup errors are preserved and
+cannot be hidden by an earlier actor or settlement error.
+
+## Test Plan
+
+RED:
+
+- Missing Pi/auth/model or partial devnet configuration reaches task work.
+- Role command construction enables built-in or cross-role tools.
+- One actor exits and a tracked child remains alive.
+- Dry-run, placeholder, or non-finalized settlement produces GO.
+- A failure leaves a stale latest pointer or multiple candidate proof roots.
+- A successful-looking report is accepted before all children exit.
+
+GREEN:
+
+- Add strict preflight configuration parsing and safe-path validation.
+- Add Rust child supervisor with bounded Pi command construction, timeout,
+  signal/error cleanup, wait, and redacted logs.
+- Reuse actor files and the #7101 runtime chain as configured `demo-mvp` inputs.
+- Run canonical verification only after all actor/runtime children exit.
+- Write one GO/NO-GO result and atomically update latest only for this run.
+
+REFACTOR:
+
+- Keep config, preflight, command construction, process supervision, proof
+  finalization, and reporting separate.
+- Keep files below 200 lines and functions below 25 lines.
+- Reuse existing strict path, process, evidence, and report helpers.
+
+INTEGRATION:
+
+- Run deterministic stub-child contracts for preflight, cleanup, NO-GO, and
+  single-output semantics.
+- Run a bounded local three-Pi rehearsal with existing Codex OAuth.
+- Run required Solana devnet settlement or record explicit external NO-GO.
+- Verify reports after all children exit.
+- Run formatting, strict workspace clippy, `make check`, focused suites, and
+  issue shell-surface accounting.
+
+## Rollback
+
+Preserve spec, RED, GREEN, REFACTOR, and integration commits. The Make alias and
+new command can be reverted without changing existing `demo-mvp`, Pi tools,
+runtime transaction semantics, actor artifacts, or report compatibility.


### PR DESCRIPTION
## Human Summary

- Adds `make demo-agent-transaction`, which owns the local KAMN node and three persistent, role-bounded Pi agents from preflight through cleanup.
- Drives one authenticated task, escrow, completion, and release story, then reuses the actor-triggered Solana devnet settlement instead of submitting a second transfer.
- Produces participant-private Agent A/B evidence, restricted-public Agent C evidence, one runtime receipt chain, and human/machine reports with explicit claim boundaries.
- Updates the README and evaluator runbook with the reproducible command, required external keys, and the exact meaning of the report's settlement execution surface.

Closes #7102

Spec: [`specs/7102-canonical-agent-transaction-demo.md`](https://github.com/njfio/kamn/blob/7102-canonical-agent-transaction-demo/specs/7102-canonical-agent-transaction-demo.md)

## Testing

- `cargo fmt --check`
- `CARGO_TARGET_DIR=target/mvp-demo-proof cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `CARGO_TARGET_DIR=target/mvp-demo-proof make check`
- `cargo test -p kamn-e2e-harness --test agent_transaction_demo_config_contract`
- `cargo test -p kamn-e2e-harness --test agent_transaction_demo_preflight_contract`
- `cargo test -p kamn-e2e-harness --test agent_transaction_demo_supervisor_contract`
- `cargo test -p kamn-e2e-harness --test agent_transaction_demo_success_contract`
- `cargo test -p kamn-e2e-harness --test mvp_demo_runtime_receipt_chain_contract`
- `cargo test -p kamn-e2e-harness --test mvp_demo_live_task_settlement_binding_contract`
- `cargo test -p kamn-e2e-harness --test mvp_evaluator_demo_runbook_contract`
- Live manual check: three Pi agents completed one local KAMN transaction and one finalized Solana devnet transfer; terminal result was `GO`.
- `cargo run -p kamn-e2e-harness -- verify-mvp-demo --report .kamn/demo/latest/proof/report.json` returned `PASS` after all children exited.

## Notes for Reviewers

- Review focus: process cleanup, the narrow local `task:create` bootstrap grant, Pi terminal-tool abort handling, v2 handoff transaction binding, and reuse of actor devnet evidence.
- `execution_surface:"command-override"` labels the bounded adapter into the existing report collector. It confirms the already-executed actor signature and transaction balances; it does not simulate or resubmit settlement.
- Mutable proof output and all agent/Solana key material remain ignored under `.kamn/` or external paths.

shell_loc_delta_actual: 7
rust_loc_delta_actual: 2252
shell_to_rust_ratio_delta_actual: 0.0031
shell_surface_ratio_target_status: improved

## AI Agent Details

- The Rust supervisor validates Pi OAuth/model, key files, devnet configuration, binary paths, and exclusive loopback endpoint ownership before mutation.
- Actor order is B register, A create, B accept/read receipt, A fund, B complete, A release/A evidence, B evidence, C restricted verification.
- The report adapter runs `solana confirm --verbose --output json` for the exact actor signature and verifies payer/recipient pre/post balance movement before report construction.
- Existing `make demo-mvp` remains unchanged until repeated fresh canonical live rehearsals justify promotion.
