### PR TITLE
[7133] Commit durable receipt chains in service projections

### DIFF
--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests.rs
@@ -28,5 +28,7 @@ mod task_escrow_solana_asset_movement_contract_tests;
 mod task_escrow_solana_asset_movement_live_contract_tests;
 #[path = "task_escrow_persistence_contract_tests/task_projection_contract_tests.rs"]
 mod task_projection_contract_tests;
+#[path = "task_escrow_persistence_contract_tests/task_projection_receipt_chain_contract_tests.rs"]
+mod task_projection_receipt_chain_contract_tests;
 #[path = "task_escrow_persistence_contract_tests/task_projection_settlement_contract_tests.rs"]
 mod task_projection_settlement_contract_tests;

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_projection_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_projection_contract_tests.rs
@@ -2,7 +2,7 @@ use super::super::*;
 use serde_json::Value;
 
 #[path = "task_projection_contract_tests/support.rs"]
-mod projection_support;
+pub(crate) mod projection_support;
 use projection_support::ProjectionCase;
 
 pub(super) const CREATOR: &str = "kamn:did:agent:projection-creator";

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_projection_contract_tests/support.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_projection_contract_tests/support.rs
@@ -2,7 +2,7 @@ use super::super::super::*;
 use super::super::support::*;
 use super::{CREATOR, OUTSIDER, PROVIDER, VERIFIER};
 
-pub(super) struct ProjectionCase {
+pub(crate) struct ProjectionCase {
     _env: ServiceApiTestEnvGuards,
     _state_guard: EnvVarGuard,
     snapshot: crate::service_api_endpoint::ServiceApiSnapshot,
@@ -10,7 +10,7 @@ pub(super) struct ProjectionCase {
 }
 
 impl ProjectionCase {
-    pub(super) fn new(label: &str) -> Self {
+    pub(crate) fn new(label: &str) -> Self {
         let env = acquire_service_api_test_env();
         let state_file = unique_named_state_file(format!("kamn-projection-{label}").as_str());
         let (_, state_guard) = set_state_file_env(state_file.as_path());
@@ -22,7 +22,7 @@ impl ProjectionCase {
         }
     }
 
-    pub(super) fn seed_transaction(&self) -> String {
+    pub(crate) fn seed_transaction(&self) -> String {
         let task_id = self.seed_task();
         let escrow = serde_json::json!({"task_id": task_id, "amount_lamports": 10_000});
         fund_escrow(
@@ -35,7 +35,7 @@ impl ProjectionCase {
         task_id
     }
 
-    pub(super) fn seed_task(&self) -> String {
+    pub(crate) fn seed_task(&self) -> String {
         self.register_actors();
         let body = task_body();
         let task = create_task(
@@ -55,7 +55,7 @@ impl ProjectionCase {
         task.task_id
     }
 
-    pub(super) fn query(&self, actor: &str, nonce: u64, task_id: &str, view: &str) -> String {
+    pub(crate) fn query(&self, actor: &str, nonce: u64, task_id: &str, view: &str) -> String {
         let path = format!("/v1/tasks/{task_id}/{view}");
         raw_signed_request(
             &self.snapshot,
@@ -88,6 +88,38 @@ impl ProjectionCase {
         self.write_state(&state);
     }
 
+    pub(crate) fn seed_completed_transaction(&self) -> String {
+        let task_id = self.seed_transaction();
+        complete_task(
+            &self.snapshot,
+            reserve_loopback_addr().as_str(),
+            PROVIDER,
+            3,
+            task_id.as_str(),
+        );
+        task_id
+    }
+
+    pub(crate) fn retry_task_create(&self, nonce: u64) {
+        create_task(
+            &self.snapshot,
+            reserve_loopback_addr().as_str(),
+            CREATOR,
+            nonce,
+            task_body().to_string().as_str(),
+        );
+    }
+
+    pub(crate) fn state(&self) -> serde_json::Value {
+        read_state_json(self.state_file.as_path())
+    }
+
+    pub(crate) fn mutate_state(&self, mutate: impl FnOnce(&mut serde_json::Value)) {
+        let mut state = self.state();
+        mutate(&mut state);
+        self.write_state(&state);
+    }
+
     fn write_state(&self, state: &serde_json::Value) {
         fs::write(
             self.state_file.as_path(),
@@ -96,7 +128,7 @@ impl ProjectionCase {
         .expect("write tampered state");
     }
 
-    pub(super) fn cleanup(self) {
+    pub(crate) fn cleanup(self) {
         let _ = fs::remove_file(self.state_file);
     }
 

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_projection_receipt_chain_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_projection_receipt_chain_contract_tests.rs
@@ -150,7 +150,7 @@ fn assert_actions(projection: &Value, expected: &[&str]) {
         .expect("participant receipt details");
     let actions: Vec<_> = receipts
         .iter()
-        .map(|receipt| receipt["action"].as_str().unwrap())
+        .map(|receipt| receipt["action"].as_str().expect("receipt action"))
         .collect();
     assert_eq!(actions, expected);
     for receipt in receipts {

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_projection_receipt_chain_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_projection_receipt_chain_contract_tests.rs
@@ -1,0 +1,174 @@
+use super::super::*;
+use super::task_projection_contract_tests::projection_support::ProjectionCase;
+use serde_json::Value;
+
+const CREATOR: &str = "kamn:did:agent:projection-creator";
+const PROVIDER: &str = "kamn:did:agent:projection-provider";
+const VERIFIER: &str = "kamn:did:agent:projection-verifier";
+const CHAIN_ERROR: &str = "SERVICE_RECEIPT_CHAIN_INVALID";
+
+#[test]
+fn integration_projection_commits_chain_with_actor_scoped_private_receipts() {
+    let case = ProjectionCase::new("receipt-chain-privacy");
+    let task_id = case.seed_transaction();
+
+    let creator = query_value(&case, CREATOR, 4, &task_id, "participant-view");
+    let provider = query_value(&case, PROVIDER, 3, &task_id, "participant-view");
+    let verifier = query_value(&case, VERIFIER, 2, &task_id, "verifier-view");
+
+    assert_shared_commitments(&creator, &provider, &verifier);
+    assert_actions(&creator, &["task:create", "escrow:fund"]);
+    assert_actions(&provider, &["task:accept"]);
+    assert_restricted_public(&verifier);
+    case.cleanup();
+}
+
+#[test]
+fn integration_retry_and_restart_preserve_chain_without_duplicate_transition() {
+    let case = ProjectionCase::new("receipt-chain-retry");
+    let task_id = case.seed_transaction();
+    let before = query_value(&case, CREATOR, 4, &task_id, "participant-view");
+    let receipt_count = case.state()["task_transition_receipts"]
+        .as_array()
+        .expect("task receipts")
+        .len();
+
+    case.retry_task_create(5);
+    let after = query_value(&case, CREATOR, 6, &task_id, "participant-view");
+
+    assert_eq!(
+        before["receipt_chain_commitment"],
+        after["receipt_chain_commitment"]
+    );
+    assert_eq!(
+        case.state()["task_transition_receipts"]
+            .as_array()
+            .expect("task receipts")
+            .len(),
+        receipt_count
+    );
+    case.cleanup();
+}
+
+#[test]
+fn integration_projection_rejects_tampered_receipt_order_and_identity() {
+    assert_tamper_rejected("receipt-order", |state| {
+        state["task_transition_receipts"]
+            .as_array_mut()
+            .expect("task receipts")
+            .reverse();
+    });
+    assert_tamper_rejected("receipt-duplicate", |state| {
+        let receipts = task_receipts(state);
+        let duplicate = receipts[0]["receipt_id"].clone();
+        receipts[1]["receipt_id"] = duplicate;
+    });
+}
+
+#[test]
+fn integration_projection_rejects_tampered_actor_action_state_and_resource() {
+    for (label, field, value) in [
+        ("receipt-actor", "actor_did", CREATOR),
+        ("receipt-action", "action", "task:complete"),
+        ("receipt-state", "resulting_state", "completed"),
+        ("receipt-resource", "task_id", "task-cross-resource"),
+    ] {
+        assert_tamper_rejected(label, |state| {
+            task_receipts(state)[1][field] = Value::String(value.to_owned());
+        });
+    }
+}
+
+#[test]
+fn integration_projection_rejects_missing_authorization_and_conflicting_key() {
+    assert_tamper_rejected("receipt-authorization", |state| {
+        state["authorization_receipts"]
+            .as_array_mut()
+            .expect("authorization receipts")
+            .retain(|receipt| receipt["action"] != "task:accept");
+    });
+
+    let case = ProjectionCase::new("receipt-conflicting-key");
+    let task_id = case.seed_completed_transaction();
+    case.mutate_state(|state| {
+        let receipts = task_receipts(state);
+        let duplicate = receipts[1]["idempotency_key"].clone();
+        receipts[2]["idempotency_key"] = duplicate;
+    });
+    assert_chain_error(&case.query(VERIFIER, 2, &task_id, "verifier-view"));
+    case.cleanup();
+}
+
+fn assert_tamper_rejected(label: &str, tamper: impl FnOnce(&mut Value)) {
+    let case = ProjectionCase::new(label);
+    let task_id = case.seed_transaction();
+    case.mutate_state(tamper);
+    assert_chain_error(&case.query(VERIFIER, 2, &task_id, "verifier-view"));
+    case.cleanup();
+}
+
+fn task_receipts(state: &mut Value) -> &mut Vec<Value> {
+    state["task_transition_receipts"]
+        .as_array_mut()
+        .expect("task receipts")
+}
+
+fn assert_chain_error(response: &str) {
+    assert!(response.contains("500 Internal Server Error"), "{response}");
+    assert!(response.contains(CHAIN_ERROR), "{response}");
+}
+
+fn query_value(case: &ProjectionCase, actor: &str, nonce: u64, task: &str, view: &str) -> Value {
+    let response = case.query(actor, nonce, task, view);
+    assert!(response.contains("HTTP/1.1 200 OK"), "{response}");
+    parse_service_api_payload(extract_http_response_body(&response)).expect("projection payload")
+}
+
+fn assert_shared_commitments(creator: &Value, provider: &Value, verifier: &Value) {
+    assert_eq!(
+        creator["schema_version"],
+        "kamn.runtime.task-disclosure-projection.v2"
+    );
+    assert_eq!(
+        creator["receipt_chain_commitment"],
+        provider["receipt_chain_commitment"]
+    );
+    assert_eq!(
+        creator["receipt_chain_commitment"],
+        verifier["receipt_chain_commitment"]
+    );
+    assert_eq!(creator["public_commitment"], verifier["public_commitment"]);
+    let commitment = creator["receipt_chain_commitment"]
+        .as_str()
+        .expect("chain commitment");
+    assert!(commitment.starts_with("sha256:") && commitment.len() == 71);
+}
+
+fn assert_actions(projection: &Value, expected: &[&str]) {
+    let receipts = projection["receipt_chain_receipts"]
+        .as_array()
+        .expect("participant receipt details");
+    let actions: Vec<_> = receipts
+        .iter()
+        .map(|receipt| receipt["action"].as_str().unwrap())
+        .collect();
+    assert_eq!(actions, expected);
+    for receipt in receipts {
+        for private in ["actor_did", "correlation_id", "idempotency_key"] {
+            assert!(receipt.get(private).is_none(), "{receipt}");
+        }
+    }
+}
+
+fn assert_restricted_public(projection: &Value) {
+    for private in [
+        "receipt_chain_receipts",
+        "task_receipt_ids",
+        "completion_evidence_digest",
+        "actor_did",
+        "correlation_id",
+        "idempotency_key",
+    ] {
+        assert!(projection.get(private).is_none(), "{projection}");
+    }
+}

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_projection_settlement_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_projection_settlement_contract_tests.rs
@@ -17,13 +17,19 @@ fn integration_participant_projection_uses_persisted_settlement_evidence() {
     let task_id = escrow_task_id(&context.harness, &escrow_id);
     let (response, projection) = query_projection(&context.harness, &task_id, 184);
     assert_settlement_projection(&response, &projection, &released);
-    assert_failed_intent_is_rejected(
-        &context.harness.snapshot,
-        context.harness.bind_addr.as_str(),
-        context.harness.state_file.as_path(),
-        &task_id,
-        &escrow_id,
-    );
+    for (nonce, field, value) in [
+        (185, "actor_did", "kamn:did:agent:foreign-settler"),
+        (186, "state", "failed"),
+    ] {
+        assert_tampered_intent_is_rejected(
+            &context.harness,
+            &task_id,
+            &escrow_id,
+            nonce,
+            field,
+            value,
+        );
+    }
 }
 
 fn projection_context() -> LiveSolanaAssetMovementContext {
@@ -78,35 +84,29 @@ fn assert_settlement_projection(response: &str, projection: &Value, released: &V
     assert_eq!(projection["settlement_commitment"], "finalized");
 }
 
-fn assert_failed_intent_is_rejected(
-    snapshot: &crate::service_api_endpoint::ServiceApiSnapshot,
-    bind_addr: &str,
-    state_file: &std::path::Path,
+fn assert_tampered_intent_is_rejected(
+    harness: &AssetMovementHarness,
     task_id: &str,
     escrow_id: &str,
+    nonce: u64,
+    field: &str,
+    value: &str,
 ) {
-    mark_intent_failed(state_file, escrow_id);
-    let path = format!("/v1/tasks/{task_id}/participant-view");
-    let response = raw_signed_request(
-        snapshot,
-        bind_addr,
-        SignedRequest {
-            max_requests: 1,
-            method: "GET",
-            path: path.as_str(),
-            caller_did: ACTOR,
-            nonce: 185,
-            body: "",
-            extra_headers: &[("X-KAMN-Authz-Scope", "tasks:read")],
-        },
-    );
+    let original = read_state_json(harness.state_file.as_path());
+    mutate_intent(harness.state_file.as_path(), escrow_id, field, value);
+    let (response, _) = query_projection(harness, task_id, nonce);
     assert!(response.contains("500 Internal Server Error"), "{response}");
-    assert!(response.contains("TRANSACTION_PROJECTION_INCONSISTENT"));
+    assert!(response.contains("SERVICE_RECEIPT_CHAIN_INVALID"));
+    write_state(harness.state_file.as_path(), &original);
 }
 
-fn mark_intent_failed(state_file: &std::path::Path, escrow_id: &str) {
+fn mutate_intent(state_file: &std::path::Path, escrow_id: &str, field: &str, value: &str) {
     let mut state = read_state_json(state_file);
-    state["settlement_intents"][escrow_id]["state"] = Value::String("failed".to_owned());
-    fs::write(state_file, serde_json::to_vec(&state).expect("state json"))
-        .expect("write tampered settlement intent");
+    state["settlement_intents"][escrow_id][field] = Value::String(value.to_owned());
+    write_state(state_file, &state);
+}
+
+fn write_state(state_file: &std::path::Path, state: &Value) {
+    fs::write(state_file, serde_json::to_vec(state).expect("state json"))
+        .expect("write settlement intent state");
 }

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_projection_settlement_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_projection_settlement_contract_tests.rs
@@ -75,6 +75,10 @@ fn query_projection(harness: &AssetMovementHarness, task_id: &str, nonce: u64) -
 
 fn assert_settlement_projection(response: &str, projection: &Value, released: &Value) {
     assert!(response.contains("HTTP/1.1 200 OK"), "{response}");
+    assert_eq!(
+        projection["schema_version"],
+        "kamn.runtime.task-disclosure-projection.v2"
+    );
     assert_eq!(projection["escrow_state"], "released");
     assert_eq!(projection["network"], "solana-devnet");
     assert_eq!(
@@ -82,6 +86,30 @@ fn assert_settlement_projection(response: &str, projection: &Value, released: &V
         released["settlement_tx_signature"]
     );
     assert_eq!(projection["settlement_commitment"], "finalized");
+    assert_eq!(
+        participant_receipt_actions(projection),
+        expected_receipt_actions()
+    );
+}
+
+fn participant_receipt_actions(projection: &Value) -> Vec<&str> {
+    projection["receipt_chain_receipts"]
+        .as_array()
+        .expect("participant receipt chain")
+        .iter()
+        .map(|receipt| receipt["action"].as_str().expect("receipt action"))
+        .collect()
+}
+
+fn expected_receipt_actions() -> Vec<&'static str> {
+    vec![
+        "task:create",
+        "task:accept",
+        "escrow:fund",
+        "task:complete",
+        "escrow:release-authorize",
+        "settlement:confirmed",
+    ]
 }
 
 fn assert_tampered_intent_is_rejected(

--- a/crates/kamn-node/src/service_api_endpoint/message_store/authority_digest.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/authority_digest.rs
@@ -1,9 +1,14 @@
-use super::{ServiceApiEscrowTransitionReceiptRecord, ServiceApiTaskTransitionReceiptRecord};
+use super::{
+    ServiceApiAuthorizationReceiptRecord, ServiceApiEscrowTransitionReceiptRecord,
+    ServiceApiSettlementIntentRecord, ServiceApiTaskTransitionReceiptRecord,
+};
 use k256::sha2::{Digest, Sha256};
 
 const PROFILE_DOMAIN: &str = "kamn.service.profile-authority.v1";
 const TASK_DOMAIN: &str = "kamn.service.task-receipt.v1";
 const ESCROW_DOMAIN: &str = "kamn.service.escrow-receipt.v1";
+const AUTHORIZATION_DOMAIN: &str = "kamn.service.authorization-receipt.v1";
+const SETTLEMENT_DOMAIN: &str = "kamn.service.settlement-intent.v1";
 
 pub(super) fn profile(
     did: &str,
@@ -69,6 +74,40 @@ pub(super) fn escrow(receipt: &ServiceApiEscrowTransitionReceiptRecord) -> Strin
             amount.as_str(),
             receipt.terms_digest.as_str(),
             receipt.release_policy.as_str(),
+        ],
+    )
+}
+
+pub(super) fn authorization(receipt: &ServiceApiAuthorizationReceiptRecord) -> String {
+    digest(
+        AUTHORIZATION_DOMAIN,
+        &[
+            receipt.receipt_id.as_str(),
+            receipt.correlation_id.as_str(),
+            receipt.actor_did.as_str(),
+            receipt.resource.as_str(),
+            receipt.action.as_str(),
+            receipt.role.as_str(),
+            receipt.decision.as_str(),
+            receipt.reason_code.as_str(),
+        ],
+    )
+}
+
+pub(super) fn settlement(intent: &ServiceApiSettlementIntentRecord) -> String {
+    let amount = intent.amount_lamports.to_string();
+    digest(
+        SETTLEMENT_DOMAIN,
+        &[
+            intent.settlement_intent_id.as_str(),
+            intent.escrow_id.as_str(),
+            intent.actor_did.as_str(),
+            intent.idempotency_key.as_str(),
+            amount.as_str(),
+            intent.network.as_str(),
+            intent.expected_signature.as_str(),
+            intent.signed_transaction_digest.as_str(),
+            intent.state.as_str(),
         ],
     )
 }

--- a/crates/kamn-node/src/service_api_endpoint/message_store/task_projection.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/task_projection.rs
@@ -89,9 +89,9 @@ fn build_projection(
 ) -> Result<(ServiceApiTaskPublicProjection, receipt_chain::ReceiptChain), TaskProjectionError> {
     let escrow = bound_escrow(snapshot, task)?;
     let transaction_id = matching_transaction_id(task, escrow)?;
-    require_settlement_consistency(snapshot, escrow)?;
-    let chain = receipt_chain::derive(snapshot, task, escrow)?;
     let mut projection = public_fields(task, escrow, transaction_id)?;
+    let chain = receipt_chain::derive(snapshot, task, escrow)?;
+    require_settlement_consistency(snapshot, escrow)?;
     projection.receipt_chain_commitment = chain.commitment.clone();
     projection.public_commitment = commitment::public_commitment(&projection);
     Ok((projection, chain))

--- a/crates/kamn-node/src/service_api_endpoint/message_store/task_projection.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/task_projection.rs
@@ -4,6 +4,7 @@ use crate::service_api_endpoint::projection_models::{
 };
 
 mod commitment;
+mod receipt_chain;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum TaskProjectionError {
@@ -11,6 +12,7 @@ pub(crate) enum TaskProjectionError {
     Forbidden,
     EscrowBindingMissing,
     Inconsistent,
+    ReceiptChainInvalid,
     Persistence(String),
 }
 
@@ -27,13 +29,13 @@ pub(crate) fn participant(
         return Ok(None);
     };
     let role = participant_role(task, requester_did).ok_or(TaskProjectionError::Forbidden)?;
-    let public = build_public_projection(&store.snapshot, task)?;
-    let receipts = task_receipt_ids(&store.snapshot, task_id);
+    let (public, chain) = build_projection(&store.snapshot, task)?;
     Ok(Some(ServiceApiParticipantTaskProjection {
         view_scope: "participant-private".to_owned(),
         participant_role: role.to_owned(),
         public,
-        task_receipt_ids: receipts,
+        task_receipt_ids: chain.task_receipt_ids(requester_did),
+        receipt_chain_receipts: chain.participant_receipts(requester_did),
         completion_evidence_digest: task.completion_evidence_digest.clone(),
     }))
 }
@@ -50,9 +52,10 @@ pub(crate) fn verifier(
     let Some(task) = store.snapshot.tasks.get(task_id) else {
         return Ok(None);
     };
+    let (public, _) = build_projection(&store.snapshot, task)?;
     Ok(Some(ServiceApiVerifierTaskProjection {
         view_scope: "restricted-public".to_owned(),
-        public: build_public_projection(&store.snapshot, task)?,
+        public,
     }))
 }
 
@@ -80,16 +83,18 @@ fn participant_role<'a>(
     (task.provider_did.as_deref() == Some(requester)).then_some("provider")
 }
 
-fn build_public_projection(
+fn build_projection(
     snapshot: &ServiceApiPersistedMessageStoreSnapshot,
     task: &ServiceApiPersistedTaskRecord,
-) -> Result<ServiceApiTaskPublicProjection, TaskProjectionError> {
+) -> Result<(ServiceApiTaskPublicProjection, receipt_chain::ReceiptChain), TaskProjectionError> {
     let escrow = bound_escrow(snapshot, task)?;
     let transaction_id = matching_transaction_id(task, escrow)?;
     require_settlement_consistency(snapshot, escrow)?;
+    let chain = receipt_chain::derive(snapshot, task, escrow)?;
     let mut projection = public_fields(task, escrow, transaction_id)?;
+    projection.receipt_chain_commitment = chain.commitment.clone();
     projection.public_commitment = commitment::public_commitment(&projection);
-    Ok(projection)
+    Ok((projection, chain))
 }
 
 fn bound_escrow<'a>(
@@ -167,18 +172,7 @@ fn public_fields(
         network,
         settlement_tx_signature: escrow.settlement.settlement_tx_signature.clone(),
         settlement_commitment: escrow.settlement.settlement_commitment.clone(),
+        receipt_chain_commitment: String::new(),
         public_commitment: String::new(),
     })
-}
-
-fn task_receipt_ids(
-    snapshot: &ServiceApiPersistedMessageStoreSnapshot,
-    task_id: &str,
-) -> Vec<String> {
-    snapshot
-        .task_transition_receipts
-        .iter()
-        .filter(|receipt| receipt.task_id == task_id)
-        .map(|receipt| receipt.receipt_id.clone())
-        .collect()
 }

--- a/crates/kamn-node/src/service_api_endpoint/message_store/task_projection.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/task_projection.rs
@@ -91,7 +91,6 @@ fn build_projection(
     let transaction_id = matching_transaction_id(task, escrow)?;
     let mut projection = public_fields(task, escrow, transaction_id)?;
     let chain = receipt_chain::derive(snapshot, task, escrow)?;
-    require_settlement_consistency(snapshot, escrow)?;
     projection.receipt_chain_commitment = chain.commitment.clone();
     projection.public_commitment = commitment::public_commitment(&projection);
     Ok((projection, chain))
@@ -125,28 +124,6 @@ fn matching_transaction_id<'a>(
         (Some(task_id), Some(escrow_id)) if task_id == escrow_id => Ok(task_id),
         _ => Err(TaskProjectionError::Inconsistent),
     }
-}
-
-fn require_settlement_consistency(
-    snapshot: &ServiceApiPersistedMessageStoreSnapshot,
-    escrow: &ServiceApiPersistedEscrowRecord,
-) -> Result<(), TaskProjectionError> {
-    let Some(signature) = escrow.settlement.settlement_tx_signature.as_deref() else {
-        return Ok(());
-    };
-    let intent = snapshot
-        .settlement_intents
-        .get(&escrow.escrow_id)
-        .ok_or(TaskProjectionError::Inconsistent)?;
-    if intent.state == "confirmed"
-        && intent.expected_signature == signature
-        && Some(intent.amount_lamports) == escrow.amount_lamports
-        && intent.network == "solana:devnet"
-        && escrow.network.as_deref() == Some("solana-devnet")
-    {
-        return Ok(());
-    }
-    Err(TaskProjectionError::Inconsistent)
 }
 
 fn public_fields(

--- a/crates/kamn-node/src/service_api_endpoint/message_store/task_projection/commitment.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/task_projection/commitment.rs
@@ -13,6 +13,7 @@ pub(super) fn public_commitment(projection: &ServiceApiTaskPublicProjection) -> 
         projection.network.as_str(),
         projection.settlement_tx_signature.as_deref().unwrap_or(""),
         projection.settlement_commitment.as_deref().unwrap_or(""),
+        projection.receipt_chain_commitment.as_str(),
     ];
     let canonical = fields.map(length_frame).join("|");
     format!("sha256:{}", hex_digest(Sha256::digest(canonical)))

--- a/crates/kamn-node/src/service_api_endpoint/message_store/task_projection/receipt_chain.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/task_projection/receipt_chain.rs
@@ -1,0 +1,101 @@
+use super::*;
+use crate::service_api_endpoint::projection_models::ServiceApiParticipantReceiptProjection;
+
+mod binding;
+mod commitment;
+mod entry;
+mod settlement;
+mod validation;
+
+pub(super) struct ReceiptChain {
+    entries: Vec<ReceiptChainEntry>,
+    pub(super) commitment: String,
+}
+
+pub(super) struct ReceiptChainEntry {
+    receipt_id: String,
+    receipt_digest: String,
+    authorization_digest: String,
+    actor_did: String,
+    action: String,
+    resource_id: String,
+    correlation_id: String,
+    idempotency_key: String,
+    prior_state: String,
+    resulting_state: String,
+}
+
+impl ReceiptChain {
+    pub(super) fn participant_receipts(
+        &self,
+        requester: &str,
+    ) -> Vec<ServiceApiParticipantReceiptProjection> {
+        self.entries
+            .iter()
+            .filter(|entry| entry.actor_did == requester)
+            .map(ReceiptChainEntry::participant_projection)
+            .collect()
+    }
+
+    pub(super) fn task_receipt_ids(&self, requester: &str) -> Vec<String> {
+        self.entries
+            .iter()
+            .filter(|entry| entry.actor_did == requester && entry.action.starts_with("task:"))
+            .map(|entry| entry.receipt_id.clone())
+            .collect()
+    }
+}
+
+impl ReceiptChainEntry {
+    fn participant_projection(&self) -> ServiceApiParticipantReceiptProjection {
+        ServiceApiParticipantReceiptProjection {
+            receipt_id: self.receipt_id.clone(),
+            receipt_digest: self.receipt_digest.clone(),
+            action: self.action.clone(),
+            resource_id: self.resource_id.clone(),
+            resulting_state: self.resulting_state.clone(),
+        }
+    }
+}
+
+pub(super) fn derive(
+    snapshot: &ServiceApiPersistedMessageStoreSnapshot,
+    task: &ServiceApiPersistedTaskRecord,
+    escrow: &ServiceApiPersistedEscrowRecord,
+) -> Result<ReceiptChain, TaskProjectionError> {
+    let task_receipts = relevant_task_receipts(snapshot, task);
+    let escrow_receipts = relevant_escrow_receipts(snapshot, escrow);
+    validation::task_phases(task, &task_receipts)?;
+    validation::escrow_phases(escrow, &escrow_receipts)?;
+    let mut entries =
+        entry::mutation_entries(snapshot, task, escrow, &task_receipts, &escrow_receipts)?;
+    validation::unique_fields(&entries)?;
+    settlement::append(snapshot, escrow, &mut entries)?;
+    let commitment = commitment::chain(&entries);
+    Ok(ReceiptChain {
+        entries,
+        commitment,
+    })
+}
+
+fn relevant_task_receipts<'a>(
+    snapshot: &'a ServiceApiPersistedMessageStoreSnapshot,
+    task: &ServiceApiPersistedTaskRecord,
+) -> Vec<&'a ServiceApiTaskTransitionReceiptRecord> {
+    snapshot
+        .task_transition_receipts
+        .iter()
+        .filter(|receipt| receipt.task_id == task.task_id)
+        .collect()
+}
+
+fn relevant_escrow_receipts<'a>(
+    snapshot: &'a ServiceApiPersistedMessageStoreSnapshot,
+    escrow: &ServiceApiPersistedEscrowRecord,
+) -> Vec<&'a ServiceApiEscrowTransitionReceiptRecord> {
+    snapshot
+        .escrow_transition_receipts
+        .iter()
+        .filter(|receipt| receipt.escrow_id == escrow.escrow_id)
+        .collect()
+}

--- a/crates/kamn-node/src/service_api_endpoint/message_store/task_projection/receipt_chain/binding.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/task_projection/receipt_chain/binding.rs
@@ -1,0 +1,100 @@
+use super::*;
+
+pub(super) fn authorization<'a>(
+    snapshot: &'a ServiceApiPersistedMessageStoreSnapshot,
+    actor: &str,
+    action: &str,
+    resource: &str,
+) -> Result<&'a ServiceApiAuthorizationReceiptRecord, TaskProjectionError> {
+    snapshot
+        .authorization_receipts
+        .iter()
+        .find(|receipt| allowed(receipt, actor, action, resource))
+        .ok_or(TaskProjectionError::ReceiptChainInvalid)
+}
+
+fn allowed(
+    receipt: &ServiceApiAuthorizationReceiptRecord,
+    actor: &str,
+    action: &str,
+    resource: &str,
+) -> bool {
+    receipt.actor_did == actor
+        && receipt.action == action
+        && receipt.resource == resource
+        && receipt.decision == "allow"
+}
+
+pub(super) fn task_actor<'a>(
+    task: &'a ServiceApiPersistedTaskRecord,
+    action: &str,
+) -> Result<&'a str, TaskProjectionError> {
+    match action {
+        "task:create" => required(&task.creator_did),
+        "task:accept" | "task:complete" => required(&task.provider_did),
+        _ => invalid(),
+    }
+}
+
+pub(super) fn escrow_actor<'a>(
+    escrow: &'a ServiceApiPersistedEscrowRecord,
+    action: &str,
+) -> Result<&'a str, TaskProjectionError> {
+    match action {
+        "escrow:fund" => required(&escrow.funder_did),
+        "escrow:release-authorize" => required(&escrow.release_authority_did),
+        _ => invalid(),
+    }
+}
+
+pub(super) fn require_task(
+    task: &ServiceApiPersistedTaskRecord,
+    receipt: &ServiceApiTaskTransitionReceiptRecord,
+    actor: &str,
+) -> Result<(), TaskProjectionError> {
+    let valid = receipt.actor_did == actor
+        && task.transaction_id.as_deref() == Some(receipt.transaction_id.as_str())
+        && task.terms_digest.as_deref() == Some(receipt.terms_digest.as_str())
+        && completion_evidence_matches(task, receipt);
+    valid
+        .then_some(())
+        .ok_or(TaskProjectionError::ReceiptChainInvalid)
+}
+
+fn completion_evidence_matches(
+    task: &ServiceApiPersistedTaskRecord,
+    receipt: &ServiceApiTaskTransitionReceiptRecord,
+) -> bool {
+    if receipt.action == "task:complete" {
+        return receipt.completion_evidence_digest == task.completion_evidence_digest;
+    }
+    receipt.completion_evidence_digest.is_none()
+}
+
+pub(super) fn require_escrow(
+    task: &ServiceApiPersistedTaskRecord,
+    escrow: &ServiceApiPersistedEscrowRecord,
+    receipt: &ServiceApiEscrowTransitionReceiptRecord,
+    actor: &str,
+) -> Result<(), TaskProjectionError> {
+    let valid = receipt.actor_did == actor
+        && receipt.task_id == task.task_id
+        && escrow.transaction_id.as_deref() == Some(receipt.transaction_id.as_str())
+        && escrow.terms_digest.as_deref() == Some(receipt.terms_digest.as_str())
+        && escrow.network.as_deref() == Some(receipt.network.as_str())
+        && escrow.amount_lamports == Some(receipt.amount_lamports)
+        && escrow.release_policy.as_deref() == Some(receipt.release_policy.as_str());
+    valid
+        .then_some(())
+        .ok_or(TaskProjectionError::ReceiptChainInvalid)
+}
+
+fn required(value: &Option<String>) -> Result<&str, TaskProjectionError> {
+    value
+        .as_deref()
+        .ok_or(TaskProjectionError::ReceiptChainInvalid)
+}
+
+fn invalid<T>() -> Result<T, TaskProjectionError> {
+    Err(TaskProjectionError::ReceiptChainInvalid)
+}

--- a/crates/kamn-node/src/service_api_endpoint/message_store/task_projection/receipt_chain/commitment.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/task_projection/receipt_chain/commitment.rs
@@ -1,0 +1,40 @@
+use super::ReceiptChainEntry;
+use k256::sha2::{Digest, Sha256};
+
+const DOMAIN: &str = "kamn.service.receipt-chain.v1";
+
+pub(super) fn chain(entries: &[ReceiptChainEntry]) -> String {
+    let mut hasher = Sha256::new();
+    append(&mut hasher, DOMAIN);
+    append(&mut hasher, entries.len().to_string().as_str());
+    for entry in entries {
+        append_entry(&mut hasher, entry);
+    }
+    format!("sha256:{}", hex(&hasher.finalize()))
+}
+
+fn append_entry(hasher: &mut Sha256, entry: &ReceiptChainEntry) {
+    for value in [
+        entry.receipt_id.as_str(),
+        entry.receipt_digest.as_str(),
+        entry.authorization_digest.as_str(),
+        entry.actor_did.as_str(),
+        entry.action.as_str(),
+        entry.resource_id.as_str(),
+        entry.correlation_id.as_str(),
+        entry.idempotency_key.as_str(),
+        entry.prior_state.as_str(),
+        entry.resulting_state.as_str(),
+    ] {
+        append(hasher, value);
+    }
+}
+
+fn append(hasher: &mut Sha256, value: &str) {
+    hasher.update((value.len() as u64).to_be_bytes());
+    hasher.update(value.as_bytes());
+}
+
+fn hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|byte| format!("{byte:02x}")).collect()
+}

--- a/crates/kamn-node/src/service_api_endpoint/message_store/task_projection/receipt_chain/entry.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/task_projection/receipt_chain/entry.rs
@@ -1,0 +1,150 @@
+use super::*;
+
+pub(super) fn mutation_entries(
+    snapshot: &ServiceApiPersistedMessageStoreSnapshot,
+    task: &ServiceApiPersistedTaskRecord,
+    escrow: &ServiceApiPersistedEscrowRecord,
+    tasks: &[&ServiceApiTaskTransitionReceiptRecord],
+    escrows: &[&ServiceApiEscrowTransitionReceiptRecord],
+) -> Result<Vec<ReceiptChainEntry>, TaskProjectionError> {
+    let mut entries = vec![task_entry(snapshot, task, tasks[0])?];
+    entries.push(task_entry(snapshot, task, tasks[1])?);
+    entries.push(escrow_entry(snapshot, task, escrow, escrows[0])?);
+    if let Some(receipt) = tasks.get(2) {
+        entries.push(task_entry(snapshot, task, receipt)?);
+    }
+    if let Some(receipt) = escrows.get(1) {
+        entries.push(escrow_entry(snapshot, task, escrow, receipt)?);
+    }
+    Ok(entries)
+}
+
+fn task_entry(
+    snapshot: &ServiceApiPersistedMessageStoreSnapshot,
+    task: &ServiceApiPersistedTaskRecord,
+    receipt: &ServiceApiTaskTransitionReceiptRecord,
+) -> Result<ReceiptChainEntry, TaskProjectionError> {
+    let actor = binding::task_actor(task, receipt.action.as_str())?;
+    binding::require_task(task, receipt, actor)?;
+    build_entry(snapshot, MutationReceipt::Task(receipt), actor)
+}
+
+fn escrow_entry(
+    snapshot: &ServiceApiPersistedMessageStoreSnapshot,
+    task: &ServiceApiPersistedTaskRecord,
+    escrow: &ServiceApiPersistedEscrowRecord,
+    receipt: &ServiceApiEscrowTransitionReceiptRecord,
+) -> Result<ReceiptChainEntry, TaskProjectionError> {
+    let actor = binding::escrow_actor(escrow, receipt.action.as_str())?;
+    binding::require_escrow(task, escrow, receipt, actor)?;
+    build_entry(snapshot, MutationReceipt::Escrow(receipt), actor)
+}
+
+enum MutationReceipt<'a> {
+    Task(&'a ServiceApiTaskTransitionReceiptRecord),
+    Escrow(&'a ServiceApiEscrowTransitionReceiptRecord),
+}
+
+impl MutationReceipt<'_> {
+    fn receipt_id(&self) -> &str {
+        match self {
+            Self::Task(receipt) => &receipt.receipt_id,
+            Self::Escrow(receipt) => &receipt.receipt_id,
+        }
+    }
+
+    fn action(&self) -> &str {
+        match self {
+            Self::Task(receipt) => &receipt.action,
+            Self::Escrow(receipt) => &receipt.action,
+        }
+    }
+
+    fn authorization_action(&self) -> &str {
+        match self.action() {
+            "escrow:release-authorize" => "escrow:release",
+            action => action,
+        }
+    }
+
+    fn resource_id(&self) -> &str {
+        match self {
+            Self::Task(receipt) => &receipt.task_id,
+            Self::Escrow(receipt) => &receipt.escrow_id,
+        }
+    }
+
+    fn authorization_resource(&self) -> String {
+        match self {
+            Self::Task(receipt) if receipt.action == "task:create" => "transaction:new".to_owned(),
+            Self::Task(receipt) => format!("task:{}", receipt.task_id),
+            Self::Escrow(receipt) if receipt.action == "escrow:fund" => {
+                format!("task:{}", receipt.task_id)
+            }
+            Self::Escrow(receipt) => format!("escrow:{}", receipt.escrow_id),
+        }
+    }
+
+    fn correlation_id(&self) -> &str {
+        match self {
+            Self::Task(receipt) => &receipt.correlation_id,
+            Self::Escrow(receipt) => &receipt.correlation_id,
+        }
+    }
+
+    fn idempotency_key(&self) -> &str {
+        match self {
+            Self::Task(receipt) => &receipt.idempotency_key,
+            Self::Escrow(receipt) => &receipt.idempotency_key,
+        }
+    }
+
+    fn states(&self) -> (&str, &str) {
+        match self {
+            Self::Task(receipt) => (&receipt.prior_state, &receipt.resulting_state),
+            Self::Escrow(receipt) => (&receipt.prior_state, &receipt.resulting_state),
+        }
+    }
+
+    fn digest(&self) -> String {
+        match self {
+            Self::Task(receipt) => authority_digest::task(receipt),
+            Self::Escrow(receipt) => authority_digest::escrow(receipt),
+        }
+    }
+}
+
+fn build_entry(
+    snapshot: &ServiceApiPersistedMessageStoreSnapshot,
+    receipt: MutationReceipt<'_>,
+    actor: &str,
+) -> Result<ReceiptChainEntry, TaskProjectionError> {
+    let authorization = authorized_receipt(snapshot, &receipt, actor)?;
+    let (prior_state, resulting_state) = receipt.states();
+    Ok(ReceiptChainEntry {
+        receipt_id: receipt.receipt_id().to_owned(),
+        receipt_digest: receipt.digest(),
+        authorization_digest: authority_digest::authorization(authorization),
+        actor_did: actor.to_owned(),
+        action: receipt.action().to_owned(),
+        resource_id: receipt.resource_id().to_owned(),
+        correlation_id: receipt.correlation_id().to_owned(),
+        idempotency_key: receipt.idempotency_key().to_owned(),
+        prior_state: prior_state.to_owned(),
+        resulting_state: resulting_state.to_owned(),
+    })
+}
+
+fn authorized_receipt<'a>(
+    snapshot: &'a ServiceApiPersistedMessageStoreSnapshot,
+    receipt: &MutationReceipt<'_>,
+    actor: &str,
+) -> Result<&'a ServiceApiAuthorizationReceiptRecord, TaskProjectionError> {
+    let resource = receipt.authorization_resource();
+    binding::authorization(
+        snapshot,
+        actor,
+        receipt.authorization_action(),
+        resource.as_str(),
+    )
+}

--- a/crates/kamn-node/src/service_api_endpoint/message_store/task_projection/receipt_chain/settlement.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/task_projection/receipt_chain/settlement.rs
@@ -1,0 +1,49 @@
+use super::*;
+
+pub(super) fn append(
+    snapshot: &ServiceApiPersistedMessageStoreSnapshot,
+    escrow: &ServiceApiPersistedEscrowRecord,
+    entries: &mut Vec<ReceiptChainEntry>,
+) -> Result<(), TaskProjectionError> {
+    let Some(signature) = escrow.settlement.settlement_tx_signature.as_deref() else {
+        return Ok(());
+    };
+    let intent = snapshot
+        .settlement_intents
+        .get(&escrow.escrow_id)
+        .ok_or(TaskProjectionError::ReceiptChainInvalid)?;
+    require_binding(escrow, intent, signature)?;
+    entries.push(entry(intent));
+    Ok(())
+}
+
+fn require_binding(
+    escrow: &ServiceApiPersistedEscrowRecord,
+    intent: &ServiceApiSettlementIntentRecord,
+    signature: &str,
+) -> Result<(), TaskProjectionError> {
+    let valid = intent.state == "confirmed"
+        && intent.escrow_id == escrow.escrow_id
+        && escrow.release_authority_did.as_deref() == Some(intent.actor_did.as_str())
+        && intent.expected_signature == signature
+        && escrow.amount_lamports == Some(intent.amount_lamports)
+        && intent.network == "solana:devnet";
+    valid
+        .then_some(())
+        .ok_or(TaskProjectionError::ReceiptChainInvalid)
+}
+
+fn entry(intent: &ServiceApiSettlementIntentRecord) -> ReceiptChainEntry {
+    ReceiptChainEntry {
+        receipt_id: intent.settlement_intent_id.clone(),
+        receipt_digest: authority_digest::settlement(intent),
+        authorization_digest: String::new(),
+        actor_did: intent.actor_did.clone(),
+        action: "settlement:confirmed".to_owned(),
+        resource_id: intent.escrow_id.clone(),
+        correlation_id: String::new(),
+        idempotency_key: intent.idempotency_key.clone(),
+        prior_state: "submitted".to_owned(),
+        resulting_state: intent.state.clone(),
+    }
+}

--- a/crates/kamn-node/src/service_api_endpoint/message_store/task_projection/receipt_chain/validation.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/task_projection/receipt_chain/validation.rs
@@ -1,0 +1,74 @@
+use super::*;
+use std::collections::BTreeSet;
+
+const TASK_PHASES: &[(&str, &str, &str)] = &[
+    ("task:create", "none", "created"),
+    ("task:accept", "created", "accepted"),
+    ("task:complete", "accepted", "completed"),
+];
+const ESCROW_PHASES: &[(&str, &str, &str)] = &[
+    ("escrow:fund", "unfunded", "funded"),
+    ("escrow:release-authorize", "funded", "release-authorized"),
+];
+
+pub(super) fn task_phases(
+    task: &ServiceApiPersistedTaskRecord,
+    receipts: &[&ServiceApiTaskTransitionReceiptRecord],
+) -> Result<(), TaskProjectionError> {
+    let expected = if task.state == "completed" {
+        TASK_PHASES
+    } else {
+        &TASK_PHASES[..2]
+    };
+    validate(receipts, expected)
+}
+
+pub(super) fn escrow_phases(
+    escrow: &ServiceApiPersistedEscrowRecord,
+    receipts: &[&ServiceApiEscrowTransitionReceiptRecord],
+) -> Result<(), TaskProjectionError> {
+    let expected = if matches!(escrow.state.as_str(), "release-authorized" | "released") {
+        ESCROW_PHASES
+    } else {
+        &ESCROW_PHASES[..1]
+    };
+    validate(receipts, expected)
+}
+
+trait PhaseReceipt {
+    fn phase(&self) -> (&str, &str, &str);
+}
+
+impl PhaseReceipt for &ServiceApiTaskTransitionReceiptRecord {
+    fn phase(&self) -> (&str, &str, &str) {
+        (&self.action, &self.prior_state, &self.resulting_state)
+    }
+}
+
+impl PhaseReceipt for &ServiceApiEscrowTransitionReceiptRecord {
+    fn phase(&self) -> (&str, &str, &str) {
+        (&self.action, &self.prior_state, &self.resulting_state)
+    }
+}
+
+fn validate<T: PhaseReceipt>(
+    receipts: &[T],
+    expected: &[(&str, &str, &str)],
+) -> Result<(), TaskProjectionError> {
+    let actual: Vec<_> = receipts.iter().map(PhaseReceipt::phase).collect();
+    (actual == expected)
+        .then_some(())
+        .ok_or(TaskProjectionError::ReceiptChainInvalid)
+}
+
+pub(super) fn unique_fields(entries: &[ReceiptChainEntry]) -> Result<(), TaskProjectionError> {
+    let receipt_ids: BTreeSet<_> = entries.iter().map(|entry| &entry.receipt_id).collect();
+    let actor_keys: BTreeSet<_> = entries
+        .iter()
+        .map(|entry| (&entry.actor_did, &entry.idempotency_key))
+        .collect();
+    if receipt_ids.len() == entries.len() && actor_keys.len() == entries.len() {
+        return Ok(());
+    }
+    Err(TaskProjectionError::ReceiptChainInvalid)
+}

--- a/crates/kamn-node/src/service_api_endpoint/message_store/task_projection/receipt_chain/validation.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/task_projection/receipt_chain/validation.rs
@@ -2,8 +2,8 @@ use super::*;
 use std::collections::BTreeSet;
 
 const TASK_PHASES: &[(&str, &str, &str)] = &[
-    ("task:create", "none", "created"),
-    ("task:accept", "created", "accepted"),
+    ("task:create", "none", "submitted"),
+    ("task:accept", "submitted", "accepted"),
     ("task:complete", "accepted", "completed"),
 ];
 const ESCROW_PHASES: &[(&str, &str, &str)] = &[

--- a/crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/mutations/update_routes/state_routes_release/live_settlement.rs
+++ b/crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/mutations/update_routes/state_routes_release/live_settlement.rs
@@ -17,10 +17,10 @@ pub(super) async fn release(
 ) -> ReleaseResult {
     let mut store = state.message_store.lock().await;
     validate_release_eligibility(&mut store, context, escrow_id)?;
-    release_authority::persist(&mut store, context, escrow_id)?;
     if let Some(existing) = released_escrow(&mut store, escrow_id)? {
         return Ok(Ok(Some(existing)));
     }
+    release_authority::persist(&mut store, context, escrow_id)?;
     let prepared = resolve_prepared(&mut store, config, escrow_id)?;
     persist_request_intent(&mut store, context, escrow_id, &prepared)?;
     let evidence = submit(&mut store, config, &prepared, escrow_id)?;

--- a/crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/mutations/update_routes/state_routes_release/live_settlement.rs
+++ b/crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/mutations/update_routes/state_routes_release/live_settlement.rs
@@ -1,35 +1,42 @@
 use super::*;
 
 mod errors;
+mod release_authority;
 use errors::{
     invalid_release_key, settlement_evidence_mismatch_error, settlement_intent_conflict_error,
     settlement_outcome_ambiguous_error, settlement_transaction_expired_error,
 };
+
+type ReleaseResult = Result<Result<Option<ServiceApiEscrowStatusBody>, String>, Box<Response>>;
 
 pub(super) async fn release(
     state: &Arc<ServiceApiRuntimeState>,
     context: &ServiceApiRequestContext,
     escrow_id: &str,
     config: &LiveSolanaSettlementConfig,
-) -> Result<Result<Option<ServiceApiEscrowStatusBody>, String>, Box<Response>> {
+) -> ReleaseResult {
     let mut store = state.message_store.lock().await;
     validate_release_eligibility(&mut store, context, escrow_id)?;
+    release_authority::persist(&mut store, context, escrow_id)?;
     if let Some(existing) = released_escrow(&mut store, escrow_id)? {
         return Ok(Ok(Some(existing)));
     }
-    let actor = super::super::super::super::task_actor(context)?;
-    let key = release_idempotency_key(context)?;
     let prepared = resolve_prepared(&mut store, config, escrow_id)?;
-    persist_intent(
-        &mut store,
-        actor.as_str(),
-        escrow_id,
-        key.as_str(),
-        &prepared,
-    )?;
+    persist_request_intent(&mut store, context, escrow_id, &prepared)?;
     let evidence = submit(&mut store, config, &prepared, escrow_id)?;
     validate_evidence(&mut store, config, &prepared, &evidence, escrow_id)?;
     Ok(store.finalize_settlement_intent(escrow_id, &settlement_metadata_from_evidence(evidence)))
+}
+
+fn persist_request_intent(
+    store: &mut ServiceApiMessageStore,
+    context: &ServiceApiRequestContext,
+    escrow_id: &str,
+    prepared: &PreparedLiveSettlement,
+) -> Result<(), Box<Response>> {
+    let actor = super::super::super::super::task_actor(context)?;
+    let key = release_idempotency_key(context)?;
+    persist_intent(store, actor.as_str(), escrow_id, key.as_str(), prepared)
 }
 
 fn released_escrow(

--- a/crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/mutations/update_routes/state_routes_release/live_settlement/release_authority.rs
+++ b/crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/mutations/update_routes/state_routes_release/live_settlement/release_authority.rs
@@ -1,0 +1,20 @@
+use super::*;
+
+pub(super) fn persist(
+    store: &mut ServiceApiMessageStore,
+    context: &ServiceApiRequestContext,
+    escrow_id: &str,
+) -> Result<(), Box<Response>> {
+    let actor = super::super::super::super::super::task_actor(context)?;
+    store
+        .authorize_escrow_release(
+            actor.as_str(),
+            escrow_id,
+            context.parsed_request.body.as_str(),
+            context.correlation_id.as_str(),
+        )
+        .map(|_| ())
+        .map_err(|error| {
+            Box::new(super::super::super::super::super::escrow_lifecycle_error_response(error))
+        })
+}

--- a/crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/queries/task_projection.rs
+++ b/crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/queries/task_projection.rs
@@ -81,6 +81,11 @@ fn projection_contract_error(error: message_store::TaskProjectionError) -> Respo
             "TRANSACTION_PROJECTION_INCONSISTENT",
             "projection inconsistent",
         ),
+        ReceiptChainInvalid => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "SERVICE_RECEIPT_CHAIN_INVALID",
+            "receipt chain invalid",
+        ),
         Persistence(error) => return super::persistence_error("task projection failed", error),
     };
     super::super::payload::json_error_response(status, "task-projection", code, message)

--- a/crates/kamn-node/src/service_api_endpoint/projection_models.rs
+++ b/crates/kamn-node/src/service_api_endpoint/projection_models.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 pub(crate) const TASK_PROJECTION_SCHEMA_VERSION: &str =
-    "kamn.runtime.task-disclosure-projection.v1";
+    "kamn.runtime.task-disclosure-projection.v2";
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct ServiceApiTaskPublicProjection {
@@ -17,7 +17,17 @@ pub(crate) struct ServiceApiTaskPublicProjection {
     pub(crate) settlement_tx_signature: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) settlement_commitment: Option<String>,
+    pub(crate) receipt_chain_commitment: String,
     pub(crate) public_commitment: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct ServiceApiParticipantReceiptProjection {
+    pub(crate) receipt_id: String,
+    pub(crate) receipt_digest: String,
+    pub(crate) action: String,
+    pub(crate) resource_id: String,
+    pub(crate) resulting_state: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -27,6 +37,7 @@ pub(crate) struct ServiceApiParticipantTaskProjection {
     #[serde(flatten)]
     pub(crate) public: ServiceApiTaskPublicProjection,
     pub(crate) task_receipt_ids: Vec<String>,
+    pub(crate) receipt_chain_receipts: Vec<ServiceApiParticipantReceiptProjection>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) completion_evidence_digest: Option<String>,
 }

--- a/specs/7133-commit-durable-receipt-chains.md
+++ b/specs/7133-commit-durable-receipt-chains.md
@@ -17,7 +17,9 @@ allowlisted shared facts without participant-private evidence.
 - The single escrow bound to that task and its funding, release authority,
   amount, network, policy, and lifecycle state.
 - Durable allowed authorization receipts matched to mutation receipts by
-  correlation ID, actor, action, and resource.
+  actor, action, and resource. The earliest matching allowed receipt is
+  canonical because ingress and route revalidation may persist more than one
+  authorization check for the same mutation.
 - Durable task and escrow transition receipts, including their service-derived
   receipt digests.
 - The #7125 settlement intent and finalized escrow evidence when settlement is
@@ -84,8 +86,7 @@ is an authority source.
   prefix for the persisted task and escrow states.
 - A receipt bound to another task, escrow, transaction, actor, action, terms,
   amount, network, or release policy.
-- A missing, denied, duplicate, or mismatched authorization receipt for a
-  mutation entry.
+- A missing, denied, or mismatched authorization receipt for a mutation entry.
 - Duplicate receipt IDs or conflicting actor-scoped idempotency keys.
 - Settlement evidence that is missing, non-confirmed, cross-escrow,
   cross-actor, or inconsistent with the finalized escrow evidence.
@@ -130,8 +131,13 @@ is an authority source.
 - `crates/kamn-node/src/service_api_endpoint/message_store/task_projection.rs`
 - `crates/kamn-node/src/service_api_endpoint/message_store/task_projection/commitment.rs`
 - `crates/kamn-node/src/service_api_endpoint/message_store/task_projection/receipt_chain.rs`
+- `crates/kamn-node/src/service_api_endpoint/message_store/task_projection/receipt_chain/*.rs`
 - `crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/queries/task_projection.rs`
+- `crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/mutations/update_routes/state_routes_release/live_settlement.rs`
+- `crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/mutations/update_routes/state_routes_release/live_settlement/release_authority.rs`
 - `crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_projection_contract_tests.rs`
+- `crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_projection_receipt_chain_contract_tests.rs`
+- `crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_projection_settlement_contract_tests.rs`
 - Focused test support or extracted contract files when required by size gates.
 
 ## Test Plan

--- a/specs/7133-commit-durable-receipt-chains.md
+++ b/specs/7133-commit-durable-receipt-chains.md
@@ -1,0 +1,164 @@
+# Issue #7133: Commit Durable Receipt Chains In Service Projections
+
+## Objective
+
+Make the service derive one deterministic, versioned receipt-chain commitment
+from durable authorization, task, escrow, and settlement facts. Participant
+projections expose only receipt details authorized for the requesting actor;
+the restricted-public projection exposes the common commitment and existing
+allowlisted shared facts without participant-private evidence.
+
+## Inputs And Outputs
+
+### Inputs
+
+- The persisted task and its canonical terms, transaction, creator, provider,
+  lifecycle state, and completion evidence.
+- The single escrow bound to that task and its funding, release authority,
+  amount, network, policy, and lifecycle state.
+- Durable allowed authorization receipts matched to mutation receipts by
+  correlation ID, actor, action, and resource.
+- Durable task and escrow transition receipts, including their service-derived
+  receipt digests.
+- The #7125 settlement intent and finalized escrow evidence when settlement is
+  present.
+- The authenticated requester DID and requested projection scope.
+
+### Outputs
+
+- Both projection scopes use
+  `kamn.runtime.task-disclosure-projection.v2`.
+- Both scopes include `receipt_chain_commitment`, formatted as
+  `sha256:<64 lowercase hex characters>` and derived under the domain
+  `kamn.service.receipt-chain.v1`.
+- `public_commitment` includes the receipt-chain commitment as one canonical
+  shared field, so participant and restricted-public projections agree on the
+  same public result.
+- Participant-private output includes actor-scoped receipt entries containing
+  only `receipt_id`, `receipt_digest`, `action`, `resource_id`, and
+  `resulting_state` for mutations performed by the requester.
+- Restricted-public output includes no receipt entries, receipt IDs, receipt
+  digests, actor DIDs, correlation IDs, idempotency keys, roles, or private
+  completion evidence.
+
+## Canonical Receipt Chain
+
+The service selects records for exactly one task, its bound escrow, and its
+settlement intent. It validates the applicable lifecycle prefix in this order:
+
+1. `task:create`
+2. `task:accept`
+3. `escrow:fund`
+4. `task:complete`
+5. `escrow:release-authorize`
+6. confirmed settlement
+
+Each mutation entry commits its phase, receipt ID, service receipt digest,
+actor, action, resource binding, prior state, resulting state, and the digest
+of its matching allowed authorization receipt. The settlement entry commits
+the settlement intent ID, escrow binding, actor, idempotency key, amount,
+network, expected signature, signed transaction digest, and confirmed state.
+Length-prefixed fields, an entry count, and the fixed domain separate all
+values. Optional later phases may be absent only when the current task and
+escrow states prove that the lifecycle has not reached them.
+
+The chain is derived from persisted records on every projection read. No
+Pi-local value, MCP response, caller-supplied commitment, or cached projection
+is an authority source.
+
+## Boundaries And Non-Goals
+
+- Do not change Pi actor-evidence schemas or the independent verifier.
+- Do not add grants or broaden Agent C visibility.
+- Do not introduce a second settlement path or weaken #7125 settlement checks.
+- Do not add dependencies, chains, public CLI flags, or service routes.
+- Do not expose correlation IDs, idempotency keys, authorization roles, signed
+  transaction JSON, or another participant's private receipt details.
+- Do not change SDK or agent-lib projection behavior; they continue preserving
+  the server-generated JSON without rewriting it.
+
+## Failure Modes
+
+- Missing or duplicate required lifecycle receipts.
+- Reordered lifecycle phases or state transitions that do not form the legal
+  prefix for the persisted task and escrow states.
+- A receipt bound to another task, escrow, transaction, actor, action, terms,
+  amount, network, or release policy.
+- A missing, denied, duplicate, or mismatched authorization receipt for a
+  mutation entry.
+- Duplicate receipt IDs or conflicting actor-scoped idempotency keys.
+- Settlement evidence that is missing, non-confirmed, cross-escrow,
+  cross-actor, or inconsistent with the finalized escrow evidence.
+- A participant projection containing another actor's private receipt entry.
+- A restricted-public projection containing any non-allowlisted private field.
+- Persistence read or decode failure.
+
+## Error Semantics
+
+- Any receipt-chain validation failure returns HTTP 500 through the existing
+  task-projection error envelope with code `SERVICE_RECEIPT_CHAIN_INVALID`.
+- Missing escrow binding retains `TASK_ESCROW_BINDING_MISSING`.
+- Unregistered and non-participant access retain the existing 403 codes.
+- Persistence failures retain the existing hard-fail persistence response.
+- There is no fallback to the legacy public commitment or an incomplete chain.
+
+## Acceptance Criteria
+
+- [ ] The service deterministically derives the versioned chain commitment from
+  durable authorization, task, escrow, and conditional settlement facts.
+- [ ] Canonical entries bind order, actor, action, state, resource, and service
+  receipt digest.
+- [ ] Retry and restart preserve receipt identity and chain commitment without
+  duplicating a transition or settlement.
+- [ ] Duplicate, reordered, cross-resource, cross-actor, and conflicting-key
+  chains fail with `SERVICE_RECEIPT_CHAIN_INVALID`.
+- [ ] Creator and provider projections expose only requester-owned receipt
+  identity, digest, action, resource, and resulting-state details.
+- [ ] Restricted-public output exposes the shared chain commitment and existing
+  allowlisted facts without receipt or participant-private detail.
+- [ ] Participant and restricted-public projections share the same chain and
+  public commitments.
+- [ ] Persisted-state tests cover tampered order, actor, action, state, resource,
+  retry, restart, authorization, and settlement cases.
+- [ ] Formatting, strict Clippy, focused tests, and real service projection
+  wiring pass.
+
+## Files To Touch
+
+- `crates/kamn-node/src/service_api_endpoint/projection_models.rs`
+- `crates/kamn-node/src/service_api_endpoint/message_store/authority_digest.rs`
+- `crates/kamn-node/src/service_api_endpoint/message_store/task_projection.rs`
+- `crates/kamn-node/src/service_api_endpoint/message_store/task_projection/commitment.rs`
+- `crates/kamn-node/src/service_api_endpoint/message_store/task_projection/receipt_chain.rs`
+- `crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/queries/task_projection.rs`
+- `crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_projection_contract_tests.rs`
+- Focused test support or extracted contract files when required by size gates.
+
+## Test Plan
+
+### RED
+
+- Add persisted-state integration contracts for deterministic commitments,
+  participant privacy, restricted-public allowlisting, retry, and restart.
+- Add tamper cases for order, duplicate IDs, actor, action, state, resource,
+  authorization matching, idempotency, and settlement binding.
+- Confirm the new contracts fail because v2 chain fields and fail-closed chain
+  validation do not exist.
+
+### GREEN
+
+- Implement the minimum canonical digesting, chain validation, projection
+  models, and error mapping required to pass the RED contracts.
+
+### REFACTOR
+
+- Keep hashing, chain selection/validation, projection assembly, and HTTP error
+  translation single-purpose and within repository size limits.
+- Run formatting, strict Clippy, focused tests, and touched-size policy.
+
+### INTEGRATION
+
+- Exercise both signed service projection routes against persisted state after
+  retry and service restart.
+- Prove both scopes return the same chain/public commitments and that the
+  restricted-public serialized field set is exact.

--- a/specs/7133-commit-durable-receipt-chains.md
+++ b/specs/7133-commit-durable-receipt-chains.md
@@ -105,23 +105,23 @@ is an authority source.
 
 ## Acceptance Criteria
 
-- [ ] The service deterministically derives the versioned chain commitment from
+- [x] The service deterministically derives the versioned chain commitment from
   durable authorization, task, escrow, and conditional settlement facts.
-- [ ] Canonical entries bind order, actor, action, state, resource, and service
+- [x] Canonical entries bind order, actor, action, state, resource, and service
   receipt digest.
-- [ ] Retry and restart preserve receipt identity and chain commitment without
+- [x] Retry and restart preserve receipt identity and chain commitment without
   duplicating a transition or settlement.
-- [ ] Duplicate, reordered, cross-resource, cross-actor, and conflicting-key
+- [x] Duplicate, reordered, cross-resource, cross-actor, and conflicting-key
   chains fail with `SERVICE_RECEIPT_CHAIN_INVALID`.
-- [ ] Creator and provider projections expose only requester-owned receipt
+- [x] Creator and provider projections expose only requester-owned receipt
   identity, digest, action, resource, and resulting-state details.
-- [ ] Restricted-public output exposes the shared chain commitment and existing
+- [x] Restricted-public output exposes the shared chain commitment and existing
   allowlisted facts without receipt or participant-private detail.
-- [ ] Participant and restricted-public projections share the same chain and
+- [x] Participant and restricted-public projections share the same chain and
   public commitments.
-- [ ] Persisted-state tests cover tampered order, actor, action, state, resource,
+- [x] Persisted-state tests cover tampered order, actor, action, state, resource,
   retry, restart, authorization, and settlement cases.
-- [ ] Formatting, strict Clippy, focused tests, and real service projection
+- [x] Formatting, strict Clippy, focused tests, and real service projection
   wiring pass.
 
 ## Files To Touch
@@ -168,3 +168,19 @@ is an authority source.
   retry and service restart.
 - Prove both scopes return the same chain/public commitments and that the
   restricted-public serialized field set is exact.
+
+## Validation Evidence
+
+- Ubuntu run `29856598101` passed formatting, strict Clippy, touched Rust size,
+  service/runtime integration, all receipt-chain contracts, the settlement
+  projection contract, and both repeated/restart release contracts. The job
+  was later cancelled by its 20-minute cap during unrelated workspace work.
+- Ubuntu run `29858368256` passed formatting, strict Clippy, touched Rust size,
+  production panic/expect, and service/runtime integration after refactor. Its
+  workspace test step failed while linking unrelated `kamn-e2e-harness` tests
+  because the runner reported `No space left on device`.
+- The post-refactor focused local settlement projection contract passed with
+  `1 passed; 0 failed; 689 filtered out`. Cargo was then interrupted while
+  loading unrelated integration binaries containing no matching test.
+- No shell, Python, workflow, or template surface changed. Rust LOC delta is
+  `+804`; shell-to-Rust ratio delta is `0.0` (neutral).


### PR DESCRIPTION
## Human Summary

- Makes durable authorization, task, escrow, release, and settlement receipts the authority for service task projections.
- Adds a versioned receipt-chain commitment shared by participant and restricted-public views while exposing receipt details only to the owning participant.
- Fails closed with `SERVICE_RECEIPT_CHAIN_INVALID` for missing, reordered, cross-actor, cross-resource, conflicting-key, or settlement-inconsistent chains.
- Preserves repeated and restart settlement idempotency by keeping terminal released state authoritative.

Closes #7133

Spec: [`specs/7133-commit-durable-receipt-chains.md`](https://github.com/njfio/kamn/blob/7133-commit-receipt-chains/specs/7133-commit-durable-receipt-chains.md)

## Testing

- `cargo fmt --all -- --check`
- `git diff --check`
- Ubuntu fast gate [29856598101](https://github.com/njfio/kamn/actions/runs/29856598101): receipt-chain contracts, settlement projection, repeated/restart release, service integration, strict Clippy, formatting, and touched-size checks passed. The aggregate job was later cancelled at its 20-minute cap during unrelated workspace work.
- Ubuntu fast gate [29858368256](https://github.com/njfio/kamn/actions/runs/29858368256): post-refactor service integration, strict Clippy, formatting, touched-size, and production panic/expect checks passed. The workspace test step failed linking an unrelated `kamn-e2e-harness` test because the runner reported `No space left on device`.
- Focused local: `CARGO_BUILD_JOBS=2 cargo test -p kamn-node integration_participant_projection_uses_persisted_settlement_evidence -- --nocapture` produced `1 passed; 0 failed; 689 filtered out`; Cargo was then interrupted while loading unrelated integration binaries with no matching test.

## Notes for Reviewers

- Review the canonical entry validation under `task_projection/receipt_chain/`, especially authorization selection and settlement intent binding.
- Restricted-public output contains the shared commitment but no receipt IDs, digests, actors, correlation IDs, idempotency keys, or participant-private evidence.
- No shell, Python, workflow, template, dependency, schema, or public route surface changed.
- `shell_loc_delta_actual: 0`
- `rust_loc_delta_actual: 804`
- `shell_to_rust_ratio_delta_actual: 0.0`
- `shell_surface_ratio_target_status: neutral`

## AI Agent Details

- Projection schema advances to `kamn.runtime.task-disclosure-projection.v2`.
- The public commitment includes the receipt-chain commitment.
- Live settlement persists `escrow:release-authorize` before first submission while confirmed retries return before mutating terminal escrow state.
- The branch preserves the required spec, RED, GREEN, REFACTOR, and INTEGRATION commit arc.