### PR TITLE
fix: restore strict Clippy format checks

### DIFF
--- a/crates/kamn-e2e-harness/src/mvp_demo/agent_harness.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/agent_harness.rs
@@ -40,10 +40,7 @@ pub(crate) fn validate_agent_harness_evidence_path(
     artifact_path: &str,
 ) -> Result<(), String> {
     let artifact = std::fs::read_to_string(artifact_path).map_err(|error| {
-        format!(
-            "failed to read agent harness evidence {}: {error}",
-            artifact_path
-        )
+        format!("failed to read agent harness evidence {artifact_path}: {error}")
     })?;
     validate_agent_harness_evidence(artifact.as_str(), report_path, report_json)
 }

--- a/crates/kamn-e2e-harness/src/mvp_demo/report.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/report.rs
@@ -131,8 +131,7 @@ fn claim(id: &str, label: &str, status: &str, summary: &str) -> String {
 
 fn roadmap_claim() -> String {
     format!(
-        "{{\"id\":\"production_readiness\",\"label\":\"{}\",\"required\":false,\"status\":\"NOT_CLAIMED\",\"summary\":\"production readiness is not claimed\"}}",
-        CLAIM_LABEL_ROADMAP
+        "{{\"id\":\"production_readiness\",\"label\":\"{CLAIM_LABEL_ROADMAP}\",\"required\":false,\"status\":\"NOT_CLAIMED\",\"summary\":\"production readiness is not claimed\"}}"
     )
 }
 

--- a/crates/kamn-e2e-harness/src/mvp_demo/report_markdown.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/report_markdown.rs
@@ -47,8 +47,7 @@ fn markdown_agent_harness(input: &DemoReportInput<'_>) -> Result<String, String>
     };
     let execution_surface = agent_harness_execution_surface(path)?;
     Ok(format!(
-        "## Agent Harness Evidence\n\n- Claim: `mcp_agent_harness_verification`\n- Agent harness evidence: `{}`\n- Execution surface: `{}`\n",
-        path, execution_surface
+        "## Agent Harness Evidence\n\n- Claim: `mcp_agent_harness_verification`\n- Agent harness evidence: `{path}`\n- Execution surface: `{execution_surface}`\n"
     ))
 }
 

--- a/crates/kamn-e2e-harness/src/mvp_demo/three_agent_claim.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/three_agent_claim.rs
@@ -79,8 +79,7 @@ fn receipt_artifact_fields(
 
 fn claim_header() -> String {
     format!(
-        "\"id\":\"three_agent_escrow_verification\",\"label\":\"{}\",\"required\":true,\"status\":\"PASS\",\"summary\":\"Agent C verifies escrow settlement from restricted proof view\"",
-        CLAIM_LABEL_DEVNET_BACKED,
+        "\"id\":\"three_agent_escrow_verification\",\"label\":\"{CLAIM_LABEL_DEVNET_BACKED}\",\"required\":true,\"status\":\"PASS\",\"summary\":\"Agent C verifies escrow settlement from restricted proof view\""
     )
 }
 

--- a/crates/kamn-e2e-harness/tests/mvp_demo_agent_harness_claim_contract/artifact.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_demo_agent_harness_claim_contract/artifact.rs
@@ -117,7 +117,6 @@ fn agent_artifact_for_report_with_surface(
     three_agent_boundary: &str,
 ) -> String {
     format!(
-        r#"{{"schema_version":"kamn.mvp.agent-harness-evidence.v1","harness":"mcp-agent","execution_surface":"{}","report_path":"{}","verifier_status":"PASS","participant_agents":["agent_a","agent_b","agent_c_verifier"],"tool_markers":["register","create_task","fund_escrow","release_escrow","verify_proof"],"claim_boundaries":{{"settlement_claim_label":"{}","dry_run_counted_as_success":false,"placeholder_counted_as_success":false,"verifier_private_view_visible":{}}}{}}}"#,
-        execution_surface, report_path, settlement_label, private_visible, three_agent_boundary
+        r#"{{"schema_version":"kamn.mvp.agent-harness-evidence.v1","harness":"mcp-agent","execution_surface":"{execution_surface}","report_path":"{report_path}","verifier_status":"PASS","participant_agents":["agent_a","agent_b","agent_c_verifier"],"tool_markers":["register","create_task","fund_escrow","release_escrow","verify_proof"],"claim_boundaries":{{"settlement_claim_label":"{settlement_label}","dry_run_counted_as_success":false,"placeholder_counted_as_success":false,"verifier_private_view_visible":{private_visible}}}{three_agent_boundary}}}"#
     )
 }

--- a/specs/7127-clippy-format-args.md
+++ b/specs/7127-clippy-format-args.md
@@ -2,12 +2,12 @@
 
 ## Objective
 
-Restore the strict workspace Clippy gate by converting four legacy positional
+Restore the strict workspace Clippy gate by converting five legacy positional
 format arguments in the MVP demo harness to Rust captured format arguments.
 
 ## Inputs/Outputs
 
-- Input: the existing strings and local values passed to four `format!` calls.
+- Input: the existing strings and local values passed to five `format!` calls.
 - Output: byte-for-byte equivalent formatted strings and errors.
 - Verification: strict Clippy, formatting, and focused MVP demo harness tests.
 
@@ -25,7 +25,7 @@ format arguments in the MVP demo harness to Rust captured format arguments.
 
 ## Acceptance Criteria
 
-- [ ] All four reported `uninlined_format_args` findings are removed.
+- [ ] All five reported `uninlined_format_args` findings are removed.
 - [ ] Existing formatted output remains unchanged.
 - [ ] `cargo fmt --check` passes.
 - [ ] Strict workspace Clippy passes with all targets and features.
@@ -37,6 +37,7 @@ format arguments in the MVP demo harness to Rust captured format arguments.
 - `crates/kamn-e2e-harness/src/mvp_demo/report.rs`
 - `crates/kamn-e2e-harness/src/mvp_demo/report_markdown.rs`
 - `crates/kamn-e2e-harness/src/mvp_demo/three_agent_claim.rs`
+- `crates/kamn-e2e-harness/tests/mvp_demo_agent_harness_claim_contract/artifact.rs`
 - `specs/7127-clippy-format-args.md`
 
 ## Error Semantics
@@ -49,11 +50,12 @@ agent-harness file-read error must render the same path and underlying error.
 ### RED
 
 Run `cargo clippy --workspace --all-targets --all-features -- -D warnings` and
-observe the four `clippy::uninlined_format_args` failures.
+observe the five `clippy::uninlined_format_args` failures. The fifth all-targets
+fixture finding becomes visible only after the four library findings are fixed.
 
 ### GREEN
 
-Use captured arguments in only the four reported `format!` calls, then rerun
+Use captured arguments in only the five reported `format!` calls, then rerun
 strict Clippy.
 
 ### REFACTOR

--- a/specs/7127-clippy-format-args.md
+++ b/specs/7127-clippy-format-args.md
@@ -1,0 +1,66 @@
+# Issue 7127: Restore Strict Clippy Format Arguments
+
+## Objective
+
+Restore the strict workspace Clippy gate by converting four legacy positional
+format arguments in the MVP demo harness to Rust captured format arguments.
+
+## Inputs/Outputs
+
+- Input: the existing strings and local values passed to four `format!` calls.
+- Output: byte-for-byte equivalent formatted strings and errors.
+- Verification: strict Clippy, formatting, and focused MVP demo harness tests.
+
+## Boundaries/Non-goals
+
+- Do not change runtime behavior, public APIs, dependencies, or error semantics.
+- Do not clean up unrelated lint findings.
+- Do not modify shell, workflow, or template surfaces.
+
+## Failure Modes
+
+- A positional argument remains and strict Clippy continues to fail.
+- A format string changes its rendered output.
+- The focused MVP demo harness contracts regress.
+
+## Acceptance Criteria
+
+- [ ] All four reported `uninlined_format_args` findings are removed.
+- [ ] Existing formatted output remains unchanged.
+- [ ] `cargo fmt --check` passes.
+- [ ] Strict workspace Clippy passes with all targets and features.
+- [ ] Focused MVP demo harness tests pass.
+
+## Files to Touch
+
+- `crates/kamn-e2e-harness/src/mvp_demo/agent_harness.rs`
+- `crates/kamn-e2e-harness/src/mvp_demo/report.rs`
+- `crates/kamn-e2e-harness/src/mvp_demo/report_markdown.rs`
+- `crates/kamn-e2e-harness/src/mvp_demo/three_agent_claim.rs`
+- `specs/7127-clippy-format-args.md`
+
+## Error Semantics
+
+No error codes, messages, propagation, or fallback behavior may change. The
+agent-harness file-read error must render the same path and underlying error.
+
+## Test Plan
+
+### RED
+
+Run `cargo clippy --workspace --all-targets --all-features -- -D warnings` and
+observe the four `clippy::uninlined_format_args` failures.
+
+### GREEN
+
+Use captured arguments in only the four reported `format!` calls, then rerun
+strict Clippy.
+
+### REFACTOR
+
+Run formatting and inspect the diff for behavior-neutral output changes only.
+
+### INTEGRATION
+
+Run focused `kamn-e2e-harness` MVP demo tests plus the repository `make check`
+gate.


### PR DESCRIPTION
## Human Summary

- Replaces five legacy positional format arguments with captured arguments.
- Restores the strict Clippy source path without changing rendered strings or error behavior.
- Keeps the repair limited to the baseline lint blocker tracked by #7127.
- Includes merged #7129 so validation uses the patched dependency lockfile now on main.
- Spec: specs/7127-clippy-format-args.md

Closes #7127

## Testing

- cargo fmt --check
- git diff --check
- Standalone Rust assertions comparing old and new rendered output for all five substitutions
- Final-head Ubuntu ci-fast-gate run 29826083470 passed cargo-audit policy, format, strict all-target Clippy, production expect, and panic-surface gates.
- Final-head Supply-Chain Advisory run 29826073472 passed.
- Final-head E2E Live Tests run 29826073459 passed all three jobs: CLI Smoke, MCP Agent, and SDK-Direct.
- The broad fast-gate test step ran until it was canceled by the configured 20-minute job timeout; GitHub reported zero failed steps.

## Notes for Reviewers

Review focus is byte-for-byte output equivalence in the five changed format calls. The repository full-suite workflow remains unreachable from manual dispatch because its Rust detector skips Rust steps; that CI defect is not changed in this PR.