### PR TITLE
fix: patch newly reported Rust advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,9 +127,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "anyhow"
-version = "1.0.101"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arc-swap"
@@ -793,9 +793,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/specs/7129-cargo-audit-advisory-drift.md
+++ b/specs/7129-cargo-audit-advisory-drift.md
@@ -1,0 +1,81 @@
+# Issue 7129: Restore Cargo Audit Policy
+
+## Objective
+
+Restore the fail-closed cargo-audit policy after two new RustSec advisories by
+updating only the affected lockfile entries to their first patched versions.
+
+## Inputs/Outputs
+
+- Input: `Cargo.lock` entries for `anyhow` and `crossbeam-epoch`.
+- Input: RustSec advisories `RUSTSEC-2026-0190` and `RUSTSEC-2026-0204`.
+- Output: `anyhow` locked at `1.0.103` or newer.
+- Output: `crossbeam-epoch` locked at `0.9.20` or newer.
+- Output: an audit policy report with no violation from either advisory.
+
+## Boundaries/Non-goals
+
+- Change no manifests, source code, audit threshold, or waiver policy.
+- Do not add, remove, or broadly upgrade dependencies.
+- Do not modify issue #7127 format behavior.
+- Preserve reproducibility under `--locked` commands.
+
+## Failure Modes
+
+- Either vulnerable lockfile version remains.
+- Cargo resolves unrelated package updates.
+- The lockfile becomes inconsistent with workspace manifests.
+- Cargo audit still reports either advisory as a policy violation.
+- A waiver hides an advisory instead of applying the available patch.
+
+## Acceptance Criteria
+
+- [ ] `anyhow` resolves to at least `1.0.103`.
+- [ ] `crossbeam-epoch` resolves to at least `0.9.20`.
+- [ ] Only those two package versions and checksums change in `Cargo.lock`.
+- [ ] No cargo-audit threshold or waiver changes are made.
+- [ ] `cargo metadata --locked` succeeds.
+- [ ] The cargo-audit policy checker passes.
+- [ ] The manually dispatched `ci-fast-gate` reaches downstream Rust gates.
+
+## Files to Touch
+
+- `Cargo.lock`
+- `specs/7129-cargo-audit-advisory-drift.md`
+
+## Error Semantics
+
+Audit failures remain hard failures. Unknown-severity, unwaived, or
+above-threshold advisories must continue to stop CI with structured reason
+codes. No fallback or silent waiver is permitted.
+
+## Test Plan
+
+### RED
+
+Run `cargo audit --json` and the repository cargo-audit policy checker against
+the current lockfile. Confirm `RUSTSEC-2026-0190` and `RUSTSEC-2026-0204`
+produce the recorded policy failure.
+
+### GREEN
+
+Run these approved precise updates:
+
+```bash
+cargo update -p anyhow --precise 1.0.103
+cargo update -p crossbeam-epoch --precise 0.9.20
+```
+
+Confirm the lockfile diff contains no unrelated packages, then rerun the audit
+policy checker.
+
+### REFACTOR
+
+Review the diff for lockfile-only minimality. Do not introduce manifests,
+waivers, helper scripts, or abstractions.
+
+### INTEGRATION
+
+Run `cargo metadata --locked`, the repository audit-policy tests, and a manual
+`ci-fast-gate` workflow dispatch on the issue branch. Require the workflow to
+pass the audit policy step and execute downstream Rust gates.


### PR DESCRIPTION
## Human Summary

- Updates anyhow from 1.0.101 to the first patched 1.0.103 release.
- Updates crossbeam-epoch from 0.9.18 to the first patched 0.9.20 release.
- Changes no manifests, audit thresholds, waivers, source code, or unrelated lockfile packages.
- Spec: specs/7129-cargo-audit-advisory-drift.md

Closes #7129

## Testing

- Fresh cargo audit JSON no longer contains RUSTSEC-2026-0190 or RUSTSEC-2026-0204.
- Repository cargo-audit policy checker: pass.
- bash scripts/ci/test_check_cargo_audit_policy.sh
- cargo metadata --locked --format-version 1 --no-deps
- cargo tree -i anyhow --locked
- git diff --check
- Combined Ubuntu ci-fast-gate run 29824484767: cargo-audit, format, strict all-target Clippy, production expect, and panic-surface gates passed.
- The fast-gate test step was canceled only by the workflow 20-minute job timeout; no test failure was reported.
- Full locked workspace suite is pending in 60-minute ci-deep-validate run 29825914568.

## Notes for Reviewers

Review focus is the exact two-package Cargo.lock diff. The remaining audit findings are existing explicitly waived baseline entries; no policy was weakened.