### PR TITLE
[7121] Publish MVP planning artifacts and restore repository hygiene

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__/
 *.pyc
 *.pyo
 *.pyd
+*.egg-info/

--- a/crates/kamn-e2e-harness/tests/mvp_planning_artifact_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_planning_artifact_contract.rs
@@ -3,12 +3,18 @@ use std::path::PathBuf;
 const BRAINSTORM: &str = "docs/brainstorms/2026-06-26-kamn-forward-strategy-requirements.md";
 const MVP_PLAN: &str = "docs/plans/2026-06-26-001-kamn-mvp-demo-readiness-plan.md";
 const RAIL_PLAN: &str = "docs/plans/2026-07-10-001-kamn-agent-transaction-rail-mega-plan.md";
+const ARTIFACTS: [(&str, &str); 3] = [
+    (BRAINSTORM, "superseded"),
+    (MVP_PLAN, "superseded"),
+    (RAIL_PLAN, "completed"),
+];
 
 #[test]
 fn spec_c01_historical_artifacts_are_explicitly_bounded() {
-    require_markers(BRAINSTORM, &["artifact_status: historical", "current_status: superseded"]);
-    require_markers(MVP_PLAN, &["artifact_status: historical", "current_status: superseded"]);
-    require_markers(RAIL_PLAN, &["artifact_status: historical", "current_status: completed"]);
+    for (path, status) in ARTIFACTS {
+        require_markers(path, &["artifact_status: historical"]);
+        require_markers(path, &[&format!("current_status: {status}")]);
+    }
 }
 
 #[test]
@@ -19,10 +25,13 @@ fn spec_c02_plan_lineage_resolves_at_repository_paths() {
 
 #[test]
 fn spec_c03_public_artifacts_exclude_private_path_placeholders() {
-    for path in [BRAINSTORM, MVP_PLAN, RAIL_PLAN] {
+    for (path, _) in ARTIFACTS {
         let content = read_repo_file(path);
         assert!(!content.contains("/Users/"), "private user path in {path}");
-        assert!(!content.contains("/absolute/path/"), "absolute path placeholder in {path}");
+        assert!(
+            !content.contains("/absolute/path/"),
+            "absolute path placeholder in {path}"
+        );
         require_markers(path, &["not production", "devnet"]);
     }
 }

--- a/crates/kamn-e2e-harness/tests/mvp_planning_artifact_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_planning_artifact_contract.rs
@@ -1,0 +1,57 @@
+use std::path::PathBuf;
+
+const BRAINSTORM: &str = "docs/brainstorms/2026-06-26-kamn-forward-strategy-requirements.md";
+const MVP_PLAN: &str = "docs/plans/2026-06-26-001-kamn-mvp-demo-readiness-plan.md";
+const RAIL_PLAN: &str = "docs/plans/2026-07-10-001-kamn-agent-transaction-rail-mega-plan.md";
+
+#[test]
+fn spec_c01_historical_artifacts_are_explicitly_bounded() {
+    require_markers(BRAINSTORM, &["artifact_status: historical", "current_status: superseded"]);
+    require_markers(MVP_PLAN, &["artifact_status: historical", "current_status: superseded"]);
+    require_markers(RAIL_PLAN, &["artifact_status: historical", "current_status: completed"]);
+}
+
+#[test]
+fn spec_c02_plan_lineage_resolves_at_repository_paths() {
+    require_markers(MVP_PLAN, &[BRAINSTORM]);
+    require_markers(RAIL_PLAN, &[BRAINSTORM, MVP_PLAN]);
+}
+
+#[test]
+fn spec_c03_public_artifacts_exclude_private_path_placeholders() {
+    for path in [BRAINSTORM, MVP_PLAN, RAIL_PLAN] {
+        let content = read_repo_file(path);
+        assert!(!content.contains("/Users/"), "private user path in {path}");
+        assert!(!content.contains("/absolute/path/"), "absolute path placeholder in {path}");
+        require_markers(path, &["not production", "devnet"]);
+    }
+}
+
+#[test]
+fn spec_c04_python_metadata_policy_is_explicit() {
+    let ignore = read_repo_file(".gitignore");
+    assert!(ignore.lines().any(|line| line == "*.egg-info/"));
+
+    let lockfile = read_repo_file("uv.lock");
+    require_content("uv.lock", &lockfile, "version = 1");
+}
+
+fn require_markers(path: &str, markers: &[&str]) {
+    let content = read_repo_file(path);
+    for marker in markers {
+        require_content(path, &content, marker);
+    }
+}
+
+fn require_content(path: &str, content: &str, marker: &str) {
+    assert!(content.contains(marker), "{path} is missing `{marker}`");
+}
+
+fn read_repo_file(path: &str) -> String {
+    std::fs::read_to_string(repo_root().join(path))
+        .unwrap_or_else(|error| panic!("{path} should be readable: {error}"))
+}
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..")
+}

--- a/docs/brainstorms/2026-06-26-kamn-forward-strategy-requirements.md
+++ b/docs/brainstorms/2026-06-26-kamn-forward-strategy-requirements.md
@@ -1,0 +1,160 @@
+---
+date: 2026-06-26
+topic: kamn-forward-strategy
+artifact_status: historical
+current_status: superseded
+---
+
+# KAMN Forward Strategy
+
+> Historical decision artifact. This dated branch analysis is superseded by
+> the completed agent-transaction plan. It is not production or mainnet
+> evidence; current settlement claims remain limited to Solana devnet.
+
+## Problem Frame
+KAMN is no longer just paper architecture. Current `main` contains callable Rust
+runtime, CLI, MCP, SDK, service API, live proof, and E2E harness surfaces. The
+project's own validation docs now list multiple bounded proof slices, including
+service API, TCP relay, restart persistence, escrow, bridge, live Solana devnet,
+websocket, MCP, CLI, and asset-movement lanes.
+
+The project is still not ready to be described as broadly production-ready. The
+dominant risk is proof dilution: too many specs, scripts, governance contracts,
+and validation surfaces relative to the number of undeniable product/runtime
+paths a maintainer or evaluator can run and understand.
+
+Branch scan result: after `git fetch --all --prune`, `origin/main` at
+`560cbbb3` is the latest integrated product state. Newer open PR branches are
+Dependabot-only Cargo dependency bumps. The freshest non-dependency unmerged
+feature branch found, `origin/6880-verify-task-operations`, is stale relative to
+`main` and should not replace `main` as the analysis base.
+
+## What Works
+- Runtime entrypoints are real: `kamn-node`, `kamn-cli`, `kamn-mcp-server`, and
+  `kamn-e2e-harness` are callable binaries in the workspace.
+- Service API has a substantial route surface, auth taxonomy, replay guard,
+  anti-spam posture, websocket fanout, relay spool, and state persistence paths.
+- Persistence is better than old file-only claims: JSON state writes are atomic,
+  SQLite state-file storage is supported by extension, and relay projection is
+  idempotent.
+- Current validation docs are unusually honest about proof boundaries; the
+  canonical `current-proven-runtime-slices.md` index separates proven slices
+  from unproven production, consensus, finality, and fault-tolerance claims.
+- E2E live CI exists and can run SDK-direct and MCP-agent modes against a KAMN
+  stack plus a checked-out Kolme local API runtime.
+
+## What Does Not Work Yet
+- Local quality gates are not green on current `main`: `cargo fmt --check`
+  reports formatting drift and strict clippy fails in `kamn-core` when warnings
+  are promoted to errors.
+- `cargo check --workspace --all-targets --all-features` passes, but with many
+  warnings. That is not enough for the repo's own `make check` contract.
+- Broad production readiness, consensus/multi-node finality, generalized
+  external settlement, broad live economic-settlement parity, and global fault
+  tolerance remain explicitly unproven.
+- The E2E harness still contains deterministic infrastructure placeholders for
+  parts of infra/deploy/evidence/teardown modeling, so harness pass semantics
+  need careful labeling.
+- CI is layered and sophisticated, but proof is fragmented across fast gate,
+  deep validate, live workflows, dry-run policy checks, and local-heavy opt-ins.
+
+## What Is Real
+- `kamn-node` dispatches CLI parsing into runtime orchestration and serves
+  service API / observability endpoints when configured.
+- Service API message send persists message state, appends recipient relay spool
+  entries, and publishes websocket lifecycle events.
+- Service API state defaults to a temp-file path derived from bind address, can
+  be overridden, and can use SQLite when the state-file extension is `.sqlite`,
+  `.sqlite3`, or `.db`.
+- Websocket support is no longer a one-shot-only implementation; current source
+  has broadcast fanout, sequence numbers, state-transition mode, and presence
+  mode.
+- Kolme-related surfaces include real cryptographic signing paths and live
+  provider integration claims in source/docs, not only markdown plans.
+
+## What Is Not Real Enough
+- The main user/product story is still hard to evaluate from one command and one
+  operator narrative. A newcomer sees a strong platform, but also a very large
+  governance system.
+- Production datastore posture is not yet an obvious default path. File/SQLite
+  state-file support proves durability slices, but the product still needs a
+  crisp production storage story.
+- Some broad claims are only partially supported by bounded slices. The project
+  should keep marketing, README, and roadmap language anchored to validated
+  proof slices.
+- Security and supply-chain posture have advisory/non-blocking areas and should
+  be separated from hard merge gates in status language.
+
+## Requirements
+- R1. Establish a single "what KAMN does today" operator path that can be run
+  from fresh checkout and produces one human-readable proof bundle.
+- R2. Make local quality gates green before feature expansion: formatting,
+  strict clippy, and targeted tests should match the README and `Makefile`
+  contract.
+- R3. Convert current bounded proof slices into a claim matrix: claim, evidence
+  command, proof status, non-goals, and freshness date.
+- R4. Prioritize one end-to-end product path over new architecture breadth:
+  authenticated agent message or task flow, durable state, relay/projection,
+  websocket visibility, and audit/proof export.
+- R5. Label harness placeholders and dry-run lanes explicitly in generated
+  evidence so they cannot be mistaken for live runtime proof.
+- R6. Reduce proof fragmentation by defining one recommended local smoke lane,
+  one CI PR lane, and one scheduled/live lane for evaluator confidence.
+- R7. Stop adding new major nouns until each existing major noun has equivalent
+  runtime depth or is demoted to roadmap language.
+
+## Success Criteria
+- A new maintainer can answer "what does KAMN do?" by running one smoke command
+  and reading one proof report.
+- `make check` passes locally on the selected branch.
+- The claim matrix has no broad production claim without a linked command,
+  validation doc, and explicit non-goal.
+- The next feature PR improves one runtime proof path instead of adding another
+  isolated spec/governance layer.
+- Dry-run, placeholder, local-heavy, live, and production terms are used
+  consistently in docs and evidence output.
+
+## Scope Boundaries
+- Do not redesign the whole architecture before cleaning proof and local gate
+  health.
+- Do not weaken tests, clippy, formatting, or governance gates to make the repo
+  look green.
+- Do not market broad production readiness until consensus/finality/fault
+  tolerance and generalized settlement claims have matching live evidence.
+- Do not start with SDK expansion or new surfaces; finish the strongest current
+  path first.
+
+## Key Decisions
+- Base analysis on `origin/main`, not a newer Dependabot branch: dependency
+  bumps do not represent current product strategy.
+- Treat the project as partially real, not fake: current code has callable
+  runtime and proof paths, but production maturity remains bounded.
+- Move forward by consolidation and proof depth, not by creating more specs,
+  scripts, or validation taxonomies.
+- First engineering objective should be local quality gate recovery because it
+  blocks trustworthy iteration.
+
+## Dependencies / Assumptions
+- GitHub branch and PR metadata are current as of the fetch performed for this
+  brainstorm.
+- Live E2E claims depend on external Kolme checkout/build availability and
+  secrets for MCP-agent mode where required.
+- This brainstorm did not execute live E2E workflows or long full test suites.
+
+## Outstanding Questions
+
+### Resolve Before Planning
+- None.
+
+### Deferred to Planning
+- [Affects R1][Technical] Which existing smoke/live lane should become the
+  canonical one-command proof path?
+- [Affects R2][Technical] Should strict clippy be fixed in one gate-recovery
+  issue or split by crate/module to preserve small TDD arcs?
+- [Affects R4][Product] Is the primary product proof path agent messaging,
+  task lifecycle, escrow settlement, or Solana-backed asset movement?
+- [Affects R6][Technical] Which CI lanes should be required for PR confidence
+  versus scheduled confidence?
+
+## Next Steps
+-> /prompts:ce-plan for structured implementation planning.

--- a/docs/plans/2026-06-26-001-kamn-mvp-demo-readiness-plan.md
+++ b/docs/plans/2026-06-26-001-kamn-mvp-demo-readiness-plan.md
@@ -1,0 +1,1113 @@
+---
+date: 2026-06-26
+topic: kamn-mvp-demo-readiness
+origin: docs/brainstorms/2026-06-26-kamn-forward-strategy-requirements.md
+status: execution-ready
+artifact_status: historical
+current_status: superseded
+---
+
+# KAMN MVP Demo Readiness Plan
+
+> Historical decision artifact. The July 10 agent-transaction plan supersedes
+> this execution plan. It is not production or mainnet evidence; current
+> settlement claims remain limited to Solana devnet.
+
+## Executive Decision
+
+Move KAMN from "bounded proof slices exist" to "MVP demo is real, reproducible, and locally provable" by consolidating the existing service API, durable state, relay, websocket, audit, and Solana devnet asset-movement slices into one evaluator-facing demo path.
+
+The MVP is not broad production readiness. The MVP is one coherent local KAMN story:
+
+1. A fresh checkout can run one canonical demo command or a small command sequence.
+2. The local KAMN runtime starts real local services.
+3. Two authenticated agent identities execute a message/task flow.
+4. Durable state, relay/projection, websocket/event visibility, and audit/proof export are all exercised from the same run.
+5. Any escrow, settlement, exchange, or asset-movement claim is backed by Solana devnet transaction evidence, never by fake in-memory settlement.
+6. The final report labels each claim as `real`, `devnet-backed`, `local-only`, `dry-run`, `placeholder`, or `roadmap`.
+
+Recommended canonical outcome:
+
+```bash
+make demo-mvp
+```
+
+The implementation should allow a preflight/configured form for evaluator runs:
+
+```bash
+KAMN_MVP_DEVNET_MODE=required \
+KAMN_MVP_SOLANA_RPC_URL=https://api.devnet.solana.com \
+make demo-mvp
+```
+
+`make demo-mvp` may generate ephemeral devnet key material and request faucet funds when no explicit devnet keypair is supplied. For reliable recorded demos, it must also support a pre-funded devnet keypair file override. If devnet funding, transaction submission, confirmation, or balance proof fails, the demo must produce `NO-GO` evidence, not silently downgrade to local-only or dry-run settlement.
+
+## Source Requirements Carried Forward
+
+Source: `docs/brainstorms/2026-06-26-kamn-forward-strategy-requirements.md`
+
+Hard requirements carried into this plan:
+
+- Local quality gates are currently red and must be fixed before feature expansion.
+- Do not weaken formatting, strict clippy, tests, or proof semantics.
+- Prefer consolidating working surfaces over adding new architecture.
+- Prioritize proof depth over new specs, governance, or documentation breadth.
+- Explicitly separate `real`, `devnet-backed`, `local-only`, `dry-run`, `placeholder`, and `roadmap`.
+- Use devnet-backed execution/evidence for any exchange, escrow, settlement, or asset-movement claim.
+- Keep the final result credible for a technical evaluator, not only CI.
+
+Resolved planning decisions from the brainstorm:
+
+- Canonical proof path: a new `make demo-mvp` wrapper over a Rust-owned demo/proof runner, not the current localhost-only SDK demo.
+- Strict clippy strategy: one gate-recovery issue first, split by crate/module only if the first issue becomes too large to review safely.
+- Primary product proof path: authenticated agent task/message flow with devnet-backed escrow release/asset movement as the settlement proof.
+- CI lane shape: PR proves contract/schema/local deterministic slices; scheduled/manual proves live devnet and full evaluator run.
+
+## Branch And Base State
+
+Planning base after refresh:
+
+- Local branch: `main`
+- Upstream tracking: `origin/main`
+- Latest integrated non-dependency product base: `origin/main`
+- Open PRs found during refresh: Dependabot-only Cargo updates:
+  - `#7015` `dependabot/cargo/libp2p-gossipsub-0.49.4`
+  - `#7017` `dependabot/cargo/rand-0.8.6`
+  - `#7018` `dependabot/cargo/fuzz/rand-0.8.6`
+  - `#7019` `dependabot/cargo/rustls-webpki-0.103.13`
+- Newer non-dependency branch scan: `origin/6880-verify-task-operations` exists but is stale relative to `main`.
+
+Decision: plan against `origin/main`; do not switch to a dependency branch for product/MVP work.
+
+Current local gate evidence:
+
+- `cargo fmt --check` exits `1` with large formatting drift across workspace files.
+- `cargo clippy --workspace --all-targets --all-features --message-format short -- -D warnings` exits `101` in `kamn-core`; representative failures include unused imports, `unused_mut`, `type_complexity`, `ptr_arg`, `manual_is_multiple_of`, wildcard-or-pattern, needless question mark, too many arguments, test `unwrap`, missing docs, module inception, and redundant closures.
+- Because `Makefile` defines `make check` as `cargo fmt --check` plus strict workspace clippy, `make check` is currently red.
+
+## Existing Surfaces To Consolidate
+
+Use these existing surfaces. Avoid a parallel demo architecture unless the existing surface blocks proof clarity.
+
+### Local Runtime And Service API
+
+Relevant files:
+
+- `crates/kamn-node/src/main.rs`
+- `crates/kamn-node/src/service_api_endpoint/server.rs`
+- `crates/kamn-node/src/service_api_endpoint/state_io.rs`
+- `crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes.rs`
+- `crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/mutations/update_routes/message_routes.rs`
+- `crates/kamn-node/src/service_api_endpoint/websocket.rs`
+- `crates/kamn-sdk/src/live.rs`
+- `crates/kamn-sdk/src/service_client.rs`
+
+What is real now:
+
+- Service API runtime starts from `kamn-node`.
+- Auth public key, TLS, state file, relay spool, live Solana bridge, live settlement, replay guard, anti-spam, request budget, and websocket fanout are initialized at startup.
+- State file defaults can be overridden; JSON persistence is atomic; `.sqlite`, `.sqlite3`, and `.db` state files route through SQLite storage.
+- Relay spool is durable NDJSON and can be projected into relayed message state.
+- Message send persists state, appends relay entries, and publishes websocket events.
+- Websocket fanout publishes message, channel, task, and bridge lifecycle events with sequence numbers.
+
+### Existing Proof Slices
+
+Relevant docs:
+
+- `docs/validation/current-proven-runtime-slices.md`
+- `docs/validation/working-vertical-slice.md`
+- `docs/validation/durable-cross-node-relay-slice.md`
+- `docs/validation/restart-persistence-slice.md`
+- `docs/validation/live-solana-devnet-proof-slice.md`
+- `docs/validation/live-solana-bridge-dispatch-slice.md`
+- `docs/validation/live-solana-bridge-websocket-slice.md`
+- `docs/validation/escrow-settlement-slice.md`
+- `docs/validation/external-chain-backed-settlement-slice.md`
+- `docs/validation/solana-devnet-asset-movement-slice.md`
+
+What is real now:
+
+- Working vertical slice proves two identities, service API message delivery, task lifecycle, and audit export.
+- Durable relay slice proves relay spool preservation, later projection, and recipient-visible delivered state after fresh boot.
+- Restart persistence slice proves message, task, escrow, directory, relayed, and delivered state continuity.
+- Live Solana devnet proof captures live JSON-RPC health/version/slot evidence and normalizes finality labels.
+- Live Solana bridge websocket slice proves live-backed bridge evidence reaches `/v1/events/ws`.
+- Solana devnet asset-movement slice proves a bounded runtime path for real Solana devnet transfer submission and persisted `settlement_tx_signature`, with an ignored live proof for direct devnet execution.
+
+What is not real enough:
+
+- The current `make demo` is a localhost signed SDK exchange, not the full product story.
+- `crates/kamn-sdk/examples/local_e2e_demo.rs` uses `InMemoryKamnClient`; it must not be used for MVP settlement/asset-movement claims.
+- `crates/kamn-e2e-harness/src/run_contract/orchestration/phase_model/steps/infra_deploy.rs` still emits `deterministic placeholder` details for infra/deploy steps. These placeholders cannot count as MVP runtime proof.
+- Current proof is fragmented across docs, tests, scripts, ignored live tests, local-heavy paths, and CI workflows.
+
+### Devnet Sources And Constraints
+
+Official Solana docs used for planning:
+
+- Clusters and public endpoints: https://solana.com/docs/references/clusters
+- RPC overview: https://solana.com/docs/rpc
+- `requestAirdrop`: https://solana.com/docs/rpc/http/requestairdrop
+- `sendTransaction`: https://solana.com/docs/rpc/http/sendtransaction
+- `getSignatureStatuses`: https://solana.com/docs/rpc/http/getsignaturestatuses
+- `getTransaction`: https://solana.com/docs/rpc/http/gettransaction
+- `getBalance`: https://solana.com/docs/rpc/http/getbalance
+- Transactions: https://solana.com/docs/core/transactions
+
+Planning implications:
+
+- Devnet is the correct public cluster for developer/evaluator experimentation.
+- Devnet tokens are not real and devnet may reset; the report must state this.
+- Public RPC endpoints are shared, rate-limited infrastructure and are not production-grade.
+- `sendTransaction` acceptance does not prove confirmation; the demo must check status/transaction evidence after submission.
+- Balance movement evidence should use before/after `getBalance` at the configured commitment.
+- Faucet/rate-limit failures are expected external blockers; they must produce `NO-GO: devnet_unavailable` or equivalent, not a local-only pass.
+
+## MVP Claim Matrix
+
+The final proof report must include a machine-readable claim matrix and a human-readable rendering.
+
+Required claim classes:
+
+| Claim class | Meaning | MVP rule |
+| --- | --- | --- |
+| `real` | Executed against actual KAMN local runtime code/processes in the demo run | Required for runtime, service API, auth, message/task, relay, websocket, audit |
+| `devnet-backed` | Executed against Solana devnet with transaction/status/balance evidence | Required for settlement or asset movement |
+| `local-only` | Executed locally with no external value movement | Allowed for KAMN runtime, auth, message/task, state, relay, websocket, audit |
+| `dry-run` | Planned or simulated command only | Not allowed for MVP completion claims |
+| `placeholder` | Deterministic fixture or placeholder detail | Not allowed in required MVP proof path |
+| `roadmap` | Explicitly not implemented/proven in MVP | Required for production readiness, mainnet, generalized settlement, consensus/finality |
+
+Required final report checks:
+
+- No required MVP claim can be `dry-run`.
+- No required MVP claim can contain a placeholder detail.
+- Any claim containing `escrow`, `settlement`, `exchange`, `asset`, `transfer`, `lamports`, or `value movement` must be `devnet-backed`.
+- `devnet-backed` settlement evidence must include:
+  - `network=solana:devnet`
+  - `rpc_url`
+  - payer pubkey
+  - recipient pubkey
+  - lamports requested
+  - settlement transaction signature
+  - configured commitment
+  - transaction status proof
+  - transaction detail or slot proof
+  - recipient balance before/after and observed delta
+  - persisted KAMN linkage (`settlement_tx_signature`, `settlement_network`, `settlement_commitment`)
+  - repeated-release idempotency evidence that the same escrow does not submit a second transfer
+
+## Target Product Story
+
+The evaluator story should read like this:
+
+1. "KAMN starts a local service-api runtime with durable state files under one demo run directory."
+2. "Alice and Bob have authenticated agent identities and signed requests."
+3. "Alice sends Bob a task/message through KAMN."
+4. "The message is persisted, placed in durable relay/projection state, visible to Bob, and observable on websocket events."
+5. "Bob accepts/completes the task or produces an artifact."
+6. "KAMN exports audit/proof evidence for the message/task lifecycle."
+7. "KAMN releases a bounded escrow through the existing service-api settlement path."
+8. "The settlement claim is backed by a real Solana devnet transaction, status check, transaction/balance evidence, persisted KAMN signature linkage, and idempotent repeated-release behavior."
+9. "The final report states exactly what was local, what was devnet-backed, what was dry-run, what was not claimed, and what remains roadmap."
+
+Do not use `InMemoryKamnClient` for this story except as a negative control or legacy comparison. The demo must use real local KAMN runtime processes and service API routes.
+
+## GitHub Issue And Spec Breakdown
+
+Open one parent tracking issue, then the child issues below. The parent issue is not an implementation issue; it tracks the MVP umbrella and links child specs/PRs.
+
+Parent issue:
+
+- Title: `feat: KAMN MVP demo readiness tracker`
+- Body must include problem statement, acceptance criteria, non-goals, and links to this plan plus the brainstorm.
+- Non-goal: do not implement code directly under the parent issue.
+
+First 5 child issues, in dependency order:
+
+### Issue 1: Restore Local Quality Gates Before MVP Expansion
+
+Suggested title: `fix: restore local formatting and strict clippy gates`
+
+Purpose:
+
+- Make `make check` green before expanding MVP features.
+
+Spec path after issue creation:
+
+- `specs/<issue>-restore-local-quality-gates.md`
+
+Acceptance criteria:
+
+- `cargo fmt --check` passes.
+- `cargo clippy --workspace --all-targets --all-features -- -D warnings` passes.
+- `make check` passes.
+- No clippy/test weakening is introduced.
+- If scope is too large, split by crate/module but do not start feature work until all split gate-recovery issues are green.
+
+Red evidence:
+
+- Existing `cargo fmt --check` failure.
+- Existing strict workspace clippy failure in `kamn-core`.
+
+Likely touched surfaces:
+
+- Rust files across `crates/kamn-core`, `crates/kamn-node`, `crates/kamn-sdk`, and support tests.
+- Avoid touching scripts/workflows unless the gate itself is incorrectly configured.
+
+Completion evidence:
+
+```bash
+cargo fmt --check
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+make check
+cargo test -p kamn-core
+cargo test -p kamn-node
+```
+
+Risk gate:
+
+- Do not add `#[allow(...)]`, relax lint levels, remove tests, or demote warnings to make the gate green unless the issue/spec explicitly justifies a narrow false positive.
+
+### Issue 2: Define MVP Claim Matrix And Proof Contract
+
+Suggested title: `feat: define MVP demo proof contract and claim taxonomy`
+
+Purpose:
+
+- Freeze the proof/report schema before implementing the runner.
+- Make overclaiming impossible in the generated report.
+
+Spec path after issue creation:
+
+- `specs/<issue>-mvp-demo-proof-contract.md`
+
+Acceptance criteria:
+
+- A checked-in schema or Rust model defines the claim matrix and report fields.
+- A contract test fails if required MVP claims are missing.
+- A contract test fails if a required claim is `dry-run` or `placeholder`.
+- A contract test fails if settlement/asset wording is not `devnet-backed`.
+- A docs/runbook section explains the allowed claim classes.
+
+Red tests first:
+
+```bash
+cargo test -p kamn-e2e-harness --test mvp_demo_claim_contract -- --nocapture
+cargo test -p kamn-core --test mvp_demo_claim_docs_contract -- --nocapture
+```
+
+Expected initial failure:
+
+- No MVP report schema exists.
+- No required claim matrix exists.
+- No placeholder/dry-run rejection contract exists.
+
+Likely touched surfaces:
+
+- `crates/kamn-e2e-harness/src/verify/`
+- `crates/kamn-e2e-harness/tests/`
+- `docs/validation/`
+- `docs/developer/readme-contract-reference.md` only if needed for discoverability.
+
+Completion evidence:
+
+```bash
+cargo test -p kamn-e2e-harness --test mvp_demo_claim_contract -- --nocapture
+cargo test -p kamn-core --test mvp_demo_claim_docs_contract -- --nocapture
+cargo fmt --check
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+```
+
+Risk gate:
+
+- Do not write a report schema that permits ambiguous labels such as `live-ish`, `simulated-live`, or `real-ish`.
+
+### Issue 3: Add Canonical Local KAMN MVP Demo Command
+
+Suggested title: `feat: add canonical local KAMN MVP demo command`
+
+Purpose:
+
+- Provide the local, evaluator-friendly product story without relying on in-memory SDK demo paths.
+
+Spec path after issue creation:
+
+- `specs/<issue>-canonical-local-mvp-demo-command.md`
+
+Acceptance criteria:
+
+- `make demo-mvp` exists.
+- The command starts real local KAMN service-api runtime processes or a real in-process service API server backed by the same runtime code.
+- The command writes all state/evidence under a run directory, for example `.kamn/demo/<run-id>/`.
+- The command proves authenticated agent identity, signed request or equivalent service-auth evidence, message/task flow, durable state, relay/projection, websocket event visibility, audit/proof export, and human-readable report generation.
+- The command labels this phase's runtime story as `real` and `local-only`, except settlement, which must be absent or marked `not-claimed` until Issue 4.
+- The command must fail if required evidence files are missing.
+- The command must not count harness `deterministic placeholder` infra/deploy details as proof.
+
+Red tests first:
+
+```bash
+cargo test -p kamn-e2e-harness --test mvp_demo_local_runtime_contract -- --nocapture
+cargo test -p kamn-node --test mvp_demo_service_api_contract -- --nocapture
+bash scripts/ci/test_readme_contract.sh
+```
+
+Expected initial failure:
+
+- `make demo-mvp` does not exist.
+- No single report ties local runtime, auth, relay, websocket, audit, and proof together.
+
+Likely touched surfaces:
+
+- `Makefile`
+- `crates/kamn-e2e-harness/src/lib.rs`
+- `crates/kamn-e2e-harness/src/main.rs` if the binary dispatch is split there.
+- `crates/kamn-e2e-harness/src/verify/`
+- `crates/kamn-e2e-harness/tests/`
+- `crates/kamn-sdk/src/live.rs`
+- `crates/kamn-sdk/src/service_client*.rs`
+- `crates/kamn-node/src/service_api_endpoint/*` only if a real route/report gap is found.
+- `docs/validation/mvp-demo-slice.md`
+- `docs/validation/current-proven-runtime-slices.md`
+
+Shell-surface process note:
+
+- Because `Makefile` is touched, the GitHub issue body must include the shell-surface DoR estimates from `AGENTS.md`.
+- The PR summary/closure must include shell-surface DoD actuals.
+
+Completion evidence:
+
+```bash
+make demo-mvp
+test -f .kamn/demo/latest/proof/report.json
+test -f .kamn/demo/latest/proof/report.md
+cargo test -p kamn-e2e-harness --test mvp_demo_local_runtime_contract -- --nocapture
+cargo test -p kamn-node integration_service_api_endpoint_working_vertical_slice_proves_delivery_dispatch_and_audit_evidence -- --exact --nocapture
+cargo test -p kamn-node integration_service_api_endpoint_recipient_mailbox_and_delivery_status_contract -- --exact --nocapture
+cargo test -p kamn-node regression_service_api_endpoint_non_recipient_query_keeps_relayed_status_across_restart -- --exact --nocapture
+```
+
+Risk gate:
+
+- If the runner uses `kamn-e2e-harness run`, first remove or quarantine placeholder infra/deploy records from required MVP proof. Placeholder records may remain as roadmap/development metadata but cannot satisfy required claims.
+
+### Issue 4: Make Settlement And Asset Movement Devnet-Backed In The MVP Demo
+
+Suggested title: `feat: require Solana devnet-backed settlement evidence in MVP demo`
+
+Purpose:
+
+- Connect the MVP demo report to the existing Solana devnet asset-movement lane whenever settlement or asset movement is claimed.
+
+Spec path after issue creation:
+
+- `specs/<issue>-mvp-demo-devnet-backed-settlement.md`
+
+Acceptance criteria:
+
+- The MVP demo can run with `KAMN_MVP_DEVNET_MODE=required`.
+- The demo prepares or consumes devnet keypair material without committing secrets.
+- The demo funds or verifies the devnet payer account.
+- The demo executes escrow release through the real service-api settlement path.
+- The demo records a real Solana devnet transaction signature and commitment.
+- The demo verifies transaction status and transaction/balance evidence after submission.
+- The KAMN persisted escrow record contains `settlement_tx_signature`, `settlement_network=solana:devnet`, and `settlement_commitment`.
+- Repeated release for the same escrow reuses the same persisted transaction linkage.
+- If devnet RPC, faucet, transaction, confirmation, or balance proof fails, the report is `NO-GO` and does not claim settlement success.
+
+Red tests first:
+
+```bash
+cargo test -p kamn-e2e-harness --test mvp_demo_devnet_settlement_contract -- --nocapture
+cargo test -p kamn-node --test solana_devnet_asset_movement_slice_contract -- --nocapture
+cargo test -p kamn-node --bin kamn-node 'main_tests::service_api_endpoint_tests::task_escrow_persistence_contract_tests::task_escrow_solana_asset_movement_contract_tests::integration_service_api_endpoint_live_solana_asset_movement_release_persists_transaction_signature_metadata' -- --exact --nocapture
+```
+
+Expected initial failure:
+
+- MVP report does not yet include devnet-backed settlement fields.
+- `make demo-mvp` does not yet gate settlement wording on devnet evidence.
+
+Live proof command:
+
+```bash
+KAMN_MVP_DEVNET_MODE=required \
+KAMN_MVP_SOLANA_RPC_URL=https://api.devnet.solana.com \
+make demo-mvp
+```
+
+Operator confirmation command using existing ignored proof:
+
+```bash
+cargo test -p kamn-node --bin kamn-node \
+  'main_tests::service_api_endpoint_tests::task_escrow_persistence_contract_tests::task_escrow_solana_asset_movement_live_contract_tests::integration_service_api_endpoint_live_solana_asset_movement_release_submits_real_devnet_transfer' \
+  -- --ignored --exact --nocapture
+```
+
+Likely touched surfaces:
+
+- `crates/kamn-e2e-harness/src/`
+- `crates/kamn-e2e-harness/tests/`
+- `crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch/*`
+- `crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops.rs`
+- `crates/kamn-node/tests/solana_devnet_asset_movement_slice_contract.rs`
+- `docs/validation/solana-devnet-asset-movement-slice.md`
+- `docs/validation/mvp-demo-slice.md`
+
+Completion evidence:
+
+```bash
+cargo test -p kamn-node --test solana_devnet_asset_movement_slice_contract -- --nocapture
+cargo test -p kamn-e2e-harness --test mvp_demo_devnet_settlement_contract -- --nocapture
+KAMN_MVP_DEVNET_MODE=required KAMN_MVP_SOLANA_RPC_URL=https://api.devnet.solana.com make demo-mvp
+```
+
+Risk gates:
+
+- No fallback from devnet settlement to local-only release when `KAMN_MVP_DEVNET_MODE=required`.
+- No "asset movement" wording unless balance delta and transaction evidence are present.
+- No mainnet support in the MVP.
+- Public devnet faucet/rate-limit failure is `NO-GO: devnet_unavailable`, not a test pass.
+
+### Issue 5: Wire Evaluator Report, Verification, Docs, And CI Lanes
+
+Suggested title: `integrate: wire MVP demo proof report and evaluator verification`
+
+Purpose:
+
+- Make the demo easy to run, easy to verify, and honest in CI/manual workflows.
+
+Spec path after issue creation:
+
+- `specs/<issue>-mvp-demo-report-verification-ci.md`
+
+Acceptance criteria:
+
+- The demo emits both:
+  - `.kamn/demo/<run-id>/proof/report.json`
+  - `.kamn/demo/<run-id>/proof/report.md`
+- A verifier command reads `report.json` and fails closed on missing/ambiguous/overstated claims.
+- `report.md` is evaluator-readable without requiring source inspection.
+- README or validation docs advertise one command sequence and the non-claims.
+- PR CI runs deterministic contract tests and report-schema tests.
+- Scheduled/manual CI can run devnet-backed proof when credentials/RPC/faucet availability are present.
+- CI and docs separate PR confidence from scheduled/live confidence.
+
+Red tests first:
+
+```bash
+cargo test -p kamn-e2e-harness --test mvp_demo_report_verifier_contract -- --nocapture
+cargo test -p kamn-core --test ci_strategy_docs doc_contains_mvp_demo_lane_boundaries -- --exact
+bash scripts/ci/test_ci_tools.sh
+```
+
+Expected initial failure:
+
+- No verifier command exists.
+- CI strategy lacks MVP demo lane boundary markers.
+- README/validation docs do not advertise the final command/report contract.
+
+Likely touched surfaces:
+
+- `README.md`
+- `docs/validation/mvp-demo-slice.md`
+- `docs/validation/current-proven-runtime-slices.md`
+- `docs/ci/strategy.md`
+- `.github/workflows/e2e-live.yml` only if adding scheduled/manual MVP run is necessary.
+- `scripts/ci/test_ci_tools.sh` only for deterministic contract coverage.
+- `crates/kamn-e2e-harness/src/verify/`
+
+Shell/workflow surface process note:
+
+- If scripts, workflows, issue templates, or `Makefile` are touched, follow `AGENTS.md` shell-surface DoR/DoD fields exactly.
+
+Completion evidence:
+
+```bash
+make demo-mvp
+cargo run -p kamn-e2e-harness -- verify-mvp-demo --report .kamn/demo/latest/proof/report.json
+cargo test -p kamn-e2e-harness --test mvp_demo_report_verifier_contract -- --nocapture
+cargo test -p kamn-core --test ci_strategy_docs doc_contains_mvp_demo_lane_boundaries -- --exact
+bash scripts/ci/test_ci_tools.sh
+```
+
+Risk gate:
+
+- Do not require live devnet proof in the hot PR fast gate unless the repo accepts rate-limit/flakiness risk. Prefer PR schema/local deterministic proof plus manual/scheduled live devnet proof.
+
+## Phased Execution Plan
+
+### Phase 0: Preflight, Issue Creation, And Branch Discipline
+
+What this proves:
+
+- Work starts from the latest appropriate branch and obeys repo process.
+
+Actions:
+
+1. Run branch refresh:
+
+   ```bash
+   git fetch --all --prune
+   git status --short --branch
+   gh pr list --repo njfio/kamn --state open --limit 50
+   ```
+
+2. Create parent tracker issue.
+3. Create Issue 1 with acceptance criteria and non-goals.
+4. Create `specs/<issue>-restore-local-quality-gates.md`.
+5. Commit spec before any tests or implementation.
+
+Likely touched files:
+
+- `specs/<issue>-restore-local-quality-gates.md`
+
+Risk gate:
+
+- Do not implement anything before the issue exists and the spec is committed.
+
+Rollback/checkpoint:
+
+- If issue creation fails due missing GitHub auth, stop execution and report the blocker. Do not start code.
+- If branch state changes underfoot, fetch again and re-check whether a newer non-dependency product branch supersedes `main`.
+
+### Phase 1: Restore Local Gate Health
+
+What this proves:
+
+- The repo can be iterated honestly under its own `make check` contract.
+
+Actions:
+
+1. Preserve red evidence from:
+
+   ```bash
+   cargo fmt --check
+   cargo clippy --workspace --all-targets --all-features -- -D warnings
+   ```
+
+2. Apply formatting with `cargo fmt`.
+3. Fix strict clippy by category:
+   - unused imports/mut
+   - mechanical lint suggestions
+   - test `unwrap`/`unwrap_err` replacements
+   - module inception and type-complexity extractions
+   - missing docs on exported items
+4. Run focused tests for touched modules.
+5. Run `make check`.
+6. Commit in repo-required TDD arc:
+   - spec commit
+   - red evidence/test commit if new regression tests are needed
+   - green implementation commit
+   - mandatory refactor commit
+   - integration/gate evidence commit if required
+
+Likely touched files:
+
+- Many Rust files under `crates/kamn-core/src/`
+- Some Rust tests under `crates/kamn-core/tests/`
+- Possibly `crates/kamn-sdk/tests/`
+
+Red tests first:
+
+- Existing red `cargo fmt --check`
+- Existing red strict clippy
+
+Acceptance criteria:
+
+- `make check` is green.
+- No lint/test weakening.
+- Touched functions/files respect AGENTS size rules or have follow-up issues where pre-existing debt is out of scope.
+
+Verification commands:
+
+```bash
+cargo fmt --check
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+make check
+cargo test -p kamn-core
+cargo test -p kamn-node
+```
+
+Risk gates:
+
+- If missing docs are numerous, prefer documenting stable public API items over adding broad allow attributes.
+- If this becomes too large, split Issue 1 into crate/module sub-issues, but keep all MVP feature issues blocked until gate recovery is complete.
+
+Rollback/checkpoint:
+
+- Commit after mechanical formatting separately from semantic lint fixes.
+- If semantic lint fixes introduce failures, revert only the current lint-fix commit and keep the formatting commit if it is clean.
+
+### Phase 2: Freeze MVP Claim Contract
+
+What this proves:
+
+- The final demo cannot overclaim.
+
+Actions:
+
+1. Create Issue 2 and spec.
+2. Add red report-schema/claim-matrix tests.
+3. Define required claims and statuses.
+4. Add negative fixtures:
+   - settlement claim marked `local-only`
+   - required runtime claim marked `dry-run`
+   - placeholder text in required proof
+   - missing devnet transaction signature
+   - balance delta missing for asset movement
+5. Implement verifier/model.
+6. Wire docs contract.
+
+Likely touched files:
+
+- `crates/kamn-e2e-harness/src/verify/`
+- `crates/kamn-e2e-harness/tests/`
+- `fixtures/` if the repo already has a suitable fixture pattern
+- `docs/validation/mvp-demo-slice.md`
+
+Red tests first:
+
+```bash
+cargo test -p kamn-e2e-harness --test mvp_demo_claim_contract -- --nocapture
+```
+
+Completion evidence:
+
+- Positive report fixture passes.
+- Negative report fixtures fail with deterministic reason codes:
+  - `mvp_claim_required_missing`
+  - `mvp_claim_placeholder_forbidden`
+  - `mvp_claim_dry_run_forbidden`
+  - `mvp_settlement_requires_devnet_backing`
+  - `mvp_devnet_signature_missing`
+  - `mvp_devnet_balance_delta_missing`
+
+Verification commands:
+
+```bash
+cargo test -p kamn-e2e-harness --test mvp_demo_claim_contract -- --nocapture
+cargo test -p kamn-core --test mvp_demo_claim_docs_contract -- --nocapture
+cargo fmt --check
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+```
+
+Risk gates:
+
+- The verifier must be fail-closed and deterministic.
+- Human-readable report rendering must derive from the same JSON, not a separate hand-written summary.
+
+Rollback/checkpoint:
+
+- If report schema design churns, keep negative tests and adjust only the model/rendering. Do not weaken the negative tests.
+
+### Phase 3: Build The Local Runtime Demo Spine
+
+What this proves:
+
+- A local evaluator can run a real KAMN runtime story from one command without reading scattered test docs.
+
+Actions:
+
+1. Create Issue 3 and spec.
+2. Add red test asserting `make demo-mvp` contract or Rust runner command exists.
+3. Implement a Rust-owned runner, preferably in `kamn-e2e-harness`, that:
+   - creates `.kamn/demo/<run-id>/`
+   - starts local `kamn-node` service API runtime(s) on loopback
+   - sets explicit state, relay spool, audit export, TLS-disabled-loopback-only, and auth env vars
+   - waits for `/healthz`
+   - opens websocket event listener
+   - sends signed/authenticated service API requests
+   - creates message/task flow
+   - verifies recipient-visible message/task status
+   - restarts or reopens state enough to prove durable state and relay/projection
+   - captures audit export
+   - writes report JSON/Markdown
+4. Add `make demo-mvp` as the thin wrapper.
+5. Update validation docs.
+
+Likely touched files:
+
+- `Makefile`
+- `crates/kamn-e2e-harness/src/lib.rs`
+- `crates/kamn-e2e-harness/src/verify/`
+- `crates/kamn-e2e-harness/tests/`
+- `crates/kamn-sdk/src/service_client*.rs`
+- `crates/kamn-node/src/service_api_endpoint/*` only for missing route/report evidence
+- `docs/validation/mvp-demo-slice.md`
+
+Red tests first:
+
+```bash
+cargo test -p kamn-e2e-harness --test mvp_demo_local_runtime_contract -- --nocapture
+```
+
+Completion evidence required in report:
+
+- git SHA and branch
+- exact command line
+- generated run id
+- local node bind address(es)
+- health check status
+- state file path and hash
+- relay spool path and before/after status
+- Alice/Bob DIDs or agent identifiers
+- auth/signature/replay evidence
+- message id and status progression
+- task id and state progression
+- websocket event frames with increasing sequence
+- audit export file path and hash
+- claim matrix with runtime claims as `real`/`local-only`
+- settlement claim absent or `not-claimed` until Issue 4
+
+Verification commands:
+
+```bash
+make demo-mvp
+cargo test -p kamn-e2e-harness --test mvp_demo_local_runtime_contract -- --nocapture
+cargo test -p kamn-node integration_service_api_endpoint_working_vertical_slice_proves_delivery_dispatch_and_audit_evidence -- --exact --nocapture
+cargo test -p kamn-node integration_service_api_endpoint_recipient_mailbox_and_delivery_status_contract -- --exact --nocapture
+cargo test -p kamn-node regression_service_api_endpoint_non_recipient_query_keeps_relayed_status_across_restart -- --exact --nocapture
+```
+
+Risk gates:
+
+- Do not use `InMemoryKamnClient` for MVP proof.
+- Do not accept a report if required evidence is sourced from deterministic placeholder text.
+- Do not require a separate Kolme checkout for the minimal local KAMN MVP unless the issue/spec proves it is necessary.
+
+Rollback/checkpoint:
+
+- Keep the runner behind a new command until stable.
+- If process orchestration is flaky, first reduce the local story to one KAMN node plus service API state proof, then add multi-process relay once deterministic.
+
+### Phase 4: Add Devnet-Backed Settlement And Asset Movement
+
+What this proves:
+
+- Any settlement or asset-movement claim in the MVP is backed by real Solana devnet execution/evidence.
+
+Actions:
+
+1. Create Issue 4 and spec.
+2. Add red tests that reject settlement wording without devnet evidence.
+3. Reuse the existing `live_settlement_dispatch` path.
+4. Add runner support for:
+   - auto-generated ephemeral devnet keypair JSON, or explicit keypair file
+   - recipient pubkey generation or explicit recipient
+   - devnet payer funding/preflight
+   - `KAMN_SERVICE_API_LIVE_SOLANA_BRIDGE_RPC_URL`
+   - `KAMN_SERVICE_API_LIVE_SOLANA_SETTLEMENT_KEYPAIR_FILE`
+   - `KAMN_SERVICE_API_LIVE_SOLANA_SETTLEMENT_RECIPIENT_PUBKEY`
+   - `KAMN_SERVICE_API_LIVE_SOLANA_SETTLEMENT_LAMPORTS`
+   - `KAMN_SERVICE_API_LIVE_SOLANA_SETTLEMENT_COMMITMENT=finalized`
+5. Call the real service API escrow release path.
+6. Query devnet evidence after release.
+7. Verify repeated release idempotency.
+8. Write devnet-backed claim fields into the report.
+
+Likely touched files:
+
+- `crates/kamn-e2e-harness/src/`
+- `crates/kamn-e2e-harness/tests/`
+- `crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch/*`
+- `crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops.rs`
+- `docs/validation/mvp-demo-slice.md`
+- `docs/validation/solana-devnet-asset-movement-slice.md`
+
+Red tests first:
+
+```bash
+cargo test -p kamn-e2e-harness --test mvp_demo_devnet_settlement_contract -- --nocapture
+cargo test -p kamn-node --test solana_devnet_asset_movement_slice_contract -- --nocapture
+```
+
+Completion evidence required in report:
+
+- `claim_class=devnet-backed`
+- `settlement_network=solana:devnet`
+- devnet RPC URL
+- payer pubkey
+- recipient pubkey
+- lamports
+- payer balance before/after if collected
+- recipient balance before/after
+- settlement transaction signature
+- transaction status at configured commitment
+- transaction detail or slot proof
+- persisted KAMN escrow state with the same transaction signature
+- repeated release returns same signature and does not emit second transfer
+- clear statement: devnet tokens are not real, devnet can reset, this is not mainnet/production settlement
+
+Verification commands:
+
+```bash
+KAMN_MVP_DEVNET_MODE=required \
+KAMN_MVP_SOLANA_RPC_URL=https://api.devnet.solana.com \
+make demo-mvp
+
+cargo test -p kamn-node --test solana_devnet_asset_movement_slice_contract -- --nocapture
+
+cargo test -p kamn-node --bin kamn-node \
+  'main_tests::service_api_endpoint_tests::task_escrow_persistence_contract_tests::task_escrow_solana_asset_movement_live_contract_tests::integration_service_api_endpoint_live_solana_asset_movement_release_submits_real_devnet_transfer' \
+  -- --ignored --exact --nocapture
+```
+
+Risk gates:
+
+- If devnet faucet is rate-limited, support an explicit pre-funded devnet keypair path. Do not fake funding.
+- If `sendTransaction` succeeds but confirmation/status lookup fails, report `NO-GO`.
+- If balance delta does not match expected lamports, report `NO-GO`.
+- If the KAMN state linkage does not match the devnet signature, report `NO-GO`.
+
+Rollback/checkpoint:
+
+- Keep local runtime demo from Phase 3 working even when devnet is unavailable, but label it `local-only` and `settlement_not_claimed`.
+- Do not merge Issue 4 as MVP-complete without at least one successful devnet-backed evidence run captured in the PR or release evidence.
+
+### Phase 5: Evaluator Report, Verifier, Docs, And CI
+
+What this proves:
+
+- The result is understandable and independently checkable.
+
+Actions:
+
+1. Create Issue 5 and spec.
+2. Add report verifier command.
+3. Add human-readable report template derived from JSON.
+4. Add docs:
+   - `docs/validation/mvp-demo-slice.md`
+   - README quick path update
+   - CI strategy lane boundaries
+5. Add deterministic CI contract tests.
+6. Add manual/scheduled live devnet lane only if needed.
+
+Likely touched files:
+
+- `README.md`
+- `docs/validation/mvp-demo-slice.md`
+- `docs/validation/current-proven-runtime-slices.md`
+- `docs/ci/strategy.md`
+- `crates/kamn-e2e-harness/src/verify/`
+- `crates/kamn-e2e-harness/tests/`
+- `.github/workflows/e2e-live.yml` only if live lane wiring is required
+- `scripts/ci/test_ci_tools.sh` only if deterministic CI regression command is needed
+
+Red tests first:
+
+```bash
+cargo test -p kamn-e2e-harness --test mvp_demo_report_verifier_contract -- --nocapture
+cargo test -p kamn-core --test ci_strategy_docs doc_contains_mvp_demo_lane_boundaries -- --exact
+```
+
+Completion evidence:
+
+```bash
+make demo-mvp
+cargo run -p kamn-e2e-harness -- verify-mvp-demo --report .kamn/demo/latest/proof/report.json
+cargo test -p kamn-e2e-harness --test mvp_demo_report_verifier_contract -- --nocapture
+bash scripts/ci/test_ci_tools.sh
+```
+
+Risk gates:
+
+- PR fast gate should not depend on live public RPC unless the repo explicitly accepts the flake/cost tradeoff.
+- Scheduled/manual live proof must upload report artifacts and preserve `NO-GO` when external devnet is unavailable.
+
+Rollback/checkpoint:
+
+- If CI live lane is flaky, keep deterministic verifier tests in PR CI and make live devnet proof manual/scheduled with artifact upload.
+- Do not remove the local evaluator command while iterating on CI.
+
+### Phase 6: Demo Rehearsal And Release Readiness
+
+What this proves:
+
+- The MVP path is usable by someone other than the implementer.
+
+Actions:
+
+1. Fresh clone rehearsal on a clean machine or clean worktree.
+2. Run:
+
+   ```bash
+   make check
+   KAMN_MVP_DEVNET_MODE=required KAMN_MVP_SOLANA_RPC_URL=https://api.devnet.solana.com make demo-mvp
+   cargo run -p kamn-e2e-harness -- verify-mvp-demo --report .kamn/demo/latest/proof/report.json
+   ```
+
+3. Read `report.md` without source context.
+4. Confirm non-claims are visible:
+   - not production-ready
+   - not mainnet
+   - not generalized settlement
+   - not consensus/finality beyond bounded evidence
+   - not global fault tolerance
+5. Record known residual risks.
+
+Completion evidence:
+
+- One final proof bundle from fresh checkout.
+- One verifier pass.
+- One PR description with issue link, spec link, command evidence, shell-surface actuals if applicable, and explicit non-claims.
+
+Risk gates:
+
+- If a fresh checkout cannot run the command from docs, MVP is not complete.
+- If the report requires maintainers to inspect source code to understand proof status, MVP is not complete.
+
+Rollback/checkpoint:
+
+- If the rehearsal fails due local runner behavior, fix before PR.
+- If the rehearsal fails only due public devnet/faucet outage, rerun with pre-funded devnet keypair or private devnet RPC and label the evidence source.
+
+## Verification Command Matrix
+
+Always run after Phase 1:
+
+```bash
+cargo fmt --check
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+make check
+```
+
+Core local runtime proof commands:
+
+```bash
+cargo test -p kamn-node integration_service_api_endpoint_working_vertical_slice_proves_delivery_dispatch_and_audit_evidence -- --exact --nocapture
+cargo test -p kamn-node integration_runtime_daemon_without_route_map_preserves_relay_spool_entries -- --exact --nocapture
+cargo test -p kamn-node integration_service_api_endpoint_cross_node_relay_delivery_contract -- --exact --nocapture
+cargo test -p kamn-node integration_service_api_endpoint_recipient_mailbox_and_delivery_status_contract -- --exact --nocapture
+cargo test -p kamn-node regression_service_api_endpoint_non_recipient_query_keeps_relayed_status_across_restart -- --exact --nocapture
+cargo test -p kamn-node integration_service_api_endpoint_persists_task_and_escrow_state_across_restart -- --exact --nocapture
+cargo test -p kamn-node --test live_solana_bridge_websocket_slice_contract -- --nocapture
+```
+
+Solana/devnet proof commands:
+
+```bash
+python3 scripts/runtime/run_live_solana_devnet_proof.py \
+  --rpc-url https://api.devnet.solana.com \
+  --output-json /tmp/live-solana-devnet-report.json
+
+python3 scripts/runtime/validate_live_solana_devnet_proof.py \
+  --report-file /tmp/live-solana-devnet-report.json \
+  --output-json /tmp/live-solana-devnet-validation.json
+
+KAMN_SOLANA_DEVNET_REPORT_FILE=/tmp/live-solana-devnet-report.json \
+KAMN_SOLANA_DEVNET_NORMALIZATION_REPORT=/tmp/live-solana-devnet-normalization.json \
+  cargo test -p kamn-core --test live_solana_devnet_receipt_normalization -- --nocapture
+
+python3 scripts/runtime/check_live_solana_devnet_proof_policy.py \
+  --validation-report-file /tmp/live-solana-devnet-validation.json \
+  --normalization-report-file /tmp/live-solana-devnet-normalization.json \
+  --expected-final-decision GO \
+  --output-json /tmp/live-solana-devnet-policy.json
+```
+
+Existing asset-movement commands:
+
+```bash
+cargo test -p kamn-node --test solana_devnet_asset_movement_slice_contract -- --nocapture
+
+cargo test -p kamn-node --bin kamn-node \
+  'main_tests::service_api_endpoint_tests::task_escrow_persistence_contract_tests::task_escrow_solana_asset_movement_contract_tests::integration_service_api_endpoint_live_solana_asset_movement_release_persists_transaction_signature_metadata' \
+  -- --exact --nocapture
+
+cargo test -p kamn-node --bin kamn-node \
+  'main_tests::service_api_endpoint_tests::task_escrow_persistence_contract_tests::task_escrow_solana_asset_movement_contract_tests::integration_service_api_endpoint_live_solana_asset_movement_release_is_idempotent_for_repeated_submit' \
+  -- --exact --nocapture
+
+cargo test -p kamn-node --bin kamn-node \
+  'main_tests::service_api_endpoint_tests::task_escrow_persistence_contract_tests::task_escrow_solana_asset_movement_contract_tests::integration_service_api_endpoint_live_solana_asset_movement_release_reuses_signature_after_restart' \
+  -- --exact --nocapture
+```
+
+Final MVP commands:
+
+```bash
+make demo-mvp
+KAMN_MVP_DEVNET_MODE=required KAMN_MVP_SOLANA_RPC_URL=https://api.devnet.solana.com make demo-mvp
+cargo run -p kamn-e2e-harness -- verify-mvp-demo --report .kamn/demo/latest/proof/report.json
+```
+
+## Rollback And Checkpoint Strategy
+
+Branching:
+
+- Use repo-required issue branches: `<issue>-<slug>`.
+- Do not push directly to `main`.
+- Keep the parent tracker separate from child implementation branches.
+
+Commits:
+
+- Commit the spec before tests or implementation.
+- Preserve red -> green -> refactor -> integrate sequence.
+- Use Lore protocol trailers in commits.
+- Keep formatting-only commits separate from semantic commits.
+
+Checkpoints:
+
+- Checkpoint after each issue's spec commit.
+- Checkpoint after red tests demonstrate the gap.
+- Checkpoint after green implementation.
+- Checkpoint after mandatory refactor.
+- Checkpoint after integration/proof evidence.
+
+Rollback:
+
+- If gate recovery breaks tests, revert only the current semantic lint-fix commit.
+- If the demo runner becomes flaky, keep the last passing local-only runner and isolate devnet work behind `KAMN_MVP_DEVNET_MODE=required`.
+- If public devnet is unavailable, keep the report `NO-GO` and rerun with a pre-funded devnet keypair or private devnet RPC. Do not merge a fake settlement pass.
+- If CI live proof is flaky, move live proof to manual/scheduled and keep deterministic verifier/schema tests in PR CI.
+
+Evidence retention:
+
+- Demo artifacts should live under `.kamn/demo/<run-id>/`.
+- `.kamn/demo/latest` may be a local symlink or pointer file, but build artifacts and secrets must not be committed.
+- PR evidence should include report excerpts and artifact paths, not committed private key material.
+
+## Do Not Build Yet
+
+Do not spend MVP time on:
+
+- Mainnet settlement or production custody.
+- Generalized multi-chain settlement.
+- Full bridge finality.
+- Byzantine-safe dispute resolution.
+- Broad multi-node consensus/finality.
+- Global fault-tolerance under arbitrary partitions.
+- UI dashboard or marketing landing page.
+- New SDK language surfaces.
+- More governance/spec/doc taxonomies not needed by the demo.
+- New dependencies unless an issue/spec explicitly justifies them and the user approves.
+- Refactoring unrelated modules beyond what is needed for gate recovery and touched-surface size limits.
+- Replacing the whole runtime architecture.
+- Treating `InMemoryKamnClient` as proof for exchange, escrow, settlement, or asset movement.
+
+## Recommended Execution Mode
+
+Recommended next workflow: `ce:work` issue-by-issue, starting with Issue 1.
+
+Reason:
+
+- The immediate blocker is sequential and gate-sensitive: `make check` must become green before MVP expansion.
+- The repo process requires issue-first, spec-before-code, TDD, mandatory refactor, and integration wiring. `ce:work` is the right long-running implementation mode for that.
+- Do not start with `team`: parallel implementation before gate recovery will create conflicts across many Rust files.
+- After Issue 2 freezes the claim contract, consider a small `team` split:
+  - one lane for local demo runner,
+  - one lane for report verifier/docs,
+  - one lane for devnet proof hardening.
+- If running under OMX runtime and persistent autonomous completion is desired, use a `ralph`-style single-owner loop after the first two issues are fully specified and the gate recovery plan is accepted.
+
+Default next action:
+
+1. Open parent tracker issue.
+2. Open Issue 1.
+3. Write and commit `specs/<issue>-restore-local-quality-gates.md`.
+4. Start `ce:work` on Issue 1 only.
+
+Do not start Issues 2-5 until `make check` is green or Issue 1 has been deliberately split into smaller gate-recovery sub-issues that together restore `make check`.

--- a/docs/plans/2026-07-10-001-kamn-agent-transaction-rail-mega-plan.md
+++ b/docs/plans/2026-07-10-001-kamn-agent-transaction-rail-mega-plan.md
@@ -1,0 +1,1494 @@
+---
+title: KAMN Agent Transaction Rail
+type: feat
+status: proposed
+date: 2026-07-10
+origin: docs/brainstorms/2026-06-26-kamn-forward-strategy-requirements.md
+supersedes: docs/plans/2026-06-26-001-kamn-mvp-demo-readiness-plan.md
+artifact_status: historical
+current_status: completed
+---
+
+# KAMN Agent Transaction Rail Mega Plan
+
+> Historical decision artifact. The implementation completed on 2026-07-13
+> through tracker `#7088`; this plan is not production or mainnet evidence, and
+> settlement claims remain limited to Solana devnet.
+
+## Executive Decision
+
+KAMN should stop expanding as a broad messaging/network/governance platform and
+finish one narrow product:
+
+> An authenticated agent-to-agent job transaction rail where Agent A hires
+> Agent B, task-bound escrow is funded and settled on Solana devnet, and Agent C
+> independently verifies the public proof without seeing participant-private
+> data.
+
+This plan moves KAMN from a collection of individually credible proof slices to
+one coherent, runtime-enforced, evaluator-friendly transaction.
+
+The final MVP is not production escrow, a marketplace, a general messaging
+network, a multi-chain bridge, or a production consensus system. It is one
+complete transaction whose identity, authorization, state, settlement, views,
+and proof can all be traced to runtime receipts.
+
+## Simple Human Explanation
+
+When this plan is complete, a human evaluator should be able to say:
+
+1. Agent A and Agent B each created a cryptographically authenticated KAMN
+   identity.
+2. Agent A offered Agent B a specific job with agreed terms and a devnet amount.
+3. Only Agent B could accept and complete that job.
+4. Only Agent A could fund and authorize release of the associated escrow.
+5. KAMN moved developer-test value on Solana devnet and persisted the confirmed
+   transaction signature.
+6. Agent A and Agent B saw richer participant records.
+7. Agent C saw only the restricted public proof.
+8. All three views agreed on the public transaction facts.
+9. A verifier independently recomputed the proof from runtime artifacts.
+10. One command reproduced the story from a fresh checkout.
+
+## Why This Plan Exists
+
+KAMN already has real components:
+
+- Key-bound DIDs and signed request authentication.
+- Nonce and replay protection.
+- Agent registration and profile persistence.
+- Messages, channels, tasks, escrow endpoints, websocket events, and audit
+  output.
+- JSON/SQLite-oriented durable state surfaces.
+- CLI, SDK, MCP, Pi extension, and evaluator harness entrypoints.
+- Independent Pi Agent A and Agent B task coordination.
+- Independent Agent C restricted observation artifacts.
+- Real Solana devnet transfer, confirmation, balance, and persisted signature
+  evidence.
+- A fail-closed proof report and canonical verifier.
+
+The current weakness is composition. The agent task flow, Agent C observation,
+and devnet settlement are proven in separate slices. The generated three-agent
+transcript describes a unified story, but the same independent agents do not yet
+drive the same task-bound escrow and settlement transaction.
+
+The service also authenticates signers without yet enforcing a complete
+business authorization model. Task and escrow transitions are not consistently
+bound to the creator, assignee, funder, beneficiary, or verifier role.
+
+## Current Truth
+
+### Real Now
+
+- A local KAMN node and service API run.
+- Signed requests are verified against key-bound DIDs.
+- Nonces are persistent and replay attempts fail.
+- Agent registration is service-backed.
+- Tasks can be created, queried, accepted, and completed.
+- Escrow records can be funded and released.
+- Escrow release can execute a real Solana devnet transfer when configured.
+- State, websocket events, audit evidence, proof reports, and report verification
+  exist.
+- Separate Pi processes can coordinate one accepted task.
+- A third Pi process can produce and verify a source-bound restricted artifact.
+
+### Not Real Enough
+
+- A scope header is checked against a route, but there is no complete
+  server-side grant/role model proving that the signer is entitled to that
+  scope.
+- Registration is not clearly required before every protected product action.
+- Task mutation does not consistently enforce creator/assignee roles.
+- Escrow records do not yet carry complete task, actor, amount, terms, and
+  release-policy semantics.
+- Escrow release authorization is not tied to the escrow owner or task state.
+- Crash recovery around an externally successful but not-yet-persisted Solana
+  transfer can create ambiguous retry risk.
+- Participant-private and restricted-public views are evaluator artifacts, not
+  service-generated role projections.
+- The three-agent settlement transcript contains generated step labels rather
+  than receipts emitted by the same live actors for every step.
+- Placeholder orchestration paths still exist outside the canonical MVP lane.
+- The repository has too much governance, script, spec, fixture, and marker-test
+  surface relative to the product path.
+
+## Product Contract
+
+### Canonical User Story
+
+1. Agent A registers.
+2. Agent B registers.
+3. Agent C registers as a verifier or obtains an authenticated verifier grant.
+4. Agent A creates transaction `T` and task `K` for Agent B.
+5. The task includes a canonical terms digest and devnet amount.
+6. Agent B accepts task `K`.
+7. Agent A funds escrow `E`, which is permanently linked to `T` and `K`.
+8. Agent B submits completion evidence and completes task `K`.
+9. Agent A authorizes escrow release.
+10. KAMN persists a release intent before external submission.
+11. KAMN submits and confirms one Solana devnet transfer.
+12. KAMN persists the transaction signature and marks escrow settled.
+13. Agent A and Agent B query participant-private views.
+14. Agent C queries a restricted-public verification view.
+15. Agent C independently verifies the shared public commitments.
+16. The proof exporter writes a human and machine report from those receipts.
+
+### Required Shared Public Facts
+
+Every view must agree on:
+
+- `transaction_id`
+- `task_id`
+- `escrow_id`
+- transaction state
+- task state
+- escrow state
+- terms digest
+- amount in lamports
+- settlement network
+- settlement transaction signature
+- settlement commitment/finality
+- runtime receipt digests
+- public commitment digest
+- timestamps or monotonic sequence markers
+
+### Participant-Private Facts
+
+Agent A and Agent B may see:
+
+- Full task terms or encrypted task payload references.
+- Participant identities and roles.
+- Completion evidence references.
+- Release authorization evidence.
+- Participant-specific audit details.
+- Any private data explicitly included in the accepted terms.
+
+The MVP does not need to invent sensitive fields merely to demonstrate privacy.
+It needs at least one real participant-only field whose absence from Agent C is
+enforced and tested.
+
+### Restricted Agent C Facts
+
+Agent C may see only:
+
+- Shared public facts listed above.
+- Public receipt and artifact digests.
+- Redaction and view-scope markers.
+- Enough settlement evidence to independently verify the devnet transaction.
+
+Agent C must not receive:
+
+- Raw task payload or completion payload.
+- Participant-private digest fields.
+- Signing keys, auth headers, nonces, or credentials.
+- Unredacted participant-only audit details.
+- Any field not in the restricted projection allowlist.
+
+## Claim Contract
+
+The proof report must continue to use these labels:
+
+- `real`: behavior actually executed by the local runtime.
+- `local-only`: real local behavior without external value movement.
+- `devnet-backed`: Solana devnet evidence exists and is independently checked.
+- `dry-run`: deliberate non-live behavior that cannot satisfy required MVP
+  success.
+- `placeholder`: illustrative or unimplemented behavior that cannot satisfy
+  required MVP success.
+- `roadmap`: explicitly deferred behavior.
+
+Additional rules:
+
+- No settlement, escrow release, transfer, or value-movement success may be
+  `local-only`.
+- No generated narrative step may be presented as an actor receipt.
+- No report field may imply server authorization unless the server enforced it.
+- A devnet transaction is necessary but not sufficient for escrow success. The
+  transaction must also be bound to the authorized task/escrow state machine.
+- The canonical verifier must recompute artifact digests and compare runtime
+  receipts, not trust copied report fields.
+
+## Target Architecture
+
+Prefer extending existing surfaces. Do not introduce a parallel service.
+
+### Existing Surfaces To Reuse
+
+- `crates/kamn-node/src/service_api_endpoint/`
+- `crates/kamn-node/src/service_api_endpoint/message_store/`
+- `crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch/`
+- `crates/kamn-sdk/src/service_client.rs`
+- `crates/kamn-agent-lib/src/lib.rs`
+- `crates/kamn-mcp-server/src/dispatch.rs`
+- `.pi/extensions/kamn-mvp/`
+- `crates/kamn-e2e-harness/src/mvp_demo/`
+- `docs/validation/mvp-evaluator-demo.md`
+- `Makefile`
+
+### New Concepts Allowed
+
+Only add concepts required to complete the transaction:
+
+- Explicit authorization grants or role assignments.
+- Canonical transaction record.
+- Task-bound escrow terms.
+- Durable settlement intent and reconciliation status.
+- Server-generated role projection.
+- Runtime actor receipt.
+
+Do not add a new general policy engine, workflow framework, blockchain adapter,
+message broker, or database unless the current architecture cannot satisfy a
+specific acceptance criterion.
+
+## Proposed Data Model
+
+Exact serialization and migration details belong in issue specs, but the
+runtime must represent these facts.
+
+### Agent Registration And Grant
+
+```text
+AgentRecord
+  did
+  public_key_binding
+  registration_status
+  capabilities
+  created_at
+
+AgentGrant
+  did
+  transaction_id or resource_id
+  role: initiator | provider | verifier
+  allowed_actions
+  status: active | revoked
+```
+
+For the MVP, grants may be transaction-scoped rather than a broad RBAC system.
+That is smaller and safer.
+
+### Transaction
+
+```text
+AgentTransaction
+  transaction_id
+  initiator_did
+  provider_did
+  verifier_policy
+  task_id
+  escrow_id
+  terms_digest
+  amount_lamports
+  state
+  created_sequence
+  updated_sequence
+```
+
+### Task
+
+```text
+TaskRecord
+  task_id
+  transaction_id
+  creator_did
+  assignee_did
+  terms_digest
+  private_payload_reference or private_payload_digest
+  completion_evidence_digest
+  state
+```
+
+### Escrow
+
+```text
+EscrowRecord
+  escrow_id
+  transaction_id
+  task_id
+  funder_did
+  beneficiary_did
+  amount_lamports
+  network
+  release_authority_did
+  release_policy
+  state
+  settlement_intent_id
+  settlement_tx_signature
+  settlement_commitment
+```
+
+### Settlement Intent
+
+```text
+SettlementIntent
+  settlement_intent_id
+  escrow_id
+  idempotency_key
+  expected_transaction_signature or signed_transaction_digest
+  state: prepared | submitted | confirmed | reconciled | failed
+  submission_attempt_count
+  last_error_code
+```
+
+### Runtime Receipt
+
+```text
+RuntimeReceipt
+  receipt_id
+  transaction_id
+  actor_did
+  actor_role
+  action
+  resource_id
+  before_state
+  after_state
+  sequence
+  public_commitment
+  artifact_digest
+```
+
+## State Machines
+
+### Transaction State
+
+```text
+created
+  -> accepted
+  -> escrow_funded
+  -> work_completed
+  -> release_authorized
+  -> settlement_submitted
+  -> settled
+```
+
+Failure states:
+
+```text
+rejected
+cancelled
+settlement_failed
+settlement_ambiguous
+```
+
+No transition may skip required prior states.
+
+### Task State
+
+```text
+submitted -> accepted -> completed
+```
+
+Rules:
+
+- Only the named provider can accept.
+- Only the named provider can complete.
+- Completion must include an evidence digest.
+- A completed task cannot return to accepted.
+
+### Escrow State
+
+```text
+created -> funded -> release_authorized -> submitting -> released
+```
+
+Rules:
+
+- Escrow is created for exactly one transaction and task.
+- Only the initiator/funder may fund in the MVP.
+- Release requires task completion.
+- Only the release authority may authorize release.
+- External transfer submission is idempotent and recoverable.
+- `released` requires confirmed devnet evidence and persisted signature.
+
+## Authorization Matrix
+
+| Action | Agent A | Agent B | Agent C |
+| --- | --- | --- | --- |
+| Register own identity | Allow | Allow | Allow |
+| Create transaction/task | Allow | Deny | Deny |
+| Read participant task view | Allow | Allow after assignment | Deny |
+| Accept task | Deny | Allow when assigned | Deny |
+| Complete task | Deny | Allow when assigned | Deny |
+| Fund escrow | Allow | Deny | Deny |
+| Authorize release | Allow after completion | Deny | Deny |
+| Query participant escrow view | Allow | Allow | Deny |
+| Query restricted verification view | Allow | Allow | Allow |
+| Verify public proof | Allow | Allow | Allow |
+| Read raw private payload | Policy-dependent participant only | Policy-dependent participant only | Deny |
+
+Every deny row requires a negative integration test with a real signed request.
+
+## Security Invariants
+
+1. Authentication and authorization are separate checks.
+2. A self-asserted scope is never treated as a grant.
+3. Registration is required before protected product actions.
+4. Resource ownership/role is checked on every task and escrow operation.
+5. Authorization decisions use the signer DID from verified request context,
+   never an untrusted body field.
+6. Nonce/replay state remains durable across restart.
+7. State transitions are idempotent or reject duplicates explicitly.
+8. External transfer retries cannot create an untracked second transfer.
+9. Agent C responses are built from an allowlist, not by deleting fields from a
+   participant response.
+10. Secrets never enter proof artifacts, logs, reports, or git.
+11. A failed external call cannot silently advance state to released.
+12. A confirmed external call followed by a persistence failure enters an
+   explicit recoverable/ambiguous state and reconciles by transaction signature.
+
+## Program Structure
+
+This program should be executed as a parent tracker plus small child issues.
+Every child follows `AGENTS.md`: issue, spec, RED, GREEN, REFACTOR, integration,
+proof, PR, merge.
+
+## First Five Issues In Dependency Order
+
+### Issue 1: Parent Tracker - Complete The Agent Transaction Rail
+
+Purpose:
+
+- Own the program checklist and dependency graph.
+- State the product and claim boundaries.
+- Link every child issue, spec, PR, demo artifact, and residual risk.
+
+Acceptance:
+
+- No implementation is committed under the tracker itself.
+- Each child issue has one concern and testable acceptance criteria.
+- The tracker distinguishes runtime proof from report-only proof.
+
+### Issue 2: Enforce Registered Identity And Transaction-Scoped Grants
+
+Depends on: Issue 1.
+
+Purpose:
+
+- Separate signature authentication from business authorization.
+- Require registered identities for protected transaction actions.
+- Add transaction/resource-scoped roles or grants.
+
+Likely files:
+
+- `crates/kamn-node/src/service_api_endpoint/auth/`
+- `crates/kamn-node/src/service_api_endpoint/middleware_impl/auth_flow/`
+- `crates/kamn-node/src/service_api_endpoint/message_store/store/agent_ops.rs`
+- `crates/kamn-sdk/src/service_request_auth.rs`
+- service API auth integration tests
+
+RED first:
+
+- Unregistered signed agent can currently call a protected task route.
+- Registered Agent C can currently present `tasks:write` or `escrow:write` and
+  reach a mutation route.
+- Revoked/absent grant is not rejected independently of signature validity.
+
+Acceptance:
+
+- Valid signature without registration returns structured forbidden/unauthorized
+  evidence.
+- Valid registration without required grant returns structured forbidden
+  evidence.
+- Scope header remains signed but is treated only as request intent.
+- Authorization decision names actor DID, resource, requested action, decision,
+  and reason code without leaking secrets.
+
+Risk gate:
+
+- Do not implement a global permission system. Use the minimum transaction or
+  resource-scoped grant needed by the MVP.
+
+### Issue 3: Bind Task Lifecycle To Creator And Assigned Provider
+
+Depends on: Issue 2.
+
+Purpose:
+
+- Persist creator, provider, transaction ID, terms digest, and completion
+  evidence.
+- Enforce the task state machine and actor roles.
+
+Likely files:
+
+- `crates/kamn-node/src/service_api_endpoint/message_store/models.rs`
+- `crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops.rs`
+- task route handlers
+- `crates/kamn-sdk/src/service_models.rs`
+- `crates/kamn-agent-lib/src/lib.rs`
+- MCP and CLI task commands
+
+RED first:
+
+- Unassigned agent can accept a task.
+- Initiator can complete a provider task.
+- Provider can mutate a different provider's task.
+- Task can skip accepted and move directly to completed.
+- Completion can omit evidence digest.
+
+Acceptance:
+
+- Task creation takes the authenticated initiator from request context.
+- Task names exactly one provider for the canonical MVP path.
+- Only that provider can accept and complete.
+- Every transition emits a durable runtime receipt.
+- Retry of an identical transition is deterministic; conflicting retry fails.
+
+Risk gate:
+
+- Data snapshot/schema changes require explicit approval under `AGENTS.md`.
+- Preserve migration and restart compatibility; do not silently discard old
+  records.
+
+### Issue 4: Add Task-Bound Escrow Terms And Release Authorization
+
+Depends on: Issues 2 and 3.
+
+Purpose:
+
+- Replace generic escrow state with task-bound business semantics.
+- Enforce funder, beneficiary, amount, network, and release authority.
+
+Likely files:
+
+- escrow models and store operations
+- escrow route handlers
+- settlement configuration models
+- SDK, agent library, MCP, and CLI escrow commands
+- persistence/restart tests
+
+RED first:
+
+- Escrow can be funded without a valid task.
+- Escrow can be funded by the wrong actor.
+- Escrow amount can disagree with task transaction terms.
+- Escrow can be released before task completion.
+- Escrow can be released by Agent B or Agent C.
+- Escrow can be rebound to another task.
+
+Acceptance:
+
+- Escrow names transaction, task, funder, beneficiary, amount, network, and
+  release authority.
+- Funding validates task acceptance and terms agreement.
+- Release authorization validates completed task and authenticated actor.
+- Every transition emits a durable runtime receipt.
+- Local-only release cannot satisfy an asset-movement success claim.
+
+### Issue 5: Make Devnet Settlement Idempotent And Recoverable
+
+Depends on: Issue 4.
+
+Purpose:
+
+- Bind one Solana devnet transfer to one authorized escrow release.
+- Prevent duplicate transfer on retry or crash.
+- Reconcile ambiguous external outcomes.
+
+Likely files:
+
+- `crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch/`
+- `state_routes_release.rs`
+- escrow settlement persistence
+- MVP devnet settlement runner and verifier
+
+RED first:
+
+- Transfer succeeds but persistence fails; retry would submit again.
+- Timeout occurs after submission but before confirmation.
+- Duplicate release request arrives concurrently.
+- Persisted signature does not match confirmed transaction.
+- Balance evidence does not match configured amount.
+
+Acceptance:
+
+- Durable settlement intent exists before submission.
+- One idempotency key maps to one escrow release.
+- Retry checks known signature/status before resubmission.
+- Ambiguous outcomes are explicit and cannot return success.
+- `released` requires confirmed signature, expected amount/balances, expected
+  recipient, expected network, and persisted evidence.
+- A restart integration test reconciles a submitted/confirmed intent.
+
+Risk gate:
+
+- This is the highest-risk issue. Do not merge without targeted security review,
+  crash-window tests, and a real funded devnet rehearsal.
+
+## Remaining Child Issues
+
+### Issue 6: Add Server-Generated Participant And Verifier Projections
+
+Depends on: Issues 2 through 5.
+
+Goal:
+
+- Generate views from authenticated server context.
+- Enforce participant-private versus restricted-public disclosure.
+
+RED first:
+
+- Agent C can query participant view.
+- Participant response and verifier response are identical.
+- Verifier response includes private digest/payload fields.
+- Public commitment disagrees across views.
+
+Acceptance:
+
+- Separate explicit response types/serializers exist.
+- Participant membership is checked before private projection.
+- Restricted view uses an allowlist.
+- A/B see at least one real field C cannot see.
+- Shared public facts and commitments match exactly.
+
+### Issue 7: Drive The Full Transaction Through Independent Pi Agents
+
+Depends on: Issue 6.
+
+Goal:
+
+- Reuse current persistent MCP sessions and coordination tools.
+- Make independent Agent A, B, and C drive the same transaction.
+
+Required actor behavior:
+
+- Agent A: register, create transaction/task, fund escrow, authorize release,
+  query participant view.
+- Agent B: register, accept task, submit completion evidence, complete task,
+  query participant view.
+- Agent C: register/authenticate as verifier, query restricted view, verify
+  public proof.
+
+RED first:
+
+- Existing Pi flow cannot carry transaction/escrow IDs through all steps.
+- Actor receipt can be produced without a matching runtime receipt.
+- Agent C artifact can be created without server restricted-view evidence.
+
+Acceptance:
+
+- Three distinct Pi process IDs.
+- Three distinct key-bound DIDs.
+- Independent nonce streams.
+- One shared transaction/task/escrow ID set.
+- All actor receipts reference runtime receipt digests.
+- No filesystem handoff is treated as authorization.
+
+### Issue 8: Replace Generated Three-Agent Narrative With Runtime Receipt Chain
+
+Depends on: Issue 7.
+
+Goal:
+
+- Remove fixed transcript step labels from success evidence.
+- Build transcript strictly from runtime receipts.
+
+RED first:
+
+- Missing actor receipt is currently replaceable by a generated step string.
+- Reordered, duplicated, or cross-transaction receipts are accepted.
+- Settlement evidence from another escrow can be copied into the report.
+
+Acceptance:
+
+- Every transcript step names a runtime receipt artifact and digest.
+- Receipt chain order and before/after state are verified.
+- Transaction, task, escrow, actor, amount, and settlement signature remain
+  consistent across the chain.
+- Synthetic step names cannot satisfy required claims.
+
+### Issue 9: Add One Canonical Agent Transaction Demo Command
+
+Depends on: Issue 8.
+
+Goal:
+
+- Produce one evaluator command and one report.
+
+Recommended staged command:
+
+```bash
+KAMN_MVP_AGENT_DRIVER=pi \
+KAMN_MVP_DEVNET_MODE=required \
+KAMN_MVP_SOLANA_RPC_URL=https://api.devnet.solana.com \
+make demo-agent-transaction
+```
+
+After repeated success, promote this path to `make demo-mvp` and retain the old
+local proof lane under an explicitly local-only name.
+
+Acceptance:
+
+- Fresh checkout prerequisites are checked before work begins.
+- Local KAMN runtime is started and stopped automatically.
+- Agent processes are launched with bounded tool allowlists.
+- Existing Codex/Pi auth is used without committed secrets.
+- Devnet configuration is validated before task creation.
+- Any failure produces a human-readable `NO-GO` report and leaves no running
+  child processes.
+- Success writes one proof directory, `report.json`, and `report.md`.
+- Report separates local runtime proof from devnet settlement proof.
+
+### Issue 10: Add Independent Evaluator Verification And Explorer Links
+
+Depends on: Issue 9.
+
+Goal:
+
+- Make a skeptical evaluator able to verify the result without trusting the
+  demo runner.
+
+Acceptance:
+
+- Canonical verifier recomputes all artifact digests.
+- Verifier checks receipt chain, authorization decisions, role projections,
+  settlement signature, recipient, amount, commitment, and balance movement.
+- Human report links the Solana explorer devnet transaction.
+- Verification can run after demo processes have exited.
+- Tampering with any shared fact fails with a specific reason code.
+
+### Issue 11: Restart, Retry, Concurrency, And Failure Matrix
+
+Depends on: Issues 5 through 10.
+
+Required tests:
+
+- Node restart after task creation.
+- Node restart after escrow funding.
+- Node restart after settlement intent persistence.
+- Process crash after transfer submission.
+- Duplicate Agent A release request.
+- Concurrent release requests.
+- Stale nonce/replay after restart.
+- Devnet RPC timeout and recovery.
+- Agent process exits mid-flow.
+- Proof generation fails after successful settlement and is retried.
+
+Acceptance:
+
+- No duplicate asset movement.
+- No state rollback from settled to pre-settlement.
+- No false `GO` after ambiguous settlement.
+- Retried proof generation does not resubmit settlement.
+
+### Issue 12: Reduce Repository Surface Around The MVP
+
+Depends on: canonical path proven green.
+
+Goal:
+
+- Make the product easier to understand and maintain.
+
+Actions requiring explicit approval:
+
+- Archive or delete superseded specs.
+- Isolate placeholder orchestration under a clearly non-MVP namespace.
+- Remove duplicate docs-marker/source-marker tests where behavior tests exist.
+- Consolidate redundant scripts and fixtures.
+- Demote unused crates/surfaces from the front-door architecture map.
+
+Acceptance:
+
+- Root README points to one product path.
+- Placeholder scenarios cannot appear in MVP success output.
+- Test taxonomy distinguishes behavior, integration, live, docs-contract, and
+  legacy compatibility tests.
+- Build/test time and repository file counts move downward.
+- No proven runtime behavior is lost.
+
+## Phased Execution Program
+
+## Phase 0: Baseline And Scope Freeze
+
+What this phase proves:
+
+- Everyone is building the same narrow product.
+- Existing claims remain honest while implementation changes.
+
+Actions:
+
+1. Open parent tracker.
+2. Record current `main` SHA and latest green commands.
+3. Link this plan and the origin brainstorm.
+4. Freeze new non-MVP nouns/features.
+5. Capture the current local and devnet proof bundles as comparison fixtures,
+   without committing secrets or mutable live artifacts.
+
+Acceptance:
+
+- Parent tracker has problem, outcome, non-goals, dependency order, and claim
+  boundary.
+- First five child issues exist with acceptance criteria.
+- No feature implementation begins before its issue/spec.
+
+Checkpoint:
+
+- Tag or record baseline commit in tracker; do not create a release tag unless
+  repository policy allows it.
+
+Rollback:
+
+- No runtime changes in this phase.
+
+## Phase 1: Authorization Foundation
+
+Issues:
+
+- Issue 2.
+
+What this phase proves:
+
+- A valid signer is not automatically authorized.
+- Registration and role/grant checks happen server-side.
+
+Tests go red first:
+
+- Signed but unregistered mutation.
+- Signed wrong-role mutation.
+- Self-asserted privileged scope.
+- Revoked grant.
+- Grant for another transaction/resource.
+
+Completion evidence:
+
+```bash
+cargo test -p kamn-node service_api -- --nocapture
+cargo test -p kamn-sdk service -- --nocapture
+cargo test -p kamn-agent-lib -- --nocapture
+cargo fmt --check
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+make check
+```
+
+Risk gate:
+
+- Security review must confirm actor DID comes from verified request context.
+- Do not merge if a caller-controlled body field can choose authorization
+  identity.
+
+Rollback:
+
+- Keep new authorization behavior behind explicit API/schema version until all
+  current clients are migrated.
+
+## Phase 2: Task And Transaction State Machine
+
+Issues:
+
+- Issue 3.
+
+What this phase proves:
+
+- One transaction and task have explicit actors, terms, and legal transitions.
+
+Tests go red first:
+
+- Wrong provider acceptance/completion.
+- Missing/incorrect terms digest.
+- Illegal transition order.
+- Cross-transaction resource substitution.
+- Duplicate/conflicting transition.
+
+Completion evidence:
+
+```bash
+cargo test -p kamn-node task_escrow -- --nocapture
+cargo test -p kamn-sdk task -- --nocapture
+cargo test -p kamn-mcp-server task -- --nocapture
+cargo test -p kamn-cli task -- --nocapture
+make check
+```
+
+Risk gate:
+
+- Snapshot/schema migration test must load the previous format or fail with an
+  explicit migration error.
+
+Rollback:
+
+- Preserve old task records read-only during migration; never silently rewrite
+  or discard them.
+
+## Phase 3: Task-Bound Escrow And Devnet Safety
+
+Issues:
+
+- Issues 4 and 5, sequentially.
+
+What this phase proves:
+
+- Escrow belongs to one authorized task.
+- One release intent results in at most one devnet transfer.
+
+Tests go red first:
+
+- Wrong actor fund/release.
+- Wrong task/amount/recipient.
+- Release before completion.
+- Crash and retry windows.
+- Concurrent release.
+- Ambiguous RPC outcome.
+
+Completion evidence:
+
+```bash
+cargo test -p kamn-node task_escrow -- --nocapture
+cargo test -p kamn-node live_settlement -- --nocapture
+cargo test -p kamn-e2e-harness devnet_settlement -- --nocapture
+make check
+```
+
+Required live evidence:
+
+```bash
+KAMN_MVP_DEVNET_MODE=required \
+KAMN_MVP_SOLANA_RPC_URL=https://api.devnet.solana.com \
+KAMN_SERVICE_API_LIVE_SOLANA_SETTLEMENT_KEYPAIR_FILE=<path-to-payer-keypair.json> \
+KAMN_SERVICE_API_LIVE_SOLANA_SETTLEMENT_RECIPIENT_PUBKEY=<recipient> \
+KAMN_SERVICE_API_LIVE_SOLANA_SETTLEMENT_LAMPORTS=<bounded-test-amount> \
+make demo-mvp
+```
+
+Risk gate:
+
+- No live rehearsal until negative authorization and idempotency tests pass.
+- Use only bounded devnet amounts.
+- A missing or ambiguous result is `NO-GO`.
+
+Rollback:
+
+- Disable live settlement configuration and leave intent in explicit failed or
+  ambiguous state. Never fake local completion.
+
+## Phase 4: Runtime Disclosure Views
+
+Issues:
+
+- Issue 6.
+
+What this phase proves:
+
+- Privacy differences are enforced by the server.
+
+Tests go red first:
+
+- Agent C participant-view request.
+- Nonparticipant participant-view request.
+- Restricted view extra-field injection.
+- Shared commitment mismatch.
+- Private field count/digest leak.
+
+Completion evidence:
+
+```bash
+cargo test -p kamn-node projection -- --nocapture
+cargo test -p kamn-sdk projection -- --nocapture
+cargo test -p kamn-e2e-harness three_agent -- --nocapture
+make check
+```
+
+Risk gate:
+
+- Restricted projection must be an allowlist serializer.
+- Do not claim encrypted private storage unless that is separately proven.
+
+Rollback:
+
+- Fail closed and return no projection if actor role cannot be resolved.
+
+## Phase 5: Independent Agent Execution
+
+Issues:
+
+- Issue 7.
+
+What this phase proves:
+
+- Independent agents, not one harness process impersonating roles, drive the
+  transaction.
+
+Tests go red first:
+
+- Same Pi PID reused.
+- Same DID reused.
+- Shared nonce domain.
+- Actor receipt missing runtime receipt digest.
+- Transaction/task/escrow mismatch.
+
+Completion evidence:
+
+- Separate Pi process output for A, B, and C.
+- Node logs show distinct DIDs and nonce sequences.
+- Runtime state shows one transaction/task/escrow relationship.
+- Agent C receives only server restricted projection.
+
+Risk gate:
+
+- Filesystem coordination may carry non-secret IDs, but it cannot authorize
+  actions or manufacture server evidence.
+
+Rollback:
+
+- Existing two-agent and artifact-level checks remain available as local-only
+  diagnostic lanes, not as final MVP success.
+
+## Phase 6: Receipt-Built Proof And Canonical Command
+
+Issues:
+
+- Issues 8, 9, and 10.
+
+What this phase proves:
+
+- The final report is a projection of runtime receipts, not a story generator.
+- One command executes and verifies the complete product.
+
+Tests go red first:
+
+- Missing/reordered/cross-run receipts.
+- Copied settlement signature.
+- Generated step without runtime artifact.
+- Report path substitution.
+- Artifact digest tampering.
+- Agent C private field leak.
+
+Completion evidence:
+
+```bash
+make demo-agent-transaction
+cargo run -p kamn-e2e-harness -- \
+  verify-mvp-demo --report .kamn/demo/latest/proof/report.json
+```
+
+Required human output:
+
+- What ran locally.
+- What ran on Solana devnet.
+- Which agents participated.
+- Which fields were private/restricted.
+- Solana explorer link.
+- Exact `GO` or `NO-GO` reason.
+- Explicit non-claims.
+
+Risk gate:
+
+- Do not promote the new command to README canonical status until three
+  consecutive fresh-run rehearsals pass.
+
+Rollback:
+
+- Keep report schema versioned. Old verifier supports old reports; new success
+  requires new schema and receipt chain.
+
+## Phase 7: Failure, Restart, And Evaluator Hardening
+
+Issues:
+
+- Issue 11.
+
+What this phase proves:
+
+- The MVP is reproducible and survives predictable failures without false
+  settlement claims.
+
+Completion evidence:
+
+- Restart/retry/concurrency matrix.
+- Three consecutive successful local rehearsals.
+- At least one successful funded devnet rehearsal after final code changes.
+- At least one deliberate `NO-GO` rehearsal.
+- Independent verifier run after all demo processes exit.
+
+Risk gate:
+
+- Any duplicate-transfer possibility is release-blocking.
+- Any private-field disclosure is release-blocking.
+- Any false `GO` is release-blocking.
+
+## Phase 8: Repository Reduction And MVP Release Candidate
+
+Issues:
+
+- Issue 12.
+
+What this phase proves:
+
+- A maintainer can find and understand the product path.
+
+Actions:
+
+- Update README around the single transaction story.
+- Add a concise architecture diagram and claim matrix.
+- Move deep historical process material away from the first evaluator path.
+- Archive/delete only with explicit approval.
+- Remove redundant marker tests only after behavior is covered.
+- Clearly label legacy placeholder harnesses.
+
+Completion evidence:
+
+```bash
+cargo fmt --check
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+make check
+make test
+make pre-push
+make demo-agent-transaction
+cargo run -p kamn-e2e-harness -- \
+  verify-mvp-demo --report .kamn/demo/latest/proof/report.json
+```
+
+Release candidate criteria:
+
+- All MVP claims map to runtime receipts.
+- All asset movement maps to confirmed devnet evidence.
+- Authorization matrix is enforced by integration tests.
+- Agent C disclosure is server-enforced.
+- One command and one report are sufficient for evaluation.
+- No known duplicate-transfer or private-disclosure risk.
+- Remaining non-MVP work is explicitly listed as roadmap.
+
+## Verification Matrix
+
+| Claim | Required evidence | Negative proof |
+| --- | --- | --- |
+| Agent identity | key-bound DID, registration record, signed request | unregistered/invalid signer rejected |
+| Authorization | transaction grant and decision receipt | wrong-role action rejected |
+| Task agreement | A create receipt, B accept receipt, terms digest | wrong provider/terms rejected |
+| Completion | B completion receipt and evidence digest | A/C completion rejected |
+| Escrow funding | task-bound escrow record and A receipt | wrong task/actor/amount rejected |
+| Release authorization | completed task and A authorization receipt | early/wrong-role release rejected |
+| Devnet movement | signature, confirmation, recipient, balances | missing/ambiguous evidence is NO-GO |
+| Participant privacy | A/B server projection | nonparticipant private request denied |
+| Agent C verification | restricted server projection and verifier receipt | private field injection rejected |
+| Full transaction | ordered runtime receipt chain | missing/reordered/cross-run receipt rejected |
+| Durability | restart and reconciliation evidence | no duplicate transfer after retry |
+
+## Human Evaluator Script
+
+The final evaluator experience should take approximately this form:
+
+1. Read the first README section.
+2. Confirm prerequisites.
+3. Run one command.
+4. Watch concise progress for Agent A, Agent B, Agent C, and Solana devnet.
+5. Open `report.md`.
+6. Open the Solana devnet explorer link.
+7. Run the canonical verifier.
+8. Inspect A/B/C view differences.
+9. Run one tamper fixture and see verification fail.
+
+The evaluator should not need to understand 16 crates, 400 specs, or the legacy
+orchestration framework to determine whether the MVP works.
+
+## Evidence Bundle Layout
+
+Recommended final structure:
+
+```text
+.kamn/demo/<run-id>/
+  state/
+    service-api-state.*
+  receipts/
+    agent-a-register.json
+    agent-b-register.json
+    agent-c-register.json
+    task-create.json
+    task-accept.json
+    escrow-fund.json
+    task-complete.json
+    release-authorize.json
+    settlement-submit.json
+    settlement-confirm.json
+    agent-a-view.json
+    agent-b-view.json
+    agent-c-view.json
+  proof/
+    receipt-chain.json
+    audit-export.json
+    settlement-evidence.json
+    report.json
+    report.md
+```
+
+Every artifact must include schema version, run/transaction identity, integrity
+digest, and only the fields appropriate to its role.
+
+## Error Taxonomy
+
+At minimum, support stable reason codes for:
+
+- `AGENT_NOT_REGISTERED`
+- `ACTION_NOT_GRANTED`
+- `RESOURCE_ROLE_MISMATCH`
+- `TASK_STATE_INVALID`
+- `TASK_TERMS_MISMATCH`
+- `ESCROW_TASK_MISMATCH`
+- `ESCROW_AMOUNT_MISMATCH`
+- `ESCROW_RELEASE_NOT_AUTHORIZED`
+- `SETTLEMENT_INTENT_CONFLICT`
+- `SETTLEMENT_OUTCOME_AMBIGUOUS`
+- `SETTLEMENT_EVIDENCE_INVALID`
+- `PROJECTION_SCOPE_DENIED`
+- `PRIVATE_FIELD_DISCLOSURE`
+- `RECEIPT_CHAIN_INVALID`
+- `PROOF_ARTIFACT_TAMPERED`
+
+Interior code returns typed/structured errors. Entrypoints log once and map to
+HTTP/MCP/CLI responses with correlation IDs.
+
+## Idempotency And Recovery Rules
+
+- Registration uses DID uniqueness.
+- Transaction/task/escrow creation uses explicit idempotency keys.
+- Repeated identical transitions return the existing receipt or deterministic
+  success.
+- Conflicting reuse of an idempotency key fails.
+- Settlement intent is durable before external submission.
+- Retry reconciles known signed transaction/signature before creating another.
+- Proof generation is separate from settlement execution and may be retried
+  without resubmission.
+- Cleanup commands never delete a run containing ambiguous settlement state.
+
+## Observability Requirements
+
+Required runtime events:
+
+- identity registered
+- authorization allowed/denied
+- transaction created
+- task accepted
+- escrow funded
+- task completed
+- release authorized
+- settlement prepared/submitted/confirmed/reconciled
+- participant projection read
+- verifier projection read
+- proof exported/verified
+
+Logs and metrics may include IDs, states, decisions, reason codes, and
+correlation IDs. They must not include keys, signatures used as credentials,
+raw private payloads, auth headers, or private completion data.
+
+## Fresh Checkout Requirements
+
+The final command must validate:
+
+- Rust toolchain available.
+- Required local shell/runtime tools available.
+- `pi` available only when Pi driver mode is selected.
+- Pi/Codex authentication available without committed secrets.
+- Solana RPC URL is devnet.
+- Keypair file exists and is not inside the repository.
+- Recipient is valid and differs from payer when required.
+- Payer has sufficient bounded devnet balance.
+- Required ports are available or dynamically allocated.
+- No stale run artifacts are reused as current success.
+
+## Performance And Ergonomics Targets
+
+- One obvious canonical command.
+- No manual multi-terminal coordination for the evaluator path.
+- Concise progress output; deep logs remain in the run directory.
+- Warm local-only run target: under 3 minutes.
+- Fresh build target: under 15 minutes on a normal developer machine.
+- Verifier target: under 30 seconds after build.
+- All child processes terminate on success, failure, or interrupt.
+- Re-running the command creates a new run without corrupting prior evidence.
+
+Targets are goals, not reasons to weaken validation.
+
+## Checkpoint And Rollback Strategy
+
+### Per-Issue Checkpoints
+
+- Spec commit.
+- RED test commit with observed failure.
+- GREEN implementation commit.
+- Mandatory refactor commit.
+- Integration wiring commit.
+- Evidence/docs closeout commit.
+
+### Branch Strategy
+
+- One issue branch per child issue.
+- Merge in dependency order.
+- Never stack multiple unresolved security/payment issues in one PR.
+- Rebase/refresh before each new issue.
+
+### Runtime Compatibility
+
+- Version new state and report schemas.
+- Preserve the ability to read prior state or fail with an explicit migration
+  requirement.
+- Keep old demo lane until the new canonical lane passes three rehearsals.
+- Never reinterpret an old local-only artifact as new devnet-backed evidence.
+
+### External Failure Rollback
+
+- Solana RPC unavailable: `NO-GO`, no local settlement success.
+- Faucet unavailable: use pre-funded evaluator key or `NO-GO`.
+- Pi unavailable/auth blocked: core deterministic runtime tests remain valid,
+  but agent-driven MVP is `NO-GO`.
+- Persistence failure after external submission: enter ambiguous/reconciliation
+  state; do not resubmit blindly.
+
+## Do Not Build Yet
+
+- Mainnet settlement.
+- Multi-chain settlement.
+- Generalized bridge product.
+- Production custody.
+- Dispute marketplace or mediator network.
+- Token economics.
+- Broad governance system.
+- New consensus protocol.
+- Production multi-node fault tolerance.
+- General agent discovery marketplace.
+- Web dashboard or polished UI before the CLI/demo path is complete.
+- New content lifecycle features.
+- New scenario families.
+- New SDK languages.
+- Broad plugin ecosystem.
+- Compliance or certification claims.
+
+## Repository Work To Pause
+
+Until the canonical transaction is complete, pause work whose primary output is:
+
+- Another planning taxonomy.
+- Another docs-only proof label.
+- Another source-marker contract without runtime behavior.
+- Another wrapper/matrix family.
+- Another placeholder orchestration step.
+- Another crate that does not serve the transaction path.
+- Another chain/provider adapter.
+
+Exceptions:
+
+- Security fixes.
+- Dependency/supply-chain fixes.
+- Build/gate repairs.
+- Changes directly required by this plan.
+
+## Success Metrics
+
+### Product Metrics
+
+- One complete agent transaction per demo run.
+- Three independent authenticated actor processes.
+- One task, one escrow, one devnet settlement, one receipt chain.
+- Zero unauthorized successful transitions in the negative matrix.
+- Zero duplicate transfers across retry/restart tests.
+- Zero private fields in Agent C projection.
+
+### Evaluator Metrics
+
+- One command from fresh checkout.
+- One human report.
+- One canonical verifier command.
+- One explorer link.
+- One deliberate tamper test that visibly fails.
+- Evaluator can explain the product in one sentence after the run.
+
+### Engineering Metrics
+
+- Formatting and strict clippy green.
+- All targeted and integration tests green.
+- Full pre-push gate green before final PR.
+- Placeholder count in canonical MVP path equals zero.
+- Repository docs/spec/script surface decreases after cleanup phase.
+
+## Final Definition Of Done
+
+The program is complete only when all statements below are true:
+
+- [ ] Agent A, B, and C are distinct registered, key-bound identities.
+- [ ] Server authorization rejects validly signed wrong-role requests.
+- [ ] Task is bound to creator, provider, transaction, and terms digest.
+- [ ] Escrow is bound to task, actors, amount, network, and release policy.
+- [ ] Only authorized transitions succeed.
+- [ ] Task completion precedes release authorization.
+- [ ] Settlement intent is durable and idempotent.
+- [ ] One confirmed Solana devnet transfer is linked to the escrow.
+- [ ] Retry/restart cannot create a second transfer.
+- [ ] A/B participant views are server-generated and richer than C's view.
+- [ ] C's restricted view is server-generated and allowlisted.
+- [ ] All views agree on shared public commitments.
+- [ ] Three Pi agents drive the same runtime transaction.
+- [ ] Every transcript step references a runtime receipt.
+- [ ] Proof report contains no synthetic required step.
+- [ ] Canonical verifier independently recomputes evidence.
+- [ ] `make demo-agent-transaction` succeeds from a fresh checkout.
+- [ ] Devnet failure produces explicit `NO-GO`.
+- [ ] Local-only mode never claims settlement success.
+- [ ] Human report explains real, local-only, devnet-backed, and non-claimed
+      behavior.
+- [ ] README presents this path as the product front door.
+- [ ] Placeholder/legacy paths are separated from MVP success.
+- [ ] Independent security and code review have no unresolved high findings.
+- [ ] PR and post-merge checks are green.
+
+## Recommended Execution Mode
+
+Use the main thread with `ce:work` and execute serially by issue dependency.
+
+Why:
+
+- Authorization, task state, escrow state, settlement safety, and projection
+  logic touch shared service boundaries.
+- Parallel implementation would create conflicting assumptions around models
+  and state transitions.
+- Security/payment issues benefit from one accountable integration owner.
+
+Use bounded subagents only for independent sidecars:
+
+- Explorer: map exact files/tests before each issue.
+- Test engineer: design negative authorization and crash-window tests.
+- Security reviewer: review grants, role checks, secret handling, and settlement
+  idempotency.
+- Verifier: independently inspect proof artifacts and final command output.
+- Code reviewer: review the completed diff before push.
+
+Do not allow subagents to recursively orchestrate or modify overlapping files.
+
+## Suggested Continuous Execution Loop
+
+For each child issue:
+
+1. Refresh `main` and confirm no newer product branch should be the base.
+2. Open/read issue and acceptance criteria.
+3. Commit spec before tests.
+4. Add failing behavior and negative tests.
+5. Record RED evidence.
+6. Implement minimum GREEN behavior.
+7. Refactor to repository limits.
+8. Wire SDK, MCP, CLI, Pi, and runtime entrypoints only where required.
+9. Run targeted tests.
+10. Run formatting, strict clippy, and `make check`.
+11. Run real integration rehearsal.
+12. Update spec with deviations/evidence.
+13. Obtain focused review.
+14. Push, open PR, wait for CI, merge, and verify post-merge `main`.
+15. Update parent tracker before starting the next issue.
+
+## Final Recommendation
+
+Continue KAMN, but judge every new change by one question:
+
+> Does this make the single agent job transaction more authorized, more real,
+> more recoverable, more private, or easier to verify?
+
+If the answer is no, defer it until after the MVP transaction rail is complete.
+
+## Sources
+
+- Origin requirements:
+  `docs/brainstorms/2026-06-26-kamn-forward-strategy-requirements.md`
+- Prior readiness plan:
+  `docs/plans/2026-06-26-001-kamn-mvp-demo-readiness-plan.md`
+- Current evaluator runbook:
+  `docs/validation/mvp-evaluator-demo.md`
+- Current Agent C artifact boundary:
+  `specs/7084-independent-agent-c-observation.md`
+- Current report-level three-agent contract:
+  `specs/7045-three-agent-escrow-verification.md`
+- Repository process:
+  `AGENTS.md`

--- a/fixtures/ci/test_file_size_policy_baseline.env
+++ b/fixtures/ci/test_file_size_policy_baseline.env
@@ -2,7 +2,7 @@ schema_version=kamn.ci.test-file-size-policy-baseline.v1
 captured_at=2026-07-12
 # Counts cover tracked crates/**/*.rs with a /tests/ path component, excluding any /tests/support/ paths.
 # Refresh baseline whenever new test files are added or removed.
-test_file_total=1318
+test_file_total=1319
 soft_warn_count=2
 # Soft warnings: kamn-mcp-server/tests/real_backend_integration_contract.rs and kamn-core/tests/journal_wal_commit_schema_contract.rs.
 severe_count=0

--- a/specs/7121-publish-mvp-planning-artifacts.md
+++ b/specs/7121-publish-mvp-planning-artifacts.md
@@ -68,18 +68,18 @@ Outputs:
 
 ## Acceptance Criteria
 
-- [ ] The three tracker-referenced documents are tracked and publicly
+- [x] The three tracker-referenced documents are tracked and publicly
   resolvable at their existing paths.
-- [ ] Each document identifies itself as a historical decision artifact and
+- [x] Each document identifies itself as a historical decision artifact and
   does not claim production or mainnet readiness.
-- [ ] No document contains a real private path, secret, credential, key
+- [x] No document contains a real private path, secret, credential, key
   material, `.kamn` run payload, or generated proof artifact.
-- [ ] `uv.lock` is tracked as reproducible Python project metadata.
-- [ ] `*.egg-info/` is ignored as generated Python build metadata.
-- [ ] A bounded Rust docs contract fails on missing paths, broken lineage,
+- [x] `uv.lock` is tracked as reproducible Python project metadata.
+- [x] `*.egg-info/` is ignored as generated Python build metadata.
+- [x] A bounded Rust docs contract fails on missing paths, broken lineage,
   unsafe claim markers, or packaging-policy drift.
-- [ ] Existing README/runbook claim contracts remain green.
-- [ ] The intentional working tree is clean after publication.
+- [x] Existing README/runbook claim contracts remain green.
+- [x] The intentional working tree is clean after publication.
 
 ## Files To Touch
 
@@ -126,6 +126,19 @@ make check
 make test
 make pre-push
 ```
+
+## Completion Evidence
+
+- RED: the new contract failed three cases for missing historical markers,
+  bounded claim language, and generated metadata policy.
+- GREEN/REFACTOR: the targeted contract passed all four cases; the README and
+  evaluator runbook contracts also passed.
+- Repository gates: `cargo fmt --check`, strict workspace clippy,
+  `make check`, and `make test` passed.
+- Local pre-push: workspace tests and critical-path coverage returned `GO`;
+  mutation testing caught 10 of 10 mutants with zero misses or timeouts.
+- Inventory deviation: the tracked Rust test-file baseline increased from
+  1,318 to 1,319 for the new artifact contract. No runtime behavior changed.
 
 ## Rollback
 

--- a/specs/7121-publish-mvp-planning-artifacts.md
+++ b/specs/7121-publish-mvp-planning-artifacts.md
@@ -1,0 +1,136 @@
+# Issue 7121: Publish MVP Planning Artifacts
+
+## Objective
+
+Publish the secret-safe historical brainstorm and plans referenced by the MVP
+tracker, and make Python packaging outputs resolve to an intentional clean
+working-tree policy.
+
+## Inputs And Outputs
+
+Inputs:
+
+- Three local historical documents referenced by tracker `#7088`.
+- Root Python packaging metadata and ignore policy.
+- Existing evaluator-facing MVP claim language and Rust docs contracts.
+
+Outputs:
+
+- Publicly resolvable historical brainstorm and plan paths.
+- Explicit historical status and bounded claim language in each artifact.
+- A tracked Python lockfile and ignored generated egg metadata.
+- A fail-closed Rust contract for artifact presence, references, status, and
+  packaging hygiene.
+
+## Boundaries And Non-Goals
+
+- Preserve the documents as dated decision artifacts; do not rewrite them as
+  current implementation or release claims.
+- Do not publish secrets, generated credentials, local proof bundles, or real
+  private key paths.
+- Do not change runtime, service API, Pi/MCP, settlement, verifier, protocol,
+  dependency, or release behavior.
+- Do not broaden the root README or evaluator runbook beyond any minimal link
+  needed to make the historical lineage discoverable.
+- Do not add shell or Python executable code.
+
+## Cleanup Plan
+
+1. Characterize references, sensitive markers, package outputs, and existing
+   documentation contracts before editing.
+2. Add RED contracts that require the missing tracked artifacts and explicit
+   historical/bounded markers.
+3. Publish the reviewed documents, track the lockfile, and ignore only
+   generated `*.egg-info/` directories.
+4. Consolidate contract helpers and verify no duplicate policy text is needed.
+5. Run targeted and repository-wide documentation, format, lint, and test
+   gates; verify a clean clone does not inherit local generated metadata.
+
+## Failure Modes
+
+- A required historical artifact remains absent from git.
+- A tracker reference resolves to a missing path.
+- A historical plan is presented as a current shipped or production claim.
+- An artifact contains a real absolute user path, credential, key, token, or
+  generated proof material.
+- `kamn_sdk.egg-info/` reappears as unexplained untracked repository state.
+- The Python lockfile remains unclassified or is ignored as generated output.
+- Documentation changes weaken MVP local/devnet/roadmap boundaries.
+
+## Error Semantics
+
+- Missing paths, required historical markers, or tracker-reference markers
+  fail the Rust contract with the exact missing marker or path.
+- Forbidden secret/path patterns fail closed and identify only the pattern and
+  document, never secret content.
+- Packaging policy drift fails when `*.egg-info/` is not ignored or `uv.lock`
+  is not tracked.
+
+## Acceptance Criteria
+
+- [ ] The three tracker-referenced documents are tracked and publicly
+  resolvable at their existing paths.
+- [ ] Each document identifies itself as a historical decision artifact and
+  does not claim production or mainnet readiness.
+- [ ] No document contains a real private path, secret, credential, key
+  material, `.kamn` run payload, or generated proof artifact.
+- [ ] `uv.lock` is tracked as reproducible Python project metadata.
+- [ ] `*.egg-info/` is ignored as generated Python build metadata.
+- [ ] A bounded Rust docs contract fails on missing paths, broken lineage,
+  unsafe claim markers, or packaging-policy drift.
+- [ ] Existing README/runbook claim contracts remain green.
+- [ ] The intentional working tree is clean after publication.
+
+## Files To Touch
+
+- `specs/7121-publish-mvp-planning-artifacts.md`
+- `docs/brainstorms/2026-06-26-kamn-forward-strategy-requirements.md`
+- `docs/plans/2026-06-26-001-kamn-mvp-demo-readiness-plan.md`
+- `docs/plans/2026-07-10-001-kamn-agent-transaction-rail-mega-plan.md`
+- `.gitignore`
+- `uv.lock`
+- `crates/kamn-e2e-harness/tests/mvp_planning_artifact_contract.rs`
+
+## Test Plan
+
+### RED
+
+1. Require all three historical paths to be tracked and readable.
+2. Require explicit historical-artifact and bounded MVP markers.
+3. Reject real absolute user paths and credential/key material patterns.
+4. Require lineage from both plans to the brainstorm and from the later plan
+   to the superseded earlier plan.
+5. Require `*.egg-info/` ignore policy while preserving tracked `uv.lock`.
+
+### GREEN
+
+- Add the reviewed artifacts with concise historical status notes.
+- Track `uv.lock` and add the standard generated metadata ignore rule.
+
+### REFACTOR
+
+- Keep the test file below 200 lines and functions below 25 lines.
+- Reuse small table-driven helpers for path, marker, and forbidden-pattern
+  checks.
+- Remove duplicated explanatory text when one shared marker is sufficient.
+
+### INTEGRATION
+
+```bash
+cargo test -p kamn-e2e-harness --test mvp_planning_artifact_contract
+cargo test -p kamn-e2e-harness --test readme_mvp_front_door_contract
+cargo test -p kamn-e2e-harness --test mvp_evaluator_demo_runbook_contract
+cargo fmt --check
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+make check
+make test
+make pre-push
+```
+
+## Rollback
+
+- Revert the issue branch as one documentation-hygiene arc if publication
+  reveals unsafe content.
+- Keep generated metadata ignored even if one historical artifact must be
+  withdrawn; replace any withdrawn public reference with an explicit rationale.
+- Do not alter runtime or proof semantics to repair a documentation failure.

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,8 @@
+version = 1
+revision = 2
+requires-python = ">=3.10"
+
+[[package]]
+name = "kamn-sdk"
+version = "0.1.0"
+source = { editable = "." }


### PR DESCRIPTION
Closes #7121

## Human Summary

- Publishes the three historical MVP planning artifacts referenced by the closed tracker, with explicit historical and bounded claim markers.
- Tracks the Python lockfile and ignores generated egg metadata so a normal checkout stays intentional.
- Adds a fail-closed Rust documentation contract for artifact presence, lineage, claim boundaries, private-path patterns, and packaging policy.
- Updates the repository test-file inventory for the one new contract.

## Testing

- RED: `CARGO_TARGET_DIR=target/mvp-demo-proof cargo test -p kamn-e2e-harness --test mvp_planning_artifact_contract -- --nocapture` failed 3 cases before publication.
- `CARGO_TARGET_DIR=target/mvp-demo-proof cargo test -p kamn-e2e-harness --test mvp_planning_artifact_contract`
- `CARGO_TARGET_DIR=target/mvp-demo-proof cargo test -p kamn-e2e-harness --test readme_mvp_front_door_contract`
- `CARGO_TARGET_DIR=target/mvp-demo-proof cargo test -p kamn-e2e-harness --test mvp_evaluator_demo_runbook_contract`
- `cargo fmt --check`
- `CARGO_TARGET_DIR=target/mvp-demo-proof cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `make check`
- `CARGO_TARGET_DIR=target/mvp-demo-proof make test`
- `CARGO_TARGET_DIR=target/mvp-demo-proof PRE_PUSH_WORKSPACE_TARGET_DIR=target/mvp-demo-proof make pre-push`
- Pre-push coverage: GO, 6/6 targets, zero line/function failures.
- Pre-push mutation: GO, 10/10 mutants caught, zero missed or timed out.

## Notes for Reviewers

The documents are intentionally preserved as historical decision artifacts. They do not upgrade KAMN's current claims to production, mainnet, custody, or generalized exchange readiness.

Post-deploy monitoring: verify the three GitHub document paths resolve after merge and that a fresh clone does not expose generated egg metadata.

shell_loc_delta_actual: 0
rust_loc_delta_actual: 66
shell_to_rust_ratio_delta_actual: 0.0
shell_surface_ratio_target_status: neutral

## AI Agent Details

- Spec: `specs/7121-publish-mvp-planning-artifacts.md`
- New contract: `crates/kamn-e2e-harness/tests/mvp_planning_artifact_contract.rs`
- The Rust test inventory baseline moved from 1,318 to 1,319 solely for that contract.
