### PR TITLE
[7134] Migrate Pi actor evidence to service receipt authority

### DIFF
--- a/.pi/extensions/kamn-mvp/live-task-workflow-retry.test.ts
+++ b/.pi/extensions/kamn-mvp/live-task-workflow-retry.test.ts
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { LiveTaskWorkflow } from "./live-task-workflow.ts";
+import { testSetup } from "./live-task-workflow-test-support.ts";
+
+test("ambiguous release survives multiple observations on the same MCP child", async () => {
+	const setup = await testSetup({ KAMN_MVP_FAKE_MCP_MODE: "ambiguous-three-releases" });
+	const workflow = new LiveTaskWorkflow(setup.env, process.cwd());
+	await workflow.register("agent_a");
+	const agentB = await workflow.register("agent_b");
+	await workflow.createTask("Settle proof", "Reconcile one signature", String(agentB.did));
+	await workflow.fundEscrow();
+	const released = await workflow.releaseEscrow();
+	const provenance = workflow.provenance("agent_a");
+	assert.equal(released.state, "release-authorized");
+	assert.deepEqual(provenance.transport_response_receipts.slice(-4).map((receipt) => receipt.outcome), ["error", "error", "error", "success"]);
+	assert.equal(provenance.transport_response_receipts.slice(-4).every((receipt) => receipt.tool === "release_escrow"), true);
+	assert.equal(provenance.last_request_id, 7);
+	await workflow.shutdown();
+});
+
+test("participant projection waits through interim views", async () => {
+	const setup = await testSetup({ KAMN_MVP_FAKE_MCP_RESULT_MODE: "pending-three-projections" });
+	const workflow = new LiveTaskWorkflow(setup.env, process.cwd());
+	await workflow.register("agent_a");
+	const agentB = await workflow.register("agent_b");
+	await workflow.createTask("Settle proof", "Wait for finalized view", String(agentB.did));
+	const projection = await workflow.queryParticipantProjection("agent_a");
+	assert.equal(projection.settlement_tx_signature, "devnet-signature-1");
+	assert.equal(workflow.provenance("agent_a").transport_response_receipts.filter(
+		(receipt) => receipt.tool === "query_participant_task_projection",
+	).length, 4);
+	await workflow.shutdown();
+});
+
+test("Agent B waits for a runtime escrow binding", async () => {
+	const setup = await testSetup({ KAMN_MVP_FAKE_MCP_RESULT_MODE: "missing-first-escrow" });
+	const workflow = new LiveTaskWorkflow(setup.env, process.cwd());
+	await workflow.register("agent_b");
+	workflow.importTask("task-live-1", {
+		transaction_id: "transaction-live-1", terms_digest: "a".repeat(64), provider_did: "kamn:did:agent-b",
+	});
+	const projection = await workflow.waitForEscrowFunding();
+	assert.equal(projection.escrow_id, "escrow-live-1");
+	assert.equal(workflow.provenance("agent_b").last_request_id, 3);
+	await workflow.shutdown();
+});
+
+test("Agent A waits for completed task state", async () => {
+	const setup = await testSetup({ KAMN_MVP_FAKE_MCP_RESULT_MODE: "completed-second-query" });
+	const workflow = new LiveTaskWorkflow(setup.env, process.cwd());
+	await workflow.register("agent_a");
+	workflow.importTask("task-live-1");
+	const task = await workflow.waitForCompleted("agent_a", { timeoutMs: 100, pollMs: 5 });
+	assert.equal(task.state, "completed");
+	assert.equal(workflow.provenance("agent_a").last_request_id, 3);
+	await workflow.shutdown();
+});
+
+test("authenticated calls retain and back off after a typed rate limit", async () => {
+	const setup = await testSetup({ KAMN_MVP_FAKE_MCP_MODE: "rate-limit-on-second" });
+	const workflow = new LiveTaskWorkflow(setup.env, process.cwd());
+	await workflow.register("agent_a");
+	const created = await workflow.createTask("Rate proof", "Respect server backoff", "kamn:did:provider");
+	const receipts = workflow.provenance("agent_a").transport_response_receipts;
+	assert.equal(created.task_id, "task-live-1");
+	assert.deepEqual(receipts.slice(-2).map((receipt) => receipt.outcome), ["error", "success"]);
+	await workflow.shutdown();
+});
+
+test("actor evidence rejects missing or mismatched projections", async () => {
+	const setup = await testSetup({ KAMN_MVP_FAKE_MCP_RESULT_MODE: "projection-authority-mismatch" });
+	const workflow = new LiveTaskWorkflow(setup.env, process.cwd());
+	assert.throws(() => workflow.actorEvidence("agent_c", 303, `sha256:${"b".repeat(64)}`), /Register Agent C/);
+	await workflow.register("agent_a");
+	const agentB = await workflow.register("agent_b");
+	await workflow.createTask("Authority", "Reject copied projection receipt", String(agentB.did));
+	await workflow.fundEscrow();
+	await workflow.releaseEscrow();
+	await workflow.queryParticipantProjection("agent_a");
+	assert.throws(() => workflow.actorEvidence("agent_a", 101, `sha256:${"b".repeat(64)}`), /PI_SERVICE_AUTHORITY_MISMATCH/);
+	await workflow.shutdown();
+});

--- a/.pi/extensions/kamn-mvp/live-task-workflow-support.ts
+++ b/.pi/extensions/kamn-mvp/live-task-workflow-support.ts
@@ -23,7 +23,8 @@ export function validateEscrowResult(result: WorkflowResult, expectedId: string 
 export function validateProjection(result: WorkflowResult, taskId: string, scope: string, step: string) {
 	if (requiredString(result, "task_id", step) !== taskId) throw new Error(`${step} returned a different task ID`);
 	if (requiredString(result, "view_scope", step) !== scope) throw new Error(`${step} returned a different view scope`);
-	requiredString(result, "public_commitment", step);
+	requiredDigest(result, "receipt_chain_commitment", step);
+	requiredDigest(result, "public_commitment", step);
 }
 export function buildActorEvidence(
 	role: AgentRole,
@@ -33,16 +34,13 @@ export function buildActorEvidence(
 	projection: WorkflowResult,
 	handoffDigest: string,
 ) {
-	const runtimeProjectionDigest = provenance.runtime_response_digests.at(-1);
-	if (!runtimeProjectionDigest) throw new Error(`${agentLabel(role)} runtime projection provenance is missing`);
+	validateProjectedReceipts(role, provenance, projection);
 	return {
 		...actorProvenance(role, piProcessId, did, provenance),
-		runtime_projection_digest: runtimeProjectionDigest,
 		...sharedProjectionFields(projection),
 		view_scope: requiredString(projection, "view_scope", `${agentLabel(role)} projection`),
 		...(role === "agent_c" ? {} : {
 			participant_role: requiredString(projection, "participant_role", `${agentLabel(role)} projection`),
-			private_receipt_digest: runtimeProjectionDigest,
 		}),
 		source_handoff_digest: handoffDigest,
 		handoff_authorized: false,
@@ -56,8 +54,9 @@ function actorProvenance(role: AgentRole, piProcessId: number, did: string, prov
 		mcp_child_process_id: provenance.child_process_id,
 		first_request_id: provenance.first_request_id,
 		last_request_id: provenance.last_request_id,
-		runtime_response_digests: provenance.runtime_response_digests,
-		runtime_response_receipts: provenance.runtime_response_receipts,
+		transport_response_digests: provenance.transport_response_digests,
+		service_profile_commitment: provenance.service_profile_commitment,
+		service_receipts: provenance.service_authority_receipts,
 	};
 }
 function sharedProjectionFields(projection: WorkflowResult) {
@@ -69,8 +68,38 @@ function sharedProjectionFields(projection: WorkflowResult) {
 		network: requiredString(projection, "network", "runtime projection"),
 		settlement_tx_signature: requiredString(projection, "settlement_tx_signature", "runtime projection"),
 		settlement_commitment: requiredString(projection, "settlement_commitment", "runtime projection"),
-		public_commitment: requiredString(projection, "public_commitment", "runtime projection"),
+		receipt_chain_commitment: requiredDigest(projection, "receipt_chain_commitment", "runtime projection"),
+		public_commitment: requiredDigest(projection, "public_commitment", "runtime projection"),
 	};
+}
+function validateProjectedReceipts(role: AgentRole, provenance: McpSessionProvenance, projection: WorkflowResult) {
+	if (role === "agent_c") {
+		if (projection.receipt_chain_receipts !== undefined) throw new Error("Agent C projection leaked private receipt authority");
+		return;
+	}
+	if (!Array.isArray(projection.receipt_chain_receipts)) throw new Error(`${agentLabel(role)} projection omitted receipt_chain_receipts`);
+	const projected = projection.receipt_chain_receipts.map((entry) => projectedReceipt(entry, role));
+	const authoritative = provenance.service_authority_receipts.map((receipt) => ({
+		receipt_id: receipt.service_receipt_id, receipt_digest: receipt.service_receipt_digest,
+		action: receipt.action, resource_id: receipt.resource_id, resulting_state: receipt.resulting_state,
+	}));
+	if (JSON.stringify(projected) !== JSON.stringify(authoritative)) throw new Error(`${agentLabel(role)} projection receipt authority mismatch`);
+}
+function projectedReceipt(value: unknown, role: AgentRole) {
+	if (typeof value !== "object" || value === null || Array.isArray(value)) throw new Error(`${agentLabel(role)} projection receipt is invalid`);
+	const receipt = value as WorkflowResult;
+	return {
+		receipt_id: requiredString(receipt, "receipt_id", "projection receipt"),
+		receipt_digest: requiredDigest(receipt, "receipt_digest", "projection receipt"),
+		action: requiredString(receipt, "action", "projection receipt"),
+		resource_id: requiredString(receipt, "resource_id", "projection receipt"),
+		resulting_state: requiredString(receipt, "resulting_state", "projection receipt"),
+	};
+}
+function requiredDigest(result: WorkflowResult, field: string, step: string): string {
+	const value = requiredString(result, field, step);
+	if (/^sha256:[0-9a-f]{64}$/.test(value)) return value;
+	throw new Error(`${step} returned invalid ${field}`);
 }
 function requiredPositiveNumber(result: WorkflowResult, field: string): number {
 	const value = result[field];

--- a/.pi/extensions/kamn-mvp/live-task-workflow-support.ts
+++ b/.pi/extensions/kamn-mvp/live-task-workflow-support.ts
@@ -74,19 +74,19 @@ function sharedProjectionFields(projection: WorkflowResult) {
 }
 function validateProjectedReceipts(role: AgentRole, provenance: McpSessionProvenance, projection: WorkflowResult) {
 	if (role === "agent_c") {
-		if (projection.receipt_chain_receipts !== undefined) throw new Error("Agent C projection leaked private receipt authority");
+		if (projection.receipt_chain_receipts !== undefined) authorityMismatch();
 		return;
 	}
-	if (!Array.isArray(projection.receipt_chain_receipts)) throw new Error(`${agentLabel(role)} projection omitted receipt_chain_receipts`);
+	if (!Array.isArray(projection.receipt_chain_receipts)) authorityMismatch();
 	const projected = projection.receipt_chain_receipts.map((entry) => projectedReceipt(entry, role));
 	const authoritative = provenance.service_authority_receipts.map((receipt) => ({
 		receipt_id: receipt.service_receipt_id, receipt_digest: receipt.service_receipt_digest,
 		action: receipt.action, resource_id: receipt.resource_id, resulting_state: receipt.resulting_state,
 	}));
-	if (JSON.stringify(projected) !== JSON.stringify(authoritative)) throw new Error(`${agentLabel(role)} projection receipt authority mismatch`);
+	if (JSON.stringify(projected) !== JSON.stringify(authoritative)) authorityMismatch();
 }
 function projectedReceipt(value: unknown, role: AgentRole) {
-	if (typeof value !== "object" || value === null || Array.isArray(value)) throw new Error(`${agentLabel(role)} projection receipt is invalid`);
+	if (typeof value !== "object" || value === null || Array.isArray(value)) authorityMismatch();
 	const receipt = value as WorkflowResult;
 	return {
 		receipt_id: requiredString(receipt, "receipt_id", "projection receipt"),
@@ -96,6 +96,7 @@ function projectedReceipt(value: unknown, role: AgentRole) {
 		resulting_state: requiredString(receipt, "resulting_state", "projection receipt"),
 	};
 }
+function authorityMismatch(): never { throw new Error("PI_SERVICE_AUTHORITY_MISMATCH"); }
 function requiredDigest(result: WorkflowResult, field: string, step: string): string {
 	const value = requiredString(result, field, step);
 	if (/^sha256:[0-9a-f]{64}$/.test(value)) return value;

--- a/.pi/extensions/kamn-mvp/live-task-workflow-test-support.ts
+++ b/.pi/extensions/kamn-mvp/live-task-workflow-test-support.ts
@@ -1,0 +1,46 @@
+import { createHash } from "node:crypto";
+import { chmod, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+
+const fixture = resolve(".pi/extensions/kamn-mvp/test-fixtures/fake-mcp-server.mjs");
+
+export async function testSetup(extra: Record<string, string> = {}) {
+	const root = await mkdtemp(resolve(tmpdir(), "kamn-live-task-"));
+	const agentAKey = resolve(root, "agent-a.key");
+	const agentBKey = resolve(root, "agent-b.key");
+	const agentCKey = resolve(root, "agent-c.key");
+	const stopFile = resolve(root, "stop");
+	await writeFile(agentAKey, "test-agent-a-key\n");
+	await writeFile(agentBKey, "test-agent-b-key\n");
+	await writeFile(agentCKey, "test-agent-c-key\n");
+	await chmod(fixture, 0o755);
+	return {
+		root, stopFile,
+		env: {
+			KAMN_MVP_PI_RUN_ID: "test-run",
+			KAMN_SERVICE_API_LIVE_SOLANA_SETTLEMENT_LAMPORTS: "1000000",
+			KAMN_MVP_LIVE_MCP_BINARY: fixture,
+			KAMN_MVP_LIVE_MCP_ENDPOINT: "http://127.0.0.1:18278",
+			KAMN_MVP_LIVE_MCP_AGENT_A_NAME: "agent-a",
+			KAMN_MVP_LIVE_MCP_AGENT_A_KEY_FILE: agentAKey,
+			KAMN_MVP_LIVE_MCP_AGENT_B_NAME: "agent-b",
+			KAMN_MVP_LIVE_MCP_AGENT_B_KEY_FILE: agentBKey,
+			KAMN_MVP_LIVE_MCP_AGENT_C_NAME: "agent-c",
+			KAMN_MVP_LIVE_MCP_AGENT_C_KEY_FILE: agentCKey,
+			KAMN_MVP_FAKE_MCP_STOP_FILE: stopFile,
+			...extra,
+		},
+	};
+}
+
+export function completionDigest(termsDigest: string): string {
+	return createHash("sha256").update(`completed:${termsDigest}`).digest("hex");
+}
+
+export function projectedReceipt(receipt: Record<string, unknown>) {
+	return {
+		receipt_id: receipt.service_receipt_id, receipt_digest: receipt.service_receipt_digest,
+		action: receipt.action, resource_id: receipt.resource_id, resulting_state: receipt.resulting_state,
+	};
+}

--- a/.pi/extensions/kamn-mvp/live-task-workflow-validation.test.ts
+++ b/.pi/extensions/kamn-mvp/live-task-workflow-validation.test.ts
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { LiveTaskWorkflow } from "./live-task-workflow.ts";
+import { testSetup } from "./live-task-workflow-test-support.ts";
+
+test("workflow rejects calls that violate registration and task order", async () => {
+	const setup = await testSetup();
+	const workflow = new LiveTaskWorkflow(setup.env, process.cwd());
+	await assert.rejects(workflow.createTask("title", "description", "kamn:did:provider"), /Register Agent A/);
+	await assert.rejects(workflow.acceptTask(), /Register Agent B/);
+	await workflow.register("agent_a");
+	await assert.rejects(workflow.createTask(" ", "description", "kamn:did:provider"), /title/);
+	await assert.rejects(workflow.queryTask("agent_a"), /Create a task/);
+	await workflow.shutdown();
+});
+
+test("workflow rejects duplicate participant DIDs", async () => {
+	const setup = await testSetup({ KAMN_MVP_FAKE_MCP_RESULT_MODE: "same-did" });
+	const workflow = new LiveTaskWorkflow(setup.env, process.cwd());
+	await workflow.register("agent_a");
+	await assert.rejects(workflow.register("agent_b"), /must be distinct/);
+	await workflow.shutdown();
+});
+
+for (const [mode, expected] of [
+	["missing-task-id", /MCP_AUTHORITY_RECEIPT_MISSING/],
+	["wrong-create-state", /MCP_AUTHORITY_RECEIPT_INVALID/],
+] as const) {
+	test(`workflow rejects ${mode} creation result`, async () => {
+		const setup = await testSetup({ KAMN_MVP_FAKE_MCP_RESULT_MODE: mode });
+		const workflow = new LiveTaskWorkflow(setup.env, process.cwd());
+		await workflow.register("agent_a");
+		await assert.rejects(workflow.createTask("title", "description", "kamn:did:provider"), expected);
+		await workflow.shutdown();
+	});
+}
+
+test("workflow rejects mismatched acceptance and task projections", async () => {
+	const mismatch = await testSetup({ KAMN_MVP_FAKE_MCP_RESULT_MODE: "wrong-accept-id" });
+	const workflow = new LiveTaskWorkflow(mismatch.env, process.cwd());
+	await workflow.register("agent_a");
+	await workflow.register("agent_b");
+	await workflow.createTask("title", "description", "kamn:did:provider");
+	await assert.rejects(workflow.acceptTask(), /different task ID/);
+	await workflow.shutdown();
+
+	const wrongState = await testSetup({ KAMN_MVP_FAKE_MCP_RESULT_MODE: "wrong-query-state" });
+	const queried = new LiveTaskWorkflow(wrongState.env, process.cwd());
+	await queried.register("agent_a");
+	await queried.register("agent_b");
+	await queried.createTask("title", "description", "kamn:did:provider");
+	await queried.acceptTask();
+	await assert.rejects(queried.queryTask("agent_a"), /expected accepted/);
+	await queried.shutdown();
+});
+
+test("independent workflows hand off one external task", async () => {
+	const setupA = await testSetup();
+	const setupB = await testSetup();
+	const agentA = new LiveTaskWorkflow(setupA.env, process.cwd());
+	const agentB = new LiveTaskWorkflow(setupB.env, process.cwd());
+	await agentA.register("agent_a");
+	await agentB.register("agent_b");
+	const created = await agentA.createTask("title", "description", "kamn:did:agent-b");
+	agentB.importTask(String(created.task_id), {
+		transaction_id: String(created.transaction_id), terms_digest: String(created.terms_digest), provider_did: String(created.provider_did),
+	});
+	const accepted = await agentB.acceptTask();
+	assert.equal(accepted.idempotency_key, `${created.transaction_id}-accept`);
+	await agentB.queryTask("agent_b");
+	const observed = await agentA.waitForAccepted("agent_a", { timeoutMs: 100, pollMs: 5 });
+	assert.deepEqual(agentA.acceptedObservation("agent_a"), observed);
+	await agentA.shutdown();
+	await agentB.shutdown();
+});
+
+test("external task import and acceptance polling fail closed", async () => {
+	const setup = await testSetup({ KAMN_MVP_FAKE_MCP_RESULT_MODE: "wrong-query-state" });
+	const workflow = new LiveTaskWorkflow(setup.env, process.cwd());
+	assert.throws(() => workflow.importTask("bad task id"), /invalid/);
+	workflow.importTask("task-live-1");
+	assert.throws(() => workflow.importTask("task-other"), /conflicts/);
+	await workflow.register("agent_a");
+	await assert.rejects(workflow.waitForAccepted("agent_a", { timeoutMs: 20, pollMs: 5 }), /timed out/);
+	const controller = new AbortController();
+	controller.abort();
+	await assert.rejects(workflow.waitForAccepted("agent_a", { timeoutMs: 20, pollMs: 5 }, controller.signal), /aborted/);
+	await workflow.shutdown();
+});

--- a/.pi/extensions/kamn-mvp/live-task-workflow.test.ts
+++ b/.pi/extensions/kamn-mvp/live-task-workflow.test.ts
@@ -70,9 +70,9 @@ test("three agents drive one completed escrow transaction through independent MC
 	assert.equal(viewC.task_id, created.task_id);
 	assert.equal(viewA.public_commitment, viewB.public_commitment);
 	assert.equal(viewB.public_commitment, viewC.public_commitment);
-	assert.equal(viewA.private_receipt_digest, "sha256:participant-a");
-	assert.equal(viewB.private_receipt_digest, "sha256:participant-b");
-	assert.equal("private_receipt_digest" in viewC, false);
+	assert.deepEqual(viewA.receipt_chain_receipts, workflow.provenance("agent_a").service_authority_receipts.map(projectedReceipt));
+	assert.deepEqual(viewB.receipt_chain_receipts, workflow.provenance("agent_b").service_authority_receipts.map(projectedReceipt));
+	assert.equal("receipt_chain_receipts" in viewC, false);
 	for (const [role, pid, scope] of [
 		["agent_a", 101, "participant-private"],
 		["agent_b", 202, "participant-private"],
@@ -83,14 +83,16 @@ test("three agents drive one completed escrow transaction through independent MC
 		assert.equal(evidence.did, `kamn:did:${role.replace("agent_", "agent-")}`);
 		assert.equal(evidence.view_scope, scope);
 		if (role !== "agent_c") assert.equal(evidence.participant_role, role === "agent_a" ? "creator" : "provider");
-		assert.equal(evidence.runtime_projection_digest, workflow.provenance(role).runtime_response_digests.at(-1));
+		assert.deepEqual(evidence.service_receipts, workflow.provenance(role).service_authority_receipts);
+		assert.equal(evidence.receipt_chain_commitment, viewC.receipt_chain_commitment);
 		assert.equal(evidence.handoff_authorized, false);
 	}
 	for (const role of ["agent_a", "agent_b", "agent_c"] as const) {
 		const provenance = workflow.provenance(role);
 		assert.ok(provenance.child_process_id > 0);
 		assert.ok(provenance.last_request_id >= provenance.first_request_id);
-		assert.equal(provenance.runtime_response_digests.every((value) => value.startsWith("sha256:")), true);
+		assert.equal(provenance.transport_response_digests.every((value) => value.startsWith("sha256:")), true);
+		assert.match(provenance.service_profile_commitment, /^sha256:[0-9a-f]{64}$/);
 	}
 	await workflow.shutdown();
 });
@@ -105,10 +107,10 @@ test("ambiguous release survives multiple observations on the same MCP child and
 	const released = await workflow.releaseEscrow();
 	const provenance = workflow.provenance("agent_a");
 
-	assert.equal(released.state, "released");
-	assert.deepEqual(provenance.runtime_response_receipts.slice(-4).map((receipt) => receipt.outcome), ["error", "error", "error", "success"]);
-	assert.equal(provenance.runtime_response_receipts.slice(-4).every((receipt) => receipt.tool === "release_escrow"), true);
-	assert.equal(provenance.runtime_response_receipts.at(-2)?.digest.startsWith("sha256:"), true);
+	assert.equal(released.state, "release-authorized");
+	assert.deepEqual(provenance.transport_response_receipts.slice(-4).map((receipt) => receipt.outcome), ["error", "error", "error", "success"]);
+	assert.equal(provenance.transport_response_receipts.slice(-4).every((receipt) => receipt.tool === "release_escrow"), true);
+	assert.equal(provenance.transport_response_receipts.at(-2)?.digest.startsWith("sha256:"), true);
 	assert.equal(provenance.last_request_id, 7);
 	await workflow.shutdown();
 });
@@ -122,7 +124,7 @@ test("participant projection waits through multiple interim views for finalized 
 	const projection = await workflow.queryParticipantProjection("agent_a");
 
 	assert.equal(projection.settlement_tx_signature, "devnet-signature-1");
-	assert.equal(workflow.provenance("agent_a").runtime_response_receipts.filter(
+	assert.equal(workflow.provenance("agent_a").transport_response_receipts.filter(
 		(receipt) => receipt.tool === "query_participant_task_projection",
 	).length, 4);
 	await workflow.shutdown();
@@ -159,7 +161,7 @@ test("authenticated workflow calls retain and back off after a typed rate limit"
 	const workflow = new LiveTaskWorkflow(setup.env, process.cwd());
 	await workflow.register("agent_a");
 	const created = await workflow.createTask("Rate proof", "Respect server backoff", "kamn:did:provider");
-	const receipts = workflow.provenance("agent_a").runtime_response_receipts;
+	const receipts = workflow.provenance("agent_a").transport_response_receipts;
 
 	assert.equal(created.task_id, "task-live-1");
 	assert.deepEqual(receipts.slice(-2).map((receipt) => receipt.outcome), ["error", "success"]);
@@ -200,8 +202,8 @@ test("workflow rejects duplicate participant DIDs", async () => {
 });
 
 for (const [mode, expected] of [
-	["missing-task-id", /omitted task_id/],
-	["wrong-create-state", /expected submitted/],
+	["missing-task-id", /MCP_AUTHORITY_RECEIPT_INVALID/],
+	["wrong-create-state", /MCP_AUTHORITY_RECEIPT_INVALID/],
 ] as const) {
 	test(`workflow rejects ${mode} creation result`, async () => {
 		const setup = await testSetup({ KAMN_MVP_FAKE_MCP_RESULT_MODE: mode });
@@ -278,6 +280,16 @@ test("external task import and acceptance polling fail closed", async () => {
 	await assert.rejects(workflow.waitForAccepted("agent_a", { timeoutMs: 20, pollMs: 5 }, controller.signal), /aborted/);
 	await workflow.shutdown();
 });
+
+function projectedReceipt(receipt: Record<string, unknown>) {
+	return {
+		receipt_id: receipt.service_receipt_id,
+		receipt_digest: receipt.service_receipt_digest,
+		action: receipt.action,
+		resource_id: receipt.resource_id,
+		resulting_state: receipt.resulting_state,
+	};
+}
 
 async function testSetup(extra: Record<string, string> = {}) {
 	const root = await mkdtemp(resolve(tmpdir(), "kamn-live-task-"));

--- a/.pi/extensions/kamn-mvp/live-task-workflow.test.ts
+++ b/.pi/extensions/kamn-mvp/live-task-workflow.test.ts
@@ -179,6 +179,19 @@ test("actor evidence requires a registered identity and final runtime projection
 	await workflow.shutdown();
 });
 
+test("actor evidence rejects projection receipts that disagree with service authority", async () => {
+	const setup = await testSetup({ KAMN_MVP_FAKE_MCP_RESULT_MODE: "projection-authority-mismatch" });
+	const workflow = new LiveTaskWorkflow(setup.env, process.cwd());
+	await workflow.register("agent_a");
+	const agentB = await workflow.register("agent_b");
+	await workflow.createTask("Authority", "Reject copied projection receipt", String(agentB.did));
+	await workflow.fundEscrow();
+	await workflow.releaseEscrow();
+	await workflow.queryParticipantProjection("agent_a");
+	assert.throws(() => workflow.actorEvidence("agent_a", 101, `sha256:${"b".repeat(64)}`), /PI_SERVICE_AUTHORITY_MISMATCH/);
+	await workflow.shutdown();
+});
+
 test("workflow rejects calls that violate registration and task order", async () => {
 	const setup = await testSetup();
 	const workflow = new LiveTaskWorkflow(setup.env, process.cwd());
@@ -202,7 +215,7 @@ test("workflow rejects duplicate participant DIDs", async () => {
 });
 
 for (const [mode, expected] of [
-	["missing-task-id", /MCP_AUTHORITY_RECEIPT_INVALID/],
+	["missing-task-id", /MCP_AUTHORITY_RECEIPT_MISSING/],
 	["wrong-create-state", /MCP_AUTHORITY_RECEIPT_INVALID/],
 ] as const) {
 	test(`workflow rejects ${mode} creation result`, async () => {

--- a/.pi/extensions/kamn-mvp/live-task-workflow.test.ts
+++ b/.pi/extensions/kamn-mvp/live-task-workflow.test.ts
@@ -1,17 +1,12 @@
 import assert from "node:assert/strict";
-import { createHash } from "node:crypto";
-import { chmod, mkdtemp, readFile, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { resolve } from "node:path";
+import { readFile } from "node:fs/promises";
 import test from "node:test";
 import { LiveTaskWorkflow } from "./live-task-workflow.ts";
-
-const fixture = resolve(".pi/extensions/kamn-mvp/test-fixtures/fake-mcp-server.mjs");
+import { completionDigest, projectedReceipt, testSetup } from "./live-task-workflow-test-support.ts";
 
 test("two agents register and share one accepted task through independent sessions", async () => {
 	const setup = await testSetup();
 	const workflow = new LiveTaskWorkflow(setup.env, process.cwd());
-
 	const agentA = await workflow.register("agent_a");
 	const agentB = await workflow.register("agent_b");
 	const created = await workflow.createTask("Review proof", "Validate the local task lifecycle", String(agentB.did));
@@ -24,12 +19,10 @@ test("two agents register and share one accepted task through independent sessio
 	assert.deepEqual([agentA.request_id, created.request_id, queryA.request_id], ["1", "2", "3"]);
 	assert.deepEqual([agentB.request_id, accepted.request_id, queryB.request_id], ["1", "2", "3"]);
 	assert.equal(created.title, "Review proof");
-	assert.equal(created.description, "Validate the local task lifecycle");
 	for (const result of [accepted, queryA, queryB]) {
 		assert.equal(result.task_id, created.task_id);
 		assert.equal(result.state, "accepted");
 	}
-
 	await workflow.shutdown();
 	await workflow.shutdown();
 	assert.equal((await readFile(setup.stopFile, "utf8")).trim().split("\n").length, 2);
@@ -55,280 +48,38 @@ test("three agents drive one completed escrow transaction through independent MC
 	assert.equal(created.provider_did, agentB.did);
 	assert.match(String(created.transaction_id), /^pi-devnet-[a-f0-9]{16}$/);
 	assert.match(String(created.terms_digest), /^[a-f0-9]{64}$/);
-	assert.match(String(created.idempotency_key), /-create$/);
 	assert.equal(accepted.idempotency_key, `${created.transaction_id}-accept`);
 	assert.equal(completed.idempotency_key, `${created.transaction_id}-complete`);
 	assert.equal(completed.completion_evidence_digest, completionDigest(String(created.terms_digest)));
 	assert.equal(funded.transaction_id, created.transaction_id);
-	assert.equal(funded.terms_digest, created.terms_digest);
 	assert.equal(funded.beneficiary_did, agentB.did);
-	assert.equal(funded.amount_lamports, 1000000);
 	assert.equal(released.idempotency_key, `${created.transaction_id}-release`);
 	assert.equal(funded.escrow_id, released.escrow_id);
-	assert.equal(viewA.task_id, created.task_id);
-	assert.equal(viewB.task_id, created.task_id);
-	assert.equal(viewC.task_id, created.task_id);
 	assert.equal(viewA.public_commitment, viewB.public_commitment);
 	assert.equal(viewB.public_commitment, viewC.public_commitment);
 	assert.deepEqual(viewA.receipt_chain_receipts, workflow.provenance("agent_a").service_authority_receipts.map(projectedReceipt));
 	assert.deepEqual(viewB.receipt_chain_receipts, workflow.provenance("agent_b").service_authority_receipts.map(projectedReceipt));
 	assert.equal("receipt_chain_receipts" in viewC, false);
-	for (const [role, pid, scope] of [
-		["agent_a", 101, "participant-private"],
-		["agent_b", 202, "participant-private"],
-		["agent_c", 303, "restricted-public"],
-	] as const) {
+	for (const [role, pid, scope] of actorCases()) {
 		const evidence = workflow.actorEvidence(role, pid, `sha256:${"b".repeat(64)}`);
 		assert.equal(evidence.pi_process_id, pid);
-		assert.equal(evidence.did, `kamn:did:${role.replace("agent_", "agent-")}`);
 		assert.equal(evidence.view_scope, scope);
-		if (role !== "agent_c") assert.equal(evidence.participant_role, role === "agent_a" ? "creator" : "provider");
 		assert.deepEqual(evidence.service_receipts, workflow.provenance(role).service_authority_receipts);
 		assert.equal(evidence.receipt_chain_commitment, viewC.receipt_chain_commitment);
-		assert.equal(evidence.handoff_authorized, false);
 	}
 	for (const role of ["agent_a", "agent_b", "agent_c"] as const) {
 		const provenance = workflow.provenance(role);
 		assert.ok(provenance.child_process_id > 0);
-		assert.ok(provenance.last_request_id >= provenance.first_request_id);
 		assert.equal(provenance.transport_response_digests.every((value) => value.startsWith("sha256:")), true);
 		assert.match(provenance.service_profile_commitment, /^sha256:[0-9a-f]{64}$/);
 	}
 	await workflow.shutdown();
 });
 
-test("ambiguous release survives multiple observations on the same MCP child and idempotency key", async () => {
-	const setup = await testSetup({ KAMN_MVP_FAKE_MCP_MODE: "ambiguous-three-releases" });
-	const workflow = new LiveTaskWorkflow(setup.env, process.cwd());
-	await workflow.register("agent_a");
-	const agentB = await workflow.register("agent_b");
-	await workflow.createTask("Settle proof", "Reconcile one signature", String(agentB.did));
-	await workflow.fundEscrow();
-	const released = await workflow.releaseEscrow();
-	const provenance = workflow.provenance("agent_a");
-
-	assert.equal(released.state, "release-authorized");
-	assert.deepEqual(provenance.transport_response_receipts.slice(-4).map((receipt) => receipt.outcome), ["error", "error", "error", "success"]);
-	assert.equal(provenance.transport_response_receipts.slice(-4).every((receipt) => receipt.tool === "release_escrow"), true);
-	assert.equal(provenance.transport_response_receipts.at(-2)?.digest.startsWith("sha256:"), true);
-	assert.equal(provenance.last_request_id, 7);
-	await workflow.shutdown();
-});
-
-test("participant projection waits through multiple interim views for finalized settlement fields", async () => {
-	const setup = await testSetup({ KAMN_MVP_FAKE_MCP_RESULT_MODE: "pending-three-projections" });
-	const workflow = new LiveTaskWorkflow(setup.env, process.cwd());
-	await workflow.register("agent_a");
-	const agentB = await workflow.register("agent_b");
-	await workflow.createTask("Settle proof", "Wait for finalized view", String(agentB.did));
-	const projection = await workflow.queryParticipantProjection("agent_a");
-
-	assert.equal(projection.settlement_tx_signature, "devnet-signature-1");
-	assert.equal(workflow.provenance("agent_a").transport_response_receipts.filter(
-		(receipt) => receipt.tool === "query_participant_task_projection",
-	).length, 4);
-	await workflow.shutdown();
-});
-
-test("Agent B waits for a runtime escrow binding before completion", async () => {
-	const setup = await testSetup({ KAMN_MVP_FAKE_MCP_RESULT_MODE: "missing-first-escrow" });
-	const workflow = new LiveTaskWorkflow(setup.env, process.cwd());
-	await workflow.register("agent_b");
-	workflow.importTask("task-live-1", {
-		transaction_id: "transaction-live-1", terms_digest: "a".repeat(64), provider_did: "kamn:did:agent-b",
-	});
-	const projection = await workflow.waitForEscrowFunding();
-
-	assert.equal(projection.escrow_id, "escrow-live-1");
-	assert.equal(workflow.provenance("agent_b").last_request_id, 3);
-	await workflow.shutdown();
-});
-
-test("Agent A waits for completed task state before release", async () => {
-	const setup = await testSetup({ KAMN_MVP_FAKE_MCP_RESULT_MODE: "completed-second-query" });
-	const workflow = new LiveTaskWorkflow(setup.env, process.cwd());
-	await workflow.register("agent_a");
-	workflow.importTask("task-live-1");
-	const task = await workflow.waitForCompleted("agent_a", { timeoutMs: 100, pollMs: 5 });
-
-	assert.equal(task.state, "completed");
-	assert.equal(workflow.provenance("agent_a").last_request_id, 3);
-	await workflow.shutdown();
-});
-
-test("authenticated workflow calls retain and back off after a typed rate limit", async () => {
-	const setup = await testSetup({ KAMN_MVP_FAKE_MCP_MODE: "rate-limit-on-second" });
-	const workflow = new LiveTaskWorkflow(setup.env, process.cwd());
-	await workflow.register("agent_a");
-	const created = await workflow.createTask("Rate proof", "Respect server backoff", "kamn:did:provider");
-	const receipts = workflow.provenance("agent_a").transport_response_receipts;
-
-	assert.equal(created.task_id, "task-live-1");
-	assert.deepEqual(receipts.slice(-2).map((receipt) => receipt.outcome), ["error", "success"]);
-	assert.equal(receipts.at(-1)?.request_id, 3);
-	await workflow.shutdown();
-});
-
-test("actor evidence requires a registered identity and final runtime projection", async () => {
-	const setup = await testSetup();
-	const workflow = new LiveTaskWorkflow(setup.env, process.cwd());
-	assert.throws(() => workflow.actorEvidence("agent_c", 303, `sha256:${"b".repeat(64)}`), /Register Agent C/);
-	await workflow.register("agent_c");
-	workflow.importTask("task-live-1");
-	assert.throws(() => workflow.actorEvidence("agent_c", 303, `sha256:${"b".repeat(64)}`), /projection/);
-	await workflow.shutdown();
-});
-
-test("actor evidence rejects projection receipts that disagree with service authority", async () => {
-	const setup = await testSetup({ KAMN_MVP_FAKE_MCP_RESULT_MODE: "projection-authority-mismatch" });
-	const workflow = new LiveTaskWorkflow(setup.env, process.cwd());
-	await workflow.register("agent_a");
-	const agentB = await workflow.register("agent_b");
-	await workflow.createTask("Authority", "Reject copied projection receipt", String(agentB.did));
-	await workflow.fundEscrow();
-	await workflow.releaseEscrow();
-	await workflow.queryParticipantProjection("agent_a");
-	assert.throws(() => workflow.actorEvidence("agent_a", 101, `sha256:${"b".repeat(64)}`), /PI_SERVICE_AUTHORITY_MISMATCH/);
-	await workflow.shutdown();
-});
-
-test("workflow rejects calls that violate registration and task order", async () => {
-	const setup = await testSetup();
-	const workflow = new LiveTaskWorkflow(setup.env, process.cwd());
-
-	await assert.rejects(workflow.createTask("title", "description", "kamn:did:provider"), /Register Agent A/);
-	await assert.rejects(workflow.acceptTask(), /Register Agent B/);
-	await assert.rejects(workflow.queryTask("agent_a"), /Register Agent A/);
-	await workflow.register("agent_a");
-	await assert.rejects(workflow.createTask(" ", "description", "kamn:did:provider"), /title/);
-	await assert.rejects(workflow.queryTask("agent_a"), /Create a task/);
-	await workflow.shutdown();
-});
-
-test("workflow rejects duplicate participant DIDs", async () => {
-	const setup = await testSetup({ KAMN_MVP_FAKE_MCP_RESULT_MODE: "same-did" });
-	const workflow = new LiveTaskWorkflow(setup.env, process.cwd());
-	await workflow.register("agent_a");
-
-	await assert.rejects(workflow.register("agent_b"), /must be distinct/);
-	await workflow.shutdown();
-});
-
-for (const [mode, expected] of [
-	["missing-task-id", /MCP_AUTHORITY_RECEIPT_MISSING/],
-	["wrong-create-state", /MCP_AUTHORITY_RECEIPT_INVALID/],
-] as const) {
-	test(`workflow rejects ${mode} creation result`, async () => {
-		const setup = await testSetup({ KAMN_MVP_FAKE_MCP_RESULT_MODE: mode });
-		const workflow = new LiveTaskWorkflow(setup.env, process.cwd());
-		await workflow.register("agent_a");
-
-		await assert.rejects(workflow.createTask("title", "description", "kamn:did:provider"), expected);
-		await workflow.shutdown();
-	});
-}
-
-function completionDigest(termsDigest: string): string {
-	return createHash("sha256").update(`completed:${termsDigest}`).digest("hex");
-}
-
-test("workflow rejects a mismatched acceptance task ID", async () => {
-	const setup = await testSetup({ KAMN_MVP_FAKE_MCP_RESULT_MODE: "wrong-accept-id" });
-	const workflow = new LiveTaskWorkflow(setup.env, process.cwd());
-	await workflow.register("agent_a");
-	await workflow.register("agent_b");
-	await workflow.createTask("title", "description", "kamn:did:provider");
-
-	await assert.rejects(workflow.acceptTask(), /different task ID/);
-	await workflow.shutdown();
-});
-
-test("workflow rejects a non-accepted query projection", async () => {
-	const setup = await testSetup({ KAMN_MVP_FAKE_MCP_RESULT_MODE: "wrong-query-state" });
-	const workflow = new LiveTaskWorkflow(setup.env, process.cwd());
-	await workflow.register("agent_a");
-	await workflow.register("agent_b");
-	await workflow.createTask("title", "description", "kamn:did:provider");
-	await workflow.acceptTask();
-
-	await assert.rejects(workflow.queryTask("agent_a"), /expected accepted/);
-	await workflow.shutdown();
-});
-
-test("Agent B imports an external task while Agent A polls accepted state", async () => {
-	const setupA = await testSetup();
-	const setupB = await testSetup();
-	const agentA = new LiveTaskWorkflow(setupA.env, process.cwd());
-	const agentB = new LiveTaskWorkflow(setupB.env, process.cwd());
-	await agentA.register("agent_a");
-	await agentB.register("agent_b");
-	const created = await agentA.createTask("title", "description", "kamn:did:agent-b");
-	agentB.importTask(String(created.task_id), {
-		transaction_id: String(created.transaction_id),
-		terms_digest: String(created.terms_digest),
-		provider_did: String(created.provider_did),
-	});
-
-	const accepted = await agentB.acceptTask();
-	assert.equal(accepted.idempotency_key, `${created.transaction_id}-accept`);
-	await agentB.queryTask("agent_b");
-	const observed = await agentA.waitForAccepted("agent_a", { timeoutMs: 100, pollMs: 5 });
-	assert.deepEqual(agentA.acceptedObservation("agent_a"), observed);
-	assert.equal(agentB.acceptedObservation("agent_b").task_id, created.task_id);
-	await agentA.shutdown();
-	await agentB.shutdown();
-});
-
-test("external task import and acceptance polling fail closed", async () => {
-	const setup = await testSetup({ KAMN_MVP_FAKE_MCP_RESULT_MODE: "wrong-query-state" });
-	const workflow = new LiveTaskWorkflow(setup.env, process.cwd());
-	assert.throws(() => workflow.importTask("bad task id"), /invalid/);
-	workflow.importTask("task-live-1");
-	assert.throws(() => workflow.importTask("task-other"), /conflicts/);
-	await workflow.register("agent_a");
-
-	await assert.rejects(workflow.waitForAccepted("agent_a", { timeoutMs: 20, pollMs: 5 }), /timed out/);
-	const controller = new AbortController();
-	controller.abort();
-	await assert.rejects(workflow.waitForAccepted("agent_a", { timeoutMs: 20, pollMs: 5 }, controller.signal), /aborted/);
-	await workflow.shutdown();
-});
-
-function projectedReceipt(receipt: Record<string, unknown>) {
-	return {
-		receipt_id: receipt.service_receipt_id,
-		receipt_digest: receipt.service_receipt_digest,
-		action: receipt.action,
-		resource_id: receipt.resource_id,
-		resulting_state: receipt.resulting_state,
-	};
-}
-
-async function testSetup(extra: Record<string, string> = {}) {
-	const root = await mkdtemp(resolve(tmpdir(), "kamn-live-task-"));
-	const agentAKey = resolve(root, "agent-a.key");
-	const agentBKey = resolve(root, "agent-b.key");
-	const agentCKey = resolve(root, "agent-c.key");
-	const stopFile = resolve(root, "stop");
-	await writeFile(agentAKey, "test-agent-a-key\n");
-	await writeFile(agentBKey, "test-agent-b-key\n");
-	await writeFile(agentCKey, "test-agent-c-key\n");
-	await chmod(fixture, 0o755);
-	return {
-		stopFile,
-			env: {
-				KAMN_MVP_PI_RUN_ID: "test-run",
-				KAMN_SERVICE_API_LIVE_SOLANA_SETTLEMENT_LAMPORTS: "1000000",
-			KAMN_MVP_LIVE_MCP_BINARY: fixture,
-			KAMN_MVP_LIVE_MCP_ENDPOINT: "http://127.0.0.1:18278",
-			KAMN_MVP_LIVE_MCP_AGENT_A_NAME: "agent-a",
-			KAMN_MVP_LIVE_MCP_AGENT_A_KEY_FILE: agentAKey,
-			KAMN_MVP_LIVE_MCP_AGENT_B_NAME: "agent-b",
-			KAMN_MVP_LIVE_MCP_AGENT_B_KEY_FILE: agentBKey,
-			KAMN_MVP_LIVE_MCP_AGENT_C_NAME: "agent-c",
-			KAMN_MVP_LIVE_MCP_AGENT_C_KEY_FILE: agentCKey,
-			KAMN_MVP_FAKE_MCP_STOP_FILE: stopFile,
-			...extra,
-		},
-	};
+function actorCases() {
+	return [
+		["agent_a", 101, "participant-private"],
+		["agent_b", 202, "participant-private"],
+		["agent_c", 303, "restricted-public"],
+	] as const;
 }

--- a/.pi/extensions/kamn-mvp/live-task-workflow.ts
+++ b/.pi/extensions/kamn-mvp/live-task-workflow.ts
@@ -84,7 +84,7 @@ export class LiveTaskWorkflow {
 		const result = await reconcileAmbiguousRelease(
 			() => this.call("agent_a", "release_escrow", { escrow_id: escrowId, payload }, signal), signal,
 		);
-		validateEscrowResult(result, escrowId, "released", "escrow release");
+		validateEscrowResult(result, escrowId, "release-authorized", "escrow release");
 		return result;
 	}
 	async queryParticipantProjection(role: "agent_a" | "agent_b", signal?: AbortSignal): Promise<WorkflowResult> {

--- a/.pi/extensions/kamn-mvp/mcp-authority.ts
+++ b/.pi/extensions/kamn-mvp/mcp-authority.ts
@@ -38,7 +38,8 @@ export function validateAuthority(tool: string, result: JsonObject, expectedActo
 }
 
 function validateEnvelopeHeader(result: JsonObject) {
-	if (result.schema_version === undefined || result.authority_kind === undefined || result.source === undefined) {
+	if (result.schema_version === undefined || result.authority_kind === undefined || result.source === undefined
+		|| result.service_result === undefined) {
 		throw new Error("MCP_AUTHORITY_RECEIPT_MISSING");
 	}
 	if (result.schema_version !== SCHEMA || result.source !== SOURCE || !isObject(result.service_result)) {
@@ -80,11 +81,13 @@ function validateMutation(tool: keyof typeof MUTATIONS, result: JsonObject, expe
 }
 
 function objectField(value: JsonObject, field: string): JsonObject {
+	if (value[field] === undefined) throw new Error("MCP_AUTHORITY_RECEIPT_MISSING");
 	if (isObject(value[field])) return value[field];
 	throw new Error("MCP_AUTHORITY_RECEIPT_INVALID");
 }
 function stringField(value: JsonObject, field: string): string {
 	const parsed = value[field];
+	if (parsed === undefined) throw new Error("MCP_AUTHORITY_RECEIPT_MISSING");
 	if (typeof parsed === "string" && parsed.length > 0) return parsed;
 	throw new Error("MCP_AUTHORITY_RECEIPT_INVALID");
 }

--- a/.pi/extensions/kamn-mvp/mcp-authority.ts
+++ b/.pi/extensions/kamn-mvp/mcp-authority.ts
@@ -1,0 +1,98 @@
+type JsonObject = Record<string, unknown>;
+
+const SCHEMA = "kamn.mcp.authority-receipt.v1";
+const SOURCE = "kamn-service";
+const MUTATIONS = {
+	create_task: { action: "task:create", resource: "task_id", states: ["submitted"] },
+	accept_task: { action: "task:accept", resource: "task_id", states: ["accepted"] },
+	complete_task: { action: "task:complete", resource: "task_id", states: ["completed"] },
+	fund_escrow: { action: "escrow:fund", resource: "escrow_id", states: ["funded"] },
+	release_escrow: { action: "escrow:release-authorize", resource: "escrow_id", states: ["release-authorized", "released"] },
+} as const;
+
+export type ServiceAuthorityReceipt = {
+	actor_did: string;
+	tool: string;
+	action: string;
+	resource_id: string;
+	resulting_state: string;
+	service_receipt_id: string;
+	service_receipt_digest: string;
+};
+export type ValidatedAuthority = {
+	serviceResult: JsonObject;
+	profileCommitment?: string;
+	receipt?: ServiceAuthorityReceipt;
+};
+
+export function requiresAuthority(tool: string): boolean {
+	return tool === "register" || tool in MUTATIONS;
+}
+
+export function validateAuthority(tool: string, result: JsonObject, expectedActor?: string): ValidatedAuthority {
+	if (!requiresAuthority(tool)) return { serviceResult: result };
+	validateEnvelopeHeader(result);
+	return tool === "register"
+		? validateRegistration(result)
+		: validateMutation(tool as keyof typeof MUTATIONS, result, expectedActor);
+}
+
+function validateEnvelopeHeader(result: JsonObject) {
+	if (result.schema_version === undefined || result.authority_kind === undefined || result.source === undefined) {
+		throw new Error("MCP_AUTHORITY_RECEIPT_MISSING");
+	}
+	if (result.schema_version !== SCHEMA || result.source !== SOURCE || !isObject(result.service_result)) {
+		throw new Error("MCP_AUTHORITY_RECEIPT_INVALID");
+	}
+}
+
+function validateRegistration(result: JsonObject): ValidatedAuthority {
+	const serviceResult = objectField(result, "service_result");
+	const actor = stringField(result, "actor_did");
+	const commitment = digestField(result, "profile_commitment");
+	if (result.authority_kind !== "service-profile-commitment" || result.tool !== "register"
+		|| result.resource_id !== actor || serviceResult.did !== actor || serviceResult.profile_commitment !== commitment) {
+		throw new Error("MCP_AUTHORITY_RECEIPT_INVALID");
+	}
+	return { serviceResult, profileCommitment: commitment };
+}
+
+function validateMutation(tool: keyof typeof MUTATIONS, result: JsonObject, expectedActor?: string): ValidatedAuthority {
+	const contract = MUTATIONS[tool];
+	const serviceResult = objectField(result, "service_result");
+	const actor = stringField(result, "actor_did");
+	const resource = stringField(result, "resource_id");
+	const state = stringField(result, "resulting_state");
+	const receiptId = stringField(result, "service_receipt_id");
+	const receiptDigest = digestField(result, "service_receipt_digest");
+	if (!expectedActor || result.authority_kind !== "service-receipt" || result.tool !== tool
+		|| actor !== expectedActor || serviceResult.actor_did !== actor || serviceResult.action !== contract.action
+		|| serviceResult[contract.resource] !== resource || serviceResult.state !== state
+		|| serviceResult.receipt_id !== receiptId || serviceResult.receipt_digest !== receiptDigest
+		|| !contract.states.some((candidate) => candidate === state)) {
+		throw new Error("MCP_AUTHORITY_RECEIPT_INVALID");
+	}
+	return {
+		serviceResult,
+		receipt: { actor_did: actor, tool, action: contract.action, resource_id: resource, resulting_state: state,
+			service_receipt_id: receiptId, service_receipt_digest: receiptDigest },
+	};
+}
+
+function objectField(value: JsonObject, field: string): JsonObject {
+	if (isObject(value[field])) return value[field];
+	throw new Error("MCP_AUTHORITY_RECEIPT_INVALID");
+}
+function stringField(value: JsonObject, field: string): string {
+	const parsed = value[field];
+	if (typeof parsed === "string" && parsed.length > 0) return parsed;
+	throw new Error("MCP_AUTHORITY_RECEIPT_INVALID");
+}
+function digestField(value: JsonObject, field: string): string {
+	const parsed = stringField(value, field);
+	if (/^sha256:[0-9a-f]{64}$/.test(parsed)) return parsed;
+	throw new Error("MCP_AUTHORITY_RECEIPT_INVALID");
+}
+function isObject(value: unknown): value is JsonObject {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/.pi/extensions/kamn-mvp/mcp-provenance.ts
+++ b/.pi/extensions/kamn-mvp/mcp-provenance.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import type { ServiceAuthorityReceipt } from "./mcp-authority.ts";
 
 type JsonObject = Record<string, unknown>;
 const PUBLIC_RESULT_FIELDS = new Set([
@@ -16,12 +17,16 @@ export type McpSessionProvenance = {
 	child_process_id: number;
 	first_request_id: number;
 	last_request_id: number;
-	runtime_response_digests: string[];
-	runtime_response_receipts: McpResponseReceipt[];
+	transport_response_digests: string[];
+	transport_response_receipts: McpResponseReceipt[];
+	service_profile_commitment: string;
+	service_authority_receipts: ServiceAuthorityReceipt[];
 };
 
 export class McpProvenanceTracker {
 	private readonly receipts: McpResponseReceipt[] = [];
+	private profileCommitment?: string;
+	private readonly authorityReceipts: ServiceAuthorityReceipt[] = [];
 	record(id: string, tool: string, outcome: McpResponseReceipt["outcome"], payload: JsonObject) {
 		const requestId = Number(id);
 		if (!Number.isSafeInteger(requestId) || requestId <= 0) throw new Error("KAMN live MCP request ID is invalid");
@@ -31,16 +36,24 @@ export class McpProvenanceTracker {
 			public_result: outcome === "success" ? publicResult(payload) : {},
 		});
 	}
+	recordProfileCommitment(commitment: string) {
+		this.profileCommitment = commitment;
+	}
+	recordAuthorityReceipt(receipt: ServiceAuthorityReceipt) {
+		this.authorityReceipts.push({ ...receipt });
+	}
 	provenance(childProcessId: number): McpSessionProvenance {
 		const first = this.receipts[0];
 		const last = this.receipts.at(-1);
-		if (!first || !last) throw new Error("KAMN live MCP session has no successful runtime provenance");
+		if (!first || !last || !this.profileCommitment) throw new Error("KAMN live MCP session has no successful authority provenance");
 		return {
 			child_process_id: childProcessId,
 			first_request_id: first.request_id,
 			last_request_id: last.request_id,
-			runtime_response_digests: this.receipts.map(({ digest }) => digest),
-			runtime_response_receipts: this.receipts.map((receipt) => ({ ...receipt })),
+			transport_response_digests: this.receipts.map(({ digest }) => digest),
+			transport_response_receipts: this.receipts.map((receipt) => ({ ...receipt })),
+			service_profile_commitment: this.profileCommitment,
+			service_authority_receipts: this.authorityReceipts.map((receipt) => ({ ...receipt })),
 		};
 	}
 }

--- a/.pi/extensions/kamn-mvp/mcp-session-authority.test.ts
+++ b/.pi/extensions/kamn-mvp/mcp-session-authority.test.ts
@@ -59,6 +59,25 @@ test("session rejects copied cross-role mutation authority", async (context) => 
 	await assert.rejects(session.call("query_agent_profile"), /MCP_AUTHORITY_RECEIPT_INVALID/);
 });
 
+for (const mode of ["wrong-tool-authority", "copied-resource-authority"] as const) {
+	test(`session rejects ${mode}`, async (context) => {
+		const setup = await testSetup();
+		const session = sessionFor(setup, mode);
+		context.after(() => session.shutdown());
+		await session.call("register");
+		await assert.rejects(session.call("create_task", { payload: taskPayload() }), /MCP_AUTHORITY_RECEIPT_INVALID/);
+	});
+}
+
+test("child exit is sticky and cannot create a replacement session", async (context) => {
+	const setup = await testSetup();
+	const session = sessionFor(setup, "success", "exit");
+	context.after(() => session.shutdown());
+	await assert.rejects(session.call("register"), /exited.*7/);
+	await assert.rejects(session.call("register"), /exited.*7/);
+	assert.equal((await readFile(setup.startFile, "utf8")).trim().split("\n").length, 1);
+});
+
 async function testSetup() {
 	const root = await mkdtemp(resolve(tmpdir(), "kamn-mcp-authority-"));
 	const keyFile = resolve(root, "agent.key");
@@ -67,13 +86,13 @@ async function testSetup() {
 	return { keyFile, startFile: resolve(root, "start"), stopFile: resolve(root, "stop") };
 }
 
-function sessionFor(setup: Awaited<ReturnType<typeof testSetup>>, resultMode: string) {
+function sessionFor(setup: Awaited<ReturnType<typeof testSetup>>, resultMode: string, fakeMode = "success") {
 	const env = {
 		KAMN_MVP_LIVE_MCP_BINARY: fixture,
 		KAMN_MVP_LIVE_MCP_ENDPOINT: "http://127.0.0.1:18278",
 		KAMN_MVP_LIVE_MCP_AGENT_A_NAME: "agent-a",
 		KAMN_MVP_LIVE_MCP_AGENT_A_KEY_FILE: setup.keyFile,
-		KAMN_MVP_FAKE_MCP_MODE: "success",
+		KAMN_MVP_FAKE_MCP_MODE: fakeMode,
 		KAMN_MVP_FAKE_MCP_RESULT_MODE: resultMode,
 		KAMN_MVP_FAKE_MCP_START_FILE: setup.startFile,
 		KAMN_MVP_FAKE_MCP_STOP_FILE: setup.stopFile,

--- a/.pi/extensions/kamn-mvp/mcp-session-authority.test.ts
+++ b/.pi/extensions/kamn-mvp/mcp-session-authority.test.ts
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import { chmod, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import test from "node:test";
+import { McpSession, readLiveMcpConfig } from "./mcp-session.ts";
+
+const fixture = resolve(".pi/extensions/kamn-mvp/test-fixtures/fake-mcp-server.mjs");
+
+test("session separates validated service authority from transport provenance", async (context) => {
+	const setup = await testSetup();
+	const session = sessionFor(setup, "success");
+	context.after(() => session.shutdown());
+	const registered = await session.call("register");
+	await session.call("create_task", { payload: taskPayload() });
+	const provenance = session.provenance() as Record<string, unknown>;
+
+	assert.equal(provenance.service_profile_commitment, digest("f"));
+	assert.deepEqual(provenance.service_authority_receipts, [{
+		actor_did: registered.did,
+		action: "task:create",
+		resource_id: "task-live-1",
+		resulting_state: "submitted",
+		service_receipt_id: "task-transition-receipt-1",
+		service_receipt_digest: digest("1"),
+		tool: "create_task",
+	}]);
+	assert.equal(Array.isArray(provenance.transport_response_digests), true);
+	assert.equal("runtime_response_digests" in provenance, false);
+	assert.equal("runtime_response_receipts" in provenance, false);
+});
+
+for (const [mode, expected] of [
+	["missing-authority", "MCP_AUTHORITY_RECEIPT_MISSING"],
+	["malformed-authority", "MCP_AUTHORITY_RECEIPT_INVALID"],
+	["mixed-authority-version", "MCP_AUTHORITY_RECEIPT_INVALID"],
+] as const) {
+	test(`${mode} is fatal and cannot open a replacement nonce stream`, async (context) => {
+		const setup = await testSetup();
+		const session = sessionFor(setup, mode);
+		context.after(() => session.shutdown());
+
+		await assert.rejects(session.call("register"), new RegExp(expected));
+		await assert.rejects(session.call("register"), new RegExp(expected));
+		assert.equal((await readFile(setup.startFile, "utf8")).trim().split("\n").length, 1);
+	});
+}
+
+test("session rejects copied cross-role mutation authority", async (context) => {
+	const setup = await testSetup();
+	const session = sessionFor(setup, "cross-role-authority");
+	context.after(() => session.shutdown());
+	await session.call("register");
+
+	await assert.rejects(
+		session.call("create_task", { payload: taskPayload() }),
+		/MCP_AUTHORITY_RECEIPT_INVALID/,
+	);
+	await assert.rejects(session.call("query_agent_profile"), /MCP_AUTHORITY_RECEIPT_INVALID/);
+});
+
+async function testSetup() {
+	const root = await mkdtemp(resolve(tmpdir(), "kamn-mcp-authority-"));
+	const keyFile = resolve(root, "agent.key");
+	await writeFile(keyFile, "test-only-key\n");
+	await chmod(fixture, 0o755);
+	return { keyFile, startFile: resolve(root, "start"), stopFile: resolve(root, "stop") };
+}
+
+function sessionFor(setup: Awaited<ReturnType<typeof testSetup>>, resultMode: string) {
+	const env = {
+		KAMN_MVP_LIVE_MCP_BINARY: fixture,
+		KAMN_MVP_LIVE_MCP_ENDPOINT: "http://127.0.0.1:18278",
+		KAMN_MVP_LIVE_MCP_AGENT_A_NAME: "agent-a",
+		KAMN_MVP_LIVE_MCP_AGENT_A_KEY_FILE: setup.keyFile,
+		KAMN_MVP_FAKE_MCP_MODE: "success",
+		KAMN_MVP_FAKE_MCP_RESULT_MODE: resultMode,
+		KAMN_MVP_FAKE_MCP_START_FILE: setup.startFile,
+		KAMN_MVP_FAKE_MCP_STOP_FILE: setup.stopFile,
+	};
+	return new McpSession(readLiveMcpConfig("AGENT_A", env, process.cwd()));
+}
+
+function taskPayload() {
+	return JSON.stringify({
+		title: "Authority proof",
+		description: "Bind service receipt",
+		provider_did: "kamn:did:agent-b",
+		transaction_id: "transaction-live-1",
+		terms_digest: "a".repeat(64),
+		idempotency_key: "transaction-live-1-create",
+	});
+}
+
+function digest(character: string): string {
+	return `sha256:${character.repeat(64)}`;
+}

--- a/.pi/extensions/kamn-mvp/mcp-session.test.ts
+++ b/.pi/extensions/kamn-mvp/mcp-session.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import { createHash } from "node:crypto";
 import { chmod, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { resolve } from "node:path";
@@ -25,22 +24,24 @@ test("session starts lazily and reuses one child for ordered calls", async () =>
 	assert.equal((await readFile(paths.stopFile, "utf8")).trim(), String(registered.pid));
 });
 
-test("session provenance binds child process, request range, and runtime response digests", async () => {
+test("session provenance separates service authority from transport diagnostics", async () => {
 	const paths = await testPaths();
 	const session = sessionFor(paths, "success");
 	const registered = await session.call("register");
 	const queried = await session.call("query_agent_profile", { did: registered.did });
 
-	assert.deepEqual(session.provenance(), {
-		child_process_id: registered.pid,
-		first_request_id: 1,
-		last_request_id: 2,
-		runtime_response_digests: [responseDigest(registered), responseDigest(queried)],
-		runtime_response_receipts: [
-			{ request_id: 1, tool: "register", outcome: "success", digest: responseDigest(registered), public_result: { did: registered.did } },
-			{ request_id: 2, tool: "query_agent_profile", outcome: "success", digest: responseDigest(queried), public_result: { did: queried.did } },
-		],
-	});
+	const provenance = session.provenance();
+	assert.equal(provenance.child_process_id, registered.pid);
+	assert.equal(provenance.first_request_id, 1);
+	assert.equal(provenance.last_request_id, 2);
+	assert.equal(provenance.transport_response_digests.length, 2);
+	assert.equal(provenance.transport_response_digests.every(isDigest), true);
+	assert.deepEqual(provenance.transport_response_receipts.map(({ request_id, tool, outcome }) => ({ request_id, tool, outcome })), [
+		{ request_id: 1, tool: "register", outcome: "success" },
+		{ request_id: 2, tool: "query_agent_profile", outcome: "success" },
+	]);
+	assert.match(provenance.service_profile_commitment, /^sha256:[0-9a-f]{64}$/);
+	assert.deepEqual(provenance.service_authority_receipts, []);
 	await session.shutdown();
 });
 
@@ -51,21 +52,16 @@ test("session provenance keeps handled error responses in the contiguous request
 	await assert.rejects(session.call("release_escrow"), /forced backend failure/);
 	const queried = await session.call("query_agent_profile", { did: registered.did });
 
-	assert.deepEqual(session.provenance(), {
-		child_process_id: registered.pid,
-		first_request_id: 1,
-		last_request_id: 3,
-		runtime_response_digests: [
-			responseDigest(registered),
-			responseDigest({ kind: "backend_error", message: "forced backend failure" }),
-			responseDigest(queried),
-		],
-		runtime_response_receipts: [
-			{ request_id: 1, tool: "register", outcome: "success", digest: responseDigest(registered), public_result: { did: registered.did } },
-			{ request_id: 2, tool: "release_escrow", outcome: "error", digest: responseDigest({ kind: "backend_error", message: "forced backend failure" }), public_result: {} },
-			{ request_id: 3, tool: "query_agent_profile", outcome: "success", digest: responseDigest(queried), public_result: { did: queried.did } },
-		],
-	});
+	const provenance = session.provenance();
+	assert.equal(provenance.child_process_id, registered.pid);
+	assert.equal(provenance.first_request_id, 1);
+	assert.equal(provenance.last_request_id, 3);
+	assert.deepEqual(provenance.transport_response_receipts.map(({ request_id, tool, outcome }) => ({ request_id, tool, outcome })), [
+		{ request_id: 1, tool: "register", outcome: "success" },
+		{ request_id: 2, tool: "release_escrow", outcome: "error" },
+		{ request_id: 3, tool: "query_agent_profile", outcome: "success" },
+	]);
+	assert.equal(provenance.transport_response_digests.every(isDigest), true);
 	await session.shutdown();
 });
 
@@ -175,6 +171,4 @@ function configEnv(keyFile: string, extra: Record<string, string>) {
 	};
 }
 
-function responseDigest(response: Record<string, unknown>): string {
-	return `sha256:${createHash("sha256").update(JSON.stringify(response)).digest("hex")}`;
-}
+function isDigest(value: string): boolean { return /^sha256:[0-9a-f]{64}$/.test(value); }

--- a/.pi/extensions/kamn-mvp/mcp-session.ts
+++ b/.pi/extensions/kamn-mvp/mcp-session.ts
@@ -114,8 +114,11 @@ export class McpSession {
 		}
 		if (!isObject(response.result)) return this.failSession(new Error("KAMN live MCP success response omitted result"));
 		this.provenanceTracker.record(pending.id, pending.tool, "success", response.result);
+		this.resolveSuccess(pending, response.result);
+	}
+	private resolveSuccess(pending: PendingRequest, result: JsonObject) {
 		try {
-			const authority = validateAuthority(pending.tool, response.result, this.registeredActor);
+			const authority = validateAuthority(pending.tool, result, this.registeredActor);
 			if (authority.profileCommitment) {
 				this.registeredActor = String(authority.serviceResult.did);
 				this.provenanceTracker.recordProfileCommitment(authority.profileCommitment);

--- a/.pi/extensions/kamn-mvp/mcp-session.ts
+++ b/.pi/extensions/kamn-mvp/mcp-session.ts
@@ -2,6 +2,7 @@ import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { existsSync } from "node:fs";
 import { resolve } from "node:path";
 import { McpProvenanceTracker, type McpSessionProvenance } from "./mcp-provenance.ts";
+import { validateAuthority } from "./mcp-authority.ts";
 export type { McpSessionProvenance } from "./mcp-provenance.ts";
 
 type Environment = Record<string, string | undefined>;
@@ -39,6 +40,7 @@ export class McpSession {
 	private pending?: PendingRequest;
 	private terminalError?: Error;
 	private sequence = 0;
+	private registeredActor?: string;
 	private readonly provenanceTracker = new McpProvenanceTracker();
 	private stdoutBuffer = "";
 	private shutdownPromise?: Promise<void>;
@@ -105,14 +107,25 @@ export class McpSession {
 		}
 		const pending = this.pending;
 		if (!pending || response.id !== pending.id) return this.failSession(new Error("KAMN live MCP response ID mismatch"));
-		this.clearPending();
 		if (response.ok !== true) {
+			this.clearPending();
 			this.provenanceTracker.record(pending.id, pending.tool, "error", isObject(response.error) ? response.error : {});
 			return pending.reject(toolError(response));
 		}
-		if (!isObject(response.result)) return pending.reject(new Error("KAMN live MCP success response omitted result"));
+		if (!isObject(response.result)) return this.failSession(new Error("KAMN live MCP success response omitted result"));
 		this.provenanceTracker.record(pending.id, pending.tool, "success", response.result);
-		pending.resolve(response.result);
+		try {
+			const authority = validateAuthority(pending.tool, response.result, this.registeredActor);
+			if (authority.profileCommitment) {
+				this.registeredActor = String(authority.serviceResult.did);
+				this.provenanceTracker.recordProfileCommitment(authority.profileCommitment);
+			}
+			if (authority.receipt) this.provenanceTracker.recordAuthorityReceipt(authority.receipt);
+			this.clearPending();
+			pending.resolve(authority.serviceResult);
+		} catch (error) {
+			this.failSession(error instanceof Error ? error : new Error("MCP_AUTHORITY_RECEIPT_INVALID"));
+		}
 	}
 	private handleExit(code: number | null, signal: NodeJS.Signals | null) {
 		if (this.shutdownPromise) return;

--- a/.pi/extensions/kamn-mvp/pi-service-authority-evidence.ts
+++ b/.pi/extensions/kamn-mvp/pi-service-authority-evidence.ts
@@ -1,0 +1,88 @@
+export const ROLES = ["agent_a", "agent_b", "agent_c"] as const;
+export type Role = typeof ROLES[number];
+export type ServiceReceipt = {
+	actor_did: string;
+	tool: string;
+	action: string;
+	resource_id: string;
+	resulting_state: string;
+	service_receipt_id: string;
+	service_receipt_digest: string;
+};
+
+const ROLE_CONTRACTS = {
+	agent_a: [
+		["create_task", "task:create", "task", "submitted"],
+		["fund_escrow", "escrow:fund", "escrow", "funded"],
+		["release_escrow", "escrow:release-authorize", "escrow", "release-authorized"],
+	],
+	agent_b: [
+		["accept_task", "task:accept", "task", "accepted"],
+		["complete_task", "task:complete", "task", "completed"],
+	],
+	agent_c: [],
+} as const;
+const RECEIPT_FIELDS = new Set([
+	"actor_did", "tool", "action", "resource_id", "resulting_state", "service_receipt_id", "service_receipt_digest",
+]);
+
+export function normalizeServiceReceipts(value: unknown): ServiceReceipt[] {
+	if (!Array.isArray(value)) fail();
+	return value.map((entry) => normalizeReceipt(entry));
+}
+
+export function validateRoleAuthority(
+	role: Role,
+	did: string,
+	taskId: string,
+	escrowId: string,
+	receipts: ServiceReceipt[],
+) {
+	const expected = ROLE_CONTRACTS[role];
+	if (receipts.length !== expected.length) fail();
+	for (const [index, contract] of expected.entries()) {
+		const receipt = receipts[index];
+		const [tool, action, resourceType, state] = contract;
+		const resource = resourceType === "task" ? taskId : escrowId;
+		if (!receipt || receipt.actor_did !== did || receipt.tool !== tool || receipt.action !== action
+			|| receipt.resource_id !== resource || receipt.resulting_state !== state) fail();
+	}
+	requireUnique(receipts.map((receipt) => receipt.service_receipt_id));
+	requireUnique(receipts.map((receipt) => `${receipt.service_receipt_id}:${receipt.service_receipt_digest}`));
+}
+
+export function validateGlobalReceiptUniqueness(receipts: ServiceReceipt[]) {
+	requireUnique(receipts.map((receipt) => receipt.service_receipt_id));
+	requireUnique(receipts.map((receipt) => `${receipt.service_receipt_id}:${receipt.service_receipt_digest}`));
+}
+
+function normalizeReceipt(value: unknown): ServiceReceipt {
+	if (!isObject(value) || Object.keys(value).some((field) => !RECEIPT_FIELDS.has(field))) fail();
+	return {
+		actor_did: text(value.actor_did),
+		tool: text(value.tool),
+		action: text(value.action),
+		resource_id: text(value.resource_id),
+		resulting_state: text(value.resulting_state),
+		service_receipt_id: text(value.service_receipt_id),
+		service_receipt_digest: shaDigest(value.service_receipt_digest),
+	};
+}
+function requireUnique(values: string[]) {
+	if (new Set(values).size !== values.length) fail();
+}
+function text(value: unknown): string {
+	if (typeof value === "string" && value.trim()) return value;
+	fail();
+}
+function shaDigest(value: unknown): string {
+	const parsed = text(value);
+	if (/^sha256:[0-9a-f]{64}$/.test(parsed)) return parsed;
+	fail();
+}
+function isObject(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+function fail(): never {
+	throw new Error("PI_SERVICE_AUTHORITY_MISMATCH");
+}

--- a/.pi/extensions/kamn-mvp/pi-transaction-evidence.test.ts
+++ b/.pi/extensions/kamn-mvp/pi-transaction-evidence.test.ts
@@ -1,19 +1,21 @@
 import assert from "node:assert/strict";
-import { mkdtemp, readFile } from "node:fs/promises";
+import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { resolve } from "node:path";
 import test from "node:test";
 import { verifyPiTransactionActors, writePiTransactionActor } from "./pi-transaction-evidence.ts";
 
-test("three actor artifacts bind independent runtime provenance to one transaction", async () => {
+type Role = "agent_a" | "agent_b" | "agent_c";
+type Overrides = Partial<Record<Role, Record<string, unknown>>>;
+
+test("three actor artifacts bind independent processes to one receipt chain", async () => {
 	const paths = await actorPaths();
 	await writeActors(paths);
 	const verified = await verifyPiTransactionActors(paths);
 
 	assert.equal(verified.task_id, "task-live-7099");
 	assert.equal(verified.escrow_id, "escrow-live-7099");
-	assert.equal(verified.settlement_tx_signature, "devnet-signature-7099");
-	assert.equal(verified.public_commitment, `sha256:${"d".repeat(64)}`);
+	assert.equal(verified.receipt_chain_commitment, digest("c"));
 	assert.deepEqual(verified.pi_process_ids, [101, 202, 303]);
 	assert.deepEqual(verified.dids, ["kamn:did:a", "kamn:did:b", "kamn:did:c"]);
 });
@@ -26,89 +28,32 @@ test("actor verification rejects process, DID, and MCP child reuse", async () =>
 	}
 });
 
-test("actor verification rejects missing runtime projection provenance and private verifier data", async () => {
-	const missing = await actorPaths();
-	await assert.rejects(
-		writeActors(missing, { agent_c: { runtime_projection_digest: `sha256:${"f".repeat(64)}` } }),
-		/PI_RUNTIME_RECEIPT_MISMATCH/,
-	);
-
-	const leaked = await actorPaths();
-	await assert.rejects(
-		writeActors(leaked, { agent_c: { private_receipt_digest: `sha256:${"e".repeat(64)}` } }),
-		/PI_VERIFIER_PRIVATE_LEAK/,
-	);
-});
-
 test("actor verification rejects copied facts and handoff authorization", async () => {
 	const mismatch = await actorPaths();
-	await writeActors(mismatch, { agent_b: { escrow_id: "escrow-other" } });
+	await writeActors(mismatch, { agent_b: { receipt_chain_commitment: digest("9") } });
 	await assert.rejects(verifyPiTransactionActors(mismatch), /PI_TRANSACTION_FACT_MISMATCH/);
 
 	const handoff = await actorPaths();
-	await assert.rejects(
-		writeActors(handoff, { agent_a: { handoff_authorized: true } }),
-		/PI_HANDOFF_AUTHORIZATION_FORBIDDEN/,
-	);
+	await assert.rejects(writeActors(handoff, { agent_a: { handoff_authorized: true } }), /PI_HANDOFF_AUTHORIZATION_FORBIDDEN/);
 });
 
-test("actor verification rejects a missing successful role operation", async () => {
-	const paths = await actorPaths();
-	const receipts = runtimeReceipts("agent_a").filter((receipt) => receipt.tool !== "release_escrow");
-	await assert.rejects(
-		writeActors(paths, { agent_a: { runtime_response_receipts: receipts } }),
-		/PI_RUNTIME_RECEIPT_MISMATCH/,
-	);
+test("actor evidence rejects verifier private fields and unknown ambient evidence", async () => {
+	const privateField = await actorPaths();
+	await assert.rejects(writeActors(privateField, { agent_c: { participant_role: "creator" } }), /PI_VERIFIER_PRIVATE_LEAK/);
+
+	const unknown = await actorPaths();
+	await assert.rejects(writeActors(unknown, { agent_a: { actor_evidence: "trusted" } }), /PI_SERVICE_AUTHORITY_MISMATCH/);
 });
 
-test("actor verification rejects a participant role that does not match the actor", async () => {
-	const paths = await actorPaths();
-	await assert.rejects(
-		writeActors(paths, { agent_b: { participant_role: "creator" } }),
-		/PI_ACTOR_IDENTITY_INVALID/,
-	);
-});
-
-test("actor evidence rejects unknown top-level fields", async () => {
-	const paths = await actorPaths();
-	await assert.rejects(
-		writeActors(paths, { agent_a: { synthetic_success_label: "release passed" } }),
-		/PI_RUNTIME_RECEIPT_MISMATCH/,
-	);
-});
-
-test("actor evidence accepts interim and final successful projection reads", async () => {
-	const paths = await actorPaths();
-	const finalDigest = `sha256:${"9".repeat(64)}`;
-	const receipts = runtimeReceipts("agent_b");
-	receipts.splice(4, 0, {
-		request_id: 5, tool: "query_participant_task_projection", outcome: "success", digest: `sha256:${"8".repeat(64)}`,
-		public_result: publicResult("agent_b", "query_participant_task_projection"),
-	});
-	receipts[5] = { ...receipts[5], request_id: 6, digest: finalDigest };
-	await writeActors(paths, { agent_b: {
-		last_request_id: 6,
-		runtime_response_digests: receipts.map((receipt) => receipt.digest),
-		runtime_response_receipts: receipts,
-		runtime_projection_digest: finalDigest,
-	} });
-
-	await assert.doesNotReject(verifyPiTransactionActors(paths));
-});
-
-test("actor evidence preserves strict public runtime result projections", async () => {
+test("actor artifact writes are idempotent and conflicts fail closed", async () => {
 	const paths = await actorPaths();
 	await writePiTransactionActor(paths.agent_a, actor("agent_a"));
-	const written = JSON.parse(await readFile(paths.agent_a, "utf8"));
-
-	assert.deepEqual(written.runtime_response_receipts[1].public_result, {
-		task_id: "task-live-7099", state: "submitted", transaction_id: "transaction-live-7099",
-	});
-	assert.equal("private_receipt_digest" in written.runtime_response_receipts.at(-1).public_result, false);
+	await assert.doesNotReject(writePiTransactionActor(paths.agent_a, actor("agent_a")));
+	await assert.rejects(
+		writePiTransactionActor(paths.agent_a, { ...actor("agent_a"), amount_lamports: 2_000_000 }),
+		/PI_ACTOR_ARTIFACT_CONFLICT/,
+	);
 });
-
-type Role = "agent_a" | "agent_b" | "agent_c";
-type Overrides = Partial<Record<Role, Record<string, unknown>>>;
 
 async function writeActors(paths: Record<Role, string>, overrides: Overrides = {}) {
 	for (const role of ["agent_a", "agent_b", "agent_c"] as const) {
@@ -116,68 +61,58 @@ async function writeActors(paths: Record<Role, string>, overrides: Overrides = {
 	}
 }
 
-function actor(role: Role) {
+function actor(role: Role): Record<string, unknown> {
 	const index = { agent_a: 1, agent_b: 2, agent_c: 3 }[role];
-	const projectionDigest = `sha256:${String(index).repeat(64)}`;
 	return {
 		actor: role,
 		pi_process_id: index * 101,
 		did: `kamn:did:${String.fromCharCode(96 + index)}`,
 		mcp_child_process_id: 1000 + index,
 		first_request_id: 1,
-		last_request_id: 5,
-		runtime_response_digests: [1, 2, 3, 4].map((value) => `sha256:${String(value).repeat(64)}`).concat(projectionDigest),
-		runtime_response_receipts: runtimeReceipts(role),
-		runtime_projection_digest: projectionDigest,
+		last_request_id: 2,
+		transport_response_digests: [digest(String(index)), digest(String(index + 3))],
+		service_profile_commitment: digest("f"),
+		service_receipts: receipts(role),
 		task_id: "task-live-7099",
 		transaction_id: "transaction-live-7099",
 		escrow_id: "escrow-live-7099",
-		amount_lamports: 1000000,
+		amount_lamports: 1_000_000,
 		network: "solana-devnet",
 		settlement_tx_signature: "devnet-signature-7099",
 		settlement_commitment: "finalized",
-		public_commitment: `sha256:${"d".repeat(64)}`,
+		receipt_chain_commitment: digest("c"),
+		public_commitment: digest("d"),
 		view_scope: role === "agent_c" ? "restricted-public" : "participant-private",
-		...(role === "agent_c" ? {} : {
-			participant_role: role === "agent_a" ? "creator" : "provider",
-			private_receipt_digest: `sha256:${"e".repeat(64)}`,
-		}),
-		source_handoff_digest: `sha256:${"b".repeat(64)}`,
+		...(role === "agent_c" ? {} : { participant_role: role === "agent_a" ? "creator" : "provider" }),
+		source_handoff_digest: digest("b"),
 		handoff_authorized: false,
 	};
 }
 
-function runtimeReceipts(role: Role) {
-	const tools = {
-		agent_a: ["register", "create_task", "fund_escrow", "release_escrow", "query_participant_task_projection"],
-		agent_b: ["register", "accept_task", "complete_task", "query_task", "query_participant_task_projection"],
-		agent_c: ["register", "query_task", "query_task", "query_task", "query_verifier_task_projection"],
-	}[role];
-	return tools.map((tool, index) => ({
-		request_id: index + 1,
-		tool,
-		outcome: "success",
-		digest: `sha256:${String(index + 1 === 5 ? { agent_a: 1, agent_b: 2, agent_c: 3 }[role] : index + 1).repeat(64)}`,
-		public_result: publicResult(role, tool),
-	}));
+function receipts(role: Role) {
+	if (role === "agent_a") return [
+		receipt(role, "create_task", "task:create", "task-live-7099", "submitted", "1"),
+		receipt(role, "fund_escrow", "escrow:fund", "escrow-live-7099", "funded", "2"),
+		receipt(role, "release_escrow", "escrow:release-authorize", "escrow-live-7099", "release-authorized", "3"),
+	];
+	if (role === "agent_b") return [
+		receipt(role, "accept_task", "task:accept", "task-live-7099", "accepted", "4"),
+		receipt(role, "complete_task", "task:complete", "task-live-7099", "completed", "5"),
+	];
+	return [];
 }
 
-function publicResult(role: Role, tool: string): Record<string, unknown> {
-	if (tool === "register") return { did: `kamn:did:${({ agent_a: "a", agent_b: "b", agent_c: "c" })[role]}` };
-	if (tool === "create_task") return { task_id: "task-live-7099", state: "submitted", transaction_id: "transaction-live-7099" };
-	if (tool === "accept_task") return { task_id: "task-live-7099", state: "accepted", transaction_id: "transaction-live-7099" };
-	if (tool === "complete_task") return { task_id: "task-live-7099", state: "completed", transaction_id: "transaction-live-7099" };
-	if (tool === "fund_escrow") return { task_id: "task-live-7099", escrow_id: "escrow-live-7099", state: "funded", amount_lamports: 1000000, network: "solana-devnet" };
-	if (tool === "release_escrow") return { escrow_id: "escrow-live-7099", state: "released", settlement_tx_signature: "devnet-signature-7099", settlement_commitment: "finalized" };
-	if (tool.includes("projection")) return { task_id: "task-live-7099", escrow_id: "escrow-live-7099", settlement_tx_signature: "devnet-signature-7099", settlement_commitment: "finalized", public_commitment: `sha256:${"d".repeat(64)}`, view_scope: role === "agent_c" ? "restricted-public" : "participant-private", ...(role === "agent_c" ? {} : { participant_role: role === "agent_a" ? "creator" : "provider" }) };
-	return { task_id: "task-live-7099", state: "accepted" };
+function receipt(role: Role, tool: string, action: string, resource_id: string, resulting_state: string, id: string) {
+	return {
+		actor_did: `kamn:did:${role === "agent_a" ? "a" : "b"}`,
+		tool, action, resource_id, resulting_state,
+		service_receipt_id: `service-receipt-${id}`,
+		service_receipt_digest: digest(id),
+	};
 }
 
 async function actorPaths(): Promise<Record<Role, string>> {
 	const root = await mkdtemp(resolve(tmpdir(), "kamn-pi-transaction-"));
-	return {
-		agent_a: resolve(root, "agent-a.json"),
-		agent_b: resolve(root, "agent-b.json"),
-		agent_c: resolve(root, "agent-c.json"),
-	};
+	return { agent_a: resolve(root, "agent-a.json"), agent_b: resolve(root, "agent-b.json"), agent_c: resolve(root, "agent-c.json") };
 }
+function digest(character: string): string { return `sha256:${character.repeat(64)}`; }

--- a/.pi/extensions/kamn-mvp/pi-transaction-evidence.ts
+++ b/.pi/extensions/kamn-mvp/pi-transaction-evidence.ts
@@ -1,44 +1,21 @@
 import { createHash } from "node:crypto";
 import { readFile, writeFile } from "node:fs/promises";
-import { normalizeRuntimeReceipts, validateFinalProjectionReceipt, validateRuntimeReceipts, type Role, type RuntimeReceipt } from "./pi-transaction-runtime-receipts.ts";
+import {
+	normalizeServiceReceipts, ROLES, validateGlobalReceiptUniqueness, validateRoleAuthority,
+	type Role, type ServiceReceipt,
+} from "./pi-service-authority-evidence.ts";
 
-const SCHEMA = "kamn.mvp.pi-transaction-actor.v1";
-const ROLES = ["agent_a", "agent_b", "agent_c"] as const;
+const SCHEMA = "kamn.mvp.pi-transaction-actor.v2";
 const SHARED = [
-	"task_id", "transaction_id", "escrow_id", "amount_lamports", "network",
-	"settlement_tx_signature", "settlement_commitment", "public_commitment",
+	"task_id", "transaction_id", "escrow_id", "amount_lamports", "network", "settlement_tx_signature",
+	"settlement_commitment", "receipt_chain_commitment", "public_commitment",
 ] as const;
 const INPUT_FIELDS = new Set([
 	"actor", "pi_process_id", "did", "mcp_child_process_id", "first_request_id", "last_request_id",
-	"runtime_response_digests", "runtime_response_receipts", "runtime_projection_digest", ...SHARED,
-	"view_scope", "participant_role", "private_receipt_digest", "source_handoff_digest", "handoff_authorized",
+	"transport_response_digests", "service_profile_commitment", "service_receipts", ...SHARED,
+	"view_scope", "participant_role", "source_handoff_digest", "handoff_authorized",
 ]);
-type ActorArtifact = {
-	schema_version: string;
-	actor: Role;
-	pi_process_id: number;
-	did: string;
-	mcp_child_process_id: number;
-	first_request_id: number;
-	last_request_id: number;
-	runtime_response_digests: string[];
-	runtime_response_receipts: RuntimeReceipt[];
-	runtime_projection_digest: string;
-	task_id: string;
-	transaction_id: string;
-	escrow_id: string;
-	amount_lamports: number;
-	network: string;
-	settlement_tx_signature: string;
-	settlement_commitment: string;
-	public_commitment: string;
-	view_scope: string;
-	participant_role?: string;
-	private_receipt_digest?: string;
-	source_handoff_digest: string;
-	handoff_authorized: boolean;
-	artifact_digest: string;
-};
+type ActorArtifact = ReturnType<typeof normalizeActor> & { artifact_digest: string };
 
 export async function writePiTransactionActor(path: string, input: Record<string, unknown>) {
 	const unsigned = normalizeActor(input);
@@ -57,53 +34,56 @@ export async function verifyPiTransactionActors(paths: Record<Role, string>) {
 	requireDistinct(actors.map((actor) => actor.pi_process_id), "PI_ACTOR_PROCESS_REUSED");
 	requireDistinct(actors.map((actor) => actor.mcp_child_process_id), "PI_ACTOR_PROCESS_REUSED");
 	requireDistinct(actors.map((actor) => actor.did), "PI_ACTOR_IDENTITY_INVALID");
-	for (const actor of actors) validateActor(actor);
 	validateSharedFacts(actors);
+	validateGlobalReceiptUniqueness(actors.flatMap((actor) => actor.service_receipts));
 	const first = actors[0];
 	return {
-		task_id: first.task_id,
-		escrow_id: first.escrow_id,
+		task_id: first.task_id, escrow_id: first.escrow_id,
 		settlement_tx_signature: first.settlement_tx_signature,
+		receipt_chain_commitment: first.receipt_chain_commitment,
 		public_commitment: first.public_commitment,
 		pi_process_ids: actors.map((actor) => actor.pi_process_id),
 		dids: actors.map((actor) => actor.did),
 	};
 }
 
-function normalizeActor(input: Record<string, unknown>): Omit<ActorArtifact, "artifact_digest"> {
-	assertKnownInputFields(input);
+function normalizeActor(input: Record<string, unknown>) {
+	if (Object.keys(input).some((field) => !INPUT_FIELDS.has(field))) authorityFail();
+	const actor = requiredRole(input.actor);
 	const artifact = {
 		schema_version: SCHEMA,
-		...identityFields(input),
-		...runtimeFields(input),
-		...transactionFields(input),
-		...disclosureFields(input),
-		source_handoff_digest: shaDigest(input.source_handoff_digest, "PI_RUNTIME_RECEIPT_MISMATCH"),
-		handoff_authorized: input.handoff_authorized === true,
-	};
-	validateActor(artifact as ActorArtifact);
-	return artifact;
-}
-function assertKnownInputFields(input: Record<string, unknown>) {
-	if (Object.keys(input).some((field) => !INPUT_FIELDS.has(field))) throw new Error("PI_RUNTIME_RECEIPT_MISMATCH");
-}
-function identityFields(input: Record<string, unknown>) {
-	return {
-		actor: requiredRole(input.actor),
+		actor,
 		pi_process_id: positiveInteger(input.pi_process_id, "PI_ACTOR_PROCESS_REUSED"),
 		did: requiredString(input.did, "PI_ACTOR_IDENTITY_INVALID"),
 		mcp_child_process_id: positiveInteger(input.mcp_child_process_id, "PI_ACTOR_PROCESS_REUSED"),
-	};
-}
-function runtimeFields(input: Record<string, unknown>) {
-	return {
 		first_request_id: positiveInteger(input.first_request_id, "PI_ACTOR_NONCE_STREAM_INVALID"),
 		last_request_id: positiveInteger(input.last_request_id, "PI_ACTOR_NONCE_STREAM_INVALID"),
-		runtime_response_digests: digestList(input.runtime_response_digests),
-		runtime_response_receipts: normalizeRuntimeReceipts(input.runtime_response_receipts),
-		runtime_projection_digest: shaDigest(input.runtime_projection_digest, "PI_RUNTIME_RECEIPT_MISMATCH"),
+		transport_response_digests: digestList(input.transport_response_digests),
+		service_profile_commitment: shaDigest(input.service_profile_commitment, "PI_SERVICE_AUTHORITY_MISMATCH"),
+		service_receipts: normalizeServiceReceipts(input.service_receipts),
+		...transactionFields(input), ...disclosureFields(input),
+		source_handoff_digest: shaDigest(input.source_handoff_digest, "PI_SERVICE_AUTHORITY_MISMATCH"),
+		handoff_authorized: input.handoff_authorized === true,
 	};
+	validateActor(artifact);
+	return artifact;
 }
+
+function validateActor(actor: ReturnType<typeof normalizeActor>) {
+	const expectedCount = actor.last_request_id - actor.first_request_id + 1;
+	if (expectedCount !== actor.transport_response_digests.length) throw new Error("PI_ACTOR_NONCE_STREAM_INVALID");
+	validateRoleAuthority(actor.actor, actor.did, actor.task_id, actor.escrow_id, actor.service_receipts);
+	if (actor.handoff_authorized) throw new Error("PI_HANDOFF_AUTHORIZATION_FORBIDDEN");
+	if (actor.actor === "agent_c") {
+		if (actor.view_scope !== "restricted-public") throw new Error("PI_VERIFIER_PROJECTION_MISSING");
+		if (actor.participant_role !== undefined) throw new Error("PI_VERIFIER_PRIVATE_LEAK");
+		return;
+	}
+	const expectedRole = actor.actor === "agent_a" ? "creator" : "provider";
+	if (actor.view_scope !== "participant-private") authorityFail();
+	if (actor.participant_role !== expectedRole) throw new Error("PI_ACTOR_IDENTITY_INVALID");
+}
+
 function transactionFields(input: Record<string, unknown>) {
 	return {
 		task_id: requiredString(input.task_id, "PI_TRANSACTION_FACT_MISMATCH"),
@@ -113,6 +93,7 @@ function transactionFields(input: Record<string, unknown>) {
 		network: requiredString(input.network, "PI_TRANSACTION_FACT_MISMATCH"),
 		settlement_tx_signature: requiredString(input.settlement_tx_signature, "PI_TRANSACTION_FACT_MISMATCH"),
 		settlement_commitment: requiredString(input.settlement_commitment, "PI_TRANSACTION_FACT_MISMATCH"),
+		receipt_chain_commitment: shaDigest(input.receipt_chain_commitment, "PI_TRANSACTION_FACT_MISMATCH"),
 		public_commitment: shaDigest(input.public_commitment, "PI_TRANSACTION_FACT_MISMATCH"),
 	};
 }
@@ -120,48 +101,24 @@ function disclosureFields(input: Record<string, unknown>) {
 	return {
 		view_scope: requiredString(input.view_scope, "PI_VERIFIER_PROJECTION_MISSING"),
 		...(input.participant_role === undefined ? {} : { participant_role: requiredString(input.participant_role, "PI_ACTOR_IDENTITY_INVALID") }),
-		...(input.private_receipt_digest === undefined ? {} : { private_receipt_digest: shaDigest(input.private_receipt_digest, "PI_VERIFIER_PRIVATE_LEAK") }),
 	};
 }
-
 async function readActor(path: string, role: Role): Promise<ActorArtifact> {
 	const parsed = JSON.parse(await readFile(path, "utf8")) as Record<string, unknown>;
-	const digestValue = shaDigest(parsed.artifact_digest, "PI_RUNTIME_RECEIPT_MISMATCH");
+	const digestValue = shaDigest(parsed.artifact_digest, "PI_SERVICE_AUTHORITY_MISMATCH");
 	const unsigned = Object.fromEntries(Object.entries(parsed).filter(([key]) => key !== "artifact_digest"));
-	if (digest(unsigned) !== digestValue) throw new Error("PI_RUNTIME_RECEIPT_MISMATCH");
-	if (unsigned.schema_version !== SCHEMA) throw new Error("PI_RUNTIME_RECEIPT_MISMATCH");
+	if (digest(unsigned) !== digestValue || unsigned.schema_version !== SCHEMA) authorityFail();
 	const input = Object.fromEntries(Object.entries(unsigned).filter(([key]) => key !== "schema_version"));
-	const normalized = normalizeActor(input) as ActorArtifact;
+	const normalized = normalizeActor(input);
 	if (normalized.actor !== role) throw new Error("PI_ACTOR_IDENTITY_INVALID");
 	return { ...normalized, artifact_digest: digestValue };
 }
-
-function validateActor(actor: Omit<ActorArtifact, "artifact_digest">) {
-	const expectedCount = actor.last_request_id - actor.first_request_id + 1;
-	if (expectedCount !== actor.runtime_response_digests.length) throw new Error("PI_ACTOR_NONCE_STREAM_INVALID");
-	validateRuntimeReceipts(actor.actor, actor.first_request_id, actor.runtime_response_digests, actor.runtime_response_receipts);
-	validateFinalProjectionReceipt(actor.actor, actor.runtime_projection_digest, actor.runtime_response_receipts);
-	if (!actor.runtime_response_digests.includes(actor.runtime_projection_digest)) throw new Error("PI_RUNTIME_RECEIPT_MISMATCH");
-	if (actor.handoff_authorized) throw new Error("PI_HANDOFF_AUTHORIZATION_FORBIDDEN");
-	if (actor.actor === "agent_c") {
-		if (actor.view_scope !== "restricted-public") throw new Error("PI_VERIFIER_PROJECTION_MISSING");
-		if (actor.private_receipt_digest !== undefined) throw new Error("PI_VERIFIER_PRIVATE_LEAK");
-		if (actor.participant_role !== undefined) throw new Error("PI_VERIFIER_PRIVATE_LEAK");
-		return;
-	}
-	const expectedRole = actor.actor === "agent_a" ? "creator" : "provider";
-	if (actor.view_scope !== "participant-private" || !actor.private_receipt_digest) throw new Error("PI_RUNTIME_RECEIPT_MISMATCH");
-	if (actor.participant_role !== expectedRole) throw new Error("PI_ACTOR_IDENTITY_INVALID");
-}
-
-
 function validateSharedFacts(actors: ActorArtifact[]) {
 	const first = actors[0] as unknown as Record<string, unknown>;
 	for (const actor of actors.slice(1) as unknown as Array<Record<string, unknown>>) {
 		if (SHARED.some((field) => actor[field] !== first[field])) throw new Error("PI_TRANSACTION_FACT_MISMATCH");
 	}
 }
-
 function requireDistinct(values: Array<string | number>, code: string) {
 	if (new Set(values).size !== values.length) throw new Error(code);
 }
@@ -183,8 +140,8 @@ function shaDigest(value: unknown, code: string): string {
 	throw new Error(code);
 }
 function digestList(value: unknown): string[] {
-	if (!Array.isArray(value) || value.length === 0) throw new Error("PI_RUNTIME_RECEIPT_MISMATCH");
-	return value.map((entry) => shaDigest(entry, "PI_RUNTIME_RECEIPT_MISMATCH"));
+	if (!Array.isArray(value) || value.length === 0) authorityFail();
+	return value.map((entry) => shaDigest(entry, "PI_SERVICE_AUTHORITY_MISMATCH"));
 }
 function digest(value: unknown): string {
 	return `sha256:${createHash("sha256").update(JSON.stringify(value)).digest("hex")}`;
@@ -192,3 +149,4 @@ function digest(value: unknown): string {
 function isNodeError(error: unknown, code: string): boolean {
 	return error instanceof Error && "code" in error && error.code === code;
 }
+function authorityFail(): never { throw new Error("PI_SERVICE_AUTHORITY_MISMATCH"); }

--- a/.pi/extensions/kamn-mvp/pi-transaction-evidence.ts
+++ b/.pi/extensions/kamn-mvp/pi-transaction-evidence.ts
@@ -15,7 +15,14 @@ const INPUT_FIELDS = new Set([
 	"transport_response_digests", "service_profile_commitment", "service_receipts", ...SHARED,
 	"view_scope", "participant_role", "source_handoff_digest", "handoff_authorized",
 ]);
-type ActorArtifact = ReturnType<typeof normalizeActor> & { artifact_digest: string };
+type ActorArtifact = {
+	schema_version: string; actor: Role; pi_process_id: number; did: string; mcp_child_process_id: number;
+	first_request_id: number; last_request_id: number; transport_response_digests: string[];
+	service_profile_commitment: string; service_receipts: ServiceReceipt[]; task_id: string; transaction_id: string;
+	escrow_id: string; amount_lamports: number; network: string; settlement_tx_signature: string;
+	settlement_commitment: string; receipt_chain_commitment: string; public_commitment: string; view_scope: string;
+	participant_role?: string; source_handoff_digest: string; handoff_authorized: boolean; artifact_digest: string;
+};
 
 export async function writePiTransactionActor(path: string, input: Record<string, unknown>) {
 	const unsigned = normalizeActor(input);
@@ -47,7 +54,7 @@ export async function verifyPiTransactionActors(paths: Record<Role, string>) {
 	};
 }
 
-function normalizeActor(input: Record<string, unknown>) {
+function normalizeActor(input: Record<string, unknown>): Omit<ActorArtifact, "artifact_digest"> {
 	if (Object.keys(input).some((field) => !INPUT_FIELDS.has(field))) authorityFail();
 	const actor = requiredRole(input.actor);
 	const artifact = {
@@ -56,8 +63,8 @@ function normalizeActor(input: Record<string, unknown>) {
 		pi_process_id: positiveInteger(input.pi_process_id, "PI_ACTOR_PROCESS_REUSED"),
 		did: requiredString(input.did, "PI_ACTOR_IDENTITY_INVALID"),
 		mcp_child_process_id: positiveInteger(input.mcp_child_process_id, "PI_ACTOR_PROCESS_REUSED"),
-		first_request_id: positiveInteger(input.first_request_id, "PI_ACTOR_NONCE_STREAM_INVALID"),
-		last_request_id: positiveInteger(input.last_request_id, "PI_ACTOR_NONCE_STREAM_INVALID"),
+		first_request_id: positiveInteger(input.first_request_id, "PI_TRANSPORT_PROVENANCE_INVALID"),
+		last_request_id: positiveInteger(input.last_request_id, "PI_TRANSPORT_PROVENANCE_INVALID"),
 		transport_response_digests: digestList(input.transport_response_digests),
 		service_profile_commitment: shaDigest(input.service_profile_commitment, "PI_SERVICE_AUTHORITY_MISMATCH"),
 		service_receipts: normalizeServiceReceipts(input.service_receipts),
@@ -69,9 +76,9 @@ function normalizeActor(input: Record<string, unknown>) {
 	return artifact;
 }
 
-function validateActor(actor: ReturnType<typeof normalizeActor>) {
+function validateActor(actor: Omit<ActorArtifact, "artifact_digest">) {
 	const expectedCount = actor.last_request_id - actor.first_request_id + 1;
-	if (expectedCount !== actor.transport_response_digests.length) throw new Error("PI_ACTOR_NONCE_STREAM_INVALID");
+	if (expectedCount !== actor.transport_response_digests.length) throw new Error("PI_TRANSPORT_PROVENANCE_INVALID");
 	validateRoleAuthority(actor.actor, actor.did, actor.task_id, actor.escrow_id, actor.service_receipts);
 	if (actor.handoff_authorized) throw new Error("PI_HANDOFF_AUTHORIZATION_FORBIDDEN");
 	if (actor.actor === "agent_c") {
@@ -140,8 +147,8 @@ function shaDigest(value: unknown, code: string): string {
 	throw new Error(code);
 }
 function digestList(value: unknown): string[] {
-	if (!Array.isArray(value) || value.length === 0) authorityFail();
-	return value.map((entry) => shaDigest(entry, "PI_SERVICE_AUTHORITY_MISMATCH"));
+	if (!Array.isArray(value) || value.length === 0) throw new Error("PI_TRANSPORT_PROVENANCE_INVALID");
+	return value.map((entry) => shaDigest(entry, "PI_TRANSPORT_PROVENANCE_INVALID"));
 }
 function digest(value: unknown): string {
 	return `sha256:${createHash("sha256").update(JSON.stringify(value)).digest("hex")}`;

--- a/.pi/extensions/kamn-mvp/pi-transaction-live-integration.test.ts
+++ b/.pi/extensions/kamn-mvp/pi-transaction-live-integration.test.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import { resolve } from "node:path";
+import test from "node:test";
+import { LiveTaskWorkflow } from "./live-task-workflow.ts";
+import { testSetup } from "./live-task-workflow-test-support.ts";
+import { verifyPiTransactionActors, writePiTransactionActor } from "./pi-transaction-evidence.ts";
+
+test("live three-role workflow persists and verifies v2 service authority", async () => {
+	const setup = await testSetup();
+	const workflow = new LiveTaskWorkflow(setup.env, process.cwd());
+	await workflow.register("agent_a");
+	const provider = await workflow.register("agent_b");
+	await workflow.register("agent_c");
+	await workflow.createTask("Authority", "Bind service receipts to Pi actors", String(provider.did));
+	await workflow.fundEscrow();
+	await workflow.acceptTask();
+	await workflow.completeTask();
+	await workflow.releaseEscrow();
+	await workflow.queryParticipantProjection("agent_a");
+	await workflow.queryParticipantProjection("agent_b");
+	await workflow.queryVerifierProjection();
+
+	const paths = {
+		agent_a: resolve(setup.root, "agent-a.json"),
+		agent_b: resolve(setup.root, "agent-b.json"),
+		agent_c: resolve(setup.root, "agent-c.json"),
+	};
+	for (const [role, pid] of [["agent_a", 101], ["agent_b", 202], ["agent_c", 303]] as const) {
+		const evidence = workflow.actorEvidence(role, pid, `sha256:${"b".repeat(64)}`);
+		await writePiTransactionActor(paths[role], evidence);
+	}
+	const verified = await verifyPiTransactionActors(paths);
+	assert.equal(verified.task_id, workflow.currentTaskId());
+	assert.match(verified.receipt_chain_commitment, /^sha256:[0-9a-f]{64}$/);
+	assert.deepEqual(verified.pi_process_ids, [101, 202, 303]);
+	await workflow.shutdown();
+});

--- a/.pi/extensions/kamn-mvp/pi-transaction-service-authority.test.ts
+++ b/.pi/extensions/kamn-mvp/pi-transaction-service-authority.test.ts
@@ -1,0 +1,159 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import test from "node:test";
+import { verifyPiTransactionActors, writePiTransactionActor } from "./pi-transaction-evidence.ts";
+
+type Role = "agent_a" | "agent_b" | "agent_c";
+type Receipt = ReturnType<typeof receipt>;
+
+test("v2 actor artifacts bind exact role service authority and chain commitment", async () => {
+	const paths = await actorPaths();
+	await Promise.all((Object.keys(paths) as Role[]).map((role) =>
+		writePiTransactionActor(paths[role], actorInput(role)),
+	));
+
+	const verified = await verifyPiTransactionActors(paths);
+	assert.equal(verified.receipt_chain_commitment, digest("c"));
+	const actorA = JSON.parse(await readFile(paths.agent_a, "utf8"));
+	assert.equal(actorA.schema_version, "kamn.mvp.pi-transaction-actor.v2");
+	assert.deepEqual(actorA.service_receipts.map((entry: Receipt) => entry.action), [
+		"task:create", "escrow:fund", "escrow:release-authorize",
+	]);
+	assert.equal("runtime_response_receipts" in actorA, false);
+	assert.equal("runtime_response_digests" in actorA, false);
+});
+
+for (const [label, mutate] of [
+	["reordered", (input: Record<string, unknown>) => {
+		(input.service_receipts as Receipt[]).reverse();
+	}],
+	["replayed", (input: Record<string, unknown>) => {
+		const receipts = input.service_receipts as Receipt[];
+		receipts[1] = { ...receipts[1], service_receipt_id: receipts[0].service_receipt_id };
+	}],
+	["cross-role", (input: Record<string, unknown>) => {
+		const receipts = input.service_receipts as Receipt[];
+		receipts[0] = { ...receipts[0], actor_did: roleDid("agent_b") };
+	}],
+] as const) {
+	test(`v2 actor evidence rejects ${label} service receipts`, async () => {
+		const paths = await actorPaths();
+		const input = actorInput("agent_a");
+		mutate(input);
+		await assert.rejects(
+			writePiTransactionActor(paths.agent_a, input),
+			/PI_SERVICE_AUTHORITY_MISMATCH/,
+		);
+	});
+}
+
+test("Agent C rejects copied participant receipt authority", async () => {
+	const paths = await actorPaths();
+	const input = actorInput("agent_c");
+	input.service_receipts = [receipt("agent_c", "task:create", "task-live-1", "submitted", "9")];
+
+	await assert.rejects(
+		writePiTransactionActor(paths.agent_c, input),
+		/PI_SERVICE_AUTHORITY_MISMATCH/,
+	);
+});
+
+test("legacy local runtime receipts cannot satisfy canonical v2 evidence", async () => {
+	const paths = await actorPaths();
+	const input = actorInput("agent_a");
+	delete input.service_receipts;
+	delete input.service_profile_commitment;
+	delete input.transport_response_digests;
+	delete input.receipt_chain_commitment;
+	input.runtime_response_digests = [digest("1")];
+	input.runtime_response_receipts = [{
+		request_id: 1,
+		tool: "register",
+		outcome: "success",
+		digest: digest("1"),
+		public_result: { did: roleDid("agent_a") },
+	}];
+	input.runtime_projection_digest = digest("1");
+
+	await assert.rejects(
+		writePiTransactionActor(paths.agent_a, input),
+		/PI_SERVICE_AUTHORITY_MISMATCH/,
+	);
+});
+
+function actorInput(role: Role): Record<string, unknown> {
+	return {
+		actor: role,
+		pi_process_id: { agent_a: 101, agent_b: 202, agent_c: 303 }[role],
+		did: roleDid(role),
+		mcp_child_process_id: { agent_a: 1001, agent_b: 1002, agent_c: 1003 }[role],
+		first_request_id: 1,
+		last_request_id: 1,
+		transport_response_digests: [digest(role === "agent_a" ? "1" : role === "agent_b" ? "2" : "3")],
+		service_profile_commitment: digest("f"),
+		service_receipts: roleReceipts(role),
+		task_id: "task-live-1",
+		transaction_id: "transaction-live-1",
+		escrow_id: "escrow-live-1",
+		amount_lamports: 1_000_000,
+		network: "solana-devnet",
+		settlement_tx_signature: "devnet-signature-1",
+		settlement_commitment: "finalized",
+		receipt_chain_commitment: digest("c"),
+		public_commitment: digest("d"),
+		view_scope: role === "agent_c" ? "restricted-public" : "participant-private",
+		...(role === "agent_c" ? {} : { participant_role: role === "agent_a" ? "creator" : "provider" }),
+		source_handoff_digest: digest("e"),
+		handoff_authorized: false,
+	};
+}
+
+function roleReceipts(role: Role): Receipt[] {
+	if (role === "agent_a") return [
+		receipt(role, "task:create", "task-live-1", "submitted", "1"),
+		receipt(role, "escrow:fund", "escrow-live-1", "funded", "2"),
+		receipt(role, "escrow:release-authorize", "escrow-live-1", "release-authorized", "3"),
+	];
+	if (role === "agent_b") return [
+		receipt(role, "task:accept", "task-live-1", "accepted", "4"),
+		receipt(role, "task:complete", "task-live-1", "completed", "5"),
+	];
+	return [];
+}
+
+function receipt(role: Role, action: string, resource: string, state: string, suffix: string) {
+	return {
+		actor_did: roleDid(role),
+		tool: ({
+			"task:create": "create_task",
+			"task:accept": "accept_task",
+			"task:complete": "complete_task",
+			"escrow:fund": "fund_escrow",
+			"escrow:release-authorize": "release_escrow",
+		} as Record<string, string>)[action],
+		action,
+		resource_id: resource,
+		resulting_state: state,
+		service_receipt_id: `service-receipt-${suffix}`,
+		service_receipt_digest: digest(suffix),
+	};
+}
+
+async function actorPaths() {
+	const root = await mkdtemp(resolve(tmpdir(), "kamn-pi-service-authority-"));
+	return {
+		agent_a: resolve(root, "agent-a.json"),
+		agent_b: resolve(root, "agent-b.json"),
+		agent_c: resolve(root, "agent-c.json"),
+	};
+}
+
+function roleDid(role: Role): string {
+	return `kamn:did:${role.replace("_", "-")}`;
+}
+
+function digest(character: string): string {
+	return `sha256:${character.repeat(64)}`;
+}

--- a/.pi/extensions/kamn-mvp/test-fixtures/fake-mcp-projections.mjs
+++ b/.pi/extensions/kamn-mvp/test-fixtures/fake-mcp-projections.mjs
@@ -1,0 +1,52 @@
+export function createProjections(resultMode) {
+	let participantAttempts = 0;
+	return {
+		participant(taskId, name) {
+			if (resultMode === "pending-three-projections" && participantAttempts++ < 3) return pending(taskId, name);
+			if (resultMode === "pending-first-projection" && participantAttempts++ === 0) return pending(taskId, name);
+			if (resultMode === "missing-first-escrow" && participantAttempts++ === 0) return unbound(taskId, name);
+			return participant(taskId, name, resultMode);
+		},
+		verifier(taskId) { return { ...shared(taskId), view_scope: "restricted-public" }; },
+	};
+}
+
+export function digest(character) { return `sha256:${character.repeat(64)}`; }
+
+function pending(taskId, name) {
+	const projection = participant(taskId, name);
+	delete projection.settlement_tx_signature;
+	delete projection.settlement_commitment;
+	return projection;
+}
+function unbound(taskId, name) {
+	const projection = participant(taskId, name);
+	delete projection.escrow_id;
+	return projection;
+}
+function participant(taskId, name, resultMode) {
+	const suffix = name.endsWith("b") ? "b" : "a";
+	const receipts = roleReceipts(suffix);
+	if (resultMode === "projection-authority-mismatch") receipts[0].receipt_digest = digest("9");
+	return {
+		...shared(taskId), view_scope: "participant-private",
+		participant_role: suffix === "a" ? "creator" : "provider",
+		task_receipt_ids: receipts.filter((receipt) => receipt.action.startsWith("task:")).map((receipt) => receipt.receipt_id),
+		receipt_chain_receipts: receipts,
+	};
+}
+function roleReceipts(suffix) {
+	const entries = suffix === "a"
+		? [["1", "task:create", "task-live-1", "submitted"], ["2", "escrow:fund", "escrow-live-1", "funded"], ["3", "escrow:release-authorize", "escrow-live-1", "release-authorized"]]
+		: [["4", "task:accept", "task-live-1", "accepted"], ["5", "task:complete", "task-live-1", "completed"]];
+	return entries.map(([id, action, resource_id, resulting_state]) => ({
+		receipt_id: `task-transition-receipt-${id}`, receipt_digest: digest(id), action, resource_id, resulting_state,
+	}));
+}
+function shared(taskId) {
+	return {
+		task_id: taskId, transaction_id: "transaction-live-1", escrow_id: "escrow-live-1",
+		amount_lamports: 1000000, network: "solana-devnet", settlement_tx_signature: "devnet-signature-1",
+		settlement_commitment: "finalized", receipt_chain_commitment: digest("c"), public_commitment: digest("d"),
+	};
+}

--- a/.pi/extensions/kamn-mvp/test-fixtures/fake-mcp-server.mjs
+++ b/.pi/extensions/kamn-mvp/test-fixtures/fake-mcp-server.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { appendFileSync } from "node:fs";
+import { createHash } from "node:crypto";
 import { createInterface } from "node:readline";
 
 const mode = process.env.KAMN_MVP_FAKE_MCP_MODE ?? "success";
@@ -35,29 +36,59 @@ createInterface({ input: process.stdin }).on("line", (line) => {
 });
 
 function successResponse(request) {
-	const result = toolResult(request);
+	const serviceResult = { ...toolResult(request), pid: process.pid, request_id: request.id };
+	const result = authorityResult(request, serviceResult);
 	return {
 		ok: true,
 		id: mode === "mismatch" ? "wrong-id" : request.id,
 		tool: request.tool,
-		result: { ...result, pid: process.pid, request_id: request.id },
+		result,
+	};
+}
+
+function authorityResult(request, serviceResult) {
+	if (!isAuthorityTool(request.tool)) return serviceResult;
+	if (resultMode === "missing-authority") return serviceResult;
+	const envelope = request.tool === "register" ? registrationAuthority(serviceResult) : mutationAuthority(request.tool, serviceResult);
+	if (resultMode === "malformed-authority" && request.tool === "register") envelope.profile_commitment = "invalid";
+	if (resultMode === "malformed-authority" && request.tool !== "register") envelope.service_receipt_digest = "invalid";
+	if (resultMode === "mixed-authority-version") envelope.schema_version = "kamn.mcp.authority-receipt.v2";
+	if (resultMode === "cross-role-authority" && request.tool !== "register") envelope.actor_did = "kamn:did:agent-b";
+	return envelope;
+}
+
+function registrationAuthority(serviceResult) {
+	return {
+		schema_version: "kamn.mcp.authority-receipt.v1", authority_kind: "service-profile-commitment", source: "kamn-service",
+		actor_did: serviceResult.did, tool: "register", resource_id: serviceResult.did,
+		profile_commitment: serviceResult.profile_commitment, service_result: serviceResult,
+	};
+}
+
+function mutationAuthority(tool, serviceResult) {
+	const resource = tool.includes("escrow") ? serviceResult.escrow_id : serviceResult.task_id;
+	return {
+		schema_version: "kamn.mcp.authority-receipt.v1", authority_kind: "service-receipt", source: "kamn-service",
+		actor_did: serviceResult.actor_did, tool, resource_id: resource, resulting_state: serviceResult.state,
+		service_receipt_id: serviceResult.receipt_id, service_receipt_digest: serviceResult.receipt_digest,
+		service_result: serviceResult,
 	};
 }
 
 function toolResult(request) {
 	if (request.tool === "register") {
-		return { did: resultMode === "same-did" ? "kamn:did:shared" : `kamn:did:${agentName}` };
+		return { did: resultMode === "same-did" ? "kamn:did:shared" : actorDid(), profile_commitment: digest("f") };
 	}
 	if (request.tool === "query_agent_profile") return { did: request.did };
 	if (request.tool === "create_task") {
 		const payload = JSON.parse(request.payload);
 		if (resultMode === "missing-task-id") return { state: "submitted", ...payload };
 		const state = resultMode === "wrong-create-state" ? "queued" : "submitted";
-		return { task_id: "task-live-1", state, ...payload };
+		return mutationResult("create_task", "task-live-1", state, payload, "1");
 	}
 	if (request.tool === "accept_task") {
 		const taskId = resultMode === "wrong-accept-id" ? "task-other" : request.task_id;
-		return { task_id: taskId, state: "accepted", ...JSON.parse(request.payload) };
+		return mutationResult("accept_task", taskId, "accepted", JSON.parse(request.payload), "4");
 	}
 	if (request.tool === "query_task") {
 		if (resultMode === "completed-second-query") {
@@ -66,10 +97,12 @@ function toolResult(request) {
 		const state = resultMode === "wrong-query-state" ? "submitted" : "accepted";
 		return { task_id: request.task_id, state };
 	}
-	if (request.tool === "complete_task") return { task_id: request.task_id, state: "completed", ...JSON.parse(request.payload) };
-	if (request.tool === "fund_escrow") return { escrow_id: "escrow-live-1", state: "funded", ...JSON.parse(request.payload) };
+	if (request.tool === "complete_task") return mutationResult("complete_task", request.task_id, "completed", JSON.parse(request.payload), "5");
+	if (request.tool === "fund_escrow") return mutationResult("fund_escrow", "escrow-live-1", "funded", JSON.parse(request.payload), "2");
 	if (request.tool === "release_escrow") {
-		return { escrow_id: request.escrow_id, state: "released", settlement_tx_signature: "devnet-signature-1", ...JSON.parse(request.payload) };
+		return mutationResult("release_escrow", request.escrow_id, "release-authorized", {
+			settlement_tx_signature: "devnet-signature-1", ...JSON.parse(request.payload),
+		}, "3");
 	}
 	if (request.tool === "query_participant_task_projection") {
 		if (resultMode === "pending-three-projections" && participantProjectionAttempts++ < 3) {
@@ -88,6 +121,23 @@ function toolResult(request) {
 	}
 	return {};
 }
+
+function mutationResult(tool, resource, state, fields, suffix) {
+	const action = {
+		create_task: "task:create", accept_task: "task:accept", complete_task: "task:complete",
+		fund_escrow: "escrow:fund", release_escrow: "escrow:release-authorize",
+	}[tool];
+	return {
+		...(tool.includes("escrow") ? { escrow_id: resource } : { task_id: resource }), ...fields,
+		actor_did: actorDid(), action, state, receipt_id: `task-transition-receipt-${suffix}`, receipt_digest: digest(suffix),
+	};
+}
+
+function isAuthorityTool(tool) {
+	return ["register", "create_task", "accept_task", "complete_task", "fund_escrow", "release_escrow"].includes(tool);
+}
+function actorDid() { return `kamn:did:${agentName}`; }
+function digest(character) { return `sha256:${character.repeat(64)}`; }
 
 function pendingParticipantProjection(taskId, name) {
 	const projection = participantProjection(taskId, name);
@@ -108,8 +158,18 @@ function participantProjection(taskId, name) {
 		...sharedProjection(taskId),
 		view_scope: "participant-private",
 		participant_role: suffix === "a" ? "creator" : "provider",
-		private_receipt_digest: `sha256:participant-${suffix}`,
+		task_receipt_ids: roleReceiptEntries(suffix).filter((receipt) => receipt.action.startsWith("task:")).map((receipt) => receipt.receipt_id),
+		receipt_chain_receipts: roleReceiptEntries(suffix),
 	};
+}
+
+function roleReceiptEntries(suffix) {
+	const entries = suffix === "a"
+		? [["1", "task:create", "task-live-1", "submitted"], ["2", "escrow:fund", "escrow-live-1", "funded"], ["3", "escrow:release-authorize", "escrow-live-1", "release-authorized"]]
+		: [["4", "task:accept", "task-live-1", "accepted"], ["5", "task:complete", "task-live-1", "completed"]];
+	return entries.map(([id, action, resource_id, resulting_state]) => ({
+		receipt_id: `task-transition-receipt-${id}`, receipt_digest: digest(id), action, resource_id, resulting_state,
+	}));
 }
 
 function sharedProjection(taskId) {
@@ -121,7 +181,8 @@ function sharedProjection(taskId) {
 		network: "solana-devnet",
 		settlement_tx_signature: "devnet-signature-1",
 		settlement_commitment: "finalized",
-		public_commitment: "sha256:shared",
+		receipt_chain_commitment: digest("c"),
+		public_commitment: digest("d"),
 	};
 }
 

--- a/.pi/extensions/kamn-mvp/test-fixtures/fake-mcp-server.mjs
+++ b/.pi/extensions/kamn-mvp/test-fixtures/fake-mcp-server.mjs
@@ -54,6 +54,8 @@ function authorityResult(request, serviceResult) {
 	if (resultMode === "malformed-authority" && request.tool !== "register") envelope.service_receipt_digest = "invalid";
 	if (resultMode === "mixed-authority-version") envelope.schema_version = "kamn.mcp.authority-receipt.v2";
 	if (resultMode === "cross-role-authority" && request.tool !== "register") envelope.actor_did = "kamn:did:agent-b";
+	if (resultMode === "wrong-tool-authority" && request.tool !== "register") envelope.tool = "query_task";
+	if (resultMode === "copied-resource-authority" && request.tool !== "register") envelope.resource_id = "task-copied";
 	return envelope;
 }
 
@@ -154,12 +156,14 @@ function unboundParticipantProjection(taskId, name) {
 
 function participantProjection(taskId, name) {
 	const suffix = name.endsWith("b") ? "b" : "a";
+	const receipts = roleReceiptEntries(suffix);
+	if (resultMode === "projection-authority-mismatch") receipts[0].receipt_digest = digest("9");
 	return {
 		...sharedProjection(taskId),
 		view_scope: "participant-private",
 		participant_role: suffix === "a" ? "creator" : "provider",
-		task_receipt_ids: roleReceiptEntries(suffix).filter((receipt) => receipt.action.startsWith("task:")).map((receipt) => receipt.receipt_id),
-		receipt_chain_receipts: roleReceiptEntries(suffix),
+		task_receipt_ids: receipts.filter((receipt) => receipt.action.startsWith("task:")).map((receipt) => receipt.receipt_id),
+		receipt_chain_receipts: receipts,
 	};
 }
 

--- a/.pi/extensions/kamn-mvp/test-fixtures/fake-mcp-server.mjs
+++ b/.pi/extensions/kamn-mvp/test-fixtures/fake-mcp-server.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { appendFileSync } from "node:fs";
-import { createHash } from "node:crypto";
 import { createInterface } from "node:readline";
+import { createProjections, digest } from "./fake-mcp-projections.mjs";
 
 const mode = process.env.KAMN_MVP_FAKE_MCP_MODE ?? "success";
 const resultMode = process.env.KAMN_MVP_FAKE_MCP_RESULT_MODE ?? "success";
@@ -9,8 +9,8 @@ const startFile = process.env.KAMN_MVP_FAKE_MCP_START_FILE;
 const stopFile = process.env.KAMN_MVP_FAKE_MCP_STOP_FILE;
 const agentName = argumentValue("--agent-name") ?? "agent-a";
 let releaseAttempts = 0;
-let participantProjectionAttempts = 0;
 let taskQueryAttempts = 0;
+const projections = createProjections(resultMode);
 if (startFile) appendFileSync(startFile, `${process.pid}\n`);
 
 process.on("SIGTERM", () => {
@@ -107,19 +107,10 @@ function toolResult(request) {
 		}, "3");
 	}
 	if (request.tool === "query_participant_task_projection") {
-		if (resultMode === "pending-three-projections" && participantProjectionAttempts++ < 3) {
-			return pendingParticipantProjection(request.task_id, agentName);
-		}
-		if (resultMode === "pending-first-projection" && participantProjectionAttempts++ === 0) {
-			return pendingParticipantProjection(request.task_id, agentName);
-		}
-		if (resultMode === "missing-first-escrow" && participantProjectionAttempts++ === 0) {
-			return unboundParticipantProjection(request.task_id, agentName);
-		}
-		return participantProjection(request.task_id, agentName);
+		return projections.participant(request.task_id, agentName);
 	}
 	if (request.tool === "query_verifier_task_projection") {
-		return { ...sharedProjection(request.task_id), view_scope: "restricted-public" };
+		return projections.verifier(request.task_id);
 	}
 	return {};
 }
@@ -139,57 +130,6 @@ function isAuthorityTool(tool) {
 	return ["register", "create_task", "accept_task", "complete_task", "fund_escrow", "release_escrow"].includes(tool);
 }
 function actorDid() { return `kamn:did:${agentName}`; }
-function digest(character) { return `sha256:${character.repeat(64)}`; }
-
-function pendingParticipantProjection(taskId, name) {
-	const projection = participantProjection(taskId, name);
-	delete projection.settlement_tx_signature;
-	delete projection.settlement_commitment;
-	return projection;
-}
-
-function unboundParticipantProjection(taskId, name) {
-	const projection = participantProjection(taskId, name);
-	delete projection.escrow_id;
-	return projection;
-}
-
-function participantProjection(taskId, name) {
-	const suffix = name.endsWith("b") ? "b" : "a";
-	const receipts = roleReceiptEntries(suffix);
-	if (resultMode === "projection-authority-mismatch") receipts[0].receipt_digest = digest("9");
-	return {
-		...sharedProjection(taskId),
-		view_scope: "participant-private",
-		participant_role: suffix === "a" ? "creator" : "provider",
-		task_receipt_ids: receipts.filter((receipt) => receipt.action.startsWith("task:")).map((receipt) => receipt.receipt_id),
-		receipt_chain_receipts: receipts,
-	};
-}
-
-function roleReceiptEntries(suffix) {
-	const entries = suffix === "a"
-		? [["1", "task:create", "task-live-1", "submitted"], ["2", "escrow:fund", "escrow-live-1", "funded"], ["3", "escrow:release-authorize", "escrow-live-1", "release-authorized"]]
-		: [["4", "task:accept", "task-live-1", "accepted"], ["5", "task:complete", "task-live-1", "completed"]];
-	return entries.map(([id, action, resource_id, resulting_state]) => ({
-		receipt_id: `task-transition-receipt-${id}`, receipt_digest: digest(id), action, resource_id, resulting_state,
-	}));
-}
-
-function sharedProjection(taskId) {
-	return {
-		task_id: taskId,
-		transaction_id: "transaction-live-1",
-		escrow_id: "escrow-live-1",
-		amount_lamports: 1000000,
-		network: "solana-devnet",
-		settlement_tx_signature: "devnet-signature-1",
-		settlement_commitment: "finalized",
-		receipt_chain_commitment: digest("c"),
-		public_commitment: digest("d"),
-	};
-}
-
 function errorResponse(request) {
 	return {
 		ok: false,

--- a/specs/7134-migrate-pi-service-authority.md
+++ b/specs/7134-migrate-pi-service-authority.md
@@ -1,0 +1,150 @@
+# Issue #7134: Migrate Pi Actor Evidence To Service Receipt Authority
+
+## Objective
+
+Make canonical Pi actor evidence derive authority only from validated
+`kamn.mcp.authority-receipt.v1` envelopes and final service projections. Keep
+Pi process, request, and response hashes as explicitly labeled transport
+provenance that cannot satisfy the actor-authority contract.
+
+## Inputs And Outputs
+
+### Inputs
+
+- A persistent authenticated MCP child for exactly one role and DID.
+- Versioned registration and mutation authority envelopes returned by
+  `kamn-mcp-server`.
+- Raw MCP responses and monotonically increasing request IDs used only for
+  transport provenance.
+- The role's final participant-private or restricted-public service projection.
+- The canonical task handoff digest.
+
+### Outputs
+
+- Actor artifacts use `kamn.mvp.pi-transaction-actor.v2`.
+- Every artifact binds the role, DID, MCP child process, contiguous request
+  range, `transport_response_digests`, task/transaction/escrow IDs, final
+  `receipt_chain_commitment`, public commitment, view scope, and handoff digest.
+- Registration authority is retained as the service profile commitment bound to
+  the role DID.
+- Agent A authority contains ordered service receipts for `task:create`,
+  `escrow:fund`, and `escrow:release-authorize`.
+- Agent B authority contains ordered service receipts for `task:accept` and
+  `task:complete`.
+- Agent C authority contains no mutation receipts and its restricted-public
+  projection contains no participant receipt details.
+- Participant receipt IDs, digests, actions, resources, and resulting states
+  match the actor-owned entries in the final service projection exactly.
+
+## Boundaries And Non-Goals
+
+- Do not change service receipt generation, MCP envelope generation, projection
+  commitment semantics, settlement, the independent Rust verifier, or demo
+  closeout behavior.
+- Do not add dependencies, OAuth, remote MCP transport, nonce resumption, or a
+  replacement MCP child after a child failure.
+- Do not treat profile commitments as mutation receipts or transport hashes as
+  service authority.
+- Compatibility actor-receipt tools may remain registered for older demos, but
+  their local artifacts cannot populate or validate v2 service authority.
+
+## Authority Validation
+
+- Registration must be a `service-profile-commitment` envelope with the exact
+  schema, source, tool, actor/resource DID, digest-shaped profile commitment,
+  and matching nested service result.
+- Canonical mutations must be `service-receipt` envelopes with the exact schema,
+  source, tool, registered actor DID, resource, resulting state, receipt ID,
+  digest, and matching nested service result.
+- The MCP session records a service authority entry only after full validation.
+  Failed calls record transport provenance only.
+- A successful mutation missing or malforming authority fails the entire MCP
+  session. A terminal child/session error remains sticky; the workflow cannot
+  create a replacement nonce stream for that role.
+- V2 normalization rejects unknown authority fields and requires exact role
+  receipt order, unique receipt IDs, and unique ID/digest pairs.
+- Participant projection receipt entries must exactly equal the role's service
+  authority entries. Agent C must have neither mutation authority nor projected
+  receipt entries.
+
+## Failure Modes
+
+- Missing, malformed, or mixed-version MCP authority envelope.
+- Fabricated, copied, reordered, duplicated, replayed, or cross-role service
+  receipt ID/digest.
+- Envelope actor, tool, resource, state, or nested result mismatch.
+- Missing or mismatched registration profile commitment.
+- Missing final receipt-chain commitment or projection receipt set.
+- Participant authority that differs from the final participant projection.
+- Agent C receipt authority or participant-private projection leakage.
+- Non-contiguous transport request IDs or a replaced MCP child.
+- V1 or compatibility-only local receipt evidence supplied as canonical v2.
+
+## Error Semantics
+
+- MCP envelope absence uses `MCP_AUTHORITY_RECEIPT_MISSING`.
+- Malformed or mismatched MCP authority uses `MCP_AUTHORITY_RECEIPT_INVALID`.
+- Actor/projection disagreement uses `PI_SERVICE_AUTHORITY_MISMATCH`.
+- Invalid process/request/hash provenance uses
+  `PI_TRANSPORT_PROVENANCE_INVALID`.
+- Child loss retains the existing fatal session error and never falls back to a
+  replacement child or local receipt.
+- Errors hard-fail at the Pi boundary; there is no compatibility fallback.
+
+## Acceptance Criteria
+
+- [ ] Every canonical registration and mutation validates its versioned MCP
+  authority envelope before the workflow consumes the nested service result.
+- [ ] Pi stores ordered service receipt IDs/digests as authority and stores local
+  hashes only as `transport_response_digests`.
+- [ ] V2 actor evidence binds identity, exact role receipts, transaction facts,
+  final chain/public commitments, view scope, and handoff digest.
+- [ ] Agent A, B, and C receipt sets exactly match their role and final
+  projections without Agent C private leakage.
+- [ ] Missing, fabricated, copied, replayed, reordered, cross-role, malformed,
+  v1, compatibility, and projection-mismatched evidence fails closed.
+- [ ] A failed MCP child/session remains terminal for its actor session.
+- [ ] Focused Pi tests and the real workflow integration path pass.
+- [ ] Formatting and strict repository checks remain clean.
+
+## Files To Touch
+
+- `.pi/extensions/kamn-mvp/mcp-authority.ts`
+- `.pi/extensions/kamn-mvp/mcp-session.ts`
+- `.pi/extensions/kamn-mvp/mcp-provenance.ts`
+- `.pi/extensions/kamn-mvp/live-task-workflow-support.ts`
+- `.pi/extensions/kamn-mvp/pi-transaction-evidence.ts`
+- Focused `.pi/extensions/kamn-mvp/*.test.ts` files and the fake MCP fixture.
+- Existing compatibility receipt modules only when needed to make their
+  non-authoritative status explicit.
+
+## Test Plan
+
+### RED
+
+- Require `McpSession` to reject missing, malformed, wrong-actor, wrong-tool,
+  copied-resource, and mixed-version authority envelopes.
+- Require workflow evidence to expose service authority separately from
+  transport provenance and bind the final v2 projection commitment.
+- Require actor verification to reject missing, reordered, copied, cross-role,
+  replayed, v1, compatibility-only, and projection-mismatched authority.
+- Prove a child crash remains terminal and cannot restart the role session.
+
+### GREEN
+
+- Add the minimal typed envelope parser and session authority tracker.
+- Emit and validate the minimal v2 actor artifact using service receipts and the
+  final service projection.
+
+### REFACTOR
+
+- Keep envelope parsing, transport provenance, authority/projection matching,
+  and artifact persistence single-purpose and within repository size limits.
+- Remove v1 runtime-receipt authority from the canonical artifact path.
+
+### INTEGRATION
+
+- Exercise the three-role fake MCP workflow with versioned authority envelopes,
+  persistent children, role-private projections, and one shared chain/public
+  commitment.
+- Run focused Pi tests plus formatting and strict repository validation.

--- a/specs/7134-migrate-pi-service-authority.md
+++ b/specs/7134-migrate-pi-service-authority.md
@@ -93,19 +93,19 @@ provenance that cannot satisfy the actor-authority contract.
 
 ## Acceptance Criteria
 
-- [ ] Every canonical registration and mutation validates its versioned MCP
+- [x] Every canonical registration and mutation validates its versioned MCP
   authority envelope before the workflow consumes the nested service result.
-- [ ] Pi stores ordered service receipt IDs/digests as authority and stores local
+- [x] Pi stores ordered service receipt IDs/digests as authority and stores local
   hashes only as `transport_response_digests`.
-- [ ] V2 actor evidence binds identity, exact role receipts, transaction facts,
+- [x] V2 actor evidence binds identity, exact role receipts, transaction facts,
   final chain/public commitments, view scope, and handoff digest.
-- [ ] Agent A, B, and C receipt sets exactly match their role and final
+- [x] Agent A, B, and C receipt sets exactly match their role and final
   projections without Agent C private leakage.
-- [ ] Missing, fabricated, copied, replayed, reordered, cross-role, malformed,
+- [x] Missing, fabricated, copied, replayed, reordered, cross-role, malformed,
   v1, compatibility, and projection-mismatched evidence fails closed.
-- [ ] A failed MCP child/session remains terminal for its actor session.
-- [ ] Focused Pi tests and the real workflow integration path pass.
-- [ ] Formatting and strict repository checks remain clean.
+- [x] A failed MCP child/session remains terminal for its actor session.
+- [x] Focused Pi tests and the real workflow integration path pass.
+- [x] Formatting and issue-scoped repository checks remain clean.
 
 ## Files To Touch
 
@@ -148,3 +148,18 @@ provenance that cannot satisfy the actor-authority contract.
   persistent children, role-private projections, and one shared chain/public
   commitment.
 - Run focused Pi tests plus formatting and strict repository validation.
+
+## Verification Evidence
+
+- `node --experimental-strip-types --test .pi/extensions/kamn-mvp/*.test.ts`:
+  59 passed, 0 failed.
+- `node --check` passed for both fake MCP fixture modules.
+- `cargo fmt --all --check` passed.
+- `git diff --check` passed.
+- `make check` and the narrower all-target `kamn-e2e-harness` Clippy command
+  both compiled without diagnostics before stalling after crate checks on the
+  known macOS local path. The full strict result is delegated to Ubuntu CI.
+
+The independent Rust artifact verifier still consumes v1 artifacts. Its v2
+service-authority migration and canonical demo closeout remain #7135 scope, as
+listed in this spec's non-goals.


### PR DESCRIPTION
## Human Summary

- Validates versioned MCP registration and mutation authority envelopes before Pi workflows consume service results.
- Migrates canonical actor artifacts to v2 ordered service receipts and final receipt-chain commitments; transport hashes remain diagnostic only.
- Rejects missing, malformed, copied, replayed, reordered, cross-role, projection-mismatched, and legacy local authority.
- Keeps MCP child/session failures sticky and verifies the live three-role artifact path end to end.

Closes #7134

Spec: [specs/7134-migrate-pi-service-authority.md](https://github.com/njfio/kamn/blob/7134-migrate-pi-service-authority/specs/7134-migrate-pi-service-authority.md)

## Testing

- `node --experimental-strip-types --test .pi/extensions/kamn-mvp/*.test.ts` (59 passed)
- `node --check .pi/extensions/kamn-mvp/test-fixtures/fake-mcp-server.mjs`
- `node --check .pi/extensions/kamn-mvp/test-fixtures/fake-mcp-projections.mjs`
- `cargo fmt --all --check`
- `git diff --check`
- `make check` compiled without diagnostics but stalled after crate checks on the local macOS path; Ubuntu CI is the full strict authority.

## Notes for Reviewers

The independent Rust actor-artifact verifier remains v1. Its v2 service-authority migration and canonical demo closeout are intentionally tracked in #7135.