### PR TITLE
feat: preserve service receipts through SDK and MCP

### DIFF
--- a/crates/kamn-agent-lib/src/client.rs
+++ b/crates/kamn-agent-lib/src/client.rs
@@ -5,7 +5,7 @@ use kamn_sdk::{
     ServiceBridgeSubmission, ServiceChannelMessages, ServiceChannelReceipt,
     ServiceContentRegistration, ServiceContentStatus, ServiceEscrowStatus, ServiceHealthStatus,
     ServiceMessageReceipt, ServiceMessageStatus, ServiceRequestAuth, ServiceTaskReceipt,
-    ServiceTaskStatus,
+    ServiceTaskStatus, ServiceTaskTransitionReceipt,
 };
 use std::env;
 
@@ -151,7 +151,7 @@ impl ServiceApiHttpClient {
         &self,
         task_id: &str,
         auth: &ServiceRequestAuth,
-    ) -> Result<ServiceTaskStatus, AgentLibError> {
+    ) -> Result<ServiceTaskTransitionReceipt, AgentLibError> {
         Ok(self.inner.accept_task(task_id, auth)?)
     }
 
@@ -161,7 +161,7 @@ impl ServiceApiHttpClient {
         task_id: &str,
         payload: &str,
         auth: &ServiceRequestAuth,
-    ) -> Result<ServiceTaskStatus, AgentLibError> {
+    ) -> Result<ServiceTaskTransitionReceipt, AgentLibError> {
         Ok(self
             .inner
             .accept_task_with_payload(task_id, payload, auth)?)
@@ -172,7 +172,7 @@ impl ServiceApiHttpClient {
         &self,
         task_id: &str,
         auth: &ServiceRequestAuth,
-    ) -> Result<ServiceTaskStatus, AgentLibError> {
+    ) -> Result<ServiceTaskTransitionReceipt, AgentLibError> {
         Ok(self.inner.complete_task(task_id, auth)?)
     }
 
@@ -182,7 +182,7 @@ impl ServiceApiHttpClient {
         task_id: &str,
         payload: &str,
         auth: &ServiceRequestAuth,
-    ) -> Result<ServiceTaskStatus, AgentLibError> {
+    ) -> Result<ServiceTaskTransitionReceipt, AgentLibError> {
         Ok(self
             .inner
             .complete_task_with_payload(task_id, payload, auth)?)

--- a/crates/kamn-agent-lib/src/lib.rs
+++ b/crates/kamn-agent-lib/src/lib.rs
@@ -18,7 +18,7 @@ pub use kamn_sdk::{
     AgentMetadata, ServiceAgentProfile, ServiceBridgeStatus, ServiceBridgeSubmission,
     ServiceChannelMessages, ServiceChannelReceipt, ServiceContentRegistration,
     ServiceContentStatus, ServiceEscrowStatus, ServiceHealthStatus, ServiceMessageReceipt,
-    ServiceMessageStatus, ServiceTaskReceipt, ServiceTaskStatus,
+    ServiceMessageStatus, ServiceTaskReceipt, ServiceTaskStatus, ServiceTaskTransitionReceipt,
 };
 
 /// Authentication helpers.
@@ -222,7 +222,10 @@ impl KamnAgentHandle {
     }
 
     /// Accepts one task through the service API.
-    pub fn accept_task(&self, task_id: &str) -> Result<ServiceTaskStatus, AgentLibError> {
+    pub fn accept_task(
+        &self,
+        task_id: &str,
+    ) -> Result<ServiceTaskTransitionReceipt, AgentLibError> {
         self.accept_task_with_payload(task_id, "{}")
     }
 
@@ -231,7 +234,7 @@ impl KamnAgentHandle {
         &self,
         task_id: &str,
         payload: &str,
-    ) -> Result<ServiceTaskStatus, AgentLibError> {
+    ) -> Result<ServiceTaskTransitionReceipt, AgentLibError> {
         let nonce = self.next_nonce()?;
         let auth = self.service_client.build_auth(
             self.identity.did(),
@@ -245,7 +248,10 @@ impl KamnAgentHandle {
     }
 
     /// Completes one task through the service API.
-    pub fn complete_task(&self, task_id: &str) -> Result<ServiceTaskStatus, AgentLibError> {
+    pub fn complete_task(
+        &self,
+        task_id: &str,
+    ) -> Result<ServiceTaskTransitionReceipt, AgentLibError> {
         self.complete_task_with_payload(task_id, "{}")
     }
 
@@ -254,7 +260,7 @@ impl KamnAgentHandle {
         &self,
         task_id: &str,
         payload: &str,
-    ) -> Result<ServiceTaskStatus, AgentLibError> {
+    ) -> Result<ServiceTaskTransitionReceipt, AgentLibError> {
         let nonce = self.next_nonce()?;
         let auth = self.service_client.build_auth(
             self.identity.did(),

--- a/crates/kamn-agent-lib/tests/task_and_escrow_service_contract.rs
+++ b/crates/kamn-agent-lib/tests/task_and_escrow_service_contract.rs
@@ -198,10 +198,10 @@ fn serve_task_escrow_connection(stream: &mut TcpStream) -> Result<(), String> {
 fn write_task_response(stream: &mut TcpStream, method: &str, path: &str) -> Result<bool, String> {
     let body = match (method, path) {
         ("POST", "/v1/tasks/task-contract-1/accept") => {
-            r#"{"task_id":"task-contract-1","state":"accepted"}"#
+            r#"{"task_id":"task-contract-1","state":"accepted","receipt_id":"task-receipt-1","receipt_digest":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","action":"task:accept"}"#
         }
         ("POST", "/v1/tasks/task-contract-1/complete") => {
-            r#"{"task_id":"task-contract-1","state":"completed"}"#
+            r#"{"task_id":"task-contract-1","state":"completed","receipt_id":"task-receipt-2","receipt_digest":"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","action":"task:complete"}"#
         }
         _ => return Ok(false),
     };
@@ -215,22 +215,33 @@ fn write_escrow_response(
     path: &str,
     body: &str,
 ) -> Result<bool, String> {
-    if method == "POST" && path == "/v1/escrow/fund" {
+    let Some(payload) = escrow_response_payload(method, path, body) else {
+        return Ok(false);
+    };
+    write_http_response(stream, 200, payload.as_str())?;
+    Ok(true)
+}
+
+fn escrow_response_payload(method: &str, path: &str, body: &str) -> Option<String> {
+    if method != "POST" {
+        return None;
+    }
+    if path == "/v1/escrow/fund" {
         let escrow_id = format!("escrow-local-{:016x}", deterministic_tag(body.as_bytes()));
-        let payload = format!("{{\"escrow_id\":\"{escrow_id}\",\"state\":\"funded\"}}");
-        write_http_response(stream, 200, payload.as_str())?;
-        return Ok(true);
+        return Some(format!(
+            r#"{{"escrow_id":"{escrow_id}","state":"funded","receipt_id":"escrow-receipt-1","receipt_digest":"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc","action":"escrow:fund"}}"#
+        ));
     }
-    if method == "POST" && path.starts_with("/v1/escrow/") && path.ends_with("/release") {
-        let escrow_id = path
-            .trim_start_matches("/v1/escrow/")
-            .trim_end_matches("/release")
-            .trim_end_matches('/');
-        let payload = format!("{{\"escrow_id\":\"{escrow_id}\",\"state\":\"released\"}}");
-        write_http_response(stream, 200, payload.as_str())?;
-        return Ok(true);
-    }
-    Ok(false)
+    let escrow_id = release_escrow_id(path)?;
+    Some(format!(
+        r#"{{"escrow_id":"{escrow_id}","state":"released","receipt_id":"escrow-receipt-2","receipt_digest":"sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd","action":"escrow:release-authorize"}}"#
+    ))
+}
+
+fn release_escrow_id(path: &str) -> Option<&str> {
+    path.strip_prefix("/v1/escrow/")?
+        .strip_suffix("/release")
+        .map(|value| value.trim_end_matches('/'))
 }
 
 #[test]

--- a/crates/kamn-cli/tests/command_activation_harness_routes.rs
+++ b/crates/kamn-cli/tests/command_activation_harness_routes.rs
@@ -33,23 +33,28 @@ fn task_and_profile_routes(method: &str, path: &str) -> Option<(u16, &'static st
         }
         ("GET", "/v1/agents/kamn:did:agent:alice") => Some((
             200,
-            r#"{"did":"kamn:did:agent:alice","reputation_score":777,"agent_type":"service-agent","model_family":"service-api","capabilities":["profile:read"]}"#,
+            r#"{"did":"kamn:did:agent:alice","reputation_score":777,"agent_type":"service-agent","model_family":"service-api","capabilities":["profile:read"],"profile_commitment":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}"#,
         )),
-        ("POST", "/v1/tasks/create") => {
-            Some((201, r#"{"task_id":"task-cli","state":"submitted"}"#))
-        }
-        ("POST", "/v1/tasks/task-cli/accept") => {
-            Some((200, r#"{"task_id":"task-cli","state":"accepted"}"#))
-        }
-        ("POST", "/v1/tasks/task-cli/complete") => {
-            Some((200, r#"{"task_id":"task-cli","state":"completed"}"#))
-        }
-        ("POST", "/v1/escrow/fund") => {
-            Some((200, r#"{"escrow_id":"escrow-cli","state":"funded"}"#))
-        }
-        ("POST", "/v1/escrow/escrow-cli/release") => {
-            Some((200, r#"{"escrow_id":"escrow-cli","state":"released"}"#))
-        }
+        ("POST", "/v1/tasks/create") => Some((
+            201,
+            r#"{"task_id":"task-cli","state":"submitted","receipt_id":"task-receipt-1","receipt_digest":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","action":"task:create"}"#,
+        )),
+        ("POST", "/v1/tasks/task-cli/accept") => Some((
+            200,
+            r#"{"task_id":"task-cli","state":"accepted","receipt_id":"task-receipt-2","receipt_digest":"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","action":"task:accept"}"#,
+        )),
+        ("POST", "/v1/tasks/task-cli/complete") => Some((
+            200,
+            r#"{"task_id":"task-cli","state":"completed","receipt_id":"task-receipt-3","receipt_digest":"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc","action":"task:complete"}"#,
+        )),
+        ("POST", "/v1/escrow/fund") => Some((
+            200,
+            r#"{"escrow_id":"escrow-cli","state":"funded","receipt_id":"escrow-receipt-1","receipt_digest":"sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd","action":"escrow:fund"}"#,
+        )),
+        ("POST", "/v1/escrow/escrow-cli/release") => Some((
+            200,
+            r#"{"escrow_id":"escrow-cli","state":"released","receipt_id":"escrow-receipt-2","receipt_digest":"sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee","action":"escrow:release-authorize"}"#,
+        )),
         _ => None,
     }
 }

--- a/crates/kamn-mcp-server/src/authority.rs
+++ b/crates/kamn-mcp-server/src/authority.rs
@@ -45,30 +45,57 @@ fn mutation(
     expected_actor: &str,
 ) -> Result<String, &'static str> {
     let value = parse(payload)?;
-    let actor = required(&value, "actor_did")?;
-    let resource = required(&value, resource_key)?;
-    let state = required(&value, "state")?;
-    let receipt_id = required(&value, "receipt_id")?;
-    let digest = required(&value, "receipt_digest")?;
-    let action = required(&value, "action")?;
-    validate_digest(digest)?;
-    validate_equal(actor, expected_actor)?;
-    validate_equal(action, expected_action(tool)?)?;
-    validate_state(tool, state)?;
-    validate_requested_resource(request, resource_key, resource)?;
+    let fields = MutationFields::parse(&value, resource_key)?;
+    fields.validate(request, tool, resource_key, expected_actor)?;
     Ok(json!({
         "schema_version": "kamn.mcp.authority-receipt.v1",
         "authority_kind": "service-receipt",
         "source": "kamn-service",
-        "actor_did": actor,
+        "actor_did": fields.actor,
         "tool": tool,
-        "resource_id": resource,
-        "resulting_state": state,
-        "service_receipt_id": receipt_id,
-        "service_receipt_digest": digest,
+        "resource_id": fields.resource,
+        "resulting_state": fields.state,
+        "service_receipt_id": fields.receipt_id,
+        "service_receipt_digest": fields.digest,
         "service_result": value,
     })
     .to_string())
+}
+
+struct MutationFields<'a> {
+    actor: &'a str,
+    resource: &'a str,
+    state: &'a str,
+    receipt_id: &'a str,
+    digest: &'a str,
+    action: &'a str,
+}
+
+impl<'a> MutationFields<'a> {
+    fn parse(value: &'a Value, resource_key: &str) -> Result<Self, &'static str> {
+        Ok(Self {
+            actor: required(value, "actor_did")?,
+            resource: required(value, resource_key)?,
+            state: required(value, "state")?,
+            receipt_id: required(value, "receipt_id")?,
+            digest: required(value, "receipt_digest")?,
+            action: required(value, "action")?,
+        })
+    }
+
+    fn validate(
+        &self,
+        request: &str,
+        tool: &str,
+        resource_key: &str,
+        expected_actor: &str,
+    ) -> Result<(), &'static str> {
+        validate_digest(self.digest)?;
+        validate_equal(self.actor, expected_actor)?;
+        validate_equal(self.action, expected_action(tool)?)?;
+        validate_state(tool, self.state)?;
+        validate_requested_resource(request, resource_key, self.resource)
+    }
 }
 
 fn parse(payload: &str) -> Result<Value, &'static str> {

--- a/crates/kamn-mcp-server/src/authority.rs
+++ b/crates/kamn-mcp-server/src/authority.rs
@@ -1,0 +1,150 @@
+use serde_json::{json, Value};
+
+pub(crate) const INVALID: &str = "MCP_AUTHORITY_RECEIPT_INVALID";
+pub(crate) const MISSING: &str = "MCP_AUTHORITY_RECEIPT_MISSING";
+
+pub(crate) fn wrap(
+    tool: &str,
+    payload: &str,
+    request: &str,
+    expected_actor: &str,
+) -> Result<Option<String>, &'static str> {
+    if tool == "register" {
+        return registration(payload, tool, expected_actor).map(Some);
+    }
+    let Some(resource_key) = mutation_resource_key(tool) else {
+        return Ok(None);
+    };
+    mutation(payload, request, tool, resource_key, expected_actor).map(Some)
+}
+
+fn registration(payload: &str, tool: &str, expected_actor: &str) -> Result<String, &'static str> {
+    let value = parse(payload)?;
+    let did = required(&value, "did")?;
+    let commitment = required(&value, "profile_commitment")?;
+    validate_digest(commitment)?;
+    validate_equal(did, expected_actor)?;
+    Ok(json!({
+        "schema_version": "kamn.mcp.authority-receipt.v1",
+        "authority_kind": "service-profile-commitment",
+        "source": "kamn-service",
+        "actor_did": did,
+        "tool": tool,
+        "resource_id": did,
+        "profile_commitment": commitment,
+        "service_result": value,
+    })
+    .to_string())
+}
+
+fn mutation(
+    payload: &str,
+    request: &str,
+    tool: &str,
+    resource_key: &str,
+    expected_actor: &str,
+) -> Result<String, &'static str> {
+    let value = parse(payload)?;
+    let actor = required(&value, "actor_did")?;
+    let resource = required(&value, resource_key)?;
+    let state = required(&value, "state")?;
+    let receipt_id = required(&value, "receipt_id")?;
+    let digest = required(&value, "receipt_digest")?;
+    let action = required(&value, "action")?;
+    validate_digest(digest)?;
+    validate_equal(actor, expected_actor)?;
+    validate_equal(action, expected_action(tool)?)?;
+    validate_state(tool, state)?;
+    validate_requested_resource(request, resource_key, resource)?;
+    Ok(json!({
+        "schema_version": "kamn.mcp.authority-receipt.v1",
+        "authority_kind": "service-receipt",
+        "source": "kamn-service",
+        "actor_did": actor,
+        "tool": tool,
+        "resource_id": resource,
+        "resulting_state": state,
+        "service_receipt_id": receipt_id,
+        "service_receipt_digest": digest,
+        "service_result": value,
+    })
+    .to_string())
+}
+
+fn parse(payload: &str) -> Result<Value, &'static str> {
+    serde_json::from_str(payload).map_err(|_| INVALID)
+}
+
+fn required<'a>(value: &'a Value, key: &str) -> Result<&'a str, &'static str> {
+    value
+        .get(key)
+        .ok_or(MISSING)?
+        .as_str()
+        .filter(|value| !value.is_empty())
+        .ok_or(INVALID)
+}
+
+fn validate_digest(value: &str) -> Result<(), &'static str> {
+    let hex = value.strip_prefix("sha256:").ok_or(INVALID)?;
+    if hex.len() == 64
+        && hex
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        return Ok(());
+    }
+    Err(INVALID)
+}
+
+fn validate_requested_resource(
+    request: &str,
+    resource_key: &str,
+    resource: &str,
+) -> Result<(), &'static str> {
+    let request = parse(request)?;
+    match request.get(resource_key).and_then(Value::as_str) {
+        Some(expected) if expected != resource => Err(INVALID),
+        _ => Ok(()),
+    }
+}
+
+fn validate_equal(actual: &str, expected: &str) -> Result<(), &'static str> {
+    if actual == expected {
+        return Ok(());
+    }
+    Err(INVALID)
+}
+
+fn expected_action(tool: &str) -> Result<&'static str, &'static str> {
+    match tool {
+        "create_task" => Ok("task:create"),
+        "accept_task" => Ok("task:accept"),
+        "complete_task" => Ok("task:complete"),
+        "fund_escrow" => Ok("escrow:fund"),
+        "release_escrow" => Ok("escrow:release-authorize"),
+        _ => Err(INVALID),
+    }
+}
+
+fn validate_state(tool: &str, state: &str) -> Result<(), &'static str> {
+    let valid = match tool {
+        "create_task" => state == "submitted",
+        "accept_task" => state == "accepted",
+        "complete_task" => state == "completed",
+        "fund_escrow" => state == "funded",
+        "release_escrow" => matches!(state, "release-authorized" | "released"),
+        _ => false,
+    };
+    if valid {
+        return Ok(());
+    }
+    Err(INVALID)
+}
+
+fn mutation_resource_key(tool: &str) -> Option<&'static str> {
+    match tool {
+        "create_task" | "accept_task" | "complete_task" => Some("task_id"),
+        "fund_escrow" | "release_escrow" => Some("escrow_id"),
+        _ => None,
+    }
+}

--- a/crates/kamn-mcp-server/src/dispatch.rs
+++ b/crates/kamn-mcp-server/src/dispatch.rs
@@ -4,6 +4,10 @@ use kamn_agent_lib::{AgentLibError, KamnAgentHandle, KolmeProofReceipt};
 
 /// Backend abstraction used by MCP tool dispatch.
 pub trait McpToolBackend {
+    /// Returns the authenticated backend actor DID.
+    fn actor_did(&self) -> &str {
+        ""
+    }
     /// Registers the local agent identity.
     fn register(&self) -> Result<String, AgentLibError>;
     /// Sends one message payload.
@@ -59,6 +63,10 @@ pub trait McpToolBackend {
 }
 
 impl McpToolBackend for KamnAgentHandle {
+    fn actor_did(&self) -> &str {
+        self.identity().did().as_str()
+    }
+
     fn register(&self) -> Result<String, AgentLibError> {
         register_service_backed_mcp_agent(self)
     }
@@ -208,45 +216,65 @@ impl McpToolBackend for KamnAgentHandle {
     fn create_task(&self, payload: &str) -> Result<String, AgentLibError> {
         let receipt = KamnAgentHandle::create_task(self, payload)?;
         Ok(format!(
-            r#"{{"task_id":"{}","state":"{}"}}"#,
+            r#"{{"actor_did":"{}","task_id":"{}","state":"{}","receipt_id":"{}","receipt_digest":"{}","action":"{}"}}"#,
+            escape_json(self.identity().did().as_str()),
             escape_json(receipt.task_id.as_str()),
             escape_json(receipt.state.as_str()),
+            escape_json(receipt.receipt_id.as_str()),
+            escape_json(receipt.receipt_digest.as_str()),
+            escape_json(receipt.action.as_str()),
         ))
     }
 
     fn accept_task(&self, task_id: &str, payload: &str) -> Result<String, AgentLibError> {
         let receipt = KamnAgentHandle::accept_task_with_payload(self, task_id, payload)?;
         Ok(format!(
-            r#"{{"task_id":"{}","state":"{}"}}"#,
+            r#"{{"actor_did":"{}","task_id":"{}","state":"{}","receipt_id":"{}","receipt_digest":"{}","action":"{}"}}"#,
+            escape_json(self.identity().did().as_str()),
             escape_json(receipt.task_id.as_str()),
             escape_json(receipt.state.as_str()),
+            escape_json(receipt.receipt_id.as_str()),
+            escape_json(receipt.receipt_digest.as_str()),
+            escape_json(receipt.action.as_str()),
         ))
     }
 
     fn complete_task(&self, task_id: &str, payload: &str) -> Result<String, AgentLibError> {
         let receipt = KamnAgentHandle::complete_task_with_payload(self, task_id, payload)?;
         Ok(format!(
-            r#"{{"task_id":"{}","state":"{}"}}"#,
+            r#"{{"actor_did":"{}","task_id":"{}","state":"{}","receipt_id":"{}","receipt_digest":"{}","action":"{}"}}"#,
+            escape_json(self.identity().did().as_str()),
             escape_json(receipt.task_id.as_str()),
             escape_json(receipt.state.as_str()),
+            escape_json(receipt.receipt_id.as_str()),
+            escape_json(receipt.receipt_digest.as_str()),
+            escape_json(receipt.action.as_str()),
         ))
     }
 
     fn fund_escrow(&self, payload: &str) -> Result<String, AgentLibError> {
         let receipt = KamnAgentHandle::fund_escrow(self, payload)?;
         Ok(format!(
-            r#"{{"escrow_id":"{}","state":"{}"}}"#,
+            r#"{{"actor_did":"{}","escrow_id":"{}","state":"{}","receipt_id":"{}","receipt_digest":"{}","action":"{}"}}"#,
+            escape_json(self.identity().did().as_str()),
             escape_json(receipt.escrow_id.as_str()),
             escape_json(receipt.state.as_str()),
+            escape_json(receipt.receipt_id.as_str()),
+            escape_json(receipt.receipt_digest.as_str()),
+            escape_json(receipt.action.as_str()),
         ))
     }
 
     fn release_escrow(&self, escrow_id: &str, payload: &str) -> Result<String, AgentLibError> {
         let receipt = KamnAgentHandle::release_escrow_with_payload(self, escrow_id, payload)?;
         Ok(format!(
-            r#"{{"escrow_id":"{}","state":"{}"}}"#,
+            r#"{{"actor_did":"{}","escrow_id":"{}","state":"{}","receipt_id":"{}","receipt_digest":"{}","action":"{}"}}"#,
+            escape_json(self.identity().did().as_str()),
             escape_json(receipt.escrow_id.as_str()),
             escape_json(receipt.state.as_str()),
+            escape_json(receipt.receipt_id.as_str()),
+            escape_json(receipt.receipt_digest.as_str()),
+            escape_json(receipt.action.as_str()),
         ))
     }
 
@@ -458,11 +486,28 @@ pub fn dispatch_tool_request_json<B: McpToolBackend>(
     };
 
     match operation {
-        Ok(result) => Ok(success_response_json(
-            request_id.as_str(),
+        Ok(result) => match crate::authority::wrap(
             tool.as_str(),
             result.as_str(),
-        )),
+            request_json,
+            backend.actor_did(),
+        ) {
+            Ok(Some(authority)) => Ok(success_response_json(
+                request_id.as_str(),
+                tool.as_str(),
+                authority.as_str(),
+            )),
+            Ok(None) => Ok(success_response_json(
+                request_id.as_str(),
+                tool.as_str(),
+                result.as_str(),
+            )),
+            Err(code) => Ok(authority_error_response_json(
+                request_id.as_str(),
+                tool.as_str(),
+                code,
+            )),
+        },
         Err(AgentLibError::UnsupportedOperation(message)) => Ok(unsupported_response_json(
             request_id.as_str(),
             tool.as_str(),
@@ -518,5 +563,14 @@ fn backend_error_response_json(request_id: &str, tool: &str, message: &str) -> S
         escape_json(request_id),
         escape_json(tool),
         escape_json(message),
+    )
+}
+
+fn authority_error_response_json(request_id: &str, tool: &str, code: &str) -> String {
+    format!(
+        r#"{{"ok":false,"id":"{}","tool":"{}","error":{{"kind":"authority_error","code":"{}","message":"service authority receipt validation failed"}}}}"#,
+        escape_json(request_id),
+        escape_json(tool),
+        escape_json(code),
     )
 }

--- a/crates/kamn-mcp-server/src/lib.rs
+++ b/crates/kamn-mcp-server/src/lib.rs
@@ -1,6 +1,7 @@
 #![warn(missing_docs)]
 //! MCP tool-server scaffold for KAMN.
 
+mod authority;
 /// MCP configuration scaffold.
 pub mod config;
 /// MCP tool dispatch and backend adapters.

--- a/crates/kamn-mcp-server/src/registration.rs
+++ b/crates/kamn-mcp-server/src/registration.rs
@@ -11,6 +11,7 @@ pub(crate) fn register_service_backed_mcp_agent(
         "agent_type": profile.agent_type,
         "model_family": profile.model_family,
         "capabilities": profile.capabilities,
+        "profile_commitment": profile.profile_commitment,
     })
     .to_string())
 }

--- a/crates/kamn-mcp-server/src/tools.rs
+++ b/crates/kamn-mcp-server/src/tools.rs
@@ -23,7 +23,7 @@ const CONTENT_ID_INPUT_SCHEMA_JSON: &str = r#"{"type":"object","required":["cont
 const BRIDGE_ID_INPUT_SCHEMA_JSON: &str = r#"{"type":"object","required":["bridge_id"],"properties":{"bridge_id":{"type":"string"}},"additionalProperties":false}"#;
 const ESCROW_PAYLOAD_INPUT_SCHEMA_JSON: &str = r#"{"type":"object","required":["escrow_id","payload"],"properties":{"escrow_id":{"type":"string"},"payload":{"type":"string"}},"additionalProperties":false}"#;
 const VERIFY_PROOF_INPUT_SCHEMA_JSON: &str = r#"{"type":"object","required":["message_id","tx_hash","block_height","finality"],"properties":{"message_id":{"type":"string"},"tx_hash":{"type":"string"},"block_height":{"type":"string"},"finality":{"type":"string"}},"additionalProperties":false}"#;
-const MCP_ENVELOPE_OUTPUT_SCHEMA_JSON: &str = r#"{"type":"object","required":["ok"],"properties":{"ok":{"type":"boolean"},"id":{"type":"string"},"tool":{"type":"string"},"result":{"type":"object"},"error":{"type":"object","required":["kind","message"],"properties":{"kind":{"type":"string"},"message":{"type":"string"}},"additionalProperties":false}},"additionalProperties":false}"#;
+const MCP_ENVELOPE_OUTPUT_SCHEMA_JSON: &str = r#"{"type":"object","required":["ok"],"properties":{"ok":{"type":"boolean"},"id":{"type":"string"},"tool":{"type":"string"},"result":{"type":"object"},"error":{"type":"object","required":["kind","message"],"properties":{"kind":{"type":"string"},"code":{"type":"string"},"message":{"type":"string"}},"additionalProperties":false}},"additionalProperties":false}"#;
 
 /// Required PRD phase-2 MCP tool names.
 pub const MCP_TOOL_NAMES: [&str; 23] = [

--- a/crates/kamn-mcp-server/tests/authority_receipt_contract.rs
+++ b/crates/kamn-mcp-server/tests/authority_receipt_contract.rs
@@ -1,0 +1,139 @@
+use kamn_agent_lib::AgentLibError;
+use kamn_mcp_server::{dispatch_tool_request_json, McpToolBackend};
+
+const DIGEST: &str = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+macro_rules! unsupported_backend_methods {
+    () => {
+        fn send_message(&self, _: &str) -> Result<String, AgentLibError> {
+            unsupported()
+        }
+        fn create_channel(&self, _: &str) -> Result<String, AgentLibError> {
+            unsupported()
+        }
+        fn list_messages(&self, _: &str) -> Result<String, AgentLibError> {
+            unsupported()
+        }
+        fn query_message(&self, _: &str) -> Result<String, AgentLibError> {
+            unsupported()
+        }
+        fn query_task(&self, _: &str) -> Result<String, AgentLibError> {
+            unsupported()
+        }
+        fn query_participant_task_projection(&self, _: &str) -> Result<String, AgentLibError> {
+            unsupported()
+        }
+        fn query_verifier_task_projection(&self, _: &str) -> Result<String, AgentLibError> {
+            unsupported()
+        }
+        fn query_agent_profile(&self, _: &str) -> Result<String, AgentLibError> {
+            unsupported()
+        }
+        fn register_content(&self, _: &str) -> Result<String, AgentLibError> {
+            unsupported()
+        }
+        fn expire_content(&self, _: &str) -> Result<String, AgentLibError> {
+            unsupported()
+        }
+        fn tombstone_content(&self, _: &str) -> Result<String, AgentLibError> {
+            unsupported()
+        }
+        fn query_content(&self, _: &str) -> Result<String, AgentLibError> {
+            unsupported()
+        }
+        fn submit_bridge_message(&self, _: &str) -> Result<String, AgentLibError> {
+            unsupported()
+        }
+        fn forward_bridge_message(&self, _: &str) -> Result<String, AgentLibError> {
+            unsupported()
+        }
+        fn query_bridge_message(&self, _: &str) -> Result<String, AgentLibError> {
+            unsupported()
+        }
+        fn create_task(&self, _: &str) -> Result<String, AgentLibError> {
+            unsupported()
+        }
+        fn fund_escrow(&self, _: &str) -> Result<String, AgentLibError> {
+            unsupported()
+        }
+        fn release_escrow(&self, _: &str, _: &str) -> Result<String, AgentLibError> {
+            unsupported()
+        }
+        fn health(&self) -> Result<String, AgentLibError> {
+            unsupported()
+        }
+        fn verify_proof(&self, _: &str, _: &str, _: u64, _: &str) -> Result<String, AgentLibError> {
+            unsupported()
+        }
+    };
+}
+
+struct AuthorityBackend;
+
+impl McpToolBackend for AuthorityBackend {
+    fn register(&self) -> Result<String, AgentLibError> {
+        Ok(format!(
+            r#"{{"did":"kamn:did:agent:test","profile_commitment":"{DIGEST}"}}"#
+        ))
+    }
+
+    fn accept_task(&self, task_id: &str, _payload: &str) -> Result<String, AgentLibError> {
+        Ok(task_authority(task_id, "accepted"))
+    }
+
+    fn complete_task(&self, task_id: &str, _payload: &str) -> Result<String, AgentLibError> {
+        Ok(format!(r#"{{"task_id":"{task_id}","state":"completed"}}"#))
+    }
+
+    unsupported_backend_methods!();
+}
+
+fn unsupported() -> Result<String, AgentLibError> {
+    Err(AgentLibError::UnsupportedOperation(
+        "unused test backend method".to_owned(),
+    ))
+}
+
+fn task_authority(task_id: &str, state: &str) -> String {
+    format!(
+        r#"{{"actor_did":"kamn:did:agent:test","task_id":"{task_id}","state":"{state}","receipt_id":"task-transition-receipt-1","receipt_digest":"{DIGEST}"}}"#
+    )
+}
+
+#[test]
+fn mutation_result_is_wrapped_as_service_authority_v1() {
+    let response = dispatch_tool_request_json(
+        &AuthorityBackend,
+        r#"{"id":"req-1","tool":"accept_task","task_id":"task-1","payload":"{}"}"#,
+    )
+    .expect("dispatch should return an envelope");
+
+    assert!(response.contains(r#""schema_version":"kamn.mcp.authority-receipt.v1""#));
+    assert!(response.contains(r#""authority_kind":"service-receipt""#));
+    assert!(response.contains(r#""source":"kamn-service""#));
+    assert!(response.contains(r#""service_receipt_id":"task-transition-receipt-1""#));
+    assert!(response.contains(r#""service_receipt_digest":"sha256:""#));
+}
+
+#[test]
+fn legacy_mutation_result_fails_closed() {
+    let response = dispatch_tool_request_json(
+        &AuthorityBackend,
+        r#"{"id":"req-2","tool":"complete_task","task_id":"task-1","payload":"{}"}"#,
+    )
+    .expect("dispatch should return an error envelope");
+
+    assert!(response.contains(r#""ok":false"#));
+    assert!(response.contains("MCP_AUTHORITY_RECEIPT_MISSING"));
+}
+
+#[test]
+fn registration_uses_service_profile_commitment_authority() {
+    let response =
+        dispatch_tool_request_json(&AuthorityBackend, r#"{"id":"req-3","tool":"register"}"#)
+            .expect("dispatch should return an envelope");
+
+    assert!(response.contains(r#""schema_version":"kamn.mcp.authority-receipt.v1""#));
+    assert!(response.contains(r#""authority_kind":"service-profile-commitment""#));
+    assert!(response.contains(r#""profile_commitment":"sha256:""#));
+}

--- a/crates/kamn-mcp-server/tests/authority_receipt_contract.rs
+++ b/crates/kamn-mcp-server/tests/authority_receipt_contract.rs
@@ -71,6 +71,10 @@ macro_rules! unsupported_backend_methods {
 struct AuthorityBackend;
 
 impl McpToolBackend for AuthorityBackend {
+    fn actor_did(&self) -> &str {
+        "kamn:did:agent:test"
+    }
+
     fn register(&self) -> Result<String, AgentLibError> {
         Ok(format!(
             r#"{{"did":"kamn:did:agent:test","profile_commitment":"{DIGEST}"}}"#
@@ -78,7 +82,19 @@ impl McpToolBackend for AuthorityBackend {
     }
 
     fn accept_task(&self, task_id: &str, _payload: &str) -> Result<String, AgentLibError> {
-        Ok(task_authority(task_id, "accepted"))
+        let authority = match task_id {
+            "wrong-resource" => task_authority("other-task", "accepted"),
+            "wrong-actor" => task_authority(task_id, "accepted")
+                .replace("kamn:did:agent:test", "kamn:did:agent:other"),
+            "wrong-action" => {
+                task_authority(task_id, "accepted").replace("task:accept", "task:complete")
+            }
+            "wrong-state" => task_authority(task_id, "accepted")
+                .replace(r#""state":"accepted""#, r#""state":"submitted""#),
+            "bad-digest" => task_authority(task_id, "accepted").replace(DIGEST, "sha256:BAD"),
+            _ => task_authority(task_id, "accepted"),
+        };
+        Ok(authority)
     }
 
     fn complete_task(&self, task_id: &str, _payload: &str) -> Result<String, AgentLibError> {
@@ -95,8 +111,13 @@ fn unsupported() -> Result<String, AgentLibError> {
 }
 
 fn task_authority(task_id: &str, state: &str) -> String {
+    let action = if state == "accepted" {
+        "task:accept"
+    } else {
+        "task:complete"
+    };
     format!(
-        r#"{{"actor_did":"kamn:did:agent:test","task_id":"{task_id}","state":"{state}","receipt_id":"task-transition-receipt-1","receipt_digest":"{DIGEST}"}}"#
+        r#"{{"actor_did":"kamn:did:agent:test","task_id":"{task_id}","state":"{state}","receipt_id":"task-transition-receipt-1","receipt_digest":"{DIGEST}","action":"{action}"}}"#
     )
 }
 
@@ -136,4 +157,26 @@ fn registration_uses_service_profile_commitment_authority() {
     assert!(response.contains(r#""schema_version":"kamn.mcp.authority-receipt.v1""#));
     assert!(response.contains(r#""authority_kind":"service-profile-commitment""#));
     assert!(response.contains(r#""profile_commitment":"sha256:""#));
+}
+
+#[test]
+fn mismatched_or_malformed_mutation_authority_fails_closed() {
+    for task_id in [
+        "wrong-resource",
+        "wrong-actor",
+        "wrong-action",
+        "wrong-state",
+        "bad-digest",
+    ] {
+        let request = format!(
+            r#"{{"id":"invalid","tool":"accept_task","task_id":"{task_id}","payload":"{{}}"}}"#
+        );
+        let response = dispatch_tool_request_json(&AuthorityBackend, request.as_str())
+            .expect("dispatch should return an authority error");
+        assert!(response.contains(r#""ok":false"#), "{response}");
+        assert!(
+            response.contains("MCP_AUTHORITY_RECEIPT_INVALID"),
+            "{response}"
+        );
+    }
 }

--- a/crates/kamn-mcp-server/tests/authority_receipt_contract.rs
+++ b/crates/kamn-mcp-server/tests/authority_receipt_contract.rs
@@ -133,7 +133,8 @@ fn mutation_result_is_wrapped_as_service_authority_v1() {
     assert!(response.contains(r#""authority_kind":"service-receipt""#));
     assert!(response.contains(r#""source":"kamn-service""#));
     assert!(response.contains(r#""service_receipt_id":"task-transition-receipt-1""#));
-    assert!(response.contains(r#""service_receipt_digest":"sha256:""#));
+    let digest_field = format!(r#""service_receipt_digest":"{DIGEST}""#);
+    assert!(response.contains(digest_field.as_str()));
 }
 
 #[test]
@@ -156,7 +157,8 @@ fn registration_uses_service_profile_commitment_authority() {
 
     assert!(response.contains(r#""schema_version":"kamn.mcp.authority-receipt.v1""#));
     assert!(response.contains(r#""authority_kind":"service-profile-commitment""#));
-    assert!(response.contains(r#""profile_commitment":"sha256:""#));
+    let commitment_field = format!(r#""profile_commitment":"{DIGEST}""#);
+    assert!(response.contains(commitment_field.as_str()));
 }
 
 #[test]

--- a/crates/kamn-mcp-server/tests/authority_receipt_contract.rs
+++ b/crates/kamn-mcp-server/tests/authority_receipt_contract.rs
@@ -90,7 +90,7 @@ impl McpToolBackend for AuthorityBackend {
 
 fn unsupported() -> Result<String, AgentLibError> {
     Err(AgentLibError::UnsupportedOperation(
-        "unused test backend method".to_owned(),
+        "unused test backend method",
     ))
 }
 

--- a/crates/kamn-mcp-server/tests/real_backend_integration_contract.rs
+++ b/crates/kamn-mcp-server/tests/real_backend_integration_contract.rs
@@ -9,6 +9,9 @@ const SERVICE_AUTH_PRIVATE_KEY_ENV: &str = "KAMN_SERVICE_API_AUTH_PRIVATE_KEY_HE
 const TEST_SERVICE_AUTH_PRIVATE_KEY_HEX: &str =
     "1111111111111111111111111111111111111111111111111111111111111111";
 const TEST_MCP_AGENT_DID: &str = "kamn:did:agent:pkh-038394c7f7ffdc1bfd761be5740fd3aeb46fdea8a79c1b9384d79c03c50fc44248--keyh-67726c2c9ade28652475e1b8fa00855e";
+const TEST_TASK_RECEIPT_ID: &str = "task-receipt-service-00000001";
+const TEST_TASK_RECEIPT_DIGEST: &str =
+    "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
 
 fn bind_loopback_listener() -> TcpListener {
     let listener = TcpListener::bind("127.0.0.1:0").expect("listener should bind");
@@ -153,6 +156,10 @@ fn write_public_or_task_response(
         ("GET", "/v1/tasks/task-contract-1") => {
             Some((200, r#"{"task_id":"task-contract-1","state":"submitted"}"#))
         }
+        ("POST", "/v1/tasks/create") => Some((
+            201,
+            r#"{"task_id":"task-authority-1","state":"submitted","receipt_id":"task-receipt-service-00000001","receipt_digest":"sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef","action":"task:create"}"#,
+        )),
         ("GET", "/v1/agents/kamn:did:agent:alice") => Some((
             200,
             r#"{"did":"kamn:did:agent:alice","reputation_score":42,"agent_type":"service-agent","model_family":"service-api","capabilities":["profile:read"],"profile_commitment":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}"#,
@@ -275,6 +282,19 @@ fn parse_framed_json(response: &str) -> String {
         "declared content length should match JSON body bytes",
     );
     body.to_owned()
+}
+
+fn assert_service_task_receipt_authority(response: &str) {
+    let value: serde_json::Value = serde_json::from_str(response).expect("valid response json");
+    let result = &value["result"];
+    assert_eq!(result["service_receipt_id"], TEST_TASK_RECEIPT_ID);
+    assert_eq!(result["service_receipt_digest"], TEST_TASK_RECEIPT_DIGEST);
+    assert_eq!(result["service_result"]["receipt_id"], TEST_TASK_RECEIPT_ID);
+    assert_eq!(
+        result["service_result"]["receipt_digest"],
+        TEST_TASK_RECEIPT_DIGEST
+    );
+    assert_eq!(result["actor_did"], TEST_MCP_AGENT_DID);
 }
 
 #[test]
@@ -530,5 +550,23 @@ fn spec_c10_real_backend_register_persists_mcp_agent_profile() {
     assert!(
         server_result.is_ok(),
         "register must consume the HTTP request"
+    );
+}
+
+#[test]
+fn spec_c11_real_backend_preserves_service_task_receipt_authority() {
+    let (bind_addr, server) = spawn_real_backend_service_server(1);
+    let backend = real_backend(bind_addr.as_str());
+    let response = dispatch_tool_request_json(
+        &backend,
+        r#"{"id":"req-11","tool":"create_task","payload":"{\"title\":\"authority\"}"}"#,
+    )
+    .expect("create_task dispatch should use the service backend");
+    assert_service_task_receipt_authority(response.as_str());
+
+    let server_result = server.join().expect("server thread should join");
+    assert!(
+        server_result.is_ok(),
+        "create task must consume the HTTP request"
     );
 }

--- a/crates/kamn-mcp-server/tests/real_backend_integration_contract.rs
+++ b/crates/kamn-mcp-server/tests/real_backend_integration_contract.rs
@@ -155,11 +155,11 @@ fn write_public_or_task_response(
         }
         ("GET", "/v1/agents/kamn:did:agent:alice") => Some((
             200,
-            r#"{"did":"kamn:did:agent:alice","reputation_score":42,"agent_type":"service-agent","model_family":"service-api","capabilities":["profile:read"]}"#,
+            r#"{"did":"kamn:did:agent:alice","reputation_score":42,"agent_type":"service-agent","model_family":"service-api","capabilities":["profile:read"],"profile_commitment":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}"#,
         )),
         ("POST", "/v1/agents/register") if body == mcp_registration_payload() => Some((
             201,
-            r#"{"did":"kamn:did:agent:pkh-038394c7f7ffdc1bfd761be5740fd3aeb46fdea8a79c1b9384d79c03c50fc44248--keyh-67726c2c9ade28652475e1b8fa00855e","reputation_score":0,"agent_type":"autonomous","model_family":"mcp-agent","capabilities":["mcp"]}"#,
+            r#"{"did":"kamn:did:agent:pkh-038394c7f7ffdc1bfd761be5740fd3aeb46fdea8a79c1b9384d79c03c50fc44248--keyh-67726c2c9ade28652475e1b8fa00855e","reputation_score":0,"agent_type":"autonomous","model_family":"mcp-agent","capabilities":["mcp"],"profile_commitment":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}"#,
         )),
         ("POST", "/v1/agents/register") => Some((
             400,

--- a/crates/kamn-mcp-server/tests/stdio_protocol_contract/support.rs
+++ b/crates/kamn-mcp-server/tests/stdio_protocol_contract/support.rs
@@ -1,12 +1,20 @@
 use kamn_agent_lib::AgentLibError;
 use kamn_mcp_server::McpToolBackend;
 
+const DIGEST: &str = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
 #[derive(Debug, Default)]
 pub(crate) struct ProtocolBackend;
 
 impl McpToolBackend for ProtocolBackend {
+    fn actor_did(&self) -> &str {
+        "kamn:did:agent:test"
+    }
+
     fn register(&self) -> Result<String, AgentLibError> {
-        Ok(r#"{"did":"kamn:did:agent:test"}"#.to_owned())
+        Ok(format!(
+            r#"{{"did":"kamn:did:agent:test","profile_commitment":"{DIGEST}"}}"#
+        ))
     }
 
     fn send_message(&self, payload: &str) -> Result<String, AgentLibError> {
@@ -98,28 +106,32 @@ impl McpToolBackend for ProtocolBackend {
     fn create_task(&self, payload: &str) -> Result<String, AgentLibError> {
         let payload_len = payload.len();
         Ok(format!(
-            r#"{{"task_id":"task-{payload_len}","state":"created"}}"#
+            r#"{{"actor_did":"kamn:did:agent:test","task_id":"task-{payload_len}","state":"submitted","receipt_id":"task-create","receipt_digest":"{DIGEST}","action":"task:create"}}"#
         ))
     }
 
     fn accept_task(&self, task_id: &str, _payload: &str) -> Result<String, AgentLibError> {
-        Ok(format!(r#"{{"task_id":"{task_id}","state":"accepted"}}"#))
+        Ok(format!(
+            r#"{{"actor_did":"kamn:did:agent:test","task_id":"{task_id}","state":"accepted","receipt_id":"task-accept","receipt_digest":"{DIGEST}","action":"task:accept"}}"#
+        ))
     }
 
     fn complete_task(&self, task_id: &str, _payload: &str) -> Result<String, AgentLibError> {
-        Ok(format!(r#"{{"task_id":"{task_id}","state":"completed"}}"#))
+        Ok(format!(
+            r#"{{"actor_did":"kamn:did:agent:test","task_id":"{task_id}","state":"completed","receipt_id":"task-complete","receipt_digest":"{DIGEST}","action":"task:complete"}}"#
+        ))
     }
 
     fn fund_escrow(&self, payload: &str) -> Result<String, AgentLibError> {
         let payload_len = payload.len();
         Ok(format!(
-            r#"{{"escrow_id":"escrow-{payload_len}","state":"funded"}}"#
+            r#"{{"actor_did":"kamn:did:agent:test","escrow_id":"escrow-{payload_len}","state":"funded","receipt_id":"escrow-fund","receipt_digest":"{DIGEST}","action":"escrow:fund"}}"#
         ))
     }
 
     fn release_escrow(&self, escrow_id: &str, _payload: &str) -> Result<String, AgentLibError> {
         Ok(format!(
-            r#"{{"escrow_id":"{escrow_id}","state":"released"}}"#
+            r#"{{"actor_did":"kamn:did:agent:test","escrow_id":"{escrow_id}","state":"released","receipt_id":"escrow-release","receipt_digest":"{DIGEST}","action":"escrow:release-authorize"}}"#
         ))
     }
 

--- a/crates/kamn-mcp-server/tests/tool_dispatch_contract.rs
+++ b/crates/kamn-mcp-server/tests/tool_dispatch_contract.rs
@@ -1,12 +1,20 @@
 use kamn_agent_lib::AgentLibError;
 use kamn_mcp_server::{dispatch_tool_request_json, McpToolBackend};
 
+const DIGEST: &str = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
 #[derive(Debug, Default)]
 struct TestBackend;
 
 impl McpToolBackend for TestBackend {
+    fn actor_did(&self) -> &str {
+        "kamn:did:agent:test"
+    }
+
     fn register(&self) -> Result<String, AgentLibError> {
-        Ok(r#"{"did":"kamn:did:agent:test"}"#.to_owned())
+        Ok(format!(
+            r#"{{"did":"kamn:did:agent:test","profile_commitment":"{DIGEST}"}}"#
+        ))
     }
 
     fn send_message(&self, payload: &str) -> Result<String, AgentLibError> {
@@ -97,27 +105,33 @@ impl McpToolBackend for TestBackend {
 
     fn create_task(&self, payload: &str) -> Result<String, AgentLibError> {
         let payload_len = payload.len();
-        Ok(format!(r#"{{"task_id":"task-{payload_len}"}}"#))
+        Ok(format!(
+            r#"{{"actor_did":"kamn:did:agent:test","task_id":"task-{payload_len}","state":"submitted","receipt_id":"task-create","receipt_digest":"{DIGEST}","action":"task:create"}}"#
+        ))
     }
 
     fn accept_task(&self, task_id: &str, _payload: &str) -> Result<String, AgentLibError> {
-        Ok(format!(r#"{{"task_id":"{task_id}","state":"accepted"}}"#))
+        Ok(format!(
+            r#"{{"actor_did":"kamn:did:agent:test","task_id":"{task_id}","state":"accepted","receipt_id":"task-accept","receipt_digest":"{DIGEST}","action":"task:accept"}}"#
+        ))
     }
 
     fn complete_task(&self, task_id: &str, _payload: &str) -> Result<String, AgentLibError> {
-        Ok(format!(r#"{{"task_id":"{task_id}","state":"completed"}}"#))
+        Ok(format!(
+            r#"{{"actor_did":"kamn:did:agent:test","task_id":"{task_id}","state":"completed","receipt_id":"task-complete","receipt_digest":"{DIGEST}","action":"task:complete"}}"#
+        ))
     }
 
     fn fund_escrow(&self, payload: &str) -> Result<String, AgentLibError> {
         let payload_len = payload.len();
         Ok(format!(
-            r#"{{"escrow_id":"escrow-{payload_len}","state":"funded"}}"#
+            r#"{{"actor_did":"kamn:did:agent:test","escrow_id":"escrow-{payload_len}","state":"funded","receipt_id":"escrow-fund","receipt_digest":"{DIGEST}","action":"escrow:fund"}}"#
         ))
     }
 
     fn release_escrow(&self, escrow_id: &str, _payload: &str) -> Result<String, AgentLibError> {
         Ok(format!(
-            r#"{{"escrow_id":"{escrow_id}","state":"released"}}"#
+            r#"{{"actor_did":"kamn:did:agent:test","escrow_id":"{escrow_id}","state":"released","receipt_id":"escrow-release","receipt_digest":"{DIGEST}","action":"escrow:release-authorize"}}"#
         ))
     }
 

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_creator_provider_lifecycle_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_creator_provider_lifecycle_contract_tests.rs
@@ -151,9 +151,9 @@ fn integration_task_transition_retry_returns_one_durable_receipt() {
     let receipts = state["task_transition_receipts"]
         .as_array()
         .expect("transition receipts should be an array");
-    assert_eq!(receipts.len(), 1);
-    assert_eq!(receipts[0]["action"], "task:accept");
-    assert_eq!(receipts[0]["transaction_id"], "transaction-lifecycle-001");
+    assert_eq!(receipts.len(), 2);
+    assert_eq!(receipts[1]["action"], "task:accept");
+    assert_eq!(receipts[1]["transaction_id"], "transaction-lifecycle-001");
     case.cleanup();
 }
 
@@ -192,7 +192,7 @@ fn integration_task_completion_evidence_and_receipts_survive_restart() {
             .as_array()
             .expect("transition receipts should be an array")
             .len(),
-        2
+        3
     );
     case.cleanup();
 }

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_creator_provider_lifecycle_contract_tests/support.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_creator_provider_lifecycle_contract_tests/support.rs
@@ -121,7 +121,7 @@ fn integration_task_create_retry_preserves_service_receipt_authority() {
     assert_eq!(
         case.state()["task_transition_receipts"]
             .as_array()
-            .unwrap()
+            .expect("task transition receipts should be an array")
             .len(),
         1
     );

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_creator_provider_lifecycle_contract_tests/support.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_creator_provider_lifecycle_contract_tests/support.rs
@@ -106,3 +106,24 @@ fn signed_request(
     }
     raw_signed_request(snapshot, bind_addr.as_str(), request)
 }
+
+#[test]
+fn integration_task_create_retry_preserves_service_receipt_authority() {
+    let case = LifecycleCase::new("create-receipt-authority");
+    case.register(PROVIDER, 1);
+    let first = case.create_valid_task(1);
+    let retried = case.create_valid_task(2);
+
+    assert_eq!(retried.receipt_id, first.receipt_id);
+    assert_eq!(retried.receipt_digest, first.receipt_digest);
+    assert!(first.receipt_id.starts_with("task-transition-receipt-"));
+    assert!(first.receipt_digest.starts_with("sha256:"));
+    assert_eq!(
+        case.state()["task_transition_receipts"]
+            .as_array()
+            .unwrap()
+            .len(),
+        1
+    );
+    case.cleanup();
+}

--- a/crates/kamn-node/src/service_api_endpoint/escrow_models.rs
+++ b/crates/kamn-node/src/service_api_endpoint/escrow_models.rs
@@ -25,6 +25,10 @@ pub(crate) struct ServiceApiEscrowStatusBody {
     pub(crate) claim_scope: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) receipt_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) receipt_digest: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) action: Option<String>,
     #[serde(flatten)]
     pub(crate) settlement: ServiceApiSettlementMetadata,
 }

--- a/crates/kamn-node/src/service_api_endpoint/message_store.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store.rs
@@ -35,6 +35,7 @@ const INITIAL_SERVICE_API_AGENT_REPUTATION_SCORE: u64 = 500;
 const INITIAL_SERVICE_API_AGENT_BALANCE: u64 = 100;
 
 mod audit_export;
+mod authority_digest;
 mod models;
 mod persistence;
 mod runtime_evidence;

--- a/crates/kamn-node/src/service_api_endpoint/message_store/authority_digest.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/authority_digest.rs
@@ -1,0 +1,96 @@
+use super::{ServiceApiEscrowTransitionReceiptRecord, ServiceApiTaskTransitionReceiptRecord};
+use k256::sha2::{Digest, Sha256};
+
+const PROFILE_DOMAIN: &str = "kamn.service.profile-authority.v1";
+const TASK_DOMAIN: &str = "kamn.service.task-receipt.v1";
+const ESCROW_DOMAIN: &str = "kamn.service.escrow-receipt.v1";
+
+pub(super) fn profile(
+    did: &str,
+    reputation_score: u64,
+    agent_type: &str,
+    model_family: &str,
+    capabilities: &[String],
+) -> String {
+    let mut hasher = Sha256::new();
+    append(&mut hasher, PROFILE_DOMAIN);
+    append(&mut hasher, did);
+    append(&mut hasher, reputation_score.to_string().as_str());
+    append(&mut hasher, agent_type);
+    append(&mut hasher, model_family);
+    append(&mut hasher, capabilities.len().to_string().as_str());
+    for capability in capabilities {
+        append(&mut hasher, capability);
+    }
+    finish(hasher)
+}
+
+pub(super) fn task(receipt: &ServiceApiTaskTransitionReceiptRecord) -> String {
+    let evidence_marker = if receipt.completion_evidence_digest.is_some() {
+        "some"
+    } else {
+        "none"
+    };
+    digest(
+        TASK_DOMAIN,
+        &[
+            receipt.receipt_id.as_str(),
+            receipt.correlation_id.as_str(),
+            receipt.idempotency_key.as_str(),
+            receipt.actor_did.as_str(),
+            receipt.task_id.as_str(),
+            receipt.transaction_id.as_str(),
+            receipt.action.as_str(),
+            receipt.prior_state.as_str(),
+            receipt.resulting_state.as_str(),
+            receipt.terms_digest.as_str(),
+            evidence_marker,
+            receipt.completion_evidence_digest.as_deref().unwrap_or(""),
+        ],
+    )
+}
+
+pub(super) fn escrow(receipt: &ServiceApiEscrowTransitionReceiptRecord) -> String {
+    let amount = receipt.amount_lamports.to_string();
+    digest(
+        ESCROW_DOMAIN,
+        &[
+            receipt.receipt_id.as_str(),
+            receipt.correlation_id.as_str(),
+            receipt.idempotency_key.as_str(),
+            receipt.actor_did.as_str(),
+            receipt.escrow_id.as_str(),
+            receipt.task_id.as_str(),
+            receipt.transaction_id.as_str(),
+            receipt.action.as_str(),
+            receipt.prior_state.as_str(),
+            receipt.resulting_state.as_str(),
+            receipt.network.as_str(),
+            amount.as_str(),
+            receipt.terms_digest.as_str(),
+            receipt.release_policy.as_str(),
+        ],
+    )
+}
+
+fn digest(domain: &str, fields: &[&str]) -> String {
+    let mut hasher = Sha256::new();
+    append(&mut hasher, domain);
+    for field in fields {
+        append(&mut hasher, field);
+    }
+    finish(hasher)
+}
+
+fn append(hasher: &mut Sha256, value: &str) {
+    hasher.update((value.len() as u64).to_be_bytes());
+    hasher.update(value.as_bytes());
+}
+
+fn finish(hasher: Sha256) -> String {
+    format!("sha256:{}", hex(&hasher.finalize()))
+}
+
+fn hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|byte| format!("{byte:02x}")).collect()
+}

--- a/crates/kamn-node/src/service_api_endpoint/message_store/store/agent_ops/defaults.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/store/agent_ops/defaults.rs
@@ -15,12 +15,23 @@ pub(super) fn default_agent_record(agent_did: &str) -> ServiceApiPersistedAgentR
 pub(super) fn agent_profile_body(
     record: &ServiceApiPersistedAgentRecord,
 ) -> ServiceApiAgentGetBody {
+    let agent_type = record_agent_type(record);
+    let model_family = record_model_family(record);
+    let capabilities = record_capabilities(record);
+    let profile_commitment = super::super::super::authority_digest::profile(
+        record.did.as_str(),
+        record.reputation_score,
+        agent_type.as_str(),
+        model_family.as_str(),
+        &capabilities,
+    );
     ServiceApiAgentGetBody {
         did: record.did.clone(),
         reputation_score: record.reputation_score,
-        agent_type: record_agent_type(record),
-        model_family: record_model_family(record),
-        capabilities: record_capabilities(record),
+        agent_type,
+        model_family,
+        capabilities,
+        profile_commitment,
     }
 }
 

--- a/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops.rs
@@ -110,8 +110,9 @@ impl ServiceApiMessageStore {
         &mut self,
         actor_did: &str,
         payload: &str,
+        correlation_id: &str,
     ) -> Result<ServiceApiTaskCreateBody, TaskLifecycleError> {
-        lifecycle::create_bound_task(self, actor_did, payload)
+        lifecycle::create_bound_task(self, actor_did, payload, correlation_id)
     }
 
     pub(crate) fn transition_bound_task(

--- a/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/escrow_lifecycle.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/escrow_lifecycle.rs
@@ -59,11 +59,13 @@ pub(super) fn fund(
     let receipt = receipt::append(
         store,
         &record,
-        actor,
-        "escrow:fund",
-        "unfunded",
-        key,
-        correlation_id,
+        receipt::ReceiptInput {
+            actor,
+            action: "escrow:fund",
+            prior_state: "unfunded",
+            key,
+            correlation_id,
+        },
     )?;
     store.snapshot.escrows.insert(escrow_id.clone(), record);
     issue_release_grant(store, escrow_id.as_str(), actor);
@@ -99,11 +101,13 @@ pub(super) fn authorize_release(
     let receipt = receipt::append(
         store,
         &updated,
-        actor,
-        "escrow:release-authorize",
-        "funded",
-        key,
-        correlation_id,
+        receipt::ReceiptInput {
+            actor,
+            action: "escrow:release-authorize",
+            prior_state: "funded",
+            key,
+            correlation_id,
+        },
     )?;
     store.snapshot.escrows.insert(escrow_id.to_owned(), updated);
     let response = receipt::response(&store.snapshot.escrows[escrow_id], Some(&receipt));

--- a/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/escrow_lifecycle.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/escrow_lifecycle.rs
@@ -43,7 +43,7 @@ pub(super) fn fund(
     if let Some(existing) = retry::funding(store, actor, &input)? {
         return Ok(receipt::response(
             existing,
-            funding_receipt_id(store, existing).as_deref(),
+            Some(funding_receipt(store, existing)?),
         ));
     }
     let task = store
@@ -56,7 +56,7 @@ pub(super) fn fund(
     let escrow_id = next_escrow_id(store, payload);
     let key = input.idempotency_key.clone();
     let record = build_record(escrow_id.as_str(), actor, input);
-    let receipt_id = receipt::append(
+    let receipt = receipt::append(
         store,
         &record,
         actor,
@@ -70,7 +70,7 @@ pub(super) fn fund(
     store.persist().map_err(persistence)?;
     Ok(receipt::response(
         &store.snapshot.escrows[&escrow_id],
-        Some(&receipt_id),
+        Some(&receipt),
     ))
 }
 
@@ -91,15 +91,12 @@ pub(super) fn authorize_release(
     let key = parse_release_key(payload)?;
     if let Some(existing) = retry::release(store, actor, escrow_id, key.as_str())? {
         let record = &store.snapshot.escrows[escrow_id];
-        return Ok(receipt::response(
-            record,
-            Some(existing.receipt_id.as_str()),
-        ));
+        return Ok(receipt::response(record, Some(existing)));
     }
     validate_release(store, actor, &escrow)?;
     let mut updated = escrow.clone();
     updated.state = "release-authorized".to_owned();
-    let receipt_id = receipt::append(
+    let receipt = receipt::append(
         store,
         &updated,
         actor,
@@ -109,7 +106,7 @@ pub(super) fn authorize_release(
         correlation_id,
     )?;
     store.snapshot.escrows.insert(escrow_id.to_owned(), updated);
-    let response = receipt::response(&store.snapshot.escrows[escrow_id], Some(&receipt_id));
+    let response = receipt::response(&store.snapshot.escrows[escrow_id], Some(&receipt));
     store.persist().map_err(persistence)?;
     Ok(response)
 }
@@ -129,16 +126,21 @@ pub(super) fn validate_release_eligibility(
     validate_release(store, actor, &escrow)
 }
 
-fn funding_receipt_id(
-    store: &ServiceApiMessageStore,
+fn funding_receipt<'a>(
+    store: &'a ServiceApiMessageStore,
     escrow: &ServiceApiPersistedEscrowRecord,
-) -> Option<String> {
+) -> Result<&'a ServiceApiEscrowTransitionReceiptRecord, EscrowLifecycleError> {
     store
         .snapshot
         .escrow_transition_receipts
         .iter()
         .find(|receipt| receipt.escrow_id == escrow.escrow_id && receipt.action == "escrow:fund")
-        .map(|receipt| receipt.receipt_id.clone())
+        .ok_or_else(|| {
+            conflict(
+                "ESCROW_RECEIPT_MISSING",
+                "escrow funding receipt is missing",
+            )
+        })
 }
 
 fn migration_required() -> EscrowLifecycleError {

--- a/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/escrow_lifecycle/receipt.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/escrow_lifecycle/receipt.rs
@@ -8,39 +8,45 @@ pub(super) fn append(
     prior_state: &str,
     key: String,
     correlation_id: &str,
-) -> Result<String, EscrowLifecycleError> {
+) -> Result<ServiceApiEscrowTransitionReceiptRecord, EscrowLifecycleError> {
     let receipt_id = format!(
         "escrow-transition-receipt-{:08}",
         store.snapshot.escrow_transition_receipts.len() + 1
     );
+    let receipt = ServiceApiEscrowTransitionReceiptRecord {
+        receipt_id: receipt_id.clone(),
+        correlation_id: correlation_id.to_owned(),
+        idempotency_key: key,
+        actor_did: actor.to_owned(),
+        escrow_id: record.escrow_id.clone(),
+        task_id: required(&record.task_id)?,
+        transaction_id: required(&record.transaction_id)?,
+        action: action.to_owned(),
+        prior_state: prior_state.to_owned(),
+        resulting_state: record.state.clone(),
+        network: required(&record.network)?,
+        amount_lamports: record.amount_lamports.ok_or_else(migration_required)?,
+        terms_digest: required(&record.terms_digest)?,
+        release_policy: required(&record.release_policy)?,
+    };
     store
         .snapshot
         .escrow_transition_receipts
-        .push(ServiceApiEscrowTransitionReceiptRecord {
-            receipt_id: receipt_id.clone(),
-            correlation_id: correlation_id.to_owned(),
-            idempotency_key: key,
-            actor_did: actor.to_owned(),
-            escrow_id: record.escrow_id.clone(),
-            task_id: required(&record.task_id)?,
-            transaction_id: required(&record.transaction_id)?,
-            action: action.to_owned(),
-            prior_state: prior_state.to_owned(),
-            resulting_state: record.state.clone(),
-            network: required(&record.network)?,
-            amount_lamports: record.amount_lamports.ok_or_else(migration_required)?,
-            terms_digest: required(&record.terms_digest)?,
-            release_policy: required(&record.release_policy)?,
-        });
-    Ok(receipt_id)
+        .push(receipt.clone());
+    Ok(receipt)
 }
 
 pub(super) fn response(
     record: &ServiceApiPersistedEscrowRecord,
-    receipt_id: Option<&str>,
+    receipt: Option<&ServiceApiEscrowTransitionReceiptRecord>,
 ) -> ServiceApiEscrowStatusBody {
     let mut response = escrow_status_response(record);
-    response.receipt_id = receipt_id.map(str::to_owned);
+    response.receipt_id = receipt.map(|value| value.receipt_id.clone());
+    response.receipt_digest = receipt.map(authority_digest::escrow);
+    response.action = receipt.map(|value| value.action.clone());
+    if let Some(receipt) = receipt {
+        response.state = receipt.resulting_state.clone();
+    }
     response
 }
 

--- a/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/escrow_lifecycle/receipt.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/escrow_lifecycle/receipt.rs
@@ -3,37 +3,49 @@ use super::*;
 pub(super) fn append(
     store: &mut ServiceApiMessageStore,
     record: &ServiceApiPersistedEscrowRecord,
-    actor: &str,
-    action: &str,
-    prior_state: &str,
-    key: String,
-    correlation_id: &str,
+    input: ReceiptInput<'_>,
 ) -> Result<ServiceApiEscrowTransitionReceiptRecord, EscrowLifecycleError> {
     let receipt_id = format!(
         "escrow-transition-receipt-{:08}",
         store.snapshot.escrow_transition_receipts.len() + 1
     );
-    let receipt = ServiceApiEscrowTransitionReceiptRecord {
-        receipt_id: receipt_id.clone(),
-        correlation_id: correlation_id.to_owned(),
-        idempotency_key: key,
-        actor_did: actor.to_owned(),
-        escrow_id: record.escrow_id.clone(),
-        task_id: required(&record.task_id)?,
-        transaction_id: required(&record.transaction_id)?,
-        action: action.to_owned(),
-        prior_state: prior_state.to_owned(),
-        resulting_state: record.state.clone(),
-        network: required(&record.network)?,
-        amount_lamports: record.amount_lamports.ok_or_else(migration_required)?,
-        terms_digest: required(&record.terms_digest)?,
-        release_policy: required(&record.release_policy)?,
-    };
+    let receipt = build(record, receipt_id, input)?;
     store
         .snapshot
         .escrow_transition_receipts
         .push(receipt.clone());
     Ok(receipt)
+}
+
+pub(super) struct ReceiptInput<'a> {
+    pub(super) actor: &'a str,
+    pub(super) action: &'a str,
+    pub(super) prior_state: &'a str,
+    pub(super) key: String,
+    pub(super) correlation_id: &'a str,
+}
+
+fn build(
+    record: &ServiceApiPersistedEscrowRecord,
+    receipt_id: String,
+    input: ReceiptInput<'_>,
+) -> Result<ServiceApiEscrowTransitionReceiptRecord, EscrowLifecycleError> {
+    Ok(ServiceApiEscrowTransitionReceiptRecord {
+        receipt_id,
+        correlation_id: input.correlation_id.to_owned(),
+        idempotency_key: input.key,
+        actor_did: input.actor.to_owned(),
+        escrow_id: record.escrow_id.clone(),
+        task_id: required(&record.task_id)?,
+        transaction_id: required(&record.transaction_id)?,
+        action: input.action.to_owned(),
+        prior_state: input.prior_state.to_owned(),
+        resulting_state: record.state.clone(),
+        network: required(&record.network)?,
+        amount_lamports: record.amount_lamports.ok_or_else(migration_required)?,
+        terms_digest: required(&record.terms_digest)?,
+        release_policy: required(&record.release_policy)?,
+    })
 }
 
 pub(super) fn response(

--- a/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/lifecycle.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/lifecycle.rs
@@ -31,35 +31,63 @@ pub(super) fn create_bound_task(
     let input = parse_create(payload, actor_did)?;
     require_registered_provider(store, input.provider_did.as_str())?;
     if let Some(existing) = find_create_retry(store, actor_did, &input)? {
-        let record = existing.clone();
-        let receipt = creation_receipt(store, record.task_id.as_str())?;
-        return Ok(create_response(&record, receipt));
+        return create_retry_response(store, existing.clone());
     }
+    create_new_task(store, actor_did, payload, correlation_id, input)
+}
+
+fn create_new_task(
+    store: &mut ServiceApiMessageStore,
+    actor: &str,
+    payload: &str,
+    correlation_id: &str,
+    input: input::CreateInput,
+) -> Result<ServiceApiTaskCreateBody, TaskLifecycleError> {
     let task_id = next_task_id(store, payload);
-    let record = build_record(task_id.as_str(), actor_did, &input);
-    let receipt = receipt::build(
-        &record,
+    let record = build_record(task_id.as_str(), actor, &input);
+    let receipt = creation_receipt_record(store, &record, actor, correlation_id, &input)?;
+    store.snapshot.tasks.insert(task_id.clone(), record);
+    store.snapshot.task_transition_receipts.push(receipt);
+    issue_grants(store, task_id.as_str(), actor, input.provider_did.as_str());
+    store.persist().map_err(persistence)?;
+    persist_task_created_audit_export(store, task_id.as_str()).map_err(persistence)?;
+    create_task_response(store, task_id.as_str())
+}
+
+fn creation_receipt_record(
+    store: &ServiceApiMessageStore,
+    record: &ServiceApiPersistedTaskRecord,
+    actor: &str,
+    correlation_id: &str,
+    input: &input::CreateInput,
+) -> Result<ServiceApiTaskTransitionReceiptRecord, TaskLifecycleError> {
+    receipt::build(
+        record,
         ReceiptInput {
-            actor: actor_did,
+            actor,
             action: "task:create",
             prior_state: "none".to_owned(),
             idempotency_key: input.idempotency_key.clone(),
             correlation_id,
             sequence: store.snapshot.task_transition_receipts.len() + 1,
         },
-    )?;
-    store.snapshot.tasks.insert(task_id.clone(), record);
-    store.snapshot.task_transition_receipts.push(receipt);
-    issue_grants(
-        store,
-        task_id.as_str(),
-        actor_did,
-        input.provider_did.as_str(),
-    );
-    store.persist().map_err(persistence)?;
-    persist_task_created_audit_export(store, task_id.as_str()).map_err(persistence)?;
-    let record = &store.snapshot.tasks[&task_id];
-    let receipt = creation_receipt(store, task_id.as_str())?;
+    )
+}
+
+fn create_retry_response(
+    store: &ServiceApiMessageStore,
+    record: ServiceApiPersistedTaskRecord,
+) -> Result<ServiceApiTaskCreateBody, TaskLifecycleError> {
+    let receipt = creation_receipt(store, record.task_id.as_str())?;
+    Ok(create_response(&record, receipt))
+}
+
+fn create_task_response(
+    store: &ServiceApiMessageStore,
+    task_id: &str,
+) -> Result<ServiceApiTaskCreateBody, TaskLifecycleError> {
+    let record = &store.snapshot.tasks[task_id];
+    let receipt = creation_receipt(store, task_id)?;
     Ok(create_response(record, receipt))
 }
 

--- a/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/lifecycle.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/lifecycle.rs
@@ -25,16 +25,31 @@ pub(super) fn create_bound_task(
     store: &mut ServiceApiMessageStore,
     actor_did: &str,
     payload: &str,
+    correlation_id: &str,
 ) -> Result<ServiceApiTaskCreateBody, TaskLifecycleError> {
     store.refresh_from_disk().map_err(persistence)?;
     let input = parse_create(payload, actor_did)?;
     require_registered_provider(store, input.provider_did.as_str())?;
     if let Some(existing) = find_create_retry(store, actor_did, &input)? {
-        return Ok(create_response(existing));
+        let record = existing.clone();
+        let receipt = creation_receipt(store, record.task_id.as_str())?;
+        return Ok(create_response(&record, receipt));
     }
     let task_id = next_task_id(store, payload);
     let record = build_record(task_id.as_str(), actor_did, &input);
+    let receipt = receipt::build(
+        &record,
+        ReceiptInput {
+            actor: actor_did,
+            action: "task:create",
+            prior_state: "none".to_owned(),
+            idempotency_key: input.idempotency_key.clone(),
+            correlation_id,
+            sequence: store.snapshot.task_transition_receipts.len() + 1,
+        },
+    )?;
     store.snapshot.tasks.insert(task_id.clone(), record);
+    store.snapshot.task_transition_receipts.push(receipt);
     issue_grants(
         store,
         task_id.as_str(),
@@ -43,7 +58,9 @@ pub(super) fn create_bound_task(
     );
     store.persist().map_err(persistence)?;
     persist_task_created_audit_export(store, task_id.as_str()).map_err(persistence)?;
-    Ok(create_response(&store.snapshot.tasks[&task_id]))
+    let record = &store.snapshot.tasks[&task_id];
+    let receipt = creation_receipt(store, task_id.as_str())?;
+    Ok(create_response(record, receipt))
 }
 
 pub(super) fn transition_bound_task(
@@ -86,10 +103,22 @@ pub(super) fn transition_bound_task(
             sequence: receipt_sequence,
         },
     )?;
-    let response = transition_response(record, receipt.receipt_id.as_str());
+    let response = transition_response(record, &receipt);
     store.snapshot.task_transition_receipts.push(receipt);
     store.persist().map_err(persistence)?;
     Ok(response)
+}
+
+fn creation_receipt<'a>(
+    store: &'a ServiceApiMessageStore,
+    task_id: &str,
+) -> Result<&'a ServiceApiTaskTransitionReceiptRecord, TaskLifecycleError> {
+    store
+        .snapshot
+        .task_transition_receipts
+        .iter()
+        .find(|receipt| receipt.task_id == task_id && receipt.action == "task:create")
+        .ok_or_else(|| conflict("TASK_RECEIPT_MISSING", "task creation receipt is missing"))
 }
 
 fn bad(code: &'static str, message: impl Into<String>) -> TaskLifecycleError {

--- a/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/lifecycle/receipt.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/lifecycle/receipt.rs
@@ -29,20 +29,26 @@ pub(super) fn build(
     })
 }
 
-pub(super) fn create_response(record: &ServiceApiPersistedTaskRecord) -> ServiceApiTaskCreateBody {
+pub(super) fn create_response(
+    record: &ServiceApiPersistedTaskRecord,
+    receipt: &ServiceApiTaskTransitionReceiptRecord,
+) -> ServiceApiTaskCreateBody {
     ServiceApiTaskCreateBody {
         task_id: record.task_id.clone(),
-        state: record.state.clone(),
+        state: receipt.resulting_state.clone(),
         transaction_id: record.transaction_id.clone(),
         creator_did: record.creator_did.clone(),
         provider_did: record.provider_did.clone(),
         terms_digest: record.terms_digest.clone(),
+        receipt_id: receipt.receipt_id.clone(),
+        receipt_digest: authority_digest::task(receipt),
+        action: receipt.action.clone(),
     }
 }
 
 pub(super) fn transition_response(
     record: &ServiceApiPersistedTaskRecord,
-    receipt_id: &str,
+    receipt: &ServiceApiTaskTransitionReceiptRecord,
 ) -> ServiceApiTaskTransitionBody {
     ServiceApiTaskTransitionBody {
         task_id: record.task_id.clone(),
@@ -51,7 +57,9 @@ pub(super) fn transition_response(
         creator_did: record.creator_did.clone(),
         provider_did: record.provider_did.clone(),
         terms_digest: record.terms_digest.clone(),
-        receipt_id: Some(receipt_id.to_owned()),
+        receipt_id: Some(receipt.receipt_id.clone()),
+        receipt_digest: Some(authority_digest::task(receipt)),
+        action: receipt.action.clone(),
     }
 }
 
@@ -59,5 +67,7 @@ pub(super) fn retry_response(
     store: &ServiceApiMessageStore,
     receipt: &ServiceApiTaskTransitionReceiptRecord,
 ) -> ServiceApiTaskTransitionBody {
-    transition_response(&store.snapshot.tasks[&receipt.task_id], &receipt.receipt_id)
+    let mut response = transition_response(&store.snapshot.tasks[&receipt.task_id], receipt);
+    response.state = receipt.resulting_state.clone();
+    response
 }

--- a/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/settlement.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/settlement.rs
@@ -42,6 +42,8 @@ pub(super) fn escrow_status_response(
         release_policy: record.release_policy.clone(),
         claim_scope: escrow_claim_scope(record).to_owned(),
         receipt_id: None,
+        receipt_digest: None,
+        action: None,
         settlement: record.settlement.clone(),
     }
 }

--- a/crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/mutations/create_routes.rs
+++ b/crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/mutations/create_routes.rs
@@ -55,7 +55,11 @@ async fn create_task(
         {
             return *response;
         }
-        store.create_bound_task(actor_did.as_str(), context.parsed_request.body.as_str())
+        store.create_bound_task(
+            actor_did.as_str(),
+            context.parsed_request.body.as_str(),
+            context.correlation_id.as_str(),
+        )
     };
     match result {
         Ok(payload) => {

--- a/crates/kamn-node/src/service_api_endpoint/models.rs
+++ b/crates/kamn-node/src/service_api_endpoint/models.rs
@@ -104,6 +104,9 @@ pub(crate) struct ServiceApiTaskCreateBody {
     pub(crate) provider_did: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) terms_digest: Option<String>,
+    pub(crate) receipt_id: String,
+    pub(crate) receipt_digest: String,
+    pub(crate) action: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -126,6 +129,9 @@ pub(crate) struct ServiceApiTaskTransitionBody {
     pub(crate) terms_digest: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) receipt_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) receipt_digest: Option<String>,
+    pub(crate) action: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -165,6 +171,7 @@ pub(crate) struct ServiceApiAgentGetBody {
     pub(crate) agent_type: String,
     pub(crate) model_family: String,
     pub(crate) capabilities: Vec<String>,
+    pub(crate) profile_commitment: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/kamn-node/src/service_api_endpoint/payload.rs
+++ b/crates/kamn-node/src/service_api_endpoint/payload.rs
@@ -155,6 +155,9 @@ pub(super) fn render_service_api_endpoint_response(
             creator_did: None,
             provider_did: None,
             terms_digest: None,
+            receipt_id: "render-only".to_owned(),
+            receipt_digest: "render-only".to_owned(),
+            action: "task:create".to_owned(),
         };
         return ServiceApiEndpointResponse {
             status_code: 201,
@@ -183,6 +186,7 @@ pub(super) fn render_service_api_endpoint_response(
             agent_type: "service-agent".to_owned(),
             model_family: "service-api".to_owned(),
             capabilities: vec!["profile:read".to_owned()],
+            profile_commitment: "render-only".to_owned(),
         };
         return ServiceApiEndpointResponse {
             status_code: 201,
@@ -221,6 +225,8 @@ pub(super) fn render_service_api_endpoint_response(
                 provider_did: None,
                 terms_digest: None,
                 receipt_id: None,
+                receipt_digest: None,
+                action: "task:accept".to_owned(),
             };
             return ServiceApiEndpointResponse {
                 status_code: 200,
@@ -237,6 +243,8 @@ pub(super) fn render_service_api_endpoint_response(
                 provider_did: None,
                 terms_digest: None,
                 receipt_id: None,
+                receipt_digest: None,
+                action: "task:complete".to_owned(),
             };
             return ServiceApiEndpointResponse {
                 status_code: 200,
@@ -260,6 +268,8 @@ pub(super) fn render_service_api_endpoint_response(
                 release_policy: None,
                 claim_scope: "render-only".to_owned(),
                 receipt_id: None,
+                receipt_digest: None,
+                action: None,
                 settlement: ServiceApiSettlementMetadata::default(),
             };
             return ServiceApiEndpointResponse {
@@ -283,6 +293,8 @@ pub(super) fn render_service_api_endpoint_response(
                 release_policy: None,
                 claim_scope: "render-only".to_owned(),
                 receipt_id: None,
+                receipt_digest: None,
+                action: None,
                 settlement: ServiceApiSettlementMetadata::default(),
             };
             return ServiceApiEndpointResponse {
@@ -414,6 +426,7 @@ pub(super) fn render_service_api_endpoint_response(
                     agent_type: "service-agent".to_owned(),
                     model_family: "service-api".to_owned(),
                     capabilities: vec!["profile:read".to_owned()],
+                    profile_commitment: "render-only".to_owned(),
                 };
                 return ServiceApiEndpointResponse {
                     status_code: 200,

--- a/crates/kamn-node/src/service_api_endpoint/websocket.rs
+++ b/crates/kamn-node/src/service_api_endpoint/websocket.rs
@@ -632,6 +632,9 @@ mod tests {
             creator_did: None,
             provider_did: None,
             terms_digest: None,
+            receipt_id: "task-transition-receipt-1".to_owned(),
+            receipt_digest: "sha256:websocket-test".to_owned(),
+            action: "task:create".to_owned(),
         });
         fanout.publish_task_transition_event(&ServiceApiTaskTransitionBody {
             task_id: "task-1".to_owned(),
@@ -641,6 +644,8 @@ mod tests {
             provider_did: None,
             terms_digest: None,
             receipt_id: None,
+            receipt_digest: None,
+            action: "task:accept".to_owned(),
         });
         fanout.publish_bridge_submitted_event(&ServiceApiBridgeSubmitBody {
             bridge_id: "bridge-1".to_owned(),

--- a/crates/kamn-sdk/src/lib.rs
+++ b/crates/kamn-sdk/src/lib.rs
@@ -44,7 +44,7 @@ pub use service::{
     ServiceApiClient, ServiceBridgeStatus, ServiceBridgeSubmission, ServiceChannelMessages,
     ServiceChannelReceipt, ServiceContentRegistration, ServiceContentStatus, ServiceEscrowStatus,
     ServiceHealthStatus, ServiceMessageReceipt, ServiceMessageStatus, ServiceRequestAuth,
-    ServiceRouteEvent, ServiceTaskReceipt, ServiceTaskStatus,
+    ServiceRouteEvent, ServiceTaskReceipt, ServiceTaskStatus, ServiceTaskTransitionReceipt,
 };
 /// Re-exported canonical service-backed agent registration payload helper.
 pub use service_agent_registration::service_agent_registration_payload;

--- a/crates/kamn-sdk/src/service.rs
+++ b/crates/kamn-sdk/src/service.rs
@@ -25,7 +25,7 @@ pub use self::service_auth_crypto::{
     service_signature_for_state_hash_with_private_key, service_signer_public_key_for_fields,
     service_verify_signature_with_public_key,
 };
-use self::service_authority::{profile_commitment, receipt_fields};
+use self::service_authority::profile_commitment;
 pub use self::service_authority_models::ServiceTaskTransitionReceipt;
 pub(crate) use self::service_client::service_client_bridge_misc_routes::agent_search_payload;
 use self::service_client::HttpResponse;

--- a/crates/kamn-sdk/src/service.rs
+++ b/crates/kamn-sdk/src/service.rs
@@ -2,6 +2,10 @@ use crate::SdkError;
 
 #[path = "service_auth_crypto.rs"]
 mod service_auth_crypto;
+#[path = "service_authority.rs"]
+mod service_authority;
+#[path = "service_authority_models.rs"]
+mod service_authority_models;
 #[path = "service_client.rs"]
 mod service_client;
 #[path = "service_endpoint.rs"]
@@ -21,6 +25,8 @@ pub use self::service_auth_crypto::{
     service_signature_for_state_hash_with_private_key, service_signer_public_key_for_fields,
     service_verify_signature_with_public_key,
 };
+use self::service_authority::{profile_commitment, receipt_fields};
+pub use self::service_authority_models::ServiceTaskTransitionReceipt;
 pub(crate) use self::service_client::service_client_bridge_misc_routes::agent_search_payload;
 use self::service_client::HttpResponse;
 pub use self::service_client::ServiceApiClient;

--- a/crates/kamn-sdk/src/service_authority.rs
+++ b/crates/kamn-sdk/src/service_authority.rs
@@ -1,0 +1,35 @@
+use super::{json_string_field, SdkError};
+
+pub(super) fn receipt_fields(body: &str) -> Result<(String, String), SdkError> {
+    let receipt_id = json_string_field(body, "receipt_id")?;
+    if receipt_id.is_empty() {
+        return Err(invalid("service receipt id was empty"));
+    }
+    let digest = json_string_field(body, "receipt_digest")?;
+    validate_digest(digest.as_str())?;
+    Ok((receipt_id, digest))
+}
+
+pub(super) fn profile_commitment(body: &str) -> Result<String, SdkError> {
+    let commitment = json_string_field(body, "profile_commitment")?;
+    validate_digest(commitment.as_str())?;
+    Ok(commitment)
+}
+
+fn validate_digest(value: &str) -> Result<(), SdkError> {
+    let Some(hex) = value.strip_prefix("sha256:") else {
+        return Err(invalid("service authority digest was malformed"));
+    };
+    if hex.len() == 64 && hex.bytes().all(is_lower_hex) {
+        return Ok(());
+    }
+    Err(invalid("service authority digest was malformed"))
+}
+
+fn is_lower_hex(byte: u8) -> bool {
+    byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte)
+}
+
+fn invalid(message: &'static str) -> SdkError {
+    SdkError::TransportFailure(message)
+}

--- a/crates/kamn-sdk/src/service_authority_models.rs
+++ b/crates/kamn-sdk/src/service_authority_models.rs
@@ -1,0 +1,14 @@
+/// Parsed response for task lifecycle mutations.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ServiceTaskTransitionReceipt {
+    /// Task identifier.
+    pub task_id: String,
+    /// Resulting lifecycle state.
+    pub state: String,
+    /// Service-issued durable receipt identifier.
+    pub receipt_id: String,
+    /// Digest of the durable service receipt.
+    pub receipt_digest: String,
+    /// Canonical durable receipt action.
+    pub action: String,
+}

--- a/crates/kamn-sdk/src/service_client.rs
+++ b/crates/kamn-sdk/src/service_client.rs
@@ -121,8 +121,12 @@ impl ServiceApiClient {
 }
 
 pub(super) fn parse_escrow_status(body: &str) -> Result<ServiceEscrowStatus, SdkError> {
+    let (receipt_id, receipt_digest) = receipt_fields(body)?;
     Ok(ServiceEscrowStatus {
         escrow_id: json_string_field(body, "escrow_id")?,
         state: json_string_field(body, "state")?,
+        receipt_id,
+        receipt_digest,
+        action: json_string_field(body, "action")?,
     })
 }

--- a/crates/kamn-sdk/src/service_client.rs
+++ b/crates/kamn-sdk/src/service_client.rs
@@ -1,4 +1,5 @@
 use super::parse_unmasked_text_frame_payload;
+use super::service_authority::receipt_fields;
 use super::{
     json_string_field, json_u64_field, map_non_success_response, parse_http_response,
     status_from_header,

--- a/crates/kamn-sdk/src/service_client_bridge_misc_routes.rs
+++ b/crates/kamn-sdk/src/service_client_bridge_misc_routes.rs
@@ -1,7 +1,8 @@
 use super::super::{
     expect_status, json_string_array_field, json_string_field, json_u64_field,
-    normalize_route_segment, SdkError, ServiceAgentBalance, ServiceAgentProfile,
-    ServiceBridgeStatus, ServiceBridgeSubmission, ServiceHealthStatus, ServiceRequestAuth,
+    normalize_route_segment, profile_commitment, SdkError, ServiceAgentBalance,
+    ServiceAgentProfile, ServiceBridgeStatus, ServiceBridgeSubmission, ServiceHealthStatus,
+    ServiceRequestAuth,
 };
 use super::ServiceApiClient;
 use crate::{service_agent_registration_payload, AgentDid, AgentMetadata, AgentQuery};
@@ -147,6 +148,7 @@ fn parse_agent_profile_response(body: &str) -> Result<ServiceAgentProfile, SdkEr
         agent_type: json_string_field(body, "agent_type")?,
         model_family: json_string_field(body, "model_family")?,
         capabilities: json_string_array_field(body, "capabilities")?,
+        profile_commitment: profile_commitment(body)?,
     })
 }
 

--- a/crates/kamn-sdk/src/service_client_message_task_routes.rs
+++ b/crates/kamn-sdk/src/service_client_message_task_routes.rs
@@ -2,7 +2,9 @@ use super::super::{
     expect_status, json_string_array_field, json_string_field, normalize_route_segment, SdkError,
     ServiceChannelMessages, ServiceChannelReceipt, ServiceMessageDelivery, ServiceMessageReceipt,
     ServiceMessageStatus, ServiceRequestAuth, ServiceTaskReceipt, ServiceTaskStatus,
+    ServiceTaskTransitionReceipt,
 };
+use super::receipt_fields;
 use super::ServiceApiClient;
 use serde_json::Value;
 
@@ -88,9 +90,13 @@ impl ServiceApiClient {
     ) -> Result<ServiceTaskReceipt, SdkError> {
         let response = self.request("POST", "/v1/tasks/create", payload, Some(auth))?;
         expect_status(response.status, 201)?;
+        let (receipt_id, receipt_digest) = receipt_fields(response.body.as_str())?;
         Ok(ServiceTaskReceipt {
             task_id: json_string_field(response.body.as_str(), "task_id")?,
             state: json_string_field(response.body.as_str(), "state")?,
+            receipt_id,
+            receipt_digest,
+            action: json_string_field(response.body.as_str(), "action")?,
         })
     }
 
@@ -115,7 +121,7 @@ impl ServiceApiClient {
         &self,
         task_id: &str,
         auth: &ServiceRequestAuth,
-    ) -> Result<ServiceTaskStatus, SdkError> {
+    ) -> Result<ServiceTaskTransitionReceipt, SdkError> {
         self.accept_task_with_payload(task_id, "{}", auth)
     }
 
@@ -125,14 +131,18 @@ impl ServiceApiClient {
         task_id: &str,
         payload: &str,
         auth: &ServiceRequestAuth,
-    ) -> Result<ServiceTaskStatus, SdkError> {
+    ) -> Result<ServiceTaskTransitionReceipt, SdkError> {
         let task_id = normalize_route_segment("task_id", task_id)?;
         let route = format!("/v1/tasks/{task_id}/accept");
         let response = self.request("POST", route.as_str(), payload, Some(auth))?;
         expect_status(response.status, 200)?;
-        Ok(ServiceTaskStatus {
+        let (receipt_id, receipt_digest) = receipt_fields(response.body.as_str())?;
+        Ok(ServiceTaskTransitionReceipt {
             task_id: json_string_field(response.body.as_str(), "task_id")?,
             state: json_string_field(response.body.as_str(), "state")?,
+            receipt_id,
+            receipt_digest,
+            action: json_string_field(response.body.as_str(), "action")?,
         })
     }
 
@@ -141,7 +151,7 @@ impl ServiceApiClient {
         &self,
         task_id: &str,
         auth: &ServiceRequestAuth,
-    ) -> Result<ServiceTaskStatus, SdkError> {
+    ) -> Result<ServiceTaskTransitionReceipt, SdkError> {
         self.complete_task_with_payload(task_id, "{}", auth)
     }
 
@@ -151,14 +161,18 @@ impl ServiceApiClient {
         task_id: &str,
         payload: &str,
         auth: &ServiceRequestAuth,
-    ) -> Result<ServiceTaskStatus, SdkError> {
+    ) -> Result<ServiceTaskTransitionReceipt, SdkError> {
         let task_id = normalize_route_segment("task_id", task_id)?;
         let route = format!("/v1/tasks/{task_id}/complete");
         let response = self.request("POST", route.as_str(), payload, Some(auth))?;
         expect_status(response.status, 200)?;
-        Ok(ServiceTaskStatus {
+        let (receipt_id, receipt_digest) = receipt_fields(response.body.as_str())?;
+        Ok(ServiceTaskTransitionReceipt {
             task_id: json_string_field(response.body.as_str(), "task_id")?,
             state: json_string_field(response.body.as_str(), "state")?,
+            receipt_id,
+            receipt_digest,
+            action: json_string_field(response.body.as_str(), "action")?,
         })
     }
 }

--- a/crates/kamn-sdk/src/service_models.rs
+++ b/crates/kamn-sdk/src/service_models.rs
@@ -51,6 +51,12 @@ pub struct ServiceTaskReceipt {
     pub task_id: String,
     /// Initial lifecycle state.
     pub state: String,
+    /// Service-issued durable receipt identifier.
+    pub receipt_id: String,
+    /// Digest of the durable service receipt.
+    pub receipt_digest: String,
+    /// Canonical durable receipt action.
+    pub action: String,
 }
 
 /// Parsed response for `GET /v1/tasks/{id}`.
@@ -69,6 +75,12 @@ pub struct ServiceEscrowStatus {
     pub escrow_id: String,
     /// Current lifecycle state.
     pub state: String,
+    /// Service-issued durable receipt identifier.
+    pub receipt_id: String,
+    /// Digest of the durable service receipt.
+    pub receipt_digest: String,
+    /// Canonical durable receipt action.
+    pub action: String,
 }
 
 /// Parsed response for `POST /v1/content/register`.
@@ -132,6 +144,8 @@ pub struct ServiceAgentProfile {
     pub model_family: String,
     /// Registered capability labels.
     pub capabilities: Vec<String>,
+    /// Deterministic commitment to the service-owned profile.
+    pub profile_commitment: String,
 }
 
 /// Parsed response for `GET /v1/agents/{did}/balance`.

--- a/crates/kamn-sdk/tests/live_transport_agent/support/contract_server_support/response_route_support/agent_route_support.rs
+++ b/crates/kamn-sdk/tests/live_transport_agent/support/contract_server_support/response_route_support/agent_route_support.rs
@@ -123,7 +123,7 @@ fn registration_payload(
     let capabilities_json = serde_json::to_string(capabilities)
         .map_err(|error| format!("capability serialization failed: {error}"))?;
     Ok(format!(
-        "{{\"did\":\"{did}\",\"reputation_score\":777,\"agent_type\":\"{agent_type}\",\"model_family\":\"{model_family}\",\"capabilities\":{capabilities_json}}}"
+        "{{\"did\":\"{did}\",\"reputation_score\":777,\"agent_type\":\"{agent_type}\",\"model_family\":\"{model_family}\",\"capabilities\":{capabilities_json},\"profile_commitment\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"}}"
     ))
 }
 

--- a/crates/kamn-sdk/tests/live_transport_agent/support/contract_server_support/response_route_support/agent_route_support.rs
+++ b/crates/kamn-sdk/tests/live_transport_agent/support/contract_server_support/response_route_support/agent_route_support.rs
@@ -151,6 +151,7 @@ fn candidate_rows() -> Vec<serde_json::Value> {
             "agent_type": "assistant",
             "model_family": "gpt-5",
             "capabilities": ["text", "code"],
+            "profile_commitment": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         }),
         serde_json::json!({
             "did": "kamn:did:agent:beta",
@@ -158,6 +159,7 @@ fn candidate_rows() -> Vec<serde_json::Value> {
             "agent_type": "assistant",
             "model_family": "gpt-4.1",
             "capabilities": ["text"],
+            "profile_commitment": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
         }),
     ]
 }

--- a/crates/kamn-sdk/tests/live_transport_task_escrow.rs
+++ b/crates/kamn-sdk/tests/live_transport_task_escrow.rs
@@ -74,7 +74,7 @@ fn transition_routes_preserve_canonical_payloads() {
             sender_did: "kamn:did:agent:transition-contract".to_owned(),
             scope: "tasks:write",
             response_status: 200,
-            response_body: r#"{"task_id":"task-1","state":"completed"}"#.to_owned(),
+            response_body: r#"{"task_id":"task-1","state":"completed","receipt_id":"task-receipt-1","receipt_digest":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","action":"task:complete"}"#.to_owned(),
         },
         support::ExpectedRequest {
             method: "POST",
@@ -83,7 +83,7 @@ fn transition_routes_preserve_canonical_payloads() {
             sender_did: "kamn:did:agent:transition-contract".to_owned(),
             scope: "escrow:write",
             response_status: 200,
-            response_body: r#"{"escrow_id":"escrow-1","state":"released"}"#.to_owned(),
+            response_body: r#"{"escrow_id":"escrow-1","state":"released","receipt_id":"escrow-receipt-1","receipt_digest":"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","action":"escrow:release-authorize"}"#.to_owned(),
         },
     ];
     let (bind_addr, server) = support::spawn_expected_server(requests);

--- a/crates/kamn-sdk/tests/live_transport_task_escrow/support/request_fixtures.rs
+++ b/crates/kamn-sdk/tests/live_transport_task_escrow/support/request_fixtures.rs
@@ -29,7 +29,7 @@ pub(crate) fn create_task_request() -> ExpectedRequest {
         "kamn:did:agent:creator-live",
         "tasks:write",
         201,
-        r#"{"task_id":"task-local-abc","state":"submitted"}"#,
+        r#"{"task_id":"task-local-abc","state":"submitted","receipt_id":"task-receipt-1","receipt_digest":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","action":"task:create"}"#,
     )
 }
 
@@ -39,7 +39,7 @@ pub(crate) fn accept_task_request() -> ExpectedRequest {
         "kamn:did:agent:assignee-live",
         "tasks:write",
         200,
-        r#"{"task_id":"task-local-abc","state":"accepted"}"#,
+        r#"{"task_id":"task-local-abc","state":"accepted","receipt_id":"task-receipt-2","receipt_digest":"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","action":"task:accept"}"#,
     )
 }
 
@@ -49,7 +49,7 @@ pub(crate) fn complete_task_request() -> ExpectedRequest {
         "kamn:did:agent:assignee-live",
         "tasks:write",
         200,
-        r#"{"task_id":"task-local-abc","state":"completed"}"#,
+        r#"{"task_id":"task-local-abc","state":"completed","receipt_id":"task-receipt-3","receipt_digest":"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc","action":"task:complete"}"#,
     )
 }
 
@@ -89,7 +89,7 @@ pub(crate) fn create_escrow_request() -> ExpectedRequest {
         "kamn:did:agent:payer-live",
         "escrow:write",
         200,
-        r#"{"escrow_id":"escrow-local-xyz","state":"funded"}"#,
+        r#"{"escrow_id":"escrow-local-xyz","state":"funded","receipt_id":"escrow-receipt-1","receipt_digest":"sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd","action":"escrow:fund"}"#,
     )
 }
 
@@ -116,7 +116,7 @@ pub(crate) fn release_escrow_request() -> ExpectedRequest {
         "kamn:did:agent:payer-live",
         "escrow:write",
         200,
-        r#"{"escrow_id":"escrow-local-xyz","state":"released"}"#,
+        r#"{"escrow_id":"escrow-local-xyz","state":"released","receipt_id":"escrow-receipt-2","receipt_digest":"sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee","action":"escrow:release-authorize"}"#,
     )
 }
 

--- a/crates/kamn-sdk/tests/service_api_client/route_family_contract_tests/registration_task_bridge_contract_tests.rs
+++ b/crates/kamn-sdk/tests/service_api_client/route_family_contract_tests/registration_task_bridge_contract_tests.rs
@@ -95,6 +95,7 @@ fn assert_task_routes(client: &ServiceApiClient, sender: &AgentDid) {
         )
         .expect("accept task should succeed");
     assert_eq!(accepted.state, "accepted");
+    assert_service_authority(&accepted.receipt_id, &accepted.receipt_digest);
     let completed = client
         .complete_task(
             "task-local-123",
@@ -102,6 +103,7 @@ fn assert_task_routes(client: &ServiceApiClient, sender: &AgentDid) {
         )
         .expect("complete task should succeed");
     assert_eq!(completed.state, "completed");
+    assert_service_authority(&completed.receipt_id, &completed.receipt_digest);
 }
 
 fn assert_escrow_routes(client: &ServiceApiClient, sender: &AgentDid) {
@@ -113,6 +115,7 @@ fn assert_escrow_routes(client: &ServiceApiClient, sender: &AgentDid) {
         )
         .expect("fund escrow should succeed");
     assert!(funded.escrow_id.starts_with("escrow-local-"));
+    assert_service_authority(&funded.receipt_id, &funded.receipt_digest);
     let released = client
         .release_escrow(
             funded.escrow_id.as_str(),
@@ -121,6 +124,13 @@ fn assert_escrow_routes(client: &ServiceApiClient, sender: &AgentDid) {
         .expect("release escrow should succeed");
     assert_eq!(released.escrow_id, funded.escrow_id);
     assert_eq!(released.state, "released");
+    assert_service_authority(&released.receipt_id, &released.receipt_digest);
+}
+
+fn assert_service_authority(receipt_id: &str, receipt_digest: &str) {
+    assert!(!receipt_id.is_empty());
+    assert!(receipt_digest.starts_with("sha256:"));
+    assert_eq!(receipt_digest.len(), 71);
 }
 
 fn assert_server_result(server: thread::JoinHandle<Result<(), String>>, message: &str) {

--- a/crates/kamn-sdk/tests/service_api_client/signed_http_route_contract_tests/message_channel_contract_tests.rs
+++ b/crates/kamn-sdk/tests/service_api_client/signed_http_route_contract_tests/message_channel_contract_tests.rs
@@ -39,6 +39,10 @@ fn assert_channel_and_task_routes(client: &ServiceApiClient, sender: &AgentDid) 
         )
         .expect("create task should succeed");
     assert!(task_response.task_id.starts_with("task-local-"));
+    assert!(task_response
+        .receipt_id
+        .starts_with("task-transition-receipt-"));
+    assert!(task_response.receipt_digest.starts_with("sha256:"));
     assert_task_status(client, sender, task_response.task_id.as_str());
 }
 

--- a/crates/kamn-sdk/tests/service_api_client/support/contract_server_support/agent_content_route_support.rs
+++ b/crates/kamn-sdk/tests/service_api_client/support/contract_server_support/agent_content_route_support.rs
@@ -15,19 +15,19 @@ pub(super) fn write_response(
 
 fn write_agent_response(stream: &mut TcpStream, method: &str, path: &str) -> Result<bool, String> {
     if method == "POST" && path == "/v1/agents/register" {
-        let payload = r#"{"did":"kamn:did:agent:sdk-register","reputation_score":500,"agent_type":"assistant","model_family":"gpt-5","capabilities":["text","code"]}"#;
+        let payload = r#"{"did":"kamn:did:agent:sdk-register","reputation_score":500,"agent_type":"assistant","model_family":"gpt-5","capabilities":["text","code"],"profile_commitment":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}"#;
         write_http_response(stream, 201, payload)?;
         return Ok(true);
     }
     if method == "POST" && path == "/v1/agents/search" {
-        let payload = r#"[{"did":"kamn:did:agent:sdk-register","reputation_score":500,"agent_type":"assistant","model_family":"gpt-5","capabilities":["text","code"]}]"#;
+        let payload = r#"[{"did":"kamn:did:agent:sdk-register","reputation_score":500,"agent_type":"assistant","model_family":"gpt-5","capabilities":["text","code"],"profile_commitment":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}]"#;
         write_http_response(stream, 200, payload)?;
         return Ok(true);
     }
     if method == "GET" && path.starts_with("/v1/agents/") {
         let did = path.trim_start_matches("/v1/agents/");
         let payload = format!(
-            "{{\"did\":\"{did}\",\"reputation_score\":500,\"agent_type\":\"service-agent\",\"model_family\":\"service-api\",\"capabilities\":[\"profile:read\"]}}"
+            "{{\"did\":\"{did}\",\"reputation_score\":500,\"agent_type\":\"service-agent\",\"model_family\":\"service-api\",\"capabilities\":[\"profile:read\"],\"profile_commitment\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"}}"
         );
         write_http_response(stream, 200, payload.as_str())?;
         return Ok(true);

--- a/crates/kamn-sdk/tests/service_api_client/support/contract_server_support/message_task_route_support/channel_task_route_support.rs
+++ b/crates/kamn-sdk/tests/service_api_client/support/contract_server_support/message_task_route_support/channel_task_route_support.rs
@@ -65,7 +65,9 @@ fn write_create_task_response(
         return Ok(false);
     }
     let task_id = format!("task-local-{:016x}", deterministic_tag(body.as_bytes()));
-    let payload = format!("{{\"task_id\":\"{task_id}\",\"state\":\"submitted\"}}");
+    let payload = format!(
+        "{{\"task_id\":\"{task_id}\",\"state\":\"submitted\",\"receipt_id\":\"task-transition-receipt-create\",\"receipt_digest\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"}}"
+    );
     write_http_response(stream, 201, payload.as_str())?;
     Ok(true)
 }

--- a/crates/kamn-sdk/tests/service_api_client/support/contract_server_support/message_task_route_support/channel_task_route_support.rs
+++ b/crates/kamn-sdk/tests/service_api_client/support/contract_server_support/message_task_route_support/channel_task_route_support.rs
@@ -66,7 +66,7 @@ fn write_create_task_response(
     }
     let task_id = format!("task-local-{:016x}", deterministic_tag(body.as_bytes()));
     let payload = format!(
-        "{{\"task_id\":\"{task_id}\",\"state\":\"submitted\",\"receipt_id\":\"task-transition-receipt-create\",\"receipt_digest\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"}}"
+        "{{\"task_id\":\"{task_id}\",\"state\":\"submitted\",\"receipt_id\":\"task-transition-receipt-create\",\"receipt_digest\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"action\":\"task:create\"}}"
     );
     write_http_response(stream, 201, payload.as_str())?;
     Ok(true)

--- a/crates/kamn-sdk/tests/service_api_client/support/contract_server_support/message_task_route_support/task_mutation_route_support.rs
+++ b/crates/kamn-sdk/tests/service_api_client/support/contract_server_support/message_task_route_support/task_mutation_route_support.rs
@@ -31,7 +31,9 @@ fn write_accept_task_response(
         return Ok(false);
     }
     let task_id = strip_suffix_id(path, "/v1/tasks/", "/accept");
-    let payload = format!("{{\"task_id\":\"{task_id}\",\"state\":\"accepted\"}}");
+    let payload = format!(
+        "{{\"task_id\":\"{task_id}\",\"state\":\"accepted\",\"receipt_id\":\"task-transition-receipt-accept\",\"receipt_digest\":\"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\"}}"
+    );
     write_http_response(stream, 200, payload.as_str())?;
     Ok(true)
 }
@@ -45,7 +47,9 @@ fn write_complete_task_response(
         return Ok(false);
     }
     let task_id = strip_suffix_id(path, "/v1/tasks/", "/complete");
-    let payload = format!("{{\"task_id\":\"{task_id}\",\"state\":\"completed\"}}");
+    let payload = format!(
+        "{{\"task_id\":\"{task_id}\",\"state\":\"completed\",\"receipt_id\":\"task-transition-receipt-complete\",\"receipt_digest\":\"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc\"}}"
+    );
     write_http_response(stream, 200, payload.as_str())?;
     Ok(true)
 }
@@ -60,7 +64,9 @@ fn write_fund_escrow_response(
         return Ok(false);
     }
     let escrow_id = format!("escrow-local-{:016x}", deterministic_tag(body.as_bytes()));
-    let payload = format!("{{\"escrow_id\":\"{escrow_id}\",\"state\":\"funded\"}}");
+    let payload = format!(
+        "{{\"escrow_id\":\"{escrow_id}\",\"state\":\"funded\",\"receipt_id\":\"escrow-transition-receipt-fund\",\"receipt_digest\":\"sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd\"}}"
+    );
     write_http_response(stream, 200, payload.as_str())?;
     Ok(true)
 }
@@ -74,7 +80,9 @@ fn write_release_escrow_response(
         return Ok(false);
     }
     let escrow_id = strip_suffix_id(path, "/v1/escrow/", "/release");
-    let payload = format!("{{\"escrow_id\":\"{escrow_id}\",\"state\":\"released\"}}");
+    let payload = format!(
+        "{{\"escrow_id\":\"{escrow_id}\",\"state\":\"released\",\"receipt_id\":\"escrow-transition-receipt-release\",\"receipt_digest\":\"sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee\"}}"
+    );
     write_http_response(stream, 200, payload.as_str())?;
     Ok(true)
 }

--- a/crates/kamn-sdk/tests/service_api_client/support/contract_server_support/message_task_route_support/task_mutation_route_support.rs
+++ b/crates/kamn-sdk/tests/service_api_client/support/contract_server_support/message_task_route_support/task_mutation_route_support.rs
@@ -32,7 +32,7 @@ fn write_accept_task_response(
     }
     let task_id = strip_suffix_id(path, "/v1/tasks/", "/accept");
     let payload = format!(
-        "{{\"task_id\":\"{task_id}\",\"state\":\"accepted\",\"receipt_id\":\"task-transition-receipt-accept\",\"receipt_digest\":\"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\"}}"
+        "{{\"task_id\":\"{task_id}\",\"state\":\"accepted\",\"receipt_id\":\"task-transition-receipt-accept\",\"receipt_digest\":\"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\",\"action\":\"task:accept\"}}"
     );
     write_http_response(stream, 200, payload.as_str())?;
     Ok(true)
@@ -48,7 +48,7 @@ fn write_complete_task_response(
     }
     let task_id = strip_suffix_id(path, "/v1/tasks/", "/complete");
     let payload = format!(
-        "{{\"task_id\":\"{task_id}\",\"state\":\"completed\",\"receipt_id\":\"task-transition-receipt-complete\",\"receipt_digest\":\"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc\"}}"
+        "{{\"task_id\":\"{task_id}\",\"state\":\"completed\",\"receipt_id\":\"task-transition-receipt-complete\",\"receipt_digest\":\"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc\",\"action\":\"task:complete\"}}"
     );
     write_http_response(stream, 200, payload.as_str())?;
     Ok(true)
@@ -65,7 +65,7 @@ fn write_fund_escrow_response(
     }
     let escrow_id = format!("escrow-local-{:016x}", deterministic_tag(body.as_bytes()));
     let payload = format!(
-        "{{\"escrow_id\":\"{escrow_id}\",\"state\":\"funded\",\"receipt_id\":\"escrow-transition-receipt-fund\",\"receipt_digest\":\"sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd\"}}"
+        "{{\"escrow_id\":\"{escrow_id}\",\"state\":\"funded\",\"receipt_id\":\"escrow-transition-receipt-fund\",\"receipt_digest\":\"sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd\",\"action\":\"escrow:fund\"}}"
     );
     write_http_response(stream, 200, payload.as_str())?;
     Ok(true)
@@ -81,7 +81,7 @@ fn write_release_escrow_response(
     }
     let escrow_id = strip_suffix_id(path, "/v1/escrow/", "/release");
     let payload = format!(
-        "{{\"escrow_id\":\"{escrow_id}\",\"state\":\"released\",\"receipt_id\":\"escrow-transition-receipt-release\",\"receipt_digest\":\"sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee\"}}"
+        "{{\"escrow_id\":\"{escrow_id}\",\"state\":\"released\",\"receipt_id\":\"escrow-transition-receipt-release\",\"receipt_digest\":\"sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee\",\"action\":\"escrow:release-authorize\"}}"
     );
     write_http_response(stream, 200, payload.as_str())?;
     Ok(true)

--- a/fixtures/ci/test_file_size_policy_baseline.env
+++ b/fixtures/ci/test_file_size_policy_baseline.env
@@ -2,7 +2,7 @@ schema_version=kamn.ci.test-file-size-policy-baseline.v1
 captured_at=2026-07-14
 # Counts cover tracked crates/**/*.rs with a /tests/ path component, excluding any /tests/support/ paths.
 # Refresh baseline whenever new test files are added or removed.
-test_file_total=1320
+test_file_total=1322
 soft_warn_count=2
 # Soft warnings: kamn-mcp-server/tests/real_backend_integration_contract.rs and kamn-core/tests/journal_wal_commit_schema_contract.rs.
 severe_count=0

--- a/specs/7132-preserve-service-receipts.md
+++ b/specs/7132-preserve-service-receipts.md
@@ -101,25 +101,39 @@ recompute them as an authority source.
 
 ## Acceptance Criteria
 
-- [ ] Task create appends and returns one durable service receipt with a
+- [x] Task create appends and returns one durable service receipt with a
   service-origin digest.
-- [ ] Task accept/complete and escrow fund/release return their existing exact
+- [x] Task accept/complete and escrow fund/release return their existing exact
   durable receipt IDs plus service-origin digests.
-- [ ] Idempotent retry returns the original receipt ID and digest byte-for-byte.
-- [ ] Registration returns a deterministic service-profile commitment bound to
+- [x] Idempotent retry returns the original receipt ID and digest byte-for-byte.
+- [x] Registration returns a deterministic service-profile commitment bound to
   the authenticated DID and persisted profile.
-- [ ] SDK and agent-lib mutation models preserve every authority field without
+- [x] SDK and agent-lib mutation models preserve every authority field without
   substitution; query models remain authority-free.
-- [ ] MCP returns `kamn.mcp.authority-receipt.v1` for every canonical mutation
+- [x] MCP returns `kamn.mcp.authority-receipt.v1` for every canonical mutation
   and the approved registration commitment variant.
-- [ ] MCP structured results separate service authority from request/process
+- [x] MCP structured results separate service authority from request/process
   transport provenance and compatible text is derived from the same value.
-- [ ] Missing, empty, malformed, cross-tool, cross-actor, cross-resource, or
+- [x] Missing, empty, malformed, cross-tool, cross-actor, cross-resource, or
   legacy mutation results fail closed with the specified error code.
-- [ ] A real-backend MCP contract proves the returned receipt ID and digest
+- [x] A real-backend MCP contract proves the returned receipt ID and digest
   equal the durable service response byte-for-byte.
-- [ ] Formatting, strict Clippy, focused SDK/agent-lib/MCP tests, and the real
+- [x] Formatting, strict Clippy, focused SDK/agent-lib/MCP tests, and the real
   backend MCP path pass.
+
+## Validation Evidence
+
+- Ubuntu fast-gate run `29843773248` passed formatting, strict Clippy, touched
+  Rust size policy, live transport, and service HTTP/WebSocket/TLS lanes.
+- The same run passed the #7132-focused agent-lib, CLI, MCP authority, real
+  backend, node durable-retry, SDK live task/escrow, and inventory contracts.
+- The broad job reached its 20-minute ceiling after retrying five unrelated
+  targets: rolling governance-history compliance, one supervisor timing test,
+  and three pre-existing settlement actor-evidence targets returning
+  `SETTLEMENT_EVIDENCE_INVALID`. No #7132 target remained failing.
+- Local Rust compilation was not used as authority because rustc repeatedly
+  stalled in the macOS loader while linking `kamn-sdk`; formatting and policy
+  checks completed locally.
 
 ## Files To Touch
 

--- a/specs/7132-preserve-service-receipts.md
+++ b/specs/7132-preserve-service-receipts.md
@@ -1,0 +1,197 @@
+# Issue 7132: Preserve Service Receipts Through SDK And MCP
+
+## Objective
+
+Preserve service-issued authority for every canonical registration, task, and
+escrow mutation from the durable KAMN service response through `kamn-sdk`,
+`kamn-agent-lib`, and `kamn-mcp-server`. MCP must return a versioned structured
+authority envelope without minting a replacement receipt or promoting local
+transport metadata into service authority.
+
+## Inputs And Outputs
+
+Inputs:
+
+- Authenticated service responses for agent registration, task create/accept/
+  complete, and escrow fund/release.
+- Durable task and escrow receipt records owned by the service message store.
+- The persisted agent profile returned by registration and subsequent queries.
+- MCP tool name, authenticated role DID, request ID, and backend result.
+
+Outputs:
+
+- Service mutation models containing the exact `receipt_id` and
+  `receipt_digest` issued from canonical durable service facts.
+- A deterministic query-backed registration authority commitment when no
+  registration transition receipt exists.
+- A `kamn.mcp.authority-receipt.v1` structured MCP result that labels service
+  authority separately from transport provenance.
+- Compatible text content derived from the same validated structured result.
+
+## Boundaries And Non-Goals
+
+- Do not build the multi-receipt chain commitment or projection changes owned
+  by #7133.
+- Do not migrate Pi evidence or canonical tool allowlists owned by #7134.
+- Do not add independent verifier or demo closeout behavior owned by #7135.
+- Do not change #7125 settlement receipt authority, create a settlement path,
+  add dependencies, or add public CLI flags.
+- Query tools remain query results. Only registration may use the explicitly
+  approved query-backed profile authority commitment.
+- Process IDs, MCP request IDs, nonces, response hashes, and client-computed
+  digests are transport provenance and can never populate service authority.
+
+## Authority Schema
+
+Mutation tools return this Rust-owned logical shape:
+
+```json
+{
+  "schema_version": "kamn.mcp.authority-receipt.v1",
+  "authority_kind": "service-receipt",
+  "source": "kamn-service",
+  "actor_did": "kamn:did:...",
+  "tool": "complete_task",
+  "resource_id": "task-...",
+  "resulting_state": "completed",
+  "service_receipt_id": "task-transition-receipt-00000003",
+  "service_receipt_digest": "sha256:..."
+}
+```
+
+Registration uses `authority_kind: service-profile-commitment`, the registered
+DID as `resource_id`, and a service-origin `profile_commitment` in place of a
+fabricated receipt ID. Transport request IDs remain outside the authority
+object in the existing dispatch/JSON-RPC envelope.
+
+The service computes each receipt digest from a domain-separated canonical
+encoding of the complete durable receipt record. Field names, order, optional
+markers, and digest domain are explicit constants in service-owned Rust code.
+SDK, agent-lib, and MCP preserve and validate the resulting strings but never
+recompute them as an authority source.
+
+## Failure Modes
+
+- A canonical mutation response omits or empties its service receipt ID.
+- A receipt digest is missing, malformed, or not a lowercase `sha256:` value.
+- A retry returns a different receipt ID or digest for the same idempotent
+  operation.
+- Task creation does not append a durable receipt before the response returns.
+- Registration authority does not match the persisted/queryable profile.
+- SDK parsing drops, rewrites, or substitutes a service authority field.
+- MCP receives an authority value whose actor, tool, resource, or state does
+  not match the authenticated operation.
+- An MCP mutation backend returns legacy resource/state JSON without service
+  authority.
+- A query response is mislabeled as a mutation receipt.
+- Structured and compatible text representations disagree.
+
+## Error Semantics
+
+- Missing canonical authority returns `MCP_AUTHORITY_RECEIPT_MISSING` at the
+  MCP boundary and an explicit SDK transport-contract error internally.
+- Malformed schema, digest, actor, tool, resource, state, or authority kind
+  returns `MCP_AUTHORITY_RECEIPT_INVALID`.
+- Durable task receipt creation or persistence failure returns the existing
+  structured service persistence error and emits no successful mutation.
+- Registration profile mismatch retains the existing hard-fail identity error.
+- Interior SDK/agent/MCP helpers return typed errors without logging. The MCP
+  protocol boundary renders one structured error and never falls back to a
+  compatibility-only authority source.
+
+## Acceptance Criteria
+
+- [ ] Task create appends and returns one durable service receipt with a
+  service-origin digest.
+- [ ] Task accept/complete and escrow fund/release return their existing exact
+  durable receipt IDs plus service-origin digests.
+- [ ] Idempotent retry returns the original receipt ID and digest byte-for-byte.
+- [ ] Registration returns a deterministic service-profile commitment bound to
+  the authenticated DID and persisted profile.
+- [ ] SDK and agent-lib mutation models preserve every authority field without
+  substitution; query models remain authority-free.
+- [ ] MCP returns `kamn.mcp.authority-receipt.v1` for every canonical mutation
+  and the approved registration commitment variant.
+- [ ] MCP structured results separate service authority from request/process
+  transport provenance and compatible text is derived from the same value.
+- [ ] Missing, empty, malformed, cross-tool, cross-actor, cross-resource, or
+  legacy mutation results fail closed with the specified error code.
+- [ ] A real-backend MCP contract proves the returned receipt ID and digest
+  equal the durable service response byte-for-byte.
+- [ ] Formatting, strict Clippy, focused SDK/agent-lib/MCP tests, and the real
+  backend MCP path pass.
+
+## Files To Touch
+
+- `crates/kamn-node/src/service_api_endpoint/models.rs`
+- `crates/kamn-node/src/service_api_endpoint/escrow_models.rs`
+- `crates/kamn-node/src/service_api_endpoint/message_store/task_models.rs`
+- `crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/lifecycle.rs`
+- `crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/lifecycle/receipt.rs`
+- `crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/escrow_lifecycle/receipt.rs`
+- Focused node task/escrow persistence and route response tests.
+- `crates/kamn-sdk/src/service_models.rs`
+- `crates/kamn-sdk/src/service_client_message_task_routes.rs`
+- `crates/kamn-sdk/src/service_client_content_routes.rs`
+- `crates/kamn-sdk/src/service_client.rs`
+- Focused SDK response parsing tests.
+- `crates/kamn-agent-lib/src/lib.rs` and focused propagation tests only if
+  public re-export/validation wiring is required.
+- `crates/kamn-mcp-server/src/dispatch.rs`
+- A bounded MCP authority-envelope module if needed to keep files and
+  functions within policy.
+- `crates/kamn-mcp-server/src/protocol.rs` and `tools.rs` only where required
+  for structured results/output schema wiring.
+- Focused dispatch, stdio protocol, inventory, and real-backend tests.
+
+## Test Plan
+
+### RED
+
+1. Prove task create, task transition, and escrow response parsers currently
+   lose `receipt_id` and have no service digest.
+2. Prove task creation currently appends no durable receipt.
+3. Require idempotent retry to preserve both receipt ID and digest.
+4. Require MCP mutation results to contain and validate the v1 authority
+   envelope; reject legacy resource/state-only results.
+5. Require registration to expose service-profile commitment authority.
+6. Require missing, malformed, mismatched, and query-as-mutation cases to fail
+   with the specified error codes.
+
+All RED tests must fail for the missing authority behavior, not for fixture or
+compilation mistakes.
+
+### GREEN
+
+Implement the minimum service receipt/digest emission, SDK model parsing, and
+MCP structured-envelope validation required to pass RED. Do not add receipt
+chain, Pi evidence, or verifier behavior.
+
+### REFACTOR
+
+- Centralize service receipt canonicalization and digest validation.
+- Keep each function at or below 25 lines and each file at or below 200 lines.
+- Remove duplicated mutation JSON formatting from MCP dispatch.
+- Keep query and mutation response types distinct.
+- Verify retry idempotency and hard-fail error propagation.
+
+### INTEGRATION
+
+```bash
+cargo test -p kamn-node task_escrow_persistence
+cargo test -p kamn-sdk service
+cargo test -p kamn-agent-lib
+cargo test -p kamn-mcp-server --test tool_dispatch_contract
+cargo test -p kamn-mcp-server --test stdio_protocol_contract
+cargo test -p kamn-mcp-server --test real_backend_integration_contract
+cargo fmt --all --check
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+```
+
+## Rollback
+
+- Revert the #7132 commit range if exact service authority cannot remain
+  backward compatible at the SDK/MCP boundary.
+- Never retain an MCP-only or client-computed receipt as a fallback.
+- Preserve existing durable task/escrow records and #7125 settlement evidence
+  during rollback.


### PR DESCRIPTION
## Human Summary

- Makes the service the durable authority for task and escrow receipt IDs/digests and registration profile commitments.
- Preserves those authority fields through the SDK and agent library without recomputing or substituting them.
- Emits validated `kamn.mcp.authority-receipt.v1` envelopes from MCP mutation tools and fails closed on missing, malformed, or mismatched evidence.
- Adds a real-backend contract proving the MCP receipt ID and digest match the durable service response byte-for-byte; query results remain authority-free.

## Testing

- `cargo fmt --all --check`
- `git diff --check`
- `bash scripts/ci/check_touched_rust_size_policy.sh --base-ref ed4df3f94`
- Ubuntu fast-gate run: https://github.com/njfio/kamn/actions/runs/29843773248
- Focused agent-lib, CLI, MCP authority, MCP real-backend, node durable-retry, SDK live task/escrow, and inventory targets passed in that run.
- Local targeted Rust tests did not complete because rustc repeatedly stalled in the macOS loader while linking `kamn-sdk`.

## Notes for Reviewers

The PR is draft because the broad bounded-tests job reached its 20-minute ceiling retrying five unrelated targets: rolling governance-history compliance, one supervisor timing/cleanup test, and three pre-existing settlement actor-evidence targets returning `SETTLEMENT_EVIDENCE_INVALID`. No #7132-owned target remained failing.

This PR provides bounded authority-unification evidence. It does not claim an exhaustive green fast gate or production readiness.

Spec: https://github.com/njfio/kamn/blob/7132-preserve-service-receipts/specs/7132-preserve-service-receipts.md

## AI Agent Details

- Service models now expose durable mutation receipts and deterministic registration commitments.
- SDK conversion validates and preserves authority fields.
- MCP validates actor, action, tool, resource, state, and digest bindings before emitting an authority envelope.
- Compatible display text is derived from the same validated structured result.
- The branch preserves the required RED, GREEN, refactor, and integration commit arc.

Closes #7132