### PR TITLE
[7109] Stabilize the governance ratio head contract

### DIFF
--- a/crates/kamn-core/tests/governance_feature_commit_ratio_base_compliance/current_head_status_contract_tests.rs
+++ b/crates/kamn-core/tests/governance_feature_commit_ratio_base_compliance/current_head_status_contract_tests.rs
@@ -1,4 +1,7 @@
-use crate::support::{f64_field, output_json, read_report, run_checker, status, u64_field};
+use crate::support::{
+    f64_field, output_json, read_report, run_checker, status, u64_field, MAX_GOVERNANCE_RATIO,
+};
+use serde_json::Value;
 
 #[test]
 fn current_branch_head_restores_ratio_compliance() {
@@ -13,9 +16,24 @@ fn current_branch_head_restores_ratio_compliance() {
         String::from_utf8_lossy(&output.stdout)
     );
     assert_eq!(status(&report), "ok");
-    assert_eq!(u64_field(&report, "governance_commit_count"), 10);
-    assert_eq!(u64_field(&report, "feature_commit_count"), 40);
-    assert_eq!(f64_field(&report, "governance_ratio"), 0.2);
-    assert_eq!(f64_field(&report, "feature_ratio"), 0.8);
+    assert_report_invariants(&report);
     assert_eq!(u64_field(&report, "non_merge_commit_total"), 50);
+}
+
+fn assert_report_invariants(report: &Value) {
+    let total = u64_field(report, "non_merge_commit_total");
+    let governance = u64_field(report, "governance_commit_count");
+    let feature = u64_field(report, "feature_commit_count");
+    let unknown = u64_field(report, "unknown_commit_count");
+    assert_eq!(governance + feature + unknown, total);
+    assert_ratio(report, "governance_ratio", governance, total);
+    assert_ratio(report, "feature_ratio", feature, total);
+    let maximum = MAX_GOVERNANCE_RATIO.parse::<f64>().expect("valid maximum");
+    assert!(f64_field(report, "governance_ratio") <= maximum);
+}
+
+fn assert_ratio(report: &Value, field: &str, count: u64, total: u64) {
+    let expected = count as f64 / total as f64;
+    let actual = f64_field(report, field);
+    assert!((actual - expected).abs() < 1e-12, "{field}: {actual}");
 }

--- a/crates/kamn-core/tests/governance_feature_commit_ratio_base_compliance/current_head_status_contract_tests.rs
+++ b/crates/kamn-core/tests/governance_feature_commit_ratio_base_compliance/current_head_status_contract_tests.rs
@@ -1,5 +1,6 @@
 use crate::support::{
     f64_field, output_json, read_report, run_checker, status, u64_field, MAX_GOVERNANCE_RATIO,
+    WINDOW_SIZE,
 };
 use serde_json::Value;
 
@@ -17,7 +18,8 @@ fn current_branch_head_restores_ratio_compliance() {
     );
     assert_eq!(status(&report), "ok");
     assert_report_invariants(&report);
-    assert_eq!(u64_field(&report, "non_merge_commit_total"), 50);
+    let window = WINDOW_SIZE.parse::<u64>().expect("valid window size");
+    assert_eq!(u64_field(&report, "non_merge_commit_total"), window);
 }
 
 fn assert_report_invariants(report: &Value) {

--- a/specs/7109-stabilize-governance-ratio-head-contract.md
+++ b/specs/7109-stabilize-governance-ratio-head-contract.md
@@ -1,0 +1,88 @@
+# Issue 7109: Stabilize Governance Ratio Head Contract
+
+## Objective
+
+Keep the current-head governance ratio contract aligned with the actual policy
+instead of one historical 50-commit composition. A compliant branch head must
+remain green when its exact governance and feature counts change but all report
+invariants and the configured threshold still hold.
+
+## Inputs And Outputs
+
+Input:
+
+- The governance feature-commit ratio report produced for `HEAD` from the fixed
+  activation base, 50-commit window, and `0.20` maximum governance ratio.
+
+Output:
+
+- A passing Rust contract when the checker succeeds and its report is internally
+  consistent, complete, and policy-compliant.
+- A failing contract when checker status, totals, ratios, or threshold compliance
+  are invalid.
+
+## Boundaries And Non-Goals
+
+- Do not change the Python checker, commit classification, activation base,
+  threshold, window size, CI configuration, or shell surface.
+- Do not weaken synthetic threshold success/failure or exact classification tests.
+- Do not encode a new expected historical commit composition.
+- This issue repairs only the stale Rust current-head assertion.
+
+## Failure Modes
+
+- Checker process failure remains a hard test failure with stdout evidence.
+- A non-`ok` report status fails.
+- A report whose governance, feature, and unknown counts do not equal the
+  non-merge total fails.
+- A report whose governance or feature ratio differs from its reported counts
+  fails.
+- A governance ratio above the configured maximum fails.
+- A window total other than 50 fails.
+
+## Error Semantics
+
+The test uses exact assertions for status and window size, relational assertions
+for counts, and floating-point tolerance only for ratios derived from integer
+counts. Checker failures are never converted to success or ignored.
+
+## Acceptance Criteria
+
+- [ ] Current `main` passes without hard-coded governance or feature counts.
+- [ ] The test requires checker success and `status=ok`.
+- [ ] Governance, feature, and unknown counts sum to the non-merge total.
+- [ ] Reported governance and feature ratios equal ratios derived from counts.
+- [ ] Governance ratio is at or below `0.20` and the total remains 50.
+- [ ] Synthetic threshold and classification contracts remain green unchanged.
+- [ ] Formatting, strict workspace clippy, the full governance contract binary,
+      and `make check` pass.
+
+## Files To Touch
+
+- `crates/kamn-core/tests/governance_feature_commit_ratio_base_compliance/current_head_status_contract_tests.rs`
+- This spec only.
+
+## Test Plan
+
+RED is the existing merged-main failure:
+
+```text
+assertion left == right failed
+left: 3
+right: 10
+```
+
+GREEN verification:
+
+```bash
+CARGO_TARGET_DIR=target/mvp-demo-proof cargo test -p kamn-core \
+  --test governance_feature_commit_ratio_base_compliance \
+  current_head_status_contract_tests::current_branch_head_restores_ratio_compliance \
+  -- --exact --nocapture
+CARGO_TARGET_DIR=target/mvp-demo-proof cargo test -p kamn-core \
+  --test governance_feature_commit_ratio_base_compliance
+cargo fmt --check
+CARGO_TARGET_DIR=target/mvp-demo-proof cargo clippy \
+  --workspace --all-targets --all-features -- -D warnings
+CARGO_TARGET_DIR=target/mvp-demo-proof make check
+```

--- a/specs/7109-stabilize-governance-ratio-head-contract.md
+++ b/specs/7109-stabilize-governance-ratio-head-contract.md
@@ -48,13 +48,13 @@ counts. Checker failures are never converted to success or ignored.
 
 ## Acceptance Criteria
 
-- [ ] Current `main` passes without hard-coded governance or feature counts.
-- [ ] The test requires checker success and `status=ok`.
-- [ ] Governance, feature, and unknown counts sum to the non-merge total.
-- [ ] Reported governance and feature ratios equal ratios derived from counts.
-- [ ] Governance ratio is at or below `0.20` and the total remains 50.
-- [ ] Synthetic threshold and classification contracts remain green unchanged.
-- [ ] Formatting, strict workspace clippy, the full governance contract binary,
+- [x] Current `main` passes without hard-coded governance or feature counts.
+- [x] The test requires checker success and `status=ok`.
+- [x] Governance, feature, and unknown counts sum to the non-merge total.
+- [x] Reported governance and feature ratios equal ratios derived from counts.
+- [x] Governance ratio is at or below `0.20` and the total remains 50.
+- [x] Synthetic threshold and classification contracts remain green unchanged.
+- [x] Formatting, strict workspace clippy, the full governance contract binary,
       and `make check` pass.
 
 ## Files To Touch
@@ -86,3 +86,12 @@ CARGO_TARGET_DIR=target/mvp-demo-proof cargo clippy \
   --workspace --all-targets --all-features -- -D warnings
 CARGO_TARGET_DIR=target/mvp-demo-proof make check
 ```
+
+## Completion Evidence
+
+- The exact current-head contract passes with the live compliant commit mix.
+- All 28 governance feature-commit ratio contracts pass unchanged outside the
+  current-head assertion.
+- `cargo fmt --check`, strict workspace clippy, and `make check` pass.
+- Full `make test` now passes this governance binary and proceeds until the
+  unrelated pre-existing `readme_compact_contract` line-cap failure.


### PR DESCRIPTION
## Human Summary

- Replaces the current-head governance test's obsolete `10/40` commit snapshot with durable report arithmetic and threshold invariants.
- Keeps the checker, 50-commit window, `0.20` maximum, classification behavior, and synthetic exact-count tests unchanged.
- Restores the local governance gate as history advances without weakening policy.

Closes #7109

Spec: `specs/7109-stabilize-governance-ratio-head-contract.md`

## Testing

- Exact current-head governance contract
- All 28 `governance_feature_commit_ratio_base_compliance` contracts
- `cargo fmt --check`
- `CARGO_TARGET_DIR=target/mvp-demo-proof cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `CARGO_TARGET_DIR=target/mvp-demo-proof make check`
- `CARGO_TARGET_DIR=target/mvp-demo-proof make test` advances past this repaired binary, then stops at the unrelated pre-existing `readme_compact_contract` README line-cap failure

## Notes for Reviewers

No checker, threshold, classification, CI, shell, dependency, API, or database behavior changes. Synthetic contracts still own exact count cases; the live-head contract now owns policy compliance.

shell_loc_delta_actual: 0
rust_loc_delta_actual: 20
shell_to_rust_ratio_delta_actual: 0.0
shell_surface_ratio_target_status: neutral
