### PR TITLE
fix: prevent duplicate settlement across recovery paths

### DIFF
--- a/crates/kamn-e2e-harness/src/agent_transaction_finalize.rs
+++ b/crates/kamn-e2e-harness/src/agent_transaction_finalize.rs
@@ -6,6 +6,10 @@ use super::{
     MvpDemoCommandConfig, VerifyMvpDemoCommandConfig,
 };
 
+#[cfg(test)]
+#[path = "agent_transaction_finalize_tests.rs"]
+mod tests;
+
 pub(super) fn finalize(
     config: &AgentTransactionDemoConfig,
     paths: &AgentTransactionEvidencePaths,

--- a/crates/kamn-e2e-harness/src/agent_transaction_finalize_fake_solana.rs
+++ b/crates/kamn-e2e-harness/src/agent_transaction_finalize_fake_solana.rs
@@ -1,0 +1,33 @@
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+
+pub(super) fn install_fake_solana(root: &Path) -> String {
+    std::fs::write(root.join("payer.json"), "[]").expect("payer fixture");
+    write_executable(
+        &root.join("solana-keygen"),
+        "#!/bin/sh\necho 2FjUiacAXtokhA8YzGiyfVEdu5D9LxKFhjptJLrz4V9T\n",
+    );
+    write_executable(&root.join("solana"), &solana_script(root));
+    let original = std::env::var("PATH").unwrap_or_default();
+    std::env::set_var("PATH", format!("{}:{original}", root.display()));
+    original
+}
+
+fn solana_script(root: &Path) -> String {
+    format!(
+        r#"#!/bin/sh
+echo "$*" >> "{}/solana-calls.log"
+cat <<'JSON'
+{{"confirmationStatus":"finalized","meta":{{"err":null,"preBalances":[2500000000,2500000000],"postBalances":[2498995000,2501000000]}},"transaction":{{"signatures":["devnet-signature-111"],"message":{{"accountKeys":["2FjUiacAXtokhA8YzGiyfVEdu5D9LxKFhjptJLrz4V9T","FV5LvudLjZQGCrPwXUY2JaVr26sQE15K25BGvsKWvyFe"]}}}}}}
+JSON
+"#,
+        root.display()
+    )
+}
+
+fn write_executable(path: &Path, body: &str) {
+    std::fs::write(path, body).expect("fake executable");
+    let mut permissions = std::fs::metadata(path).expect("metadata").permissions();
+    permissions.set_mode(0o700);
+    std::fs::set_permissions(path, permissions).expect("permissions");
+}

--- a/crates/kamn-e2e-harness/src/agent_transaction_finalize_live_evidence.rs
+++ b/crates/kamn-e2e-harness/src/agent_transaction_finalize_live_evidence.rs
@@ -1,0 +1,56 @@
+use std::path::Path;
+
+pub(super) fn write_live_evidence(root: &Path) -> [String; 4] {
+    let staging = root.join("staging");
+    std::fs::create_dir_all(&staging).expect("staging root");
+    let paths = [
+        "handoff.json",
+        "task-agent-a.json",
+        "task-agent-b.json",
+        "task-agent-c.json",
+    ]
+    .map(|name| staging.join(name));
+    let handoff = write_digest(
+        &paths[0],
+        r#"{"schema_version":"kamn.mvp.live-task-handoff.v1","task_id":"task-local-bound-7086"}"#,
+    );
+    let agent_a = write_receipt(&paths[1], "agent_a", 101);
+    let agent_b = write_receipt(&paths[2], "agent_b", 202);
+    write_observation(&paths[3], &handoff, &agent_a, &agent_b);
+    paths.map(|path| path.display().to_string())
+}
+
+fn write_receipt(path: &Path, actor: &str, pid: u64) -> String {
+    write_digest(
+        path,
+        &format!(
+            r#"{{"schema_version":"kamn.mvp.live-task-actor-receipt.v1","actor":"{actor}","task_id":"task-local-bound-7086","state":"accepted","pi_process_id":{pid}}}"#
+        ),
+    )
+}
+
+fn write_observation(path: &Path, handoff: &str, agent_a: &str, agent_b: &str) {
+    let public = format!(
+        r#"{{"task_id":"task-local-bound-7086","state":"accepted","source_handoff_digest":"{handoff}","source_agent_a_receipt_digest":"{agent_a}","source_agent_b_receipt_digest":"{agent_b}"}}"#
+    );
+    let raw = format!(
+        r#"{{"schema_version":"kamn.mvp.live-task-restricted-observation.v1","task_id":"task-local-bound-7086","state":"accepted","source_handoff_digest":"{handoff}","source_agent_a_receipt_digest":"{agent_a}","source_agent_b_receipt_digest":"{agent_b}","view_scope":"restricted-public","private_field_count":0,"private_payload_redacted":true,"agent_c_pi_process_id":303,"public_commitment":"{}"}}"#,
+        sha256(&public)
+    );
+    write_digest(path, &raw);
+}
+
+fn write_digest(path: &Path, raw: &str) -> String {
+    let digest = sha256(raw);
+    let artifact = format!(
+        "{},\"artifact_digest\":\"{digest}\"}}",
+        raw.trim_end_matches('}')
+    );
+    std::fs::write(path, artifact).expect("evidence artifact");
+    digest
+}
+
+fn sha256(value: &str) -> String {
+    use sha2::{Digest, Sha256};
+    format!("{:x}", Sha256::digest(value.as_bytes()))
+}

--- a/crates/kamn-e2e-harness/src/agent_transaction_finalize_test_support.rs
+++ b/crates/kamn-e2e-harness/src/agent_transaction_finalize_test_support.rs
@@ -1,0 +1,157 @@
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use crate::agent_transaction_evidence::AgentTransactionEvidencePaths;
+use crate::{parse_agent_transaction_demo_config, AgentTransactionDemoConfig};
+
+#[path = "../tests/support/pi_transaction_actor_fixture.rs"]
+mod actor_fixture;
+use actor_fixture::{ActorFixture, Overrides};
+
+#[path = "agent_transaction_finalize_fake_solana.rs"]
+mod fake_solana;
+use fake_solana::install_fake_solana;
+
+#[path = "agent_transaction_finalize_live_evidence.rs"]
+mod live_evidence;
+use live_evidence::write_live_evidence;
+
+const RECIPIENT_ENV: &str = "KAMN_SERVICE_API_LIVE_SOLANA_SETTLEMENT_RECIPIENT_PUBKEY";
+const LAMPORTS_ENV: &str = "KAMN_SERVICE_API_LIVE_SOLANA_SETTLEMENT_LAMPORTS";
+const COMMITMENT_ENV: &str = "KAMN_SERVICE_API_LIVE_SOLANA_SETTLEMENT_COMMITMENT";
+
+pub(super) struct ProofRetryFixture {
+    root: PathBuf,
+    original_path: String,
+    pub(super) config: AgentTransactionDemoConfig,
+    pub(super) paths: AgentTransactionEvidencePaths,
+}
+
+impl ProofRetryFixture {
+    pub(super) fn new() -> Self {
+        let root = unique_root();
+        let actors = ActorFixture::new();
+        actors.write_all(Overrides::default());
+        actors.rebind_shared_facts();
+        let paths = evidence_paths(actors.paths(), write_live_evidence(&root));
+        let config = config(&root);
+        let original_path = install_fake_solana(&root);
+        std::fs::create_dir_all(&config.output_root).expect("output root");
+        Self {
+            root,
+            original_path,
+            config,
+            paths,
+        }
+    }
+
+    pub(super) fn block_latest_publication(&self) {
+        std::fs::write(self.root.join("demo/latest"), "publication blocker")
+            .expect("latest blocker");
+    }
+
+    pub(super) fn unblock_latest_publication(&self) {
+        std::fs::remove_file(self.root.join("demo/latest")).expect("remove latest blocker");
+    }
+
+    pub(super) fn solana_calls(&self) -> String {
+        std::fs::read_to_string(self.root.join("solana-calls.log")).expect("Solana call log")
+    }
+}
+
+impl Drop for ProofRetryFixture {
+    fn drop(&mut self) {
+        std::env::set_var("PATH", self.original_path.as_str());
+    }
+}
+
+fn config(root: &Path) -> AgentTransactionDemoConfig {
+    let mut config = parse_agent_transaction_demo_config(&config_env(root)).expect("config");
+    config.output_root = root.join("demo").display().to_string();
+    config.staging_root = root.join("staging").display().to_string();
+    config.localhost_signed_demo_command = Some(localhost_command());
+    config.service_api_vertical_slice_command = Some(service_command(
+        "integration_service_api_endpoint_working_vertical_slice_proves_delivery_dispatch_and_audit_evidence",
+    ));
+    config.service_api_websocket_command = Some(service_command(
+        "integration_service_api_endpoint_websocket_upgrade_streams_state_transition_event",
+    ));
+    config
+}
+
+fn config_env(root: &Path) -> BTreeMap<String, String> {
+    let mut values = static_config_env();
+    values.insert(
+        "KAMN_SERVICE_API_LIVE_SOLANA_SETTLEMENT_KEYPAIR_FILE".to_owned(),
+        root.join("payer.json").display().to_string(),
+    );
+    values
+}
+
+fn static_config_env() -> BTreeMap<String, String> {
+    let mut values = core_config_env();
+    for (key, value) in [
+        ("KAMN_MVP_LIVE_MCP_AGENT_A_KEY_FILE", "a"),
+        ("KAMN_MVP_LIVE_MCP_AGENT_B_KEY_FILE", "b"),
+        ("KAMN_MVP_LIVE_MCP_AGENT_C_KEY_FILE", "c"),
+    ] {
+        values.insert(key.to_owned(), value.to_owned());
+    }
+    values
+}
+
+fn core_config_env() -> BTreeMap<String, String> {
+    let values = [
+        ("KAMN_MVP_AGENT_DRIVER", "pi".to_owned()),
+        ("KAMN_MVP_DEVNET_MODE", "required".to_owned()),
+        (
+            "KAMN_MVP_SOLANA_RPC_URL",
+            "https://api.devnet.solana.com".to_owned(),
+        ),
+        (
+            RECIPIENT_ENV,
+            "FV5LvudLjZQGCrPwXUY2JaVr26sQE15K25BGvsKWvyFe".to_owned(),
+        ),
+        (LAMPORTS_ENV, "1000000".to_owned()),
+        (COMMITMENT_ENV, "finalized".to_owned()),
+    ];
+    values
+        .into_iter()
+        .map(|(key, value)| (key.to_owned(), value))
+        .collect()
+}
+
+fn evidence_paths(actors: [String; 3], live: [String; 4]) -> AgentTransactionEvidencePaths {
+    AgentTransactionEvidencePaths {
+        handoff: live[0].clone(),
+        agent_a_receipt: live[1].clone(),
+        agent_b_receipt: live[2].clone(),
+        agent_c_observation: live[3].clone(),
+        actors,
+        run_id: "proof-retry".to_owned(),
+    }
+}
+
+fn localhost_command() -> Vec<String> {
+    vec!["sh".to_owned(), "-c".to_owned(), r#"cat > "$2" <<'JSON'
+{"schema_version":"kamn.sdk.localhost-signed.demo-receipt-artifact.v1","status": "pass","signed_exchange":{"from":"kamn:did:agent:alice","to":"kamn:did:agent:bob","verified": true},"signed_flow":"task"}
+JSON
+echo receipt_reconciliation=GO
+echo 'localhost signed message demo completed.'"#.to_owned(), "stub".to_owned()]
+}
+
+fn service_command(test_name: &str) -> Vec<String> {
+    vec![
+        "sh".to_owned(),
+        "-c".to_owned(),
+        format!("echo 'test {test_name} ... ok'; echo 'test result: ok'"),
+    ]
+}
+
+fn unique_root() -> PathBuf {
+    let id = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("clock")
+        .as_nanos();
+    std::env::temp_dir().join(format!("kamn-proof-retry-{}-{id}", std::process::id()))
+}

--- a/crates/kamn-e2e-harness/src/agent_transaction_finalize_tests.rs
+++ b/crates/kamn-e2e-harness/src/agent_transaction_finalize_tests.rs
@@ -1,0 +1,38 @@
+use super::finalize;
+
+#[path = "agent_transaction_finalize_test_support.rs"]
+mod support;
+use support::ProofRetryFixture;
+
+#[test]
+fn proof_retry_reuses_persisted_settlement_without_submission() {
+    let _guard = test_lock();
+    let fixture = ProofRetryFixture::new();
+    fixture.block_latest_publication();
+
+    let first =
+        finalize(&fixture.config, &fixture.paths).expect_err("latest publication must fail");
+    assert!(
+        first.contains("failed to remove previous latest demo"),
+        "unexpected proof failure: {first}"
+    );
+    fixture.unblock_latest_publication();
+    finalize(&fixture.config, &fixture.paths).expect("proof retry should pass");
+
+    let calls = fixture.solana_calls();
+    assert_eq!(
+        calls
+            .lines()
+            .filter(|line| line.starts_with("confirm "))
+            .count(),
+        2
+    );
+    assert!(!calls.contains("transfer"));
+    assert!(!calls.contains("send"));
+}
+
+fn test_lock() -> std::sync::MutexGuard<'static, ()> {
+    static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    LOCK.lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/ingress_guard_lifecycle_contract_tests/replay_guard_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/ingress_guard_lifecycle_contract_tests/replay_guard_contract_tests.rs
@@ -31,6 +31,71 @@ fn regression_service_api_endpoint_rejects_replayed_request_nonce_for_sender() {
 }
 
 #[test]
+fn integration_service_api_endpoint_rejects_previously_accepted_nonce_after_restart_reload() {
+    let _env = acquire_service_api_test_env();
+    let state_file = std::env::temp_dir().join(format!(
+        "kamn-node-ingress-replay-restart-{}-{}.json",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos()
+    ));
+    let _state_guard = EnvVarGuard::set(
+        "KAMN_SERVICE_API_STATE_FILE",
+        Some(state_file.to_string_lossy().as_ref()),
+    );
+    let sender_did = "kamn:did:agent:test-client-replay-restart";
+    let body = "{\"message\":\"replay-after-restart\"}";
+
+    let first_snapshot = build_ingress_snapshot("127.0.0.1:34072");
+    let first_server = spawn_ingress_server(
+        &first_snapshot,
+        1,
+        2_000,
+        DEFAULT_SERVICE_API_BODY_LIMIT_BYTES,
+        DEFAULT_SERVICE_API_CONCURRENCY_LIMIT,
+        DEFAULT_SERVICE_API_RATE_LIMIT_PER_SECOND,
+    );
+    let first_response = send_signed_message_request(
+        &first_snapshot,
+        first_server.bind_addr.as_str(),
+        sender_did,
+        17,
+        body,
+    );
+    assert!(first_response.contains("HTTP/1.1 202 Accepted"));
+    assert_server_ok(
+        first_server.server,
+        "first ingress server should stop cleanly after accepting the nonce",
+    );
+
+    let restarted_snapshot = build_ingress_snapshot("127.0.0.1:34073");
+    let restarted_server = spawn_ingress_server(
+        &restarted_snapshot,
+        1,
+        2_000,
+        DEFAULT_SERVICE_API_BODY_LIMIT_BYTES,
+        DEFAULT_SERVICE_API_CONCURRENCY_LIMIT,
+        DEFAULT_SERVICE_API_RATE_LIMIT_PER_SECOND,
+    );
+    let replay_response = send_signed_message_request(
+        &restarted_snapshot,
+        restarted_server.bind_addr.as_str(),
+        sender_did,
+        17,
+        body,
+    );
+
+    assert_replay_rejection(replay_response.as_str());
+    assert_server_ok(
+        restarted_server.server,
+        "restarted ingress server should stop cleanly after rejecting the replayed nonce",
+    );
+    let _ = std::fs::remove_file(state_file);
+}
+
+#[test]
 fn integration_service_api_endpoint_replay_rejection_remains_stable_with_anti_spam_enforcement() {
     let _env = acquire_service_api_test_env();
     let snapshot = build_ingress_snapshot("127.0.0.1:34066");

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/ingress_guard_lifecycle_contract_tests/replay_guard_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/ingress_guard_lifecycle_contract_tests/replay_guard_contract_tests.rs
@@ -33,66 +33,45 @@ fn regression_service_api_endpoint_rejects_replayed_request_nonce_for_sender() {
 #[test]
 fn integration_service_api_endpoint_rejects_previously_accepted_nonce_after_restart_reload() {
     let _env = acquire_service_api_test_env();
-    let state_file = std::env::temp_dir().join(format!(
-        "kamn-node-ingress-replay-restart-{}-{}.json",
-        std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .expect("clock")
-            .as_nanos()
-    ));
+    let state_file = unique_replay_state_file();
     let _state_guard = EnvVarGuard::set(
         "KAMN_SERVICE_API_STATE_FILE",
         Some(state_file.to_string_lossy().as_ref()),
     );
     let sender_did = "kamn:did:agent:test-client-replay-restart";
     let body = "{\"message\":\"replay-after-restart\"}";
-
-    let first_snapshot = build_ingress_snapshot("127.0.0.1:34072");
-    let first_server = spawn_ingress_server(
-        &first_snapshot,
-        1,
-        2_000,
-        DEFAULT_SERVICE_API_BODY_LIMIT_BYTES,
-        DEFAULT_SERVICE_API_CONCURRENCY_LIMIT,
-        DEFAULT_SERVICE_API_RATE_LIMIT_PER_SECOND,
-    );
-    let first_response = send_signed_message_request(
-        &first_snapshot,
-        first_server.bind_addr.as_str(),
-        sender_did,
-        17,
-        body,
-    );
+    let first_response = send_restart_nonce_request("127.0.0.1:34072", sender_did, body);
     assert!(first_response.contains("HTTP/1.1 202 Accepted"));
-    assert_server_ok(
-        first_server.server,
-        "first ingress server should stop cleanly after accepting the nonce",
-    );
+    let replay_response = send_restart_nonce_request("127.0.0.1:34073", sender_did, body);
+    assert_replay_rejection(replay_response.as_str());
+    let _ = std::fs::remove_file(state_file);
+}
 
-    let restarted_snapshot = build_ingress_snapshot("127.0.0.1:34073");
-    let restarted_server = spawn_ingress_server(
-        &restarted_snapshot,
+fn send_restart_nonce_request(api_bind: &str, sender_did: &str, body: &str) -> String {
+    let snapshot = build_ingress_snapshot(api_bind);
+    let server = spawn_ingress_server(
+        &snapshot,
         1,
         2_000,
         DEFAULT_SERVICE_API_BODY_LIMIT_BYTES,
         DEFAULT_SERVICE_API_CONCURRENCY_LIMIT,
         DEFAULT_SERVICE_API_RATE_LIMIT_PER_SECOND,
     );
-    let replay_response = send_signed_message_request(
-        &restarted_snapshot,
-        restarted_server.bind_addr.as_str(),
-        sender_did,
-        17,
-        body,
-    );
+    let response =
+        send_signed_message_request(&snapshot, server.bind_addr.as_str(), sender_did, 17, body);
+    assert_server_ok(server.server, "restart nonce server should stop cleanly");
+    response
+}
 
-    assert_replay_rejection(replay_response.as_str());
-    assert_server_ok(
-        restarted_server.server,
-        "restarted ingress server should stop cleanly after rejecting the replayed nonce",
-    );
-    let _ = std::fs::remove_file(state_file);
+fn unique_replay_state_file() -> std::path::PathBuf {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("clock")
+        .as_nanos();
+    std::env::temp_dir().join(format!(
+        "kamn-node-ingress-replay-restart-{}-{nanos}.json",
+        std::process::id()
+    ))
 }
 
 #[test]

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests.rs
@@ -18,6 +18,8 @@ mod task_escrow_restart_contract_tests;
 mod task_escrow_routes_contract_tests;
 #[path = "task_escrow_persistence_contract_tests/task_escrow_settlement_concurrency_contract_tests.rs"]
 mod task_escrow_settlement_concurrency_contract_tests;
+#[path = "task_escrow_persistence_contract_tests/task_escrow_settlement_monotonicity_contract_tests.rs"]
+mod task_escrow_settlement_monotonicity_contract_tests;
 #[path = "task_escrow_persistence_contract_tests/task_escrow_settlement_reconciliation_contract_tests.rs"]
 mod task_escrow_settlement_reconciliation_contract_tests;
 #[path = "task_escrow_persistence_contract_tests/task_escrow_solana_asset_movement_contract_tests.rs"]

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/settlement_concurrency_support.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/settlement_concurrency_support.rs
@@ -1,0 +1,95 @@
+use super::*;
+
+pub(super) fn concurrent_release_requests(
+    snapshot: &crate::service_api_endpoint::ServiceApiSnapshot,
+    path: &str,
+    body: &str,
+) -> Vec<String> {
+    let bind_addr = reserve_loopback_addr();
+    with_api_server(snapshot, bind_addr.as_str(), 2, |addr| {
+        let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
+        thread::scope(|scope| {
+            [183_u64, 183_u64]
+                .into_iter()
+                .map(|nonce| {
+                    spawn_release(scope, barrier.clone(), snapshot, addr, path, body, nonce)
+                })
+                .collect::<Vec<_>>()
+                .into_iter()
+                .map(join_release)
+                .collect()
+        })
+    })
+}
+
+pub(super) fn ordered_authenticated_release_race(
+    snapshot: &crate::service_api_endpoint::ServiceApiSnapshot,
+    path: &str,
+    body: &str,
+    gate: &crate::service_api_endpoint::TestPostAuthGate,
+) -> Vec<String> {
+    let bind_addr = reserve_loopback_addr();
+    with_api_server(snapshot, bind_addr.as_str(), 2, |addr| {
+        thread::scope(|scope| {
+            let first = scope.spawn(|| send_release(snapshot, addr, path, body, 193));
+            gate.expect_arrivals(1);
+            let second = scope.spawn(|| send_release(snapshot, addr, path, body, 194));
+            gate.expect_arrivals(2);
+            gate.release();
+            vec![join_release(first), join_release(second)]
+        })
+    })
+}
+
+fn send_release(
+    snapshot: &crate::service_api_endpoint::ServiceApiSnapshot,
+    addr: &str,
+    path: &str,
+    body: &str,
+    nonce: u64,
+) -> String {
+    signed_release_http(snapshot, addr, path, body, nonce)
+}
+
+fn spawn_release<'scope>(
+    scope: &'scope thread::Scope<'scope, '_>,
+    barrier: std::sync::Arc<std::sync::Barrier>,
+    snapshot: &'scope crate::service_api_endpoint::ServiceApiSnapshot,
+    addr: &'scope str,
+    path: &'scope str,
+    body: &'scope str,
+    nonce: u64,
+) -> thread::ScopedJoinHandle<'scope, String> {
+    scope.spawn(move || {
+        barrier.wait();
+        signed_release_http(snapshot, addr, path, body, nonce)
+    })
+}
+
+fn signed_release_http(
+    snapshot: &crate::service_api_endpoint::ServiceApiSnapshot,
+    addr: &str,
+    path: &str,
+    body: &str,
+    nonce: u64,
+) -> String {
+    let nonce_text = nonce.to_string();
+    let signature =
+        service_api_request_signature_for_fields(ACTOR, nonce, state_hash(snapshot).as_str(), body);
+    send_http_request_with_headers(
+        addr,
+        "POST",
+        path,
+        body,
+        &[
+            ("X-KAMN-Sender-DID", ACTOR),
+            ("X-KAMN-Request-Nonce", nonce_text.as_str()),
+            ("X-KAMN-Request-Signature", signature.as_str()),
+            ("X-KAMN-Authz-Scope", "escrow:write"),
+        ],
+    )
+}
+
+fn join_release(handle: thread::ScopedJoinHandle<'_, String>) -> String {
+    handle.join().expect("release request thread")
+}

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_settlement_concurrency_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_settlement_concurrency_contract_tests.rs
@@ -1,6 +1,10 @@
 use super::super::*;
 use super::support::*;
 
+#[path = "settlement_concurrency_support.rs"]
+mod concurrency_support;
+use concurrency_support::{concurrent_release_requests, ordered_authenticated_release_race};
+
 const ACTOR: &str = "kamn:did:agent:test-client-settlement-concurrency";
 const KEYPAIR_ENV: &str = "KAMN_SERVICE_API_LIVE_SOLANA_SETTLEMENT_KEYPAIR_FILE";
 const RECIPIENT_ENV: &str = "KAMN_SERVICE_API_LIVE_SOLANA_SETTLEMENT_RECIPIENT_PUBKEY";
@@ -66,8 +70,9 @@ fn integration_distinct_release_nonces_with_same_key_converge_on_one_persisted_s
         extra_headers: &[],
     });
 
+    let gate = crate::service_api_endpoint::set_test_post_auth_gate();
     let responses =
-        concurrent_release_requests_for_nonces(&context.harness.snapshot, &path, body, [193, 194]);
+        ordered_authenticated_release_race(&context.harness.snapshot, &path, body, &gate);
     let successes: Vec<Value> = responses
         .iter()
         .filter(|response| response.contains("HTTP/1.1 200 OK"))
@@ -80,101 +85,21 @@ fn integration_distinct_release_nonces_with_same_key_converge_on_one_persisted_s
 
     assert_eq!(
         successes.len(),
-        1,
-        "expected exactly one successful raced release: {responses:?}"
+        2,
+        "both authorized retries should succeed: {responses:?}"
     );
-    assert_eq!(
-        responses
+    let persisted_signature = settlement_tx_signature(&state["escrows"][&escrow_id]);
+    assert!(
+        successes
             .iter()
-            .filter(|response| response.contains("HTTP/1.1 409 Conflict"))
-            .count(),
-        1,
-        "expected exactly one raced release conflict: {responses:?}"
-    );
-    let conflict = responses
-        .iter()
-        .find(|response| response.contains("HTTP/1.1 409 Conflict"))
-        .expect("one raced response should conflict");
-    let conflict_payload = parse_error_envelope_from_http_response(conflict);
-    assert_ne!(
-        conflict_payload.reason_code, "service_api_auth_replay_nonce_detected",
-        "distinct nonces must not collapse into replay rejection"
-    );
-    let success = &successes[0];
-    assert_eq!(
-        settlement_tx_signature(&state["escrows"][&escrow_id]),
-        settlement_tx_signature(success),
-        "persisted release state should keep the converged signature"
+            .all(|success| settlement_tx_signature(success) == persisted_signature),
+        "both responses must converge on the persisted signature"
     );
     assert_eq!(
         crate::service_api_endpoint::test_live_solana_settlement_submission_count(),
         1,
         "same-key retries with fresh nonces must not resubmit the adapter transfer"
     );
-}
-
-fn concurrent_release_requests(
-    snapshot: &crate::service_api_endpoint::ServiceApiSnapshot,
-    path: &str,
-    body: &str,
-) -> Vec<String> {
-    concurrent_release_requests_for_nonces(snapshot, path, body, [183, 183])
-}
-
-fn concurrent_release_requests_for_nonces(
-    snapshot: &crate::service_api_endpoint::ServiceApiSnapshot,
-    path: &str,
-    body: &str,
-    nonces: [u64; 2],
-) -> Vec<String> {
-    let bind_addr = reserve_loopback_addr();
-    with_api_server(snapshot, bind_addr.as_str(), 2, |addr| {
-        let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
-        thread::scope(|scope| {
-            nonces
-                .into_iter()
-                .map(|nonce| {
-                    spawn_release(scope, barrier.clone(), snapshot, addr, path, body, nonce)
-                })
-                .collect::<Vec<_>>()
-                .into_iter()
-                .map(|handle| handle.join().expect("release request should complete"))
-                .collect()
-        })
-    })
-}
-
-fn spawn_release<'scope>(
-    scope: &'scope thread::Scope<'scope, '_>,
-    barrier: std::sync::Arc<std::sync::Barrier>,
-    snapshot: &'scope crate::service_api_endpoint::ServiceApiSnapshot,
-    addr: &'scope str,
-    path: &'scope str,
-    body: &'scope str,
-    nonce: u64,
-) -> thread::ScopedJoinHandle<'scope, String> {
-    scope.spawn(move || {
-        let nonce_text = nonce.to_string();
-        let signature = service_api_request_signature_for_fields(
-            ACTOR,
-            nonce,
-            state_hash(snapshot).as_str(),
-            body,
-        );
-        barrier.wait();
-        send_http_request_with_headers(
-            addr,
-            "POST",
-            path,
-            body,
-            &[
-                ("X-KAMN-Sender-DID", ACTOR),
-                ("X-KAMN-Request-Nonce", nonce_text.as_str()),
-                ("X-KAMN-Request-Signature", signature.as_str()),
-                ("X-KAMN-Authz-Scope", "escrow:write"),
-            ],
-        )
-    })
 }
 
 fn params() -> LiveSolanaAssetMovementParams<'static> {

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_settlement_concurrency_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_settlement_concurrency_contract_tests.rs
@@ -53,11 +53,55 @@ fn integration_concurrent_settlement_release_submits_one_transaction_identity() 
 
 #[test]
 fn integration_distinct_release_nonces_with_same_key_converge_on_one_persisted_signature() {
+    let outcome = run_distinct_release_race();
+    assert_eq!(
+        outcome.successes.len(),
+        2,
+        "both authorized retries should succeed: {:?}",
+        outcome.responses
+    );
+    let persisted = settlement_tx_signature(&outcome.state["escrows"][&outcome.escrow_id]);
+    assert!(outcome
+        .successes
+        .iter()
+        .all(|item| settlement_tx_signature(item) == persisted));
+    assert_eq!(
+        outcome.submissions, 1,
+        "fresh nonces must not resubmit transfer"
+    );
+}
+
+struct DistinctRaceOutcome {
+    responses: Vec<String>,
+    successes: Vec<Value>,
+    state: Value,
+    escrow_id: String,
+    submissions: u64,
+}
+
+fn run_distinct_release_race() -> DistinctRaceOutcome {
     let _env = acquire_service_api_test_env();
     let _override_guard =
         crate::service_api_endpoint::set_test_live_solana_settlement_override(true);
     let context = build_live_solana_asset_movement_context(params());
     let escrow_id = fund_live_escrow(&context.harness, 191, 43);
+    let responses = distinct_release_responses(&context, &escrow_id);
+    let successes = successful_payloads(&responses);
+    let state = read_state_json(context.harness.state_file.as_path());
+    let submissions = crate::service_api_endpoint::test_live_solana_settlement_submission_count();
+    DistinctRaceOutcome {
+        responses,
+        successes,
+        state,
+        escrow_id,
+        submissions,
+    }
+}
+
+fn distinct_release_responses(
+    context: &LiveSolanaAssetMovementContext,
+    escrow_id: &str,
+) -> Vec<String> {
     let path = format!("/v1/escrow/{escrow_id}/release");
     let body = r#"{"idempotency_key":"settlement-distinct-nonce-shared-key"}"#;
     provision_signed_request_grant(&SignedRequest {
@@ -69,37 +113,19 @@ fn integration_distinct_release_nonces_with_same_key_converge_on_one_persisted_s
         body,
         extra_headers: &[],
     });
+    let gate = crate::service_api_endpoint::set_test_post_auth_gate(path.as_str());
+    ordered_authenticated_release_race(&context.harness.snapshot, &path, body, &gate)
+}
 
-    let gate = crate::service_api_endpoint::set_test_post_auth_gate();
-    let responses =
-        ordered_authenticated_release_race(&context.harness.snapshot, &path, body, &gate);
-    let successes: Vec<Value> = responses
+fn successful_payloads(responses: &[String]) -> Vec<Value> {
+    responses
         .iter()
         .filter(|response| response.contains("HTTP/1.1 200 OK"))
         .map(|response| {
             parse_service_api_payload(extract_http_response_body(response))
                 .expect("success payload")
         })
-        .collect();
-    let state = read_state_json(context.harness.state_file.as_path());
-
-    assert_eq!(
-        successes.len(),
-        2,
-        "both authorized retries should succeed: {responses:?}"
-    );
-    let persisted_signature = settlement_tx_signature(&state["escrows"][&escrow_id]);
-    assert!(
-        successes
-            .iter()
-            .all(|success| settlement_tx_signature(success) == persisted_signature),
-        "both responses must converge on the persisted signature"
-    );
-    assert_eq!(
-        crate::service_api_endpoint::test_live_solana_settlement_submission_count(),
-        1,
-        "same-key retries with fresh nonces must not resubmit the adapter transfer"
-    );
+        .collect()
 }
 
 fn params() -> LiveSolanaAssetMovementParams<'static> {

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_settlement_concurrency_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_settlement_concurrency_contract_tests.rs
@@ -47,16 +47,91 @@ fn integration_concurrent_settlement_release_submits_one_transaction_identity() 
     );
 }
 
+#[test]
+fn integration_distinct_release_nonces_with_same_key_converge_on_one_persisted_signature() {
+    let _env = acquire_service_api_test_env();
+    let _override_guard =
+        crate::service_api_endpoint::set_test_live_solana_settlement_override(true);
+    let context = build_live_solana_asset_movement_context(params());
+    let escrow_id = fund_live_escrow(&context.harness, 191, 43);
+    let path = format!("/v1/escrow/{escrow_id}/release");
+    let body = r#"{"idempotency_key":"settlement-distinct-nonce-shared-key"}"#;
+    provision_signed_request_grant(&SignedRequest {
+        max_requests: 2,
+        method: "POST",
+        path: path.as_str(),
+        caller_did: ACTOR,
+        nonce: 193,
+        body,
+        extra_headers: &[],
+    });
+
+    let responses =
+        concurrent_release_requests_for_nonces(&context.harness.snapshot, &path, body, [193, 194]);
+    let successes: Vec<Value> = responses
+        .iter()
+        .filter(|response| response.contains("HTTP/1.1 200 OK"))
+        .map(|response| {
+            parse_service_api_payload(extract_http_response_body(response))
+                .expect("success payload")
+        })
+        .collect();
+    let state = read_state_json(context.harness.state_file.as_path());
+
+    assert_eq!(
+        successes.len(),
+        1,
+        "expected exactly one successful raced release: {responses:?}"
+    );
+    assert_eq!(
+        responses
+            .iter()
+            .filter(|response| response.contains("HTTP/1.1 409 Conflict"))
+            .count(),
+        1,
+        "expected exactly one raced release conflict: {responses:?}"
+    );
+    let conflict = responses
+        .iter()
+        .find(|response| response.contains("HTTP/1.1 409 Conflict"))
+        .expect("one raced response should conflict");
+    let conflict_payload = parse_error_envelope_from_http_response(conflict);
+    assert_ne!(
+        conflict_payload.reason_code, "service_api_auth_replay_nonce_detected",
+        "distinct nonces must not collapse into replay rejection"
+    );
+    let success = &successes[0];
+    assert_eq!(
+        settlement_tx_signature(&state["escrows"][&escrow_id]),
+        settlement_tx_signature(success),
+        "persisted release state should keep the converged signature"
+    );
+    assert_eq!(
+        crate::service_api_endpoint::test_live_solana_settlement_submission_count(),
+        1,
+        "same-key retries with fresh nonces must not resubmit the adapter transfer"
+    );
+}
+
 fn concurrent_release_requests(
     snapshot: &crate::service_api_endpoint::ServiceApiSnapshot,
     path: &str,
     body: &str,
 ) -> Vec<String> {
+    concurrent_release_requests_for_nonces(snapshot, path, body, [183, 183])
+}
+
+fn concurrent_release_requests_for_nonces(
+    snapshot: &crate::service_api_endpoint::ServiceApiSnapshot,
+    path: &str,
+    body: &str,
+    nonces: [u64; 2],
+) -> Vec<String> {
     let bind_addr = reserve_loopback_addr();
     with_api_server(snapshot, bind_addr.as_str(), 2, |addr| {
         let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
         thread::scope(|scope| {
-            [183_u64, 183_u64]
+            nonces
                 .into_iter()
                 .map(|nonce| {
                     spawn_release(scope, barrier.clone(), snapshot, addr, path, body, nonce)

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_settlement_monotonicity_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_settlement_monotonicity_contract_tests.rs
@@ -1,0 +1,98 @@
+use super::super::*;
+use super::support::*;
+
+const ACTOR: &str = "kamn:did:agent:test-client-settlement-monotonicity";
+
+#[test]
+fn integration_confirmed_settlement_cannot_roll_back_on_restart_retry() {
+    let outcome = run_restart_retry();
+    assert!(
+        outcome.first.contains("HTTP/1.1 200 OK"),
+        "{}",
+        outcome.first
+    );
+    assert!(
+        outcome.retry.contains("HTTP/1.1 200 OK"),
+        "{}",
+        outcome.retry
+    );
+    assert_terminal_state_unchanged(&outcome.before, &outcome.after, &outcome.escrow_id);
+    assert_eq!(
+        outcome.submissions, 1,
+        "proof retry must not submit settlement"
+    );
+}
+
+struct RetryOutcome {
+    first: String,
+    retry: String,
+    before: Value,
+    after: Value,
+    escrow_id: String,
+    submissions: u64,
+}
+
+fn run_restart_retry() -> RetryOutcome {
+    let _env = acquire_service_api_test_env();
+    let _override_guard =
+        crate::service_api_endpoint::set_test_live_solana_settlement_override(true);
+    let context = build_live_solana_asset_movement_context(params());
+    let escrow_id = fund_live_escrow(&context.harness, 211, 53);
+    let first = release(&context, 213, &escrow_id);
+    let before = read_state_json(context.harness.state_file.as_path());
+    let retry = release(&context, 214, &escrow_id);
+    let after = read_state_json(context.harness.state_file.as_path());
+    let submissions = crate::service_api_endpoint::test_live_solana_settlement_submission_count();
+    RetryOutcome {
+        first,
+        retry,
+        before,
+        after,
+        escrow_id,
+        submissions,
+    }
+}
+
+fn release(context: &LiveSolanaAssetMovementContext, nonce: u64, escrow_id: &str) -> String {
+    release_escrow_response_with_key(
+        &context.harness.snapshot,
+        context.harness.bind_addr.as_str(),
+        context.harness.caller_did,
+        nonce,
+        escrow_id,
+        "settlement-monotonic-retry",
+    )
+}
+
+fn assert_terminal_state_unchanged(before: &Value, after: &Value, escrow_id: &str) {
+    let before_intent = &before["settlement_intents"][escrow_id];
+    let after_intent = &after["settlement_intents"][escrow_id];
+    assert_eq!(after_intent["state"], "confirmed");
+    assert_eq!(after["escrows"][escrow_id]["state"], "released");
+    assert_eq!(
+        after_intent["expected_signature"],
+        before_intent["expected_signature"]
+    );
+    assert_eq!(
+        after_intent["submission_attempt_count"],
+        before_intent["submission_attempt_count"]
+    );
+    assert_eq!(
+        after_intent["last_error_code"],
+        before_intent["last_error_code"]
+    );
+}
+
+fn params() -> LiveSolanaAssetMovementParams<'static> {
+    LiveSolanaAssetMovementParams {
+        state_file_prefix: "settlement-monotonicity",
+        caller_did: ACTOR,
+        api_bind: "127.0.0.1:34138",
+        keypair_prefix: "kamn-node-settlement-monotonicity-keypair",
+        keypair_env: "KAMN_SERVICE_API_LIVE_SOLANA_SETTLEMENT_KEYPAIR_FILE",
+        recipient_env: "KAMN_SERVICE_API_LIVE_SOLANA_SETTLEMENT_RECIPIENT_PUBKEY",
+        lamports_env: "KAMN_SERVICE_API_LIVE_SOLANA_SETTLEMENT_LAMPORTS",
+        live_rpc_env: "https://api.devnet.solana.com",
+        amount_lamports: 53,
+    }
+}

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_settlement_reconciliation_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_settlement_reconciliation_contract_tests.rs
@@ -86,23 +86,7 @@ fn integration_settlement_intent_rejects_conflicting_release_key_without_submiss
 
 #[test]
 fn integration_settlement_rejects_mismatched_confirmed_evidence_without_release() {
-    let _env = acquire_service_api_test_env();
-    let _override_guard =
-        crate::service_api_endpoint::set_test_live_solana_settlement_override(true);
-    crate::service_api_endpoint::set_test_live_solana_settlement_evidence_mismatch();
-    let context = build_live_solana_asset_movement_context(params_for("evidence-mismatch", 41));
-    let escrow_id = fund_live_escrow(&context.harness, 171, 41);
-
-    let response = release_escrow_response_with_key(
-        &context.harness.snapshot,
-        context.harness.bind_addr.as_str(),
-        context.harness.caller_did,
-        173,
-        escrow_id.as_str(),
-        "settlement-evidence-mismatch",
-    );
-    let state = read_state_json(context.harness.state_file.as_path());
-
+    let (response, state, escrow_id) = mismatched_evidence_outcome();
     assert!(
         response.contains("SETTLEMENT_EVIDENCE_MISMATCH"),
         "{response}"
@@ -115,41 +99,78 @@ fn integration_settlement_rejects_mismatched_confirmed_evidence_without_release(
     assert_ne!(state["escrows"][&escrow_id]["state"], "released");
 }
 
+fn mismatched_evidence_outcome() -> (String, Value, String) {
+    let _env = acquire_service_api_test_env();
+    let _override_guard =
+        crate::service_api_endpoint::set_test_live_solana_settlement_override(true);
+    crate::service_api_endpoint::set_test_live_solana_settlement_evidence_mismatch();
+    let context = build_live_solana_asset_movement_context(params_for("evidence-mismatch", 41));
+    let escrow_id = fund_live_escrow(&context.harness, 171, 41);
+
+    let response = release_with_key(&context, 173, &escrow_id, "settlement-evidence-mismatch");
+    let state = read_state_json(context.harness.state_file.as_path());
+    (response, state, escrow_id)
+}
+
 #[test]
 fn integration_expired_ambiguous_settlement_fails_without_resubmission() {
+    let outcome = expired_settlement_outcome();
+    assert!(outcome.first.contains("SETTLEMENT_OUTCOME_AMBIGUOUS"));
+    assert!(outcome.retry.contains("HTTP/1.1 409 Conflict"));
+    assert!(outcome.retry.contains("SETTLEMENT_TRANSACTION_EXPIRED"));
+    assert_eq!(
+        outcome.state["settlement_intents"][&outcome.escrow_id]["state"],
+        "failed"
+    );
+    assert_ne!(
+        outcome.state["escrows"][&outcome.escrow_id]["state"],
+        "released"
+    );
+    assert_eq!(outcome.submissions, 1);
+}
+
+struct ExpiredOutcome {
+    first: String,
+    retry: String,
+    state: Value,
+    escrow_id: String,
+    submissions: u64,
+}
+
+fn expired_settlement_outcome() -> ExpiredOutcome {
     let _env = acquire_service_api_test_env();
     let _override_guard =
         crate::service_api_endpoint::set_test_live_solana_settlement_ambiguous_after_submit();
     let context = build_live_solana_asset_movement_context(params_for("expired", 47));
     let escrow_id = fund_live_escrow(&context.harness, 181, 47);
-    let first = release_escrow_response_with_key(
-        &context.harness.snapshot,
-        context.harness.bind_addr.as_str(),
-        context.harness.caller_did,
-        183,
-        escrow_id.as_str(),
-        "settlement-expired",
-    );
+    let first = release_with_key(&context, 183, &escrow_id, "settlement-expired");
     crate::service_api_endpoint::set_test_live_solana_settlement_expired();
-    let retry = release_escrow_response_with_key(
+    let retry = release_with_key(&context, 184, &escrow_id, "settlement-expired");
+    let state = read_state_json(context.harness.state_file.as_path());
+    let submissions = crate::service_api_endpoint::test_live_solana_settlement_submission_count();
+    ExpiredOutcome {
+        first,
+        retry,
+        state,
+        escrow_id,
+        submissions,
+    }
+}
+
+fn release_with_key(
+    context: &LiveSolanaAssetMovementContext,
+    nonce: u64,
+    escrow_id: &str,
+    key: &str,
+) -> String {
+    release_escrow_response_with_key(
         &context.harness.snapshot,
         context.harness.bind_addr.as_str(),
         context.harness.caller_did,
-        184,
-        escrow_id.as_str(),
-        "settlement-expired",
-    );
-    let state = read_state_json(context.harness.state_file.as_path());
-
-    assert!(first.contains("SETTLEMENT_OUTCOME_AMBIGUOUS"), "{first}");
-    assert!(retry.contains("HTTP/1.1 409 Conflict"), "{retry}");
-    assert!(retry.contains("SETTLEMENT_TRANSACTION_EXPIRED"), "{retry}");
-    assert_eq!(state["settlement_intents"][&escrow_id]["state"], "failed");
-    assert_ne!(state["escrows"][&escrow_id]["state"], "released");
-    assert_eq!(
-        crate::service_api_endpoint::test_live_solana_settlement_submission_count(),
-        1
-    );
+        nonce,
+        escrow_id,
+        key,
+    )
 }
 
 fn params() -> LiveSolanaAssetMovementParams<'static> {

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_settlement_reconciliation_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_settlement_reconciliation_contract_tests.rs
@@ -111,6 +111,43 @@ fn integration_settlement_rejects_mismatched_confirmed_evidence_without_release(
     assert_ne!(state["escrows"][&escrow_id]["state"], "released");
 }
 
+#[test]
+fn integration_expired_ambiguous_settlement_fails_without_resubmission() {
+    let _env = acquire_service_api_test_env();
+    let _override_guard =
+        crate::service_api_endpoint::set_test_live_solana_settlement_ambiguous_after_submit();
+    let context = build_live_solana_asset_movement_context(params_for("expired", 47));
+    let escrow_id = fund_live_escrow(&context.harness, 181, 47);
+    let first = release_escrow_response_with_key(
+        &context.harness.snapshot,
+        context.harness.bind_addr.as_str(),
+        context.harness.caller_did,
+        183,
+        escrow_id.as_str(),
+        "settlement-expired",
+    );
+    crate::service_api_endpoint::set_test_live_solana_settlement_expired();
+    let retry = release_escrow_response_with_key(
+        &context.harness.snapshot,
+        context.harness.bind_addr.as_str(),
+        context.harness.caller_did,
+        184,
+        escrow_id.as_str(),
+        "settlement-expired",
+    );
+    let state = read_state_json(context.harness.state_file.as_path());
+
+    assert!(first.contains("SETTLEMENT_OUTCOME_AMBIGUOUS"), "{first}");
+    assert!(retry.contains("HTTP/1.1 409 Conflict"), "{retry}");
+    assert!(retry.contains("SETTLEMENT_TRANSACTION_EXPIRED"), "{retry}");
+    assert_eq!(state["settlement_intents"][&escrow_id]["state"], "failed");
+    assert_ne!(state["escrows"][&escrow_id]["state"], "released");
+    assert_eq!(
+        crate::service_api_endpoint::test_live_solana_settlement_submission_count(),
+        1
+    );
+}
+
 fn params() -> LiveSolanaAssetMovementParams<'static> {
     params_for("reconciliation", 31)
 }

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_settlement_reconciliation_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_settlement_reconciliation_contract_tests.rs
@@ -108,6 +108,10 @@ fn integration_settlement_rejects_mismatched_confirmed_evidence_without_release(
         "{response}"
     );
     assert_eq!(state["settlement_intents"][&escrow_id]["state"], "failed");
+    assert_eq!(
+        state["settlement_intents"][&escrow_id]["submission_attempt_count"],
+        1
+    );
     assert_ne!(state["escrows"][&escrow_id]["state"], "released");
 }
 

--- a/crates/kamn-node/src/service_api_endpoint.rs
+++ b/crates/kamn-node/src/service_api_endpoint.rs
@@ -8,6 +8,8 @@ mod message_store;
 mod middleware_impl;
 mod models;
 mod payload;
+#[cfg(test)]
+mod post_auth_test_gate;
 mod projection_models;
 mod runtime_observability;
 mod scope_fixture;
@@ -20,6 +22,8 @@ mod websocket;
 
 #[cfg(test)]
 pub(crate) use grant_test_support::provision_test_transaction_grant;
+#[cfg(test)]
+pub(crate) use post_auth_test_gate::{set_test_post_auth_gate, TestPostAuthGate};
 
 use crate::{
     logging::{log_info, log_warn},

--- a/crates/kamn-node/src/service_api_endpoint.rs
+++ b/crates/kamn-node/src/service_api_endpoint.rs
@@ -91,8 +91,8 @@ use websocket::ServiceApiWebsocketEventFanout;
 #[cfg(test)]
 pub(crate) use live_settlement_dispatch::{
     set_test_live_solana_settlement_ambiguous_after_submit,
-    set_test_live_solana_settlement_evidence_mismatch, set_test_live_solana_settlement_override,
-    set_test_live_solana_settlement_reconcile_confirmed,
+    set_test_live_solana_settlement_evidence_mismatch, set_test_live_solana_settlement_expired,
+    set_test_live_solana_settlement_override, set_test_live_solana_settlement_reconcile_confirmed,
     test_live_settlement_observed_prepared_intent, test_live_solana_settlement_submission_count,
 };
 

--- a/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch.rs
+++ b/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch.rs
@@ -33,7 +33,7 @@ pub(super) fn submit_or_reconcile_live_settlement(
 #[cfg(test)]
 pub(crate) use test_support::{
     set_test_live_solana_settlement_ambiguous_after_submit,
-    set_test_live_solana_settlement_evidence_mismatch, set_test_live_solana_settlement_override,
-    set_test_live_solana_settlement_reconcile_confirmed,
+    set_test_live_solana_settlement_evidence_mismatch, set_test_live_solana_settlement_expired,
+    set_test_live_solana_settlement_override, set_test_live_solana_settlement_reconcile_confirmed,
     test_live_settlement_observed_prepared_intent, test_live_solana_settlement_submission_count,
 };

--- a/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch/test_support.rs
+++ b/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch/test_support.rs
@@ -9,10 +9,12 @@ static AMBIGUOUS_AFTER_SUBMIT: AtomicBool = AtomicBool::new(false);
 static RECONCILE_CONFIRMED: AtomicBool = AtomicBool::new(false);
 static SUBMISSION_COUNT: AtomicU64 = AtomicU64::new(0);
 static EVIDENCE_MISMATCH: AtomicBool = AtomicBool::new(false);
+static EXPIRED: AtomicBool = AtomicBool::new(false);
 
 pub(crate) struct TestLiveSolanaSettlementOverrideGuard {
     previous: bool,
     previous_ambiguous: bool,
+    previous_expired: bool,
 }
 
 pub(crate) fn set_test_live_solana_settlement_override(
@@ -23,6 +25,7 @@ pub(crate) fn set_test_live_solana_settlement_override(
         .expect("override lock should not poison");
     let previous = *guard;
     let previous_ambiguous = AMBIGUOUS_AFTER_SUBMIT.swap(false, Ordering::SeqCst);
+    let previous_expired = EXPIRED.swap(false, Ordering::SeqCst);
     *guard = enabled;
     OBSERVED_PREPARED_INTENT.store(false, Ordering::SeqCst);
     RECONCILE_CONFIRMED.store(false, Ordering::SeqCst);
@@ -31,6 +34,7 @@ pub(crate) fn set_test_live_solana_settlement_override(
     TestLiveSolanaSettlementOverrideGuard {
         previous,
         previous_ambiguous,
+        previous_expired,
     }
 }
 
@@ -41,6 +45,11 @@ pub(crate) fn set_test_live_solana_settlement_reconcile_confirmed() {
 
 pub(crate) fn set_test_live_solana_settlement_evidence_mismatch() {
     EVIDENCE_MISMATCH.store(true, Ordering::SeqCst);
+}
+
+pub(crate) fn set_test_live_solana_settlement_expired() {
+    AMBIGUOUS_AFTER_SUBMIT.store(false, Ordering::SeqCst);
+    EXPIRED.store(true, Ordering::SeqCst);
 }
 
 pub(crate) fn test_live_solana_settlement_submission_count() -> u64 {
@@ -89,6 +98,9 @@ pub(crate) fn maybe_submit_test_live_settlement(
     if RECONCILE_CONFIRMED.load(Ordering::SeqCst) {
         return Some(Ok(success_evidence(config, prepared)));
     }
+    if EXPIRED.load(Ordering::SeqCst) {
+        return Some(Err("SETTLEMENT_TRANSACTION_EXPIRED".to_owned()));
+    }
     SUBMISSION_COUNT.fetch_add(1, Ordering::SeqCst);
     if AMBIGUOUS_AFTER_SUBMIT.load(Ordering::SeqCst) {
         return Some(Err("SETTLEMENT_OUTCOME_AMBIGUOUS".to_owned()));
@@ -125,6 +137,7 @@ impl Drop for TestLiveSolanaSettlementOverrideGuard {
             .expect("override lock should not poison");
         *guard = self.previous;
         AMBIGUOUS_AFTER_SUBMIT.store(self.previous_ambiguous, Ordering::SeqCst);
+        EXPIRED.store(self.previous_expired, Ordering::SeqCst);
     }
 }
 

--- a/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch/transport.rs
+++ b/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch/transport.rs
@@ -84,6 +84,7 @@ fn submit_or_reconcile_live_settlement_via_rpc(
             prepared,
         ));
     }
+    require_resubmittable_blockhash(blockhash_is_valid(&client, &transaction, config)?)?;
     let signature = submit_live_settlement_transaction(&client, &transaction)?;
     if signature.to_string() != prepared.expected_signature {
         return Err("live solana settlement submitted signature mismatch".to_owned());
@@ -95,6 +96,25 @@ fn submit_or_reconcile_live_settlement_via_rpc(
         config.commitment_label.as_str(),
         prepared,
     ))
+}
+
+fn blockhash_is_valid(
+    client: &RpcClient,
+    transaction: &solana_sdk::transaction::Transaction,
+    config: &LiveSolanaSettlementConfig,
+) -> Result<bool, String> {
+    client
+        .is_blockhash_valid(&transaction.message.recent_blockhash, config.commitment)
+        .map_err(|error| {
+            format!("SETTLEMENT_OUTCOME_AMBIGUOUS: blockhash validity lookup failed: {error}")
+        })
+}
+
+fn require_resubmittable_blockhash(valid: bool) -> Result<(), String> {
+    if valid {
+        return Ok(());
+    }
+    Err("SETTLEMENT_TRANSACTION_EXPIRED".to_owned())
 }
 
 fn require_confirmation(confirmed: bool, commitment: &str) -> Result<(), String> {

--- a/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch/transport.rs
+++ b/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch/transport.rs
@@ -9,6 +9,11 @@ use std::time::Duration;
 
 mod transaction;
 use transaction::{build_live_settlement_transaction, validate_prepared_transaction};
+#[path = "transport_recovery.rs"]
+mod transport_recovery;
+use transport_recovery::{
+    blockhash_is_valid, reconcile_known_signature, require_resubmittable_blockhash,
+};
 
 pub(super) fn prepare_live_settlement(
     config: &LiveSolanaSettlementConfig,
@@ -67,54 +72,37 @@ fn submit_or_reconcile_live_settlement_via_rpc(
     prepared: &PreparedLiveSettlement,
     escrow_id: &str,
 ) -> Result<LiveSettlementEvidence, String> {
-    validate_prepared_config(config, prepared)?;
-    let transaction: solana_sdk::transaction::Transaction =
-        serde_json::from_str(prepared.signed_transaction_json.as_str()).map_err(|error| {
-            format!("live solana settlement transaction decode failed: {error}")
-        })?;
-    validate_prepared_transaction(&transaction, prepared, escrow_id)?;
+    let (transaction, expected_signature) = validated_transaction(config, prepared, escrow_id)?;
     let client = settlement_rpc_client(config);
-    let expected_signature =
-        solana_sdk::signature::Signature::from_str(prepared.expected_signature.as_str())
-            .map_err(|error| format!("live solana settlement signature decode failed: {error}"))?;
     if reconcile_known_signature(&client, &expected_signature, config)? {
-        return Ok(build_live_settlement_evidence(
-            prepared.expected_signature.clone(),
-            config.commitment_label.as_str(),
-            prepared,
-        ));
+        return Ok(settlement_evidence(config, prepared));
     }
     require_resubmittable_blockhash(blockhash_is_valid(&client, &transaction, config)?)?;
     let signature = submit_live_settlement_transaction(&client, &transaction)?;
-    if signature.to_string() != prepared.expected_signature {
-        return Err("live solana settlement submitted signature mismatch".to_owned());
-    }
+    require_expected_signature(&signature, prepared)?;
     let confirmed = confirm_live_settlement_signature(&client, &signature, config)?;
     require_confirmation(confirmed, config.commitment_label.as_str())?;
-    Ok(build_live_settlement_evidence(
-        signature.to_string(),
-        config.commitment_label.as_str(),
-        prepared,
-    ))
+    Ok(settlement_evidence(config, prepared))
 }
 
-fn blockhash_is_valid(
-    client: &RpcClient,
-    transaction: &solana_sdk::transaction::Transaction,
+fn validated_transaction(
     config: &LiveSolanaSettlementConfig,
-) -> Result<bool, String> {
-    client
-        .is_blockhash_valid(&transaction.message.recent_blockhash, config.commitment)
-        .map_err(|error| {
-            format!("SETTLEMENT_OUTCOME_AMBIGUOUS: blockhash validity lookup failed: {error}")
-        })
-}
-
-fn require_resubmittable_blockhash(valid: bool) -> Result<(), String> {
-    if valid {
-        return Ok(());
-    }
-    Err("SETTLEMENT_TRANSACTION_EXPIRED".to_owned())
+    prepared: &PreparedLiveSettlement,
+    escrow_id: &str,
+) -> Result<
+    (
+        solana_sdk::transaction::Transaction,
+        solana_sdk::signature::Signature,
+    ),
+    String,
+> {
+    validate_prepared_config(config, prepared)?;
+    let transaction = serde_json::from_str(prepared.signed_transaction_json.as_str())
+        .map_err(|error| format!("live solana settlement transaction decode failed: {error}"))?;
+    validate_prepared_transaction(&transaction, prepared, escrow_id)?;
+    let signature = solana_sdk::signature::Signature::from_str(&prepared.expected_signature)
+        .map_err(|error| format!("live solana settlement signature decode failed: {error}"))?;
+    Ok((transaction, signature))
 }
 
 fn require_confirmation(confirmed: bool, commitment: &str) -> Result<(), String> {
@@ -126,19 +114,25 @@ fn require_confirmation(confirmed: bool, commitment: &str) -> Result<(), String>
     ))
 }
 
-fn reconcile_known_signature(
-    client: &RpcClient,
+fn require_expected_signature(
     signature: &solana_sdk::signature::Signature,
-    config: &LiveSolanaSettlementConfig,
-) -> Result<bool, String> {
-    let status = client
-        .get_signature_status_with_commitment_and_history(signature, config.commitment, true)
-        .map_err(|error| format!("live solana settlement status lookup failed: {error}"))?;
-    match status {
-        Some(Ok(())) => Ok(true),
-        Some(Err(error)) => Err(format!("SETTLEMENT_TRANSACTION_FAILED: {error}")),
-        None => Ok(false),
+    prepared: &PreparedLiveSettlement,
+) -> Result<(), String> {
+    if signature.to_string() == prepared.expected_signature {
+        return Ok(());
     }
+    Err("live solana settlement submitted signature mismatch".to_owned())
+}
+
+fn settlement_evidence(
+    config: &LiveSolanaSettlementConfig,
+    prepared: &PreparedLiveSettlement,
+) -> LiveSettlementEvidence {
+    build_live_settlement_evidence(
+        prepared.expected_signature.clone(),
+        config.commitment_label.as_str(),
+        prepared,
+    )
 }
 
 fn validate_prepared_config(

--- a/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch/transport_recovery.rs
+++ b/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch/transport_recovery.rs
@@ -1,0 +1,35 @@
+use super::*;
+
+pub(super) fn blockhash_is_valid(
+    client: &RpcClient,
+    transaction: &solana_sdk::transaction::Transaction,
+    config: &LiveSolanaSettlementConfig,
+) -> Result<bool, String> {
+    client
+        .is_blockhash_valid(&transaction.message.recent_blockhash, config.commitment)
+        .map_err(|error| {
+            format!("SETTLEMENT_OUTCOME_AMBIGUOUS: blockhash validity lookup failed: {error}")
+        })
+}
+
+pub(super) fn require_resubmittable_blockhash(valid: bool) -> Result<(), String> {
+    if valid {
+        return Ok(());
+    }
+    Err("SETTLEMENT_TRANSACTION_EXPIRED".to_owned())
+}
+
+pub(super) fn reconcile_known_signature(
+    client: &RpcClient,
+    signature: &solana_sdk::signature::Signature,
+    config: &LiveSolanaSettlementConfig,
+) -> Result<bool, String> {
+    let status = client
+        .get_signature_status_with_commitment_and_history(signature, config.commitment, true)
+        .map_err(|error| format!("live solana settlement status lookup failed: {error}"))?;
+    match status {
+        Some(Ok(())) => Ok(true),
+        Some(Err(error)) => Err(format!("SETTLEMENT_TRANSACTION_FAILED: {error}")),
+        None => Ok(false),
+    }
+}

--- a/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch/transport_tests.rs
+++ b/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch/transport_tests.rs
@@ -24,6 +24,18 @@ fn escrow_binding_makes_same_blockhash_transfers_unique() {
 }
 
 #[test]
+fn expired_persisted_transaction_is_not_resubmittable() {
+    let error = require_resubmittable_blockhash(false).expect_err("expired blockhash must fail");
+
+    assert_eq!(error, "SETTLEMENT_TRANSACTION_EXPIRED");
+}
+
+#[test]
+fn valid_persisted_transaction_remains_resubmittable() {
+    require_resubmittable_blockhash(true).expect("valid blockhash should remain resubmittable");
+}
+
+#[test]
 fn persisted_transaction_integrity_rejects_tampering() {
     let payer = Keypair::new();
     let recipient = Pubkey::new_unique();

--- a/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops.rs
@@ -76,6 +76,10 @@ impl ServiceApiMessageStore {
         settlement_intent::mark_failed(self, escrow_id, error_code)
     }
 
+    pub(crate) fn mark_settlement_expired(&mut self, escrow_id: &str) -> Result<(), String> {
+        settlement_intent::mark_expired(self, escrow_id)
+    }
+
     pub(crate) fn fund_bound_escrow(
         &mut self,
         actor: &str,

--- a/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/settlement_intent.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/settlement_intent.rs
@@ -90,6 +90,21 @@ pub(super) fn mark_failed(
     store.persist()
 }
 
+pub(super) fn mark_expired(
+    store: &mut ServiceApiMessageStore,
+    escrow_id: &str,
+) -> Result<(), String> {
+    store.refresh_from_disk()?;
+    let intent = store
+        .snapshot
+        .settlement_intents
+        .get_mut(escrow_id)
+        .ok_or_else(|| "settlement intent missing during expiration".to_owned())?;
+    intent.state = "failed".to_owned();
+    intent.last_error_code = Some("SETTLEMENT_TRANSACTION_EXPIRED".to_owned());
+    store.persist()
+}
+
 fn validate_agreement(
     store: &ServiceApiMessageStore,
     escrow_id: &str,

--- a/crates/kamn-node/src/service_api_endpoint/middleware_impl/auth_flow/guards/request_validation.rs
+++ b/crates/kamn-node/src/service_api_endpoint/middleware_impl/auth_flow/guards/request_validation.rs
@@ -30,7 +30,9 @@ pub(super) async fn validate_request(
     .await?;
     drop(replay_guard);
     #[cfg(test)]
-    super::super::super::super::post_auth_test_gate::wait_at_test_post_auth_gate();
+    super::super::super::super::post_auth_test_gate::wait_at_test_post_auth_gate(
+        parsed_request.path.as_str(),
+    );
     policy_checks::validate_websocket_requirements(
         state,
         parsed_request,

--- a/crates/kamn-node/src/service_api_endpoint/middleware_impl/auth_flow/guards/request_validation.rs
+++ b/crates/kamn-node/src/service_api_endpoint/middleware_impl/auth_flow/guards/request_validation.rs
@@ -29,6 +29,8 @@ pub(super) async fn validate_request(
     )
     .await?;
     drop(replay_guard);
+    #[cfg(test)]
+    super::super::super::super::post_auth_test_gate::wait_at_test_post_auth_gate();
     policy_checks::validate_websocket_requirements(
         state,
         parsed_request,

--- a/crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/mutations/update_routes/state_routes_release/live_settlement.rs
+++ b/crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/mutations/update_routes/state_routes_release/live_settlement.rs
@@ -3,7 +3,7 @@ use super::*;
 mod errors;
 use errors::{
     invalid_release_key, settlement_evidence_mismatch_error, settlement_intent_conflict_error,
-    settlement_outcome_ambiguous_error,
+    settlement_outcome_ambiguous_error, settlement_transaction_expired_error,
 };
 
 pub(super) async fn release(
@@ -78,6 +78,16 @@ fn submit(
                     ))
                 })?;
             Err(Box::new(settlement_outcome_ambiguous_error()))
+        }
+        Err(error) if error == "SETTLEMENT_TRANSACTION_EXPIRED" => {
+            store
+                .mark_settlement_expired(escrow_id)
+                .map_err(|persist_error| {
+                    Box::new(super::super::super::super::persistence_error(
+                        persist_error.as_str(),
+                    ))
+                })?;
+            Err(Box::new(settlement_transaction_expired_error()))
         }
         Err(error) => Err(Box::new(live_settlement_evidence_error(error.as_str()))),
     }

--- a/crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/mutations/update_routes/state_routes_release/live_settlement.rs
+++ b/crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/mutations/update_routes/state_routes_release/live_settlement.rs
@@ -70,27 +70,39 @@ fn submit(
     {
         Ok(evidence) => Ok(evidence),
         Err(error) if error.starts_with("SETTLEMENT_OUTCOME_AMBIGUOUS") => {
-            store
-                .mark_settlement_outcome_ambiguous(escrow_id)
-                .map_err(|persist_error| {
-                    Box::new(super::super::super::super::persistence_error(
-                        persist_error.as_str(),
-                    ))
-                })?;
+            persist_ambiguous(store, escrow_id)?;
             Err(Box::new(settlement_outcome_ambiguous_error()))
         }
         Err(error) if error == "SETTLEMENT_TRANSACTION_EXPIRED" => {
-            store
-                .mark_settlement_expired(escrow_id)
-                .map_err(|persist_error| {
-                    Box::new(super::super::super::super::persistence_error(
-                        persist_error.as_str(),
-                    ))
-                })?;
+            persist_expired(store, escrow_id)?;
             Err(Box::new(settlement_transaction_expired_error()))
         }
         Err(error) => Err(Box::new(live_settlement_evidence_error(error.as_str()))),
     }
+}
+
+fn persist_ambiguous(
+    store: &mut ServiceApiMessageStore,
+    escrow_id: &str,
+) -> Result<(), Box<Response>> {
+    store
+        .mark_settlement_outcome_ambiguous(escrow_id)
+        .map_err(persistence_error)
+}
+
+fn persist_expired(
+    store: &mut ServiceApiMessageStore,
+    escrow_id: &str,
+) -> Result<(), Box<Response>> {
+    store
+        .mark_settlement_expired(escrow_id)
+        .map_err(persistence_error)
+}
+
+fn persistence_error(error: String) -> Box<Response> {
+    Box::new(super::super::super::super::persistence_error(
+        error.as_str(),
+    ))
 }
 
 fn validate_evidence(

--- a/crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/mutations/update_routes/state_routes_release/live_settlement/errors.rs
+++ b/crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/mutations/update_routes/state_routes_release/live_settlement/errors.rs
@@ -27,6 +27,15 @@ pub(super) fn settlement_intent_conflict_error() -> Response {
     )
 }
 
+pub(super) fn settlement_transaction_expired_error() -> Response {
+    json_error(
+        StatusCode::CONFLICT,
+        "conflict",
+        "SETTLEMENT_TRANSACTION_EXPIRED",
+        "persisted settlement transaction expired before confirmation",
+    )
+}
+
 pub(super) fn invalid_release_key(message: &str) -> Response {
     json_error(
         StatusCode::BAD_REQUEST,

--- a/crates/kamn-node/src/service_api_endpoint/post_auth_test_gate.rs
+++ b/crates/kamn-node/src/service_api_endpoint/post_auth_test_gate.rs
@@ -1,0 +1,103 @@
+use std::sync::{Arc, Condvar, Mutex};
+use std::time::{Duration, Instant};
+
+static ACTIVE_GATE: Mutex<Option<Arc<GateState>>> = Mutex::new(None);
+
+struct GateState {
+    state: Mutex<GateProgress>,
+    changed: Condvar,
+}
+
+#[derive(Default)]
+struct GateProgress {
+    arrivals: usize,
+    released: bool,
+}
+
+pub(crate) struct TestPostAuthGate {
+    state: Arc<GateState>,
+}
+
+pub(crate) fn set_test_post_auth_gate() -> TestPostAuthGate {
+    let state = Arc::new(GateState {
+        state: Mutex::new(GateProgress::default()),
+        changed: Condvar::new(),
+    });
+    *active_gate()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(state.clone());
+    TestPostAuthGate { state }
+}
+
+pub(crate) fn wait_at_test_post_auth_gate() {
+    let state = active_gate()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .clone();
+    if let Some(state) = state {
+        state.arrive_and_wait();
+    }
+}
+
+impl TestPostAuthGate {
+    pub(crate) fn expect_arrivals(&self, expected: usize) {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let mut progress = self.lock_progress();
+        while progress.arrivals < expected {
+            let timeout = deadline.saturating_duration_since(Instant::now());
+            let waited = self
+                .state
+                .changed
+                .wait_timeout(progress, timeout)
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            progress = waited.0;
+            assert!(
+                !waited.1.timed_out(),
+                "post-auth gate expected {expected} arrivals"
+            );
+        }
+    }
+
+    pub(crate) fn release(&self) {
+        let mut progress = self.lock_progress();
+        progress.released = true;
+        self.state.changed.notify_all();
+    }
+
+    fn lock_progress(&self) -> std::sync::MutexGuard<'_, GateProgress> {
+        self.state
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+}
+
+impl GateState {
+    fn arrive_and_wait(&self) {
+        let mut progress = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        progress.arrivals += 1;
+        self.changed.notify_all();
+        while !progress.released {
+            progress = self
+                .changed
+                .wait(progress)
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+        }
+    }
+}
+
+impl Drop for TestPostAuthGate {
+    fn drop(&mut self) {
+        self.release();
+        *active_gate()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = None;
+    }
+}
+
+fn active_gate() -> &'static Mutex<Option<Arc<GateState>>> {
+    &ACTIVE_GATE
+}

--- a/crates/kamn-node/src/service_api_endpoint/post_auth_test_gate.rs
+++ b/crates/kamn-node/src/service_api_endpoint/post_auth_test_gate.rs
@@ -4,6 +4,7 @@ use std::time::{Duration, Instant};
 static ACTIVE_GATE: Mutex<Option<Arc<GateState>>> = Mutex::new(None);
 
 struct GateState {
+    target_path: String,
     state: Mutex<GateProgress>,
     changed: Condvar,
 }
@@ -18,8 +19,9 @@ pub(crate) struct TestPostAuthGate {
     state: Arc<GateState>,
 }
 
-pub(crate) fn set_test_post_auth_gate() -> TestPostAuthGate {
+pub(crate) fn set_test_post_auth_gate(target_path: &str) -> TestPostAuthGate {
     let state = Arc::new(GateState {
+        target_path: target_path.to_owned(),
         state: Mutex::new(GateProgress::default()),
         changed: Condvar::new(),
     });
@@ -29,12 +31,12 @@ pub(crate) fn set_test_post_auth_gate() -> TestPostAuthGate {
     TestPostAuthGate { state }
 }
 
-pub(crate) fn wait_at_test_post_auth_gate() {
+pub(crate) fn wait_at_test_post_auth_gate(request_path: &str) {
     let state = active_gate()
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner)
         .clone();
-    if let Some(state) = state {
+    if let Some(state) = state.filter(|gate| gate.target_path == request_path) {
         state.arrive_and_wait();
     }
 }

--- a/specs/7104-agent-transaction-failure-matrix.md
+++ b/specs/7104-agent-transaction-failure-matrix.md
@@ -1,0 +1,164 @@
+# Issue 7104: Agent Transaction Failure Matrix
+
+## Objective
+
+Prove that the canonical agent transaction remains at-most-once and
+state-monotonic across restart, retry, concurrency, ambiguous Solana outcomes,
+agent exit, and proof-generation failure. Close the residual stale-blockhash
+gap without generating a replacement transaction signature.
+
+## Inputs And Outputs
+
+Inputs:
+
+- Persisted task, authorization grant, escrow agreement, settlement intent,
+  signed Solana devnet transaction, and runtime actor receipts.
+- Two independently authorized release requests carrying the same release key.
+- Solana signature status, prepared transaction blockhash validity, and bounded
+  submit/confirmation outcomes.
+- Canonical demo proof generation after settlement has already completed.
+
+Outputs:
+
+- One durable settlement signature and one monotonic terminal escrow state.
+- Explicit `NO-GO` or structured settlement errors for unresolved paths.
+- Restarted/retried execution that reconciles persisted identity before any
+  network submission.
+- Proof regeneration that reads persisted evidence and performs zero settlement
+  submissions.
+
+## Boundaries And Non-Goals
+
+- Reuse the #7092 settlement intent, service API state file, Solana adapter,
+  supervisor, and proof verifier surfaces.
+- Do not add a workflow engine, database schema, replacement-signature flow,
+  generalized recovery coordinator, or new dependency.
+- Solana devnet only. Mainnet custody, production HA, multi-region consensus,
+  refund/dispute handling, and economic-value claims remain out of scope.
+- A never-landed expired transaction is terminal for this bounded intent. An
+  operator-created replacement transaction is roadmap work and is not claimed.
+- Test-only adapters may model RPC boundaries, but integration tests must use
+  the real service API persistence and request paths.
+
+## Failure Modes
+
+- Restart loses task agreement, authorization grant, escrow, nonce history, or
+  settlement intent.
+- Retry submits before querying the persisted signature.
+- A signature absent from RPC is blindly resubmitted after its recent blockhash
+  has expired.
+- Two authorized release requests create different signatures or more than one
+  submission identity.
+- Post-submit ambiguity or local persistence failure reports `released`.
+- A confirmed settlement rolls back to `prepared`, `submitted`, `ambiguous`, or
+  an unreleased escrow state.
+- Proof generation or proof retry invokes the settlement adapter.
+- Agent failure leaves child processes alive or emits a successful proof report.
+
+## Error Semantics
+
+- Signature status unknown while the persisted blockhash is still valid:
+  `SETTLEMENT_OUTCOME_AMBIGUOUS` (503), with no release claim.
+- Signature absent and the persisted transaction blockhash is expired:
+  `SETTLEMENT_TRANSACTION_EXPIRED` (409), intent state `failed`, no resubmission,
+  and no replacement signature.
+- Confirmed on retry: reconcile the persisted signature and finalize once.
+- Conflicting agreement/release identity: existing
+  `SETTLEMENT_INTENT_CONFLICT` (409), without adapter invocation.
+- Proof failure: `AGENT_TRANSACTION_PROOF_INVALID` and `NO-GO`; persisted
+  settlement and escrow facts remain unchanged.
+- Interior errors remain typed/stable strings; HTTP and supervisor entrypoints
+  translate and log once without swallowing causes.
+
+## Acceptance Criteria
+
+- [ ] Restart after task creation preserves agreement and authorization state.
+- [ ] Restart after escrow funding preserves the task-bound funded escrow.
+- [ ] Restart from prepared, ambiguous, or submitted-equivalent intent queries
+  the known signature before any same-transaction resubmission.
+- [ ] Crash/ambiguity after transfer submission cannot create a second
+  transaction identity or duplicate asset movement.
+- [ ] Two independently authorized concurrent releases converge on one persisted
+  signature and at most one network submission.
+- [ ] Stale nonce/replay remains rejected after state reload.
+- [ ] RPC timeout followed by later confirmation reconciles to released.
+- [ ] A never-landed expired transaction becomes
+  `SETTLEMENT_TRANSACTION_EXPIRED` without resubmission or replacement.
+- [ ] Agent exit mid-flow emits `NO-GO` and cleans every child process.
+- [ ] Proof generation failure and retry perform zero settlement submissions.
+- [ ] Settled intent and escrow state cannot roll back on restart or retry.
+- [ ] Focused failure matrix, funded devnet rehearsal, security review,
+  formatting, strict clippy, `make check`, and `make test` pass.
+
+## Files To Touch
+
+- `crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch/`
+  for status-first blockhash-validity classification at the RPC boundary.
+- `crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/`
+  only where monotonic transition enforcement is missing.
+- Existing service API settlement persistence/reconciliation/concurrency tests
+  under `crates/kamn-node/src/main_tests/service_api_endpoint_tests/`.
+- Existing canonical transaction supervisor/proof tests under
+  `crates/kamn-e2e-harness/tests/` when proof retry coverage is absent.
+- This spec only; no schema, workflow, dependency, or README changes.
+
+## Test Plan
+
+### RED
+
+1. Reload a funded task/escrow snapshot and assert agreement, grant, escrow, and
+   replay nonce continuity.
+2. Race two valid, distinct-nonce releases for the same release key and assert
+   one signature rather than relying on replay rejection.
+3. Model `signature_status=None` plus `blockhash_valid=false`; assert the current
+   adapter resubmits or remains ambiguous, then require terminal expiration with
+   submission count unchanged.
+4. Model post-submit ambiguity, restart, and later confirmation; require one
+   submission identity and monotonic finalization.
+5. Fail proof writing after confirmed settlement, retry proof generation, and
+   assert the settlement submission counter remains unchanged.
+6. Reload settled state and attempt stale replay/transition; require rejection
+   with the settled escrow and intent unchanged.
+
+### GREEN
+
+- Add the minimal RPC-boundary blockhash-validity classification for a persisted
+  prepared transaction.
+- Mark proven-expired, never-landed intents failed with the stable expiration
+  code; never build a replacement transaction.
+- Add only the transition guards and test hooks needed to make restart,
+  concurrency, and proof-retry behavior observable.
+
+### REFACTOR
+
+- Keep preparation, status lookup, blockhash classification, submission,
+  confirmation, and state transition responsibilities separate.
+- Keep files below 200 lines and functions below 25 lines.
+- Remove duplicate test setup by extending existing settlement fixtures.
+
+### INTEGRATION
+
+```bash
+cargo test -p kamn-node agent_transaction_failure_matrix
+cargo test -p kamn-node task_escrow_settlement
+cargo test -p kamn-e2e-harness --test agent_transaction_demo_supervisor_contract
+cargo test -p kamn-e2e-harness --test agent_transaction_demo_success_contract
+cargo fmt --check
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+make check
+make test
+```
+
+Run one bounded funded Solana devnet rehearsal using a fresh release key and the
+existing configured payer/recipient. Record signature, recipient, lamports,
+commitment, balances, persisted intent, canonical verifier output, and proof
+report. If devnet RPC, faucet, or funding blocks the run, record explicit
+`NO-GO`; do not claim live completion.
+
+## Rollback
+
+- Preserve RED, GREEN, REFACTOR, and integration commits separately.
+- Keep a deterministic-test checkpoint before any funded rehearsal.
+- Never delete `submitted`, `ambiguous`, confirmed, or expired settlement state.
+- Before rollback or another live attempt, reconcile every persisted signature
+  and retain any finalized devnet transaction as audit evidence.

--- a/specs/7104-agent-transaction-failure-matrix.md
+++ b/specs/7104-agent-transaction-failure-matrix.md
@@ -13,7 +13,9 @@ Inputs:
 
 - Persisted task, authorization grant, escrow agreement, settlement intent,
   signed Solana devnet transaction, and runtime actor receipts.
-- Two independently authorized release requests carrying the same release key.
+- Two separately signed release requests from the configured release authority,
+  carrying distinct fresh nonces and the same release key. Multiple release
+  principals are not claimed by the current single-authority schema.
 - Solana signature status, prepared transaction blockhash validity, and bounded
   submit/confirmation outcomes.
 - Canonical demo proof generation after settlement has already completed.
@@ -37,6 +39,9 @@ Outputs:
   refund/dispute handling, and economic-value claims remain out of scope.
 - A never-landed expired transaction is terminal for this bounded intent. An
   operator-created replacement transaction is roadmap work and is not claimed.
+- While the persisted recent blockhash remains valid, recovery may rebroadcast
+  the exact persisted signed bytes. This preserves the signature and transaction
+  identity; building or signing a replacement transaction remains prohibited.
 - Test-only adapters may model RPC boundaries, but integration tests must use
   the real service API persistence and request paths.
 
@@ -57,8 +62,9 @@ Outputs:
 
 ## Error Semantics
 
-- Signature status unknown while the persisted blockhash is still valid:
-  `SETTLEMENT_OUTCOME_AMBIGUOUS` (503), with no release claim.
+- Signature status unknown while the persisted blockhash is still valid: the
+  exact persisted signed bytes may be rebroadcast, but the outcome remains
+  `SETTLEMENT_OUTCOME_AMBIGUOUS` (503) until confirmation, with no release claim.
 - Signature absent and the persisted transaction blockhash is expired:
   `SETTLEMENT_TRANSACTION_EXPIRED` (409), intent state `failed`, no resubmission,
   and no replacement signature.
@@ -72,22 +78,22 @@ Outputs:
 
 ## Acceptance Criteria
 
-- [ ] Restart after task creation preserves agreement and authorization state.
-- [ ] Restart after escrow funding preserves the task-bound funded escrow.
-- [ ] Restart from prepared, ambiguous, or submitted-equivalent intent queries
+- [x] Restart after task creation preserves agreement and authorization state.
+- [x] Restart after escrow funding preserves the task-bound funded escrow.
+- [x] Restart from prepared, ambiguous, or submitted-equivalent intent queries
   the known signature before any same-transaction resubmission.
-- [ ] Crash/ambiguity after transfer submission cannot create a second
+- [x] Crash/ambiguity after transfer submission cannot create a second
   transaction identity or duplicate asset movement.
-- [ ] Two independently authorized concurrent releases converge on one persisted
-  signature and at most one network submission.
-- [ ] Stale nonce/replay remains rejected after state reload.
-- [ ] RPC timeout followed by later confirmation reconciles to released.
-- [ ] A never-landed expired transaction becomes
+- [x] Two separately signed, fresh-nonce concurrent releases from the configured
+  authority converge on one persisted signature and at most one submission.
+- [x] Stale nonce/replay remains rejected after state reload.
+- [x] RPC timeout followed by later confirmation reconciles to released.
+- [x] A never-landed expired transaction becomes
   `SETTLEMENT_TRANSACTION_EXPIRED` without resubmission or replacement.
-- [ ] Agent exit mid-flow emits `NO-GO` and cleans every child process.
-- [ ] Proof generation failure and retry perform zero settlement submissions.
-- [ ] Settled intent and escrow state cannot roll back on restart or retry.
-- [ ] Focused failure matrix, funded devnet rehearsal, security review,
+- [x] Agent exit mid-flow emits `NO-GO` and cleans every child process.
+- [x] Proof generation failure and retry perform zero settlement submissions.
+- [x] Settled intent and escrow state cannot roll back on restart or retry.
+- [x] Focused failure matrix, funded devnet rehearsal, security review,
   formatting, strict clippy, `make check`, and `make test` pass.
 
 ## Files To Touch
@@ -154,6 +160,28 @@ existing configured payer/recipient. Record signature, recipient, lamports,
 commitment, balances, persisted intent, canonical verifier output, and proof
 report. If devnet RPC, faucet, or funding blocks the run, record explicit
 `NO-GO`; do not claim live completion.
+
+## Completion Evidence
+
+- `cargo test -p kamn-node --bin kamn-node -- --test-threads=1`: 683 passed,
+  0 failed, 1 ignored live-only test.
+- Focused `task_escrow_settlement` node tests: 7 passed, including restart,
+  expiration, concurrency, and monotonic settlement contracts.
+- Harness success, supervisor, proof-retry, formatting, strict workspace clippy,
+  `make check`, touched-Rust size policy, and full `make test`: PASS.
+- Funded Pi-driven rehearsal `run-92170-1783942418124`: `GO`, Solana devnet
+  transfer of 1,000,000 lamports finalized as signature
+  `VhsBkxsv71vyLakUrWvdgLidUjed31WFMVzYhPPwwp7M2or2XxnS9HMSaBxCuzWfmDGqZ8LpZwFfrm9zuqzNnVB`.
+- Payer balance moved from 2,456,785,000 to 2,455,780,000 lamports; recipient
+  balance moved from 2,543,000,000 to 2,544,000,000 lamports. The 5,000-lamport
+  payer delta beyond the transfer amount is the Solana transaction fee.
+- Agents A and B produced `participant-private` projections with three private
+  fields each. Agent C produced a `restricted-public` projection with zero
+  private fields while independently matching the task, escrow, amount, public
+  commitment, finalized signature, and network.
+- Canonical `verify-mvp-demo` against `.kamn/demo/latest/proof/report.json`:
+  `PASS`.
+- Production readiness remains explicitly `NOT_CLAIMED`.
 
 ## Rollback
 


### PR DESCRIPTION
## Human Summary

- Makes Solana settlement recovery status-first and classifies never-landed expired transactions as terminal without creating a replacement transaction.
- Preserves one settlement identity across restart, retry, and fresh-nonce concurrent releases, including exact-byte rebroadcast only while the original blockhash remains valid.
- Proves confirmed settlement cannot roll back and proof regeneration cannot resubmit value movement.
- Records a funded three-Pi-agent devnet rehearsal with participant-private A/B views and a restricted-public C verifier view.

Closes #7104

Spec: [specs/7104-agent-transaction-failure-matrix.md](https://github.com/njfio/kamn/blob/7104-agent-transaction-failure-matrix/specs/7104-agent-transaction-failure-matrix.md)

## Testing

- `CARGO_TARGET_DIR=target/mvp-demo-proof cargo test -p kamn-node --bin kamn-node -- --test-threads=1` (683 passed, 1 ignored live-only test)
- `CARGO_TARGET_DIR=target/mvp-demo-proof cargo test -p kamn-node --bin kamn-node task_escrow_settlement -- --test-threads=1` (7 passed)
- `CARGO_TARGET_DIR=target/mvp-demo-proof cargo test -p kamn-e2e-harness --test agent_transaction_demo_success_contract -- --test-threads=1`
- `CARGO_TARGET_DIR=target/mvp-demo-proof cargo test -p kamn-e2e-harness --test agent_transaction_demo_supervisor_contract -- --test-threads=1`
- `CARGO_TARGET_DIR=target/mvp-demo-proof cargo test -p kamn-e2e-harness --lib proof_retry_reuses_persisted_settlement_without_submission -- --test-threads=1`
- `cargo fmt --check`
- `CARGO_TARGET_DIR=target/mvp-demo-proof cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `CARGO_TARGET_DIR=target/mvp-demo-proof make check`
- `CARGO_TARGET_DIR=target/mvp-demo-proof make test`
- Funded `KAMN_MVP_AGENT_DRIVER=pi make demo-agent-transaction`: GO; 1,000,000 lamports finalized on Solana devnet as `VhsBkxsv71vyLakUrWvdgLidUjed31WFMVzYhPPwwp7M2or2XxnS9HMSaBxCuzWfmDGqZ8LpZwFfrm9zuqzNnVB`
- `CARGO_TARGET_DIR=target/mvp-demo-proof cargo run -p kamn-e2e-harness -- verify-mvp-demo --report .kamn/demo/latest/proof/report.json`: PASS
- Independent Solana `getSignatureStatuses`: finalized, `err: null`, slot `475964288`

## Notes for Reviewers

The configured service has one release authority. The concurrency proof covers two separately signed requests with distinct fresh nonces from that authority, not two release principals. Recovery may rebroadcast only the exact persisted signed bytes while the original blockhash is valid; replacement signatures remain out of scope.

Production readiness, mainnet custody, multi-authority release, refunds/disputes, and replacement transactions are not claimed.

## AI Agent Details

- Settlement recovery is split between status lookup, blockhash classification, exact-byte rebroadcast, confirmation, and persistence translation.
- Route-scoped post-auth test coordination makes the fresh-nonce concurrency race deterministic without altering unrelated requests.
- Proof retry reuses persisted actor and settlement artifacts and asserts zero send/transfer calls.
- Touched Rust size policy passes; no shell, workflow, schema, dependency, or README surface changed.