### PR TITLE
[7113] Refresh the tracked test-file inventory

### DIFF
--- a/fixtures/ci/test_file_size_policy_baseline.env
+++ b/fixtures/ci/test_file_size_policy_baseline.env
@@ -4,6 +4,7 @@ captured_at=2026-07-12
 # Refresh baseline whenever new test files are added or removed.
 test_file_total=1317
 soft_warn_count=2
+# Soft warnings: kamn-mcp-server/tests/real_backend_integration_contract.rs and kamn-core/tests/journal_wal_commit_schema_contract.rs.
 severe_count=0
 hard_fail_count=0
 severe_allowlist_csv=

--- a/fixtures/ci/test_file_size_policy_baseline.env
+++ b/fixtures/ci/test_file_size_policy_baseline.env
@@ -1,9 +1,9 @@
 schema_version=kamn.ci.test-file-size-policy-baseline.v1
-captured_at=2026-06-26
+captured_at=2026-07-12
 # Counts cover tracked crates/**/*.rs with a /tests/ path component, excluding any /tests/support/ paths.
 # Refresh baseline whenever new test files are added or removed.
-test_file_total=1288
-soft_warn_count=1
+test_file_total=1317
+soft_warn_count=2
 severe_count=0
 hard_fail_count=0
 severe_allowlist_csv=

--- a/specs/7113-refresh-test-file-inventory-baseline.md
+++ b/specs/7113-refresh-test-file-inventory-baseline.md
@@ -42,10 +42,10 @@ declarative evidence only; no fallback or tolerance is introduced.
 
 ## Acceptance Criteria
 
-- [ ] Baseline `test_file_total` equals the recomputed current inventory.
-- [ ] Soft, severe, and hard counts match current files.
-- [ ] Severe allowlist remains exact and no hard offender exists.
-- [ ] Threshold and Rust policy files remain unchanged.
+- [x] Baseline `test_file_total` equals the recomputed current inventory.
+- [x] Soft, severe, and hard counts match current files.
+- [x] Severe allowlist remains exact and no hard offender exists.
+- [x] Threshold and Rust policy files remain unchanged.
 - [ ] `test_file_size_policy`, formatting, strict clippy, `make check`, and
       `make test` pass.
 
@@ -75,3 +75,13 @@ CARGO_TARGET_DIR=target/mvp-demo-proof cargo clippy \
 CARGO_TARGET_DIR=target/mvp-demo-proof make check
 CARGO_TARGET_DIR=target/mvp-demo-proof make test
 ```
+
+## Completion Evidence
+
+- Recomputed inventory: 1,317 files, 2 soft warnings, 0 severe, 0 hard.
+- The two soft warnings are named in the fixture and remain below the budget 37.
+- All 4 test-file size policy contracts pass; thresholds and Rust policy are
+  unchanged.
+- Formatting, strict workspace clippy, and `make check` pass.
+- Full `make test` passes this policy, then fails two unrelated legacy
+  agent-harness fixture paths with `PROOF_ARTIFACT_PATH_INVALID`.

--- a/specs/7113-refresh-test-file-inventory-baseline.md
+++ b/specs/7113-refresh-test-file-inventory-baseline.md
@@ -1,0 +1,77 @@
+# Issue 7113: Refresh Test File Inventory Baseline
+
+## Objective
+
+Restore the test-file size policy contract by refreshing its tracked inventory
+total to the current repository state while preserving every size threshold,
+budget, offender rule, and fail-closed assertion.
+
+## Inputs And Outputs
+
+Input:
+
+- Tracked `crates/**/*.rs` files containing a `/tests/` path component.
+- The policy exclusion for `/tests/support/` paths.
+- Existing thresholds and baseline fixture.
+
+Output:
+
+- A baseline fixture whose inventory and oversized counts equal the recomputed
+  repository state.
+- An unchanged policy test and threshold configuration.
+
+## Boundaries And Non-Goals
+
+- Do not change test discovery, exclusions, thresholds, maximum budgets, reason
+  codes, severe allowlist, or Rust policy assertions.
+- Do not delete, split, or weaken tests to reduce the count.
+- Refresh only values proven stale by current inventory evidence.
+- This issue does not repair unrelated workspace gates.
+
+## Failure Modes
+
+- Baseline total differs from recomputed tracked test inventory.
+- Soft, severe, or hard counts are refreshed without recomputation.
+- A severe/hard offender or budget breach is hidden by fixture changes.
+- Schema, first-wave split markers, or allowlist changes accidentally.
+
+## Error Semantics
+
+The existing Rust policy remains authoritative and fail-loud. The fixture is
+declarative evidence only; no fallback or tolerance is introduced.
+
+## Acceptance Criteria
+
+- [ ] Baseline `test_file_total` equals the recomputed current inventory.
+- [ ] Soft, severe, and hard counts match current files.
+- [ ] Severe allowlist remains exact and no hard offender exists.
+- [ ] Threshold and Rust policy files remain unchanged.
+- [ ] `test_file_size_policy`, formatting, strict clippy, `make check`, and
+      `make test` pass.
+
+## Files To Touch
+
+- `fixtures/ci/test_file_size_policy_baseline.env`
+- This spec only.
+
+## Test Plan
+
+RED is the existing committed policy failure:
+
+```text
+test file inventory drift
+left: 1317
+right: 1288
+```
+
+GREEN verification:
+
+```bash
+CARGO_TARGET_DIR=target/mvp-demo-proof cargo test -p kamn-core \
+  --test test_file_size_policy -- --nocapture
+cargo fmt --check
+CARGO_TARGET_DIR=target/mvp-demo-proof cargo clippy \
+  --workspace --all-targets --all-features -- -D warnings
+CARGO_TARGET_DIR=target/mvp-demo-proof make check
+CARGO_TARGET_DIR=target/mvp-demo-proof make test
+```


### PR DESCRIPTION
## Human Summary

- Refreshes the tracked Rust test-file inventory from 1,288 to the recomputed 1,317 files.
- Records two soft-warning files while preserving zero severe and hard offenders.
- Keeps every threshold, budget, exclusion, allowlist, reason code, and policy assertion unchanged.

Closes #7113

Spec: `specs/7113-refresh-test-file-inventory-baseline.md`

## Testing

- `test_file_size_policy`: 4/4
- `cargo fmt --check`
- strict workspace clippy
- `make check`
- `make test` passes this policy and later stops at two separately tracked agent-harness verifier fixture failures (#7114)

## Notes for Reviewers

This is a recomputed fixture refresh, not a threshold or allowlist waiver. The two files above 500 lines remain far below the maximum soft-warning count of 37.

shell_loc_delta_actual: 0
rust_loc_delta_actual: 0
shell_to_rust_ratio_delta_actual: 0.0
shell_surface_ratio_target_status: neutral
