### PR TITLE
test(7123): prove the MVP from a fresh checkout

### DIFF
--- a/crates/kamn-e2e-harness/tests/fresh_checkout_evaluator_evidence_contract.rs
+++ b/crates/kamn-e2e-harness/tests/fresh_checkout_evaluator_evidence_contract.rs
@@ -1,6 +1,19 @@
 use std::path::PathBuf;
 
 const EVIDENCE: &str = "docs/validation/evidence/7123-fresh-checkout-evaluator-rehearsal.md";
+const FORBIDDEN: [&str; 5] = [
+    "/Users/",
+    "/private/",
+    "PRIVATE KEY",
+    "secret=",
+    ".kamn/devnet/",
+];
+const BOUNDED_CLAIMS: [&str; 4] = [
+    "not production",
+    "not mainnet",
+    "not custody",
+    "devnet test tokens",
+];
 
 #[test]
 fn spec_c01_evidence_binds_fresh_clone_and_live_commands() {
@@ -52,11 +65,17 @@ fn spec_c03_evidence_preserves_actor_and_disclosure_boundaries() {
 #[test]
 fn spec_c04_evidence_is_secret_safe_and_claim_bounded() {
     let content = read_evidence();
-    for forbidden in ["/Users/", "/private/", "PRIVATE KEY", "secret=", ".kamn/devnet/"] {
-        assert!(!content.contains(forbidden), "forbidden marker `{forbidden}`");
+    for forbidden in FORBIDDEN {
+        assert!(
+            !content.contains(forbidden),
+            "forbidden marker `{forbidden}`"
+        );
     }
-    for marker in ["not production", "not mainnet", "not custody", "devnet test tokens"] {
-        assert!(content.contains(marker), "missing bounded marker `{marker}`");
+    for marker in BOUNDED_CLAIMS {
+        assert!(
+            content.contains(marker),
+            "missing bounded marker `{marker}`"
+        );
     }
 }
 

--- a/crates/kamn-e2e-harness/tests/fresh_checkout_evaluator_evidence_contract.rs
+++ b/crates/kamn-e2e-harness/tests/fresh_checkout_evaluator_evidence_contract.rs
@@ -1,0 +1,77 @@
+use std::path::PathBuf;
+
+const EVIDENCE: &str = "docs/validation/evidence/7123-fresh-checkout-evaluator-rehearsal.md";
+
+#[test]
+fn spec_c01_evidence_binds_fresh_clone_and_live_commands() {
+    require(&[
+        "decision: GO",
+        "clone_source: origin/main",
+        "clone_state: fresh",
+        "inherited_target: false",
+        "inherited_kamn_state: false",
+        "make demo-agent-transaction",
+        "verify-mvp-demo",
+        "children_exited_before_verifier: true",
+    ]);
+}
+
+#[test]
+fn spec_c02_evidence_binds_new_independent_devnet_confirmation() {
+    require(&[
+        "devnet_mode: required",
+        "commitment: finalized",
+        "amount_lamports: 1000000",
+        "transfer_count: 1",
+        "retry_duplicate_count: 0",
+        "rpc_verification: GO",
+        "recipient_balance_delta_lamports: 1000000",
+        "https://explorer.solana.com/tx/",
+        "?cluster=devnet",
+    ]);
+}
+
+#[test]
+fn spec_c03_evidence_preserves_actor_and_disclosure_boundaries() {
+    require(&[
+        "actor_driver: pi",
+        "distinct_authenticated_actor_count: 3",
+        "agent_a_view: participant-private",
+        "agent_b_view: participant-private",
+        "agent_c_view: restricted-public",
+        "agent_c_participant_private_field_count: 0",
+        "task_lifecycle: GO",
+        "escrow_lifecycle: GO",
+        "durable_receipts: GO",
+        "relay_projection: GO",
+        "websocket_visibility: GO",
+        "audit_export: GO",
+    ]);
+}
+
+#[test]
+fn spec_c04_evidence_is_secret_safe_and_claim_bounded() {
+    let content = read_evidence();
+    for forbidden in ["/Users/", "/private/", "PRIVATE KEY", "secret=", ".kamn/devnet/"] {
+        assert!(!content.contains(forbidden), "forbidden marker `{forbidden}`");
+    }
+    for marker in ["not production", "not mainnet", "not custody", "devnet test tokens"] {
+        assert!(content.contains(marker), "missing bounded marker `{marker}`");
+    }
+}
+
+fn require(markers: &[&str]) {
+    let content = read_evidence();
+    for marker in markers {
+        assert!(content.contains(marker), "{EVIDENCE} is missing `{marker}`");
+    }
+}
+
+fn read_evidence() -> String {
+    std::fs::read_to_string(repo_root().join(EVIDENCE))
+        .unwrap_or_else(|error| panic!("{EVIDENCE} should be readable: {error}"))
+}
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..")
+}

--- a/docs/validation/evidence/7123-fresh-checkout-evaluator-rehearsal.md
+++ b/docs/validation/evidence/7123-fresh-checkout-evaluator-rehearsal.md
@@ -1,0 +1,91 @@
+# Fresh-Checkout MVP Evaluator Evidence
+
+decision: GO
+issue: 7123
+clone_source: origin/main
+clone_head: 6428f9f88a9aab4af248753c994070042416cebe
+clone_state: fresh
+inherited_target: false
+inherited_kamn_state: false
+run_id: run-32638-1784027703311
+actor_driver: pi
+pi_version: 0.80.3
+pi_model: openai-codex/gpt-5.5
+devnet_mode: required
+
+## Commands And Shutdown
+
+- `make demo-agent-transaction`: GO
+- `cargo run -p kamn-e2e-harness -- verify-mvp-demo --report
+  .kamn/demo/latest/proof/report.json`: PASS
+- children_exited_before_verifier: true
+- transcript_sha256:
+  `79a5ae6ce1b36056e73f5e5ba161cb8323b5d46ecc401aab5ab0f7e59621ccd9`
+- Transcript hygiene: no user path, key-file value, private-key marker, or
+  sensitive environment assignment was present. The transcript remains outside
+  git; only its digest is published.
+
+## Independent Devnet Verification
+
+- rpc_verification: GO
+- network: solana:devnet
+- commitment: finalized
+- signature:
+  `29ct6LCWQx5L9sEQ3WSWoBVbQReRP1gpVcbcPXm7D1UjYYMjannkr8s58AaMhYbhRdFv2yYRWupdYynd1TbjLdRh`
+- slot: 476189316
+- transaction_error: none
+- payer: `2FjUiacAXtokhA8YzGiyfVEdu5D9LxKFhjptJLrz4V9T`
+- recipient: `FV5LvudLjZQGCrPwXUY2JaVr26sQE15K25BGvsKWvyFe`
+- amount_lamports: 1000000
+- fee_lamports: 5000
+- recipient_balance_before_lamports: 2546000000
+- recipient_balance_after_lamports: 2547000000
+- recipient_balance_delta_lamports: 1000000
+- transfer_count: 1
+- retry_duplicate_count: 0
+- Explorer:
+  https://explorer.solana.com/tx/29ct6LCWQx5L9sEQ3WSWoBVbQReRP1gpVcbcPXm7D1UjYYMjannkr8s58AaMhYbhRdFv2yYRWupdYynd1TbjLdRh?cluster=devnet
+
+The transaction was fetched independently from Solana devnet after the demo
+and standalone verifier exited. The proof-retry test reused persisted evidence
+without submission, and the restart-monotonicity test returned the confirmed
+settlement on retry without submitting a second transfer.
+
+## Actor And Product Story
+
+- distinct_authenticated_actor_count: 3
+- Agent A DID suffix: `keyh-2d6f4037ad707813f4b82f0fae4401e1`
+- Agent B DID suffix: `keyh-74de722999161b3b42fdd016decb7ae1`
+- Agent C DID suffix: `keyh-823ad243e71d3bc1aea4032440eef59d`
+- task_lifecycle: GO
+- escrow_lifecycle: GO
+- durable_receipts: GO
+- relay_projection: GO
+- websocket_visibility: GO
+- audit_export: GO
+- Transcript actions: register A/B/C, create task, accept task, fund escrow,
+  complete task, release escrow, query A/B participant projections, and query
+  C verifier projection.
+
+## Disclosure Comparison
+
+- agent_a_view: participant-private
+- agent_a_private_field_count: 3
+- agent_b_view: participant-private
+- agent_b_private_field_count: 3
+- agent_c_view: restricted-public
+- agent_c_participant_private_field_count: 0
+- All three views bind the same task, escrow, terms, amount, finalized
+  signature, and public-view digest. A and B have distinct redacted private-view
+  digests; C receives neither participant-private digest nor raw private data.
+
+## Claim Boundary
+
+This is a real local KAMN runtime and a Solana-devnet-backed transfer using
+devnet test tokens. It is not production, not mainnet, not custody, not real
+economic value, and not a generalized exchange.
+
+The current report records `execution_surface: command-override` for both
+settlement claims. The transfer itself is finalized and independently verified,
+but direct persisted service-receipt collection is not claimed here and remains
+the required follow-up in the dependent settlement-evidence issue.

--- a/fixtures/ci/test_file_size_policy_baseline.env
+++ b/fixtures/ci/test_file_size_policy_baseline.env
@@ -1,8 +1,8 @@
 schema_version=kamn.ci.test-file-size-policy-baseline.v1
-captured_at=2026-07-12
+captured_at=2026-07-14
 # Counts cover tracked crates/**/*.rs with a /tests/ path component, excluding any /tests/support/ paths.
 # Refresh baseline whenever new test files are added or removed.
-test_file_total=1319
+test_file_total=1320
 soft_warn_count=2
 # Soft warnings: kamn-mcp-server/tests/real_backend_integration_contract.rs and kamn-core/tests/journal_wal_commit_schema_contract.rs.
 severe_count=0

--- a/specs/7123-fresh-checkout-evaluator-rehearsal.md
+++ b/specs/7123-fresh-checkout-evaluator-rehearsal.md
@@ -1,0 +1,119 @@
+# Issue 7123: Fresh-Checkout Evaluator Rehearsal
+
+## Objective
+
+Prove from a fresh clone of the merged remote head that an evaluator can run
+the canonical three-agent KAMN MVP, independently verify its finalized Solana
+devnet transfer, and inspect a secret-safe release-candidate evidence record.
+
+## Inputs And Outputs
+
+Inputs:
+
+- Merged `origin/main` commit `6428f9f88a9aab4af248753c994070042416cebe`.
+- README and `docs/validation/mvp-evaluator-demo.md` instructions only.
+- Existing local Pi OAuth and funded devnet configuration supplied outside git.
+
+Outputs:
+
+- A new clean-clone canonical run and independently verified report.
+- A secret-safe transcript outside git for operator audit.
+- A tracked evidence summary containing only public identifiers, decisions,
+  digests, counts, claim boundaries, and the Solana Explorer link.
+- A fail-closed Rust contract for the tracked evidence shape.
+
+## Boundaries And Non-Goals
+
+- Do not change runtime, settlement collection, Pi/MCP authority, protocol, API,
+  dependency, or release behavior.
+- Do not copy the development checkout's `target/`, `.kamn/`, generated files,
+  running processes, or shell history into the clean clone.
+- Do not commit environment files, key paths, key contents, credentials, raw
+  proof bundles, or the full evaluator transcript.
+- Do not claim production, mainnet, custody, generalized exchange, or real
+  economic value.
+- A `command-override` result may characterize the current baseline but does
+  not satisfy the later direct-receipt issue.
+
+## Failure Modes
+
+- Clone provenance does not match the merged remote head.
+- The canonical command needs an undocumented intervention.
+- Pi, RPC, faucet, or devnet infrastructure is unavailable.
+- The standalone verifier fails after child shutdown.
+- The signature is absent, non-finalized, copied from an older run, or does not
+  match recipient, amount, slot, and balance evidence.
+- Retry or recovery submits a second transfer.
+- Agent identities are not distinct or Agent C exposes private fields.
+- The tracked evidence contains a private path, credential, or secret value.
+
+## Error Semantics
+
+- Any unmet live prerequisite or proof mismatch records `NO-GO` with explicit
+  reason codes; it must not be rewritten as success.
+- Contract failures identify the missing or forbidden marker without printing
+  matched sensitive content.
+- Only a new finalized transaction observed through independent RPC can support
+  the devnet settlement result.
+
+## Acceptance Criteria
+
+- [ ] A temporary clone starts from the recorded merged `origin/main` SHA with
+  no inherited build or proof state.
+- [ ] `make demo-agent-transaction` produces a new required-devnet run.
+- [ ] The standalone verifier returns `GO` after all child processes exit.
+- [ ] Independent RPC confirms signature, finalized commitment, slot,
+  recipient, 1,000,000 lamports, and exact recipient balance movement.
+- [ ] Evidence shows three distinct authenticated Pi actors and the complete
+  task, authorization, escrow funding, completion, and release lifecycle.
+- [ ] Evidence shows exactly one transfer and retry/recovery idempotency.
+- [ ] Agent A and B participant-private projections differ from Agent C's
+  restricted-public projection; Agent C has zero participant-private fields.
+- [ ] Durable receipts, relay, websocket visibility, audit export, proof report,
+  and a devnet Explorer link are recorded.
+- [ ] The tracked evidence passes secret/path and bounded-claim contracts.
+
+## Files To Touch
+
+- `specs/7123-fresh-checkout-evaluator-rehearsal.md`
+- `docs/validation/evidence/7123-fresh-checkout-evaluator-rehearsal.md`
+- `crates/kamn-e2e-harness/tests/fresh_checkout_evaluator_evidence_contract.rs`
+- `fixtures/ci/test_file_size_policy_baseline.env`
+
+## Test Plan
+
+### RED
+
+Require the evidence document, fresh-clone provenance, live command/verifier
+results, independent RPC fields, actor/view boundaries, idempotency, durable
+proof surfaces, bounded claims, and secret-safe content.
+
+### GREEN
+
+Perform the rehearsal in a temporary clone and publish only the allowed summary
+fields from the new run. Record `NO-GO` honestly if an external dependency
+blocks the live path.
+
+### REFACTOR
+
+Keep the contract below 200 lines, functions below 25 lines, and marker checks
+table-driven. Keep the evidence concise and avoid duplicating the runbook.
+
+### INTEGRATION
+
+```bash
+cargo test -p kamn-e2e-harness --test fresh_checkout_evaluator_evidence_contract
+cargo fmt --check
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+make check
+make test
+make pre-push
+```
+
+## Rollback
+
+- Revert the issue branch if the evidence cannot be published without leaking
+  local configuration.
+- Preserve any valid `NO-GO` diagnosis outside success claims.
+- Never reuse an older signature or weaken privacy, idempotency, or verifier
+  semantics to obtain `GO`.

--- a/specs/7123-fresh-checkout-evaluator-rehearsal.md
+++ b/specs/7123-fresh-checkout-evaluator-rehearsal.md
@@ -58,20 +58,20 @@ Outputs:
 
 ## Acceptance Criteria
 
-- [ ] A temporary clone starts from the recorded merged `origin/main` SHA with
+- [x] A temporary clone starts from the recorded merged `origin/main` SHA with
   no inherited build or proof state.
-- [ ] `make demo-agent-transaction` produces a new required-devnet run.
-- [ ] The standalone verifier returns `GO` after all child processes exit.
-- [ ] Independent RPC confirms signature, finalized commitment, slot,
+- [x] `make demo-agent-transaction` produces a new required-devnet run.
+- [x] The standalone verifier returns `GO` after all child processes exit.
+- [x] Independent RPC confirms signature, finalized commitment, slot,
   recipient, 1,000,000 lamports, and exact recipient balance movement.
-- [ ] Evidence shows three distinct authenticated Pi actors and the complete
+- [x] Evidence shows three distinct authenticated Pi actors and the complete
   task, authorization, escrow funding, completion, and release lifecycle.
-- [ ] Evidence shows exactly one transfer and retry/recovery idempotency.
-- [ ] Agent A and B participant-private projections differ from Agent C's
+- [x] Evidence shows exactly one transfer and retry/recovery idempotency.
+- [x] Agent A and B participant-private projections differ from Agent C's
   restricted-public projection; Agent C has zero participant-private fields.
-- [ ] Durable receipts, relay, websocket visibility, audit export, proof report,
+- [x] Durable receipts, relay, websocket visibility, audit export, proof report,
   and a devnet Explorer link are recorded.
-- [ ] The tracked evidence passes secret/path and bounded-claim contracts.
+- [x] The tracked evidence passes secret/path and bounded-claim contracts.
 
 ## Files To Touch
 
@@ -109,6 +109,30 @@ make check
 make test
 make pre-push
 ```
+
+## Completion Evidence
+
+- Clean clone: `/tmp/kamn-7123-clean.47zt8r` at merged SHA
+  `6428f9f88a9aab4af248753c994070042416cebe`, without inherited `target/` or
+  `.kamn/` state.
+- Canonical run: `run-32638-1784027703311`; `make demo-agent-transaction`
+  exited zero in required Solana devnet mode.
+- Standalone verifier after child shutdown: `PASS` with exit zero.
+- Independent Solana RPC: finalized signature
+  `29ct6LCWQx5L9sEQ3WSWoBVbQReRP1gpVcbcPXm7D1UjYYMjannkr8s58AaMhYbhRdFv2yYRWupdYynd1TbjLdRh`
+  at slot `476189316`; recipient delta `1,000,000` lamports; fee `5,000`
+  lamports; transaction error `null`.
+- Actor evidence: three distinct key-bound DIDs and Pi process IDs; Agent A and
+  B each expose three participant-private fields while Agent C exposes zero.
+- Idempotency evidence: one submitted transfer, zero retry duplicates, plus
+  focused persisted-settlement retry and restart tests.
+- Quality gates: targeted contract `4/4`, `cargo fmt --check`, strict workspace
+  clippy, `make check`, and `make test` passed.
+- `make pre-push` first reached the standard 14,400-second workspace timeout
+  under host load without an assertion failure. The documented local timeout
+  override `PRE_PUSH_WORKSPACE_TIMEOUT_SECONDS=28800` then passed the unchanged
+  locked all-feature workspace suite on its first attempt, critical-path
+  coverage `GO` (`6/6` targets), and mutation `GO` (`10/10` caught).
 
 ## Rollback
 


### PR DESCRIPTION
## Human Summary

- Proves the canonical three-agent MVP from a clean clone of merged `main`, without inherited build or proof state.
- Records a new required-devnet run, standalone verifier pass, and independent Solana RPC confirmation.
- Captures participant-private A/B views versus Agent C's restricted-public view without publishing secrets or local key paths.
- Adds a fail-closed evidence contract and updates the test-file policy baseline.

Closes #7123

Spec: [specs/7123-fresh-checkout-evaluator-rehearsal.md](https://github.com/njfio/kamn/blob/7123-fresh-checkout-evaluator-rehearsal/specs/7123-fresh-checkout-evaluator-rehearsal.md)

## Testing

- `cargo test -p kamn-e2e-harness --test fresh_checkout_evaluator_evidence_contract` (4 passed)
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `make check`
- `make test`
- `CARGO_TARGET_DIR=target/mvp-demo-proof PRE_PUSH_WORKSPACE_TARGET_DIR=target/mvp-demo-proof PRE_PUSH_WORKSPACE_TIMEOUT_SECONDS=28800 make pre-push`
- Fresh clone: `make demo-agent-transaction`
- Standalone `verify-mvp-demo`
- Independent Solana devnet RPC verification

The standard 14,400-second pre-push workspace allowance expired under host load without an assertion failure. The documented local timeout override passed the unchanged locked all-feature suite on its first attempt, coverage GO for 6/6 targets, and mutation GO with 10/10 mutants caught.

## Notes for Reviewers

The evidence honestly retains `execution_surface: command-override` for settlement. Removing that compatibility seam is the dependent follow-up and is not claimed here.

- shell_loc_delta_actual: 0
- rust_loc_delta_actual: 96
- shell_to_rust_ratio_delta_actual: 0.0
- shell_surface_ratio_target_status: neutral

## AI Agent Details

- Clean run: `run-32638-1784027703311`
- Finalized slot: `476189316`
- Recipient delta: `1,000,000` lamports
- Transfer count: `1`; retry duplicates: `0`
- Three distinct key-bound DIDs and Pi processes
- Agent A/B private field count: `3` each; Agent C: `0`
