### PR TITLE
fix: reconcile ambiguous live settlement before retry

### DIFF
--- a/.pi/extensions/kamn-mvp/mcp-authority.ts
+++ b/.pi/extensions/kamn-mvp/mcp-authority.ts
@@ -7,7 +7,7 @@ const MUTATIONS = {
 	accept_task: { action: "task:accept", resource: "task_id", states: ["accepted"] },
 	complete_task: { action: "task:complete", resource: "task_id", states: ["completed"] },
 	fund_escrow: { action: "escrow:fund", resource: "escrow_id", states: ["funded"] },
-	release_escrow: { action: "escrow:release-authorize", resource: "escrow_id", states: ["release-authorized", "released"] },
+	release_escrow: { action: "escrow:release-authorize", resource: "escrow_id", states: ["release-authorized"] },
 } as const;
 
 export type ServiceAuthorityReceipt = {
@@ -22,7 +22,7 @@ export type ServiceAuthorityReceipt = {
 export type ValidatedAuthority = {
 	serviceResult: JsonObject;
 	profileCommitment?: string;
-	receipt?: ServiceAuthorityReceipt;
+	receipts?: ServiceAuthorityReceipt[];
 };
 
 export function requiresAuthority(tool: string): boolean {
@@ -73,11 +73,34 @@ function validateMutation(tool: keyof typeof MUTATIONS, result: JsonObject, expe
 		|| !contract.states.some((candidate) => candidate === state)) {
 		throw new Error("MCP_AUTHORITY_RECEIPT_INVALID");
 	}
-	return {
-		serviceResult,
-		receipt: { actor_did: actor, tool, action: contract.action, resource_id: resource, resulting_state: state,
-			service_receipt_id: receiptId, service_receipt_digest: receiptDigest },
-	};
+	const primary = receipt(actor, tool, contract.action, resource, state, receiptId, receiptDigest);
+	return { serviceResult, receipts: [primary, ...settlementReceipts(result, serviceResult, actor, tool, resource)] };
+}
+
+function settlementReceipts(result: JsonObject, service: JsonObject, actor: string, tool: string, resource: string): ServiceAuthorityReceipt[] {
+	const authority = result.settlement_service_receipt;
+	const serviceFieldsPresent = ["settlement_receipt_id", "settlement_receipt_digest", "settlement_receipt_action",
+		"settlement_receipt_resource_id", "settlement_receipt_state"].some((field) => service[field] !== undefined);
+	if (authority === undefined && !serviceFieldsPresent) return [];
+	if (tool !== "release_escrow" || !isObject(authority)) throw new Error("MCP_AUTHORITY_RECEIPT_INVALID");
+	const parsed = receipt(
+		stringField(authority, "actor_did"), stringField(authority, "tool"), stringField(authority, "action"),
+		stringField(authority, "resource_id"), stringField(authority, "resulting_state"),
+		stringField(authority, "service_receipt_id"), digestField(authority, "service_receipt_digest"),
+	);
+	if (parsed.actor_did !== actor || parsed.tool !== tool || parsed.action !== "settlement:confirmed"
+		|| parsed.resource_id !== resource || parsed.resulting_state !== "confirmed"
+		|| parsed.service_receipt_id !== service.settlement_receipt_id
+		|| parsed.service_receipt_digest !== service.settlement_receipt_digest
+		|| parsed.action !== service.settlement_receipt_action
+		|| parsed.resource_id !== service.settlement_receipt_resource_id
+		|| parsed.resulting_state !== service.settlement_receipt_state) throw new Error("MCP_AUTHORITY_RECEIPT_INVALID");
+	return [parsed];
+}
+
+function receipt(actor_did: string, tool: string, action: string, resource_id: string, resulting_state: string,
+	service_receipt_id: string, service_receipt_digest: string): ServiceAuthorityReceipt {
+	return { actor_did, tool, action, resource_id, resulting_state, service_receipt_id, service_receipt_digest };
 }
 
 function objectField(value: JsonObject, field: string): JsonObject {

--- a/.pi/extensions/kamn-mvp/mcp-session-authority.test.ts
+++ b/.pi/extensions/kamn-mvp/mcp-session-authority.test.ts
@@ -43,6 +43,28 @@ test("session preserves distinct release and settlement receipt authority", asyn
 	]);
 });
 
+test("session rejects partial settlement receipt authority", async (context) => {
+	const setup = await testSetup();
+	const session = sessionFor(setup, "partial-settlement-authority");
+	context.after(() => session.shutdown());
+	await session.call("register");
+	await assert.rejects(
+		session.call("release_escrow", { escrow_id: "escrow-live-1", payload: "{}" }),
+		/MCP_AUTHORITY_RECEIPT_(MISSING|INVALID)/,
+	);
+});
+
+test("session rejects settlement authority that drifts from the service result", async (context) => {
+	const setup = await testSetup();
+	const session = sessionFor(setup, "mismatched-settlement-authority");
+	context.after(() => session.shutdown());
+	await session.call("register");
+	await assert.rejects(
+		session.call("release_escrow", { escrow_id: "escrow-live-1", payload: "{}" }),
+		/MCP_AUTHORITY_RECEIPT_INVALID/,
+	);
+});
+
 for (const [mode, expected] of [
 	["missing-authority", "MCP_AUTHORITY_RECEIPT_MISSING"],
 	["malformed-authority", "MCP_AUTHORITY_RECEIPT_INVALID"],

--- a/.pi/extensions/kamn-mvp/mcp-session-authority.test.ts
+++ b/.pi/extensions/kamn-mvp/mcp-session-authority.test.ts
@@ -30,6 +30,19 @@ test("session separates validated service authority from transport provenance", 
 	assert.equal("runtime_response_receipts" in provenance, false);
 });
 
+test("session preserves distinct release and settlement receipt authority", async (context) => {
+	const setup = await testSetup();
+	const session = sessionFor(setup, "success");
+	context.after(() => session.shutdown());
+	const registered = await session.call("register");
+	await session.call("release_escrow", { escrow_id: "escrow-live-1", payload: "{}" });
+
+	assert.deepEqual(session.provenance().service_authority_receipts.map(({ action, actor_did }) => ({ action, actor_did })), [
+		{ action: "escrow:release-authorize", actor_did: registered.did },
+		{ action: "settlement:confirmed", actor_did: registered.did },
+	]);
+});
+
 for (const [mode, expected] of [
 	["missing-authority", "MCP_AUTHORITY_RECEIPT_MISSING"],
 	["malformed-authority", "MCP_AUTHORITY_RECEIPT_INVALID"],

--- a/.pi/extensions/kamn-mvp/mcp-session-config.ts
+++ b/.pi/extensions/kamn-mvp/mcp-session-config.ts
@@ -1,0 +1,68 @@
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+
+type Environment = Record<string, string | undefined>;
+export type LiveMcpAgent = "AGENT_A" | "AGENT_B" | "AGENT_C";
+export type LiveMcpConfig = {
+	binary: string;
+	endpoint: string;
+	agentName: string;
+	keyFile: string;
+	requestTimeoutMs: number;
+	env: NodeJS.ProcessEnv;
+};
+
+const PROCESS_ENV_ALLOWLIST = new Set([
+	"HOME", "PATH", "RUST_LOG", "TMPDIR", "KAMN_SDK_SERVICE_TIMEOUT_SECONDS",
+]);
+const FIXTURE_ENV_ALLOWLIST = new Set([
+	"KAMN_MVP_FAKE_MCP_MODE", "KAMN_MVP_FAKE_MCP_RESULT_MODE",
+	"KAMN_MVP_FAKE_MCP_START_FILE", "KAMN_MVP_FAKE_MCP_STOP_FILE",
+]);
+const AGENT_ENV = {
+	AGENT_A: { name: "KAMN_MVP_LIVE_MCP_AGENT_A_NAME", keyFile: "KAMN_MVP_LIVE_MCP_AGENT_A_KEY_FILE" },
+	AGENT_B: { name: "KAMN_MVP_LIVE_MCP_AGENT_B_NAME", keyFile: "KAMN_MVP_LIVE_MCP_AGENT_B_KEY_FILE" },
+	AGENT_C: { name: "KAMN_MVP_LIVE_MCP_AGENT_C_NAME", keyFile: "KAMN_MVP_LIVE_MCP_AGENT_C_KEY_FILE" },
+} as const;
+
+export function readLiveMcpConfig(agent: LiveMcpAgent, env: Environment = process.env, cwd = process.cwd()): LiveMcpConfig {
+	const agentEnv = AGENT_ENV[agent];
+	const binary = absolutePath(requiredEnv(env, "KAMN_MVP_LIVE_MCP_BINARY"), cwd);
+	const keyFile = absolutePath(requiredEnv(env, agentEnv.keyFile), cwd);
+	if (!existsSync(binary)) throw new Error(`KAMN live MCP binary does not exist: ${binary}`);
+	if (!existsSync(keyFile)) throw new Error(`KAMN live MCP key file does not exist: ${keyFile}`);
+	return {
+		binary, keyFile,
+		endpoint: requiredEnv(env, "KAMN_MVP_LIVE_MCP_ENDPOINT"),
+		agentName: requiredEnv(env, agentEnv.name),
+		requestTimeoutMs: requestTimeoutMs(env),
+		env: childEnvironment(env),
+	};
+}
+
+function requestTimeoutMs(env: Environment): number {
+	const raw = env.KAMN_SDK_SERVICE_TIMEOUT_SECONDS;
+	if (raw === undefined) return 10000;
+	const seconds = Number(raw.trim());
+	const milliseconds = seconds * 1000;
+	if (!/^\d+$/.test(raw.trim()) || seconds <= 0 || !Number.isSafeInteger(milliseconds)) {
+		throw new Error("KAMN_SDK_SERVICE_TIMEOUT_SECONDS must be a positive integer");
+	}
+	return milliseconds;
+}
+
+function childEnvironment(env: Environment): NodeJS.ProcessEnv {
+	return Object.fromEntries(Object.entries({ ...process.env, ...env }).filter(
+		([name, value]) => value !== undefined && (PROCESS_ENV_ALLOWLIST.has(name) || FIXTURE_ENV_ALLOWLIST.has(name)),
+	));
+}
+
+function requiredEnv(env: Environment, name: string): string {
+	const value = env[name]?.trim();
+	if (!value) throw new Error(`Missing required environment variable: ${name}`);
+	return value;
+}
+
+function absolutePath(path: string, cwd: string): string {
+	return path.startsWith("/") ? path : resolve(cwd, path);
+}

--- a/.pi/extensions/kamn-mvp/mcp-session.test.ts
+++ b/.pi/extensions/kamn-mvp/mcp-session.test.ts
@@ -93,6 +93,15 @@ test("configuration does not forward parent credentials or custody configuration
 	assert.equal(config.env.KAMN_MVP_FAKE_MCP_MODE, "success");
 });
 
+test("configuration forwards the SDK request timeout to the MCP child", async () => {
+	const paths = await testPaths();
+	const config = readLiveMcpConfig("AGENT_A", configEnv(paths.keyFile, {
+		KAMN_SDK_SERVICE_TIMEOUT_SECONDS: "181",
+	}), process.cwd());
+
+	assert.equal(config.env.KAMN_SDK_SERVICE_TIMEOUT_SECONDS, "181");
+});
+
 test("configuration selects independent Agent B identity inputs", async () => {
 	const paths = await testPaths();
 	const env = configEnv(paths.keyFile, {

--- a/.pi/extensions/kamn-mvp/mcp-session.test.ts
+++ b/.pi/extensions/kamn-mvp/mcp-session.test.ts
@@ -100,6 +100,19 @@ test("configuration forwards the SDK request timeout to the MCP child", async ()
 	}), process.cwd());
 
 	assert.equal(config.env.KAMN_SDK_SERVICE_TIMEOUT_SECONDS, "181");
+	assert.equal(config.requestTimeoutMs, 181000);
+});
+
+test("configuration rejects invalid SDK request timeouts", async () => {
+	const paths = await testPaths();
+	for (const value of ["", "0", "invalid"]) {
+		assert.throws(
+			() => readLiveMcpConfig("AGENT_A", configEnv(paths.keyFile, {
+				KAMN_SDK_SERVICE_TIMEOUT_SECONDS: value,
+			}), process.cwd()),
+			/KAMN_SDK_SERVICE_TIMEOUT_SECONDS/,
+		);
+	}
 });
 
 test("configuration selects independent Agent B identity inputs", async () => {

--- a/.pi/extensions/kamn-mvp/mcp-session.ts
+++ b/.pi/extensions/kamn-mvp/mcp-session.ts
@@ -8,11 +8,7 @@ export type { McpSessionProvenance } from "./mcp-provenance.ts";
 type Environment = Record<string, string | undefined>;
 export type LiveMcpAgent = "AGENT_A" | "AGENT_B" | "AGENT_C";
 const PROCESS_ENV_ALLOWLIST = new Set([
-	"HOME",
-	"PATH",
-	"RUST_LOG",
-	"TMPDIR",
-	"KAMN_SDK_SERVICE_TIMEOUT_SECONDS",
+	"HOME", "PATH", "RUST_LOG", "TMPDIR", "KAMN_SDK_SERVICE_TIMEOUT_SECONDS",
 ]);
 const FIXTURE_ENV_ALLOWLIST = new Set([
 	"KAMN_MVP_FAKE_MCP_MODE",

--- a/.pi/extensions/kamn-mvp/mcp-session.ts
+++ b/.pi/extensions/kamn-mvp/mcp-session.ts
@@ -7,7 +7,13 @@ export type { McpSessionProvenance } from "./mcp-provenance.ts";
 
 type Environment = Record<string, string | undefined>;
 export type LiveMcpAgent = "AGENT_A" | "AGENT_B" | "AGENT_C";
-const PROCESS_ENV_ALLOWLIST = new Set(["HOME", "PATH", "RUST_LOG", "TMPDIR"]);
+const PROCESS_ENV_ALLOWLIST = new Set([
+	"HOME",
+	"PATH",
+	"RUST_LOG",
+	"TMPDIR",
+	"KAMN_SDK_SERVICE_TIMEOUT_SECONDS",
+]);
 const FIXTURE_ENV_ALLOWLIST = new Set([
 	"KAMN_MVP_FAKE_MCP_MODE",
 	"KAMN_MVP_FAKE_MCP_RESULT_MODE",

--- a/.pi/extensions/kamn-mvp/mcp-session.ts
+++ b/.pi/extensions/kamn-mvp/mcp-session.ts
@@ -103,7 +103,7 @@ export class McpSession {
 				this.registeredActor = String(authority.serviceResult.did);
 				this.provenanceTracker.recordProfileCommitment(authority.profileCommitment);
 			}
-			if (authority.receipt) this.provenanceTracker.recordAuthorityReceipt(authority.receipt);
+			for (const receipt of authority.receipts ?? []) this.provenanceTracker.recordAuthorityReceipt(receipt);
 			this.clearPending();
 			pending.resolve(authority.serviceResult);
 		} catch (error) {

--- a/.pi/extensions/kamn-mvp/mcp-session.ts
+++ b/.pi/extensions/kamn-mvp/mcp-session.ts
@@ -35,6 +35,7 @@ export type LiveMcpConfig = {
 	endpoint: string;
 	agentName: string;
 	keyFile: string;
+	requestTimeoutMs: number;
 	env: NodeJS.ProcessEnv;
 };
 export class McpSession {
@@ -48,7 +49,7 @@ export class McpSession {
 	private shutdownPromise?: Promise<void>;
 	private readonly config: LiveMcpConfig;
 	private readonly options: { timeoutMs: number };
-	constructor(config: LiveMcpConfig, options = { timeoutMs: 10000 }) {
+	constructor(config: LiveMcpConfig, options = { timeoutMs: config.requestTimeoutMs }) {
 		this.config = config;
 		this.options = options;
 	}
@@ -171,8 +172,18 @@ export function readLiveMcpConfig(agent: LiveMcpAgent, env: Environment = proces
 		keyFile,
 		endpoint: requiredEnv(env, "KAMN_MVP_LIVE_MCP_ENDPOINT"),
 		agentName: requiredEnv(env, agentEnv.name),
+		requestTimeoutMs: requestTimeoutMs(env),
 		env: childEnvironment(env),
 	};
+}
+function requestTimeoutMs(env: Environment): number {
+	const raw = env.KAMN_SDK_SERVICE_TIMEOUT_SECONDS;
+	if (raw === undefined) return 10000;
+	const seconds = Number(raw);
+	if (!/^\d+$/.test(raw) || !Number.isSafeInteger(seconds) || seconds <= 0) {
+		throw new Error("KAMN_SDK_SERVICE_TIMEOUT_SECONDS must be a positive integer");
+	}
+	return seconds * 1000;
 }
 function childEnvironment(env: Environment): NodeJS.ProcessEnv {
 	return Object.fromEntries(

--- a/.pi/extensions/kamn-mvp/mcp-session.ts
+++ b/.pi/extensions/kamn-mvp/mcp-session.ts
@@ -1,26 +1,11 @@
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
-import { existsSync } from "node:fs";
-import { resolve } from "node:path";
 import { McpProvenanceTracker, type McpSessionProvenance } from "./mcp-provenance.ts";
 import { validateAuthority } from "./mcp-authority.ts";
+import type { LiveMcpConfig } from "./mcp-session-config.ts";
+export { readLiveMcpConfig } from "./mcp-session-config.ts";
+export type { LiveMcpAgent } from "./mcp-session-config.ts";
 export type { McpSessionProvenance } from "./mcp-provenance.ts";
 
-type Environment = Record<string, string | undefined>;
-export type LiveMcpAgent = "AGENT_A" | "AGENT_B" | "AGENT_C";
-const PROCESS_ENV_ALLOWLIST = new Set([
-	"HOME", "PATH", "RUST_LOG", "TMPDIR", "KAMN_SDK_SERVICE_TIMEOUT_SECONDS",
-]);
-const FIXTURE_ENV_ALLOWLIST = new Set([
-	"KAMN_MVP_FAKE_MCP_MODE",
-	"KAMN_MVP_FAKE_MCP_RESULT_MODE",
-	"KAMN_MVP_FAKE_MCP_START_FILE",
-	"KAMN_MVP_FAKE_MCP_STOP_FILE",
-]);
-const AGENT_ENV = {
-	AGENT_A: { name: "KAMN_MVP_LIVE_MCP_AGENT_A_NAME", keyFile: "KAMN_MVP_LIVE_MCP_AGENT_A_KEY_FILE" },
-	AGENT_B: { name: "KAMN_MVP_LIVE_MCP_AGENT_B_NAME", keyFile: "KAMN_MVP_LIVE_MCP_AGENT_B_KEY_FILE" },
-	AGENT_C: { name: "KAMN_MVP_LIVE_MCP_AGENT_C_NAME", keyFile: "KAMN_MVP_LIVE_MCP_AGENT_C_KEY_FILE" },
-} as const;
 type JsonObject = Record<string, unknown>;
 type PendingRequest = {
 	id: string;
@@ -29,14 +14,6 @@ type PendingRequest = {
 	reject: (error: Error) => void;
 	timer: NodeJS.Timeout;
 	removeAbort: () => void;
-};
-export type LiveMcpConfig = {
-	binary: string;
-	endpoint: string;
-	agentName: string;
-	keyFile: string;
-	requestTimeoutMs: number;
-	env: NodeJS.ProcessEnv;
 };
 export class McpSession {
 	private child?: ChildProcessWithoutNullStreams;
@@ -160,45 +137,6 @@ export class McpSession {
 			child.kill("SIGTERM");
 		});
 	}
-}
-export function readLiveMcpConfig(agent: LiveMcpAgent, env: Environment = process.env, cwd = process.cwd()): LiveMcpConfig {
-	const agentEnv = AGENT_ENV[agent];
-	const binary = absolutePath(requiredEnv(env, "KAMN_MVP_LIVE_MCP_BINARY"), cwd);
-	const keyFile = absolutePath(requiredEnv(env, agentEnv.keyFile), cwd);
-	if (!existsSync(binary)) throw new Error(`KAMN live MCP binary does not exist: ${binary}`);
-	if (!existsSync(keyFile)) throw new Error(`KAMN live MCP key file does not exist: ${keyFile}`);
-	return {
-		binary,
-		keyFile,
-		endpoint: requiredEnv(env, "KAMN_MVP_LIVE_MCP_ENDPOINT"),
-		agentName: requiredEnv(env, agentEnv.name),
-		requestTimeoutMs: requestTimeoutMs(env),
-		env: childEnvironment(env),
-	};
-}
-function requestTimeoutMs(env: Environment): number {
-	const raw = env.KAMN_SDK_SERVICE_TIMEOUT_SECONDS;
-	if (raw === undefined) return 10000;
-	const seconds = Number(raw);
-	if (!/^\d+$/.test(raw) || !Number.isSafeInteger(seconds) || seconds <= 0) {
-		throw new Error("KAMN_SDK_SERVICE_TIMEOUT_SECONDS must be a positive integer");
-	}
-	return seconds * 1000;
-}
-function childEnvironment(env: Environment): NodeJS.ProcessEnv {
-	return Object.fromEntries(
-		Object.entries({ ...process.env, ...env }).filter(
-			([name, value]) => value !== undefined && (PROCESS_ENV_ALLOWLIST.has(name) || FIXTURE_ENV_ALLOWLIST.has(name)),
-		),
-	);
-}
-function requiredEnv(env: Environment, name: string): string {
-	const value = env[name]?.trim();
-	if (!value) throw new Error(`Missing required environment variable: ${name}`);
-	return value;
-}
-function absolutePath(path: string, cwd: string): string {
-	return path.startsWith("/") ? path : resolve(cwd, path);
 }
 function isObject(value: unknown): value is JsonObject {
 	return typeof value === "object" && value !== null && !Array.isArray(value);

--- a/.pi/extensions/kamn-mvp/pi-service-authority-evidence.ts
+++ b/.pi/extensions/kamn-mvp/pi-service-authority-evidence.ts
@@ -15,6 +15,7 @@ const ROLE_CONTRACTS = {
 		["create_task", "task:create", "task", "submitted"],
 		["fund_escrow", "escrow:fund", "escrow", "funded"],
 		["release_escrow", "escrow:release-authorize", "escrow", "release-authorized"],
+		["release_escrow", "settlement:confirmed", "escrow", "confirmed"],
 	],
 	agent_b: [
 		["accept_task", "task:accept", "task", "accepted"],

--- a/.pi/extensions/kamn-mvp/pi-transaction-evidence.test.ts
+++ b/.pi/extensions/kamn-mvp/pi-transaction-evidence.test.ts
@@ -94,6 +94,7 @@ function receipts(role: Role) {
 		receipt(role, "create_task", "task:create", "task-live-7099", "submitted", "1"),
 		receipt(role, "fund_escrow", "escrow:fund", "escrow-live-7099", "funded", "2"),
 		receipt(role, "release_escrow", "escrow:release-authorize", "escrow-live-7099", "release-authorized", "3"),
+		receipt(role, "release_escrow", "settlement:confirmed", "escrow-live-7099", "confirmed", "6"),
 	];
 	if (role === "agent_b") return [
 		receipt(role, "accept_task", "task:accept", "task-live-7099", "accepted", "4"),

--- a/.pi/extensions/kamn-mvp/pi-transaction-service-authority.test.ts
+++ b/.pi/extensions/kamn-mvp/pi-transaction-service-authority.test.ts
@@ -19,7 +19,7 @@ test("v2 actor artifacts bind exact role service authority and chain commitment"
 	const actorA = JSON.parse(await readFile(paths.agent_a, "utf8"));
 	assert.equal(actorA.schema_version, "kamn.mvp.pi-transaction-actor.v2");
 	assert.deepEqual(actorA.service_receipts.map((entry: Receipt) => entry.action), [
-		"task:create", "escrow:fund", "escrow:release-authorize",
+		"task:create", "escrow:fund", "escrow:release-authorize", "settlement:confirmed",
 	]);
 	assert.equal("runtime_response_receipts" in actorA, false);
 	assert.equal("runtime_response_digests" in actorA, false);
@@ -115,6 +115,7 @@ function roleReceipts(role: Role): Receipt[] {
 		receipt(role, "task:create", "task-live-1", "submitted", "1"),
 		receipt(role, "escrow:fund", "escrow-live-1", "funded", "2"),
 		receipt(role, "escrow:release-authorize", "escrow-live-1", "release-authorized", "3"),
+		receipt(role, "settlement:confirmed", "escrow-live-1", "confirmed", "6"),
 	];
 	if (role === "agent_b") return [
 		receipt(role, "task:accept", "task-live-1", "accepted", "4"),
@@ -132,6 +133,7 @@ function receipt(role: Role, action: string, resource: string, state: string, su
 			"task:complete": "complete_task",
 			"escrow:fund": "fund_escrow",
 			"escrow:release-authorize": "release_escrow",
+			"settlement:confirmed": "release_escrow",
 		} as Record<string, string>)[action],
 		action,
 		resource_id: resource,

--- a/.pi/extensions/kamn-mvp/test-fixtures/fake-mcp-projections.mjs
+++ b/.pi/extensions/kamn-mvp/test-fixtures/fake-mcp-projections.mjs
@@ -37,10 +37,11 @@ function participant(taskId, name, resultMode) {
 }
 function roleReceipts(suffix) {
 	const entries = suffix === "a"
-		? [["1", "task:create", "task-live-1", "submitted"], ["2", "escrow:fund", "escrow-live-1", "funded"], ["3", "escrow:release-authorize", "escrow-live-1", "release-authorized"]]
+		? [["1", "task:create", "task-live-1", "submitted"], ["2", "escrow:fund", "escrow-live-1", "funded"], ["3", "escrow:release-authorize", "escrow-live-1", "release-authorized"], ["6", "settlement:confirmed", "escrow-live-1", "confirmed"]]
 		: [["4", "task:accept", "task-live-1", "accepted"], ["5", "task:complete", "task-live-1", "completed"]];
 	return entries.map(([id, action, resource_id, resulting_state]) => ({
-		receipt_id: `task-transition-receipt-${id}`, receipt_digest: digest(id), action, resource_id, resulting_state,
+		receipt_id: id === "6" ? "settlement-intent-escrow-live-1" : `task-transition-receipt-${id}`,
+		receipt_digest: digest(id), action, resource_id, resulting_state,
 	}));
 }
 function shared(taskId) {

--- a/.pi/extensions/kamn-mvp/test-fixtures/fake-mcp-server.mjs
+++ b/.pi/extensions/kamn-mvp/test-fixtures/fake-mcp-server.mjs
@@ -73,6 +73,13 @@ function mutationAuthority(tool, serviceResult) {
 		schema_version: "kamn.mcp.authority-receipt.v1", authority_kind: "service-receipt", source: "kamn-service",
 		actor_did: serviceResult.actor_did, tool, resource_id: resource, resulting_state: serviceResult.state,
 		service_receipt_id: serviceResult.receipt_id, service_receipt_digest: serviceResult.receipt_digest,
+		...(serviceResult.settlement_receipt_id ? { settlement_service_receipt: {
+			actor_did: serviceResult.actor_did, tool, action: serviceResult.settlement_receipt_action,
+			resource_id: serviceResult.settlement_receipt_resource_id,
+			resulting_state: serviceResult.settlement_receipt_state,
+			service_receipt_id: serviceResult.settlement_receipt_id,
+			service_receipt_digest: serviceResult.settlement_receipt_digest,
+		} } : {}),
 		service_result: serviceResult,
 	};
 }
@@ -104,6 +111,9 @@ function toolResult(request) {
 	if (request.tool === "release_escrow") {
 		return mutationResult("release_escrow", request.escrow_id, "release-authorized", {
 			settlement_tx_signature: "devnet-signature-1", ...JSON.parse(request.payload),
+			settlement_receipt_id: "settlement-intent-escrow-live-1",
+			settlement_receipt_digest: digest("6"), settlement_receipt_action: "settlement:confirmed",
+			settlement_receipt_resource_id: request.escrow_id, settlement_receipt_state: "confirmed",
 		}, "3");
 	}
 	if (request.tool === "query_participant_task_projection") {

--- a/.pi/extensions/kamn-mvp/test-fixtures/fake-mcp-server.mjs
+++ b/.pi/extensions/kamn-mvp/test-fixtures/fake-mcp-server.mjs
@@ -56,6 +56,12 @@ function authorityResult(request, serviceResult) {
 	if (resultMode === "cross-role-authority" && request.tool !== "register") envelope.actor_did = "kamn:did:agent-b";
 	if (resultMode === "wrong-tool-authority" && request.tool !== "register") envelope.tool = "query_task";
 	if (resultMode === "copied-resource-authority" && request.tool !== "register") envelope.resource_id = "task-copied";
+	if (resultMode === "partial-settlement-authority" && request.tool === "release_escrow") {
+		delete envelope.settlement_service_receipt.service_receipt_digest;
+	}
+	if (resultMode === "mismatched-settlement-authority" && request.tool === "release_escrow") {
+		envelope.settlement_service_receipt.service_receipt_id = "settlement-intent-copied";
+	}
 	return envelope;
 }
 

--- a/crates/kamn-e2e-harness/src/agent_transaction_evidence.rs
+++ b/crates/kamn-e2e-harness/src/agent_transaction_evidence.rs
@@ -100,6 +100,10 @@ fn runtime_environment(config: &AgentTransactionDemoConfig) -> Vec<(&'static str
             "KAMN_SERVICE_API_LIVE_SOLANA_SETTLEMENT_LAMPORTS",
             config.solana_lamports.to_string(),
         ),
+        (
+            "KAMN_SDK_SERVICE_TIMEOUT_SECONDS",
+            config.rpc_timeout_ms.div_ceil(1000).to_string(),
+        ),
     ]
 }
 

--- a/crates/kamn-e2e-harness/src/agent_transaction_evidence.rs
+++ b/crates/kamn-e2e-harness/src/agent_transaction_evidence.rs
@@ -102,9 +102,13 @@ fn runtime_environment(config: &AgentTransactionDemoConfig) -> Vec<(&'static str
         ),
         (
             "KAMN_SDK_SERVICE_TIMEOUT_SECONDS",
-            config.rpc_timeout_ms.div_ceil(1000).to_string(),
+            sdk_timeout_seconds(config.rpc_timeout_ms),
         ),
     ]
+}
+
+fn sdk_timeout_seconds(rpc_timeout_ms: u64) -> String {
+    rpc_timeout_ms.div_ceil(1000).to_string()
 }
 
 fn reject_existing_artifacts(root: &Path) -> Result<(), String> {
@@ -131,38 +135,6 @@ mod tests {
 
     #[test]
     fn canonical_children_inherit_supervisor_timeout_budget() {
-        let environment = runtime_environment(&config());
-        let timeout = environment
-            .iter()
-            .find(|(name, _)| *name == "KAMN_SDK_SERVICE_TIMEOUT_SECONDS")
-            .map(|(_, value)| value.as_str());
-        assert_eq!(timeout, Some("181"));
-    }
-
-    fn config() -> AgentTransactionDemoConfig {
-        AgentTransactionDemoConfig {
-            agent_driver: "pi".to_owned(),
-            devnet_mode: "required".to_owned(),
-            solana_rpc_url: "https://api.devnet.solana.com".to_owned(),
-            agent_key_files: ["a".to_owned(), "b".to_owned(), "c".to_owned()],
-            solana_keypair_file: "payer".to_owned(),
-            solana_recipient_pubkey: "recipient".to_owned(),
-            solana_lamports: 1,
-            solana_commitment: "finalized".to_owned(),
-            pi_binary: "pi".to_owned(),
-            pi_provider: "provider".to_owned(),
-            pi_model: "model".to_owned(),
-            pi_extension: "extension".to_owned(),
-            local_node_binary: "node".to_owned(),
-            mcp_binary: "mcp".to_owned(),
-            mcp_endpoint: "http://127.0.0.1:1".to_owned(),
-            output_root: "output".to_owned(),
-            rpc_timeout_ms: 180_001,
-            staging_root: "staging".to_owned(),
-            devnet_settlement_command: None,
-            localhost_signed_demo_command: None,
-            service_api_vertical_slice_command: None,
-            service_api_websocket_command: None,
-        }
+        assert_eq!(sdk_timeout_seconds(180_001), "181");
     }
 }

--- a/crates/kamn-e2e-harness/src/agent_transaction_evidence.rs
+++ b/crates/kamn-e2e-harness/src/agent_transaction_evidence.rs
@@ -120,3 +120,45 @@ fn reject_existing_artifacts(root: &Path) -> Result<(), String> {
 fn path(root: &Path, name: &str) -> String {
     root.join(name).display().to_string()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn canonical_children_inherit_supervisor_timeout_budget() {
+        let environment = runtime_environment(&config());
+        let timeout = environment
+            .iter()
+            .find(|(name, _)| *name == "KAMN_SDK_SERVICE_TIMEOUT_SECONDS")
+            .map(|(_, value)| value.as_str());
+        assert_eq!(timeout, Some("181"));
+    }
+
+    fn config() -> AgentTransactionDemoConfig {
+        AgentTransactionDemoConfig {
+            agent_driver: "pi".to_owned(),
+            devnet_mode: "required".to_owned(),
+            solana_rpc_url: "https://api.devnet.solana.com".to_owned(),
+            agent_key_files: ["a".to_owned(), "b".to_owned(), "c".to_owned()],
+            solana_keypair_file: "payer".to_owned(),
+            solana_recipient_pubkey: "recipient".to_owned(),
+            solana_lamports: 1,
+            solana_commitment: "finalized".to_owned(),
+            pi_binary: "pi".to_owned(),
+            pi_provider: "provider".to_owned(),
+            pi_model: "model".to_owned(),
+            pi_extension: "extension".to_owned(),
+            local_node_binary: "node".to_owned(),
+            mcp_binary: "mcp".to_owned(),
+            mcp_endpoint: "http://127.0.0.1:1".to_owned(),
+            output_root: "output".to_owned(),
+            rpc_timeout_ms: 180_001,
+            staging_root: "staging".to_owned(),
+            devnet_settlement_command: None,
+            localhost_signed_demo_command: None,
+            service_api_vertical_slice_command: None,
+            service_api_websocket_command: None,
+        }
+    }
+}

--- a/crates/kamn-e2e-harness/src/agent_transaction_receipt_chain.rs
+++ b/crates/kamn-e2e-harness/src/agent_transaction_receipt_chain.rs
@@ -25,7 +25,7 @@ pub(super) fn recompute(
     let mut entries = mutation_entries(&state, task, escrow, &tasks, &escrows)?;
     require_unique(&entries)?;
     entries.push(settlement_entry(&state, escrow, expected)?);
-    let receipts = durable_receipts(&entries[..entries.len() - 1]);
+    let receipts = durable_receipts(&entries);
     Ok(ReceiptChainEvidence {
         commitment: digest::chain(&entries),
         receipts,

--- a/crates/kamn-e2e-harness/src/mvp_demo/pi_transaction_actor_authority.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/pi_transaction_actor_authority.rs
@@ -76,6 +76,12 @@ fn agent_a_contracts() -> Vec<ReceiptContract> {
             Resource::Escrow,
             "release-authorized",
         ),
+        contract(
+            "release_escrow",
+            "settlement:confirmed",
+            Resource::Escrow,
+            "confirmed",
+        ),
     ]
 }
 

--- a/crates/kamn-e2e-harness/src/mvp_demo/runtime_receipt_chain.rs
+++ b/crates/kamn-e2e-harness/src/mvp_demo/runtime_receipt_chain.rs
@@ -71,6 +71,7 @@ fn ordered_receipts(actors: &[Actor; 3]) -> Vec<&ServiceReceipt> {
         &actors[0].service_receipts[1],
         &actors[1].service_receipts[1],
         &actors[0].service_receipts[2],
+        &actors[0].service_receipts[3],
     ]
 }
 

--- a/crates/kamn-e2e-harness/tests/support/service_authority_fixture.rs
+++ b/crates/kamn-e2e-harness/tests/support/service_authority_fixture.rs
@@ -28,10 +28,24 @@ pub(crate) fn state(recipient: &str) -> Value {
 pub(crate) fn actor_receipts(role: &str) -> Vec<Value> {
     let all = mutation_receipts();
     match role {
-        "agent_a" => vec![all[0].clone(), all[2].clone(), all[4].clone()],
+        "agent_a" => vec![
+            all[0].clone(),
+            all[2].clone(),
+            all[4].clone(),
+            settlement_receipt(),
+        ],
         "agent_b" => vec![all[1].clone(), all[3].clone()],
         _ => Vec::new(),
     }
+}
+
+fn settlement_receipt() -> Value {
+    let fields = settlement_entry();
+    json!({
+        "actor_did": fields[3], "tool": "release_escrow", "action": fields[4],
+        "resource_id": fields[5], "resulting_state": fields[9],
+        "service_receipt_id": fields[0], "service_receipt_digest": fields[1],
+    })
 }
 
 pub(crate) fn commitment() -> String {

--- a/crates/kamn-mcp-server/src/authority.rs
+++ b/crates/kamn-mcp-server/src/authority.rs
@@ -174,7 +174,7 @@ fn validate_state(tool: &str, state: &str) -> Result<(), &'static str> {
         "accept_task" => state == "accepted",
         "complete_task" => state == "completed",
         "fund_escrow" => state == "funded",
-        "release_escrow" => matches!(state, "release-authorized" | "released"),
+        "release_escrow" => state == "release-authorized",
         _ => false,
     };
     if valid {

--- a/crates/kamn-mcp-server/src/authority.rs
+++ b/crates/kamn-mcp-server/src/authority.rs
@@ -1,5 +1,7 @@
 use serde_json::{json, Value};
 
+mod settlement;
+
 pub(crate) const INVALID: &str = "MCP_AUTHORITY_RECEIPT_INVALID";
 pub(crate) const MISSING: &str = "MCP_AUTHORITY_RECEIPT_MISSING";
 
@@ -47,7 +49,17 @@ fn mutation(
     let value = parse(payload)?;
     let fields = MutationFields::parse(&value, resource_key)?;
     fields.validate(request, tool, resource_key, expected_actor)?;
-    Ok(json!({
+    let settlement = settlement::authority(&value, tool, fields.actor, fields.resource)?;
+    Ok(mutation_envelope(&value, tool, &fields, settlement).to_string())
+}
+
+fn mutation_envelope(
+    value: &Value,
+    tool: &str,
+    fields: &MutationFields<'_>,
+    settlement: Option<Value>,
+) -> Value {
+    let mut envelope = json!({
         "schema_version": "kamn.mcp.authority-receipt.v1",
         "authority_kind": "service-receipt",
         "source": "kamn-service",
@@ -58,8 +70,11 @@ fn mutation(
         "service_receipt_id": fields.receipt_id,
         "service_receipt_digest": fields.digest,
         "service_result": value,
-    })
-    .to_string())
+    });
+    if let Some(receipt) = settlement {
+        envelope["settlement_service_receipt"] = receipt;
+    }
+    envelope
 }
 
 struct MutationFields<'a> {

--- a/crates/kamn-mcp-server/src/authority/settlement.rs
+++ b/crates/kamn-mcp-server/src/authority/settlement.rs
@@ -59,3 +59,39 @@ impl<'a> SettlementFields<'a> {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn partial_settlement_authority_fails_closed() {
+        let value = json!({"settlement_receipt_id": "intent-1"});
+        assert_eq!(
+            authority(&value, "release_escrow", "did:a", "escrow-1"),
+            Err(MISSING)
+        );
+    }
+
+    #[test]
+    fn tampered_settlement_authority_fails_closed() {
+        let value = settlement_value("settlement:failed");
+        assert_eq!(
+            authority(&value, "release_escrow", "did:a", "escrow-1"),
+            Err(INVALID)
+        );
+    }
+
+    #[test]
+    fn released_primary_authority_fails_closed() {
+        assert_eq!(validate_state("release_escrow", "released"), Err(INVALID));
+    }
+
+    fn settlement_value(action: &str) -> Value {
+        json!({
+            "settlement_receipt_id": "intent-1", "settlement_receipt_digest": format!("sha256:{}", "a".repeat(64)),
+            "settlement_receipt_action": action, "settlement_receipt_resource_id": "escrow-1",
+            "settlement_receipt_state": "confirmed",
+        })
+    }
+}

--- a/crates/kamn-mcp-server/src/authority/settlement.rs
+++ b/crates/kamn-mcp-server/src/authority/settlement.rs
@@ -1,0 +1,61 @@
+use super::*;
+
+const FIELDS: [&str; 5] = [
+    "settlement_receipt_id",
+    "settlement_receipt_digest",
+    "settlement_receipt_action",
+    "settlement_receipt_resource_id",
+    "settlement_receipt_state",
+];
+
+pub(super) fn authority(
+    value: &Value,
+    tool: &str,
+    actor: &str,
+    primary_resource: &str,
+) -> Result<Option<Value>, &'static str> {
+    if FIELDS.iter().all(|field| value.get(field).is_none()) {
+        return Ok(None);
+    }
+    if tool != "release_escrow" {
+        return Err(INVALID);
+    }
+    let fields = SettlementFields::parse(value)?;
+    fields.validate(primary_resource)?;
+    Ok(Some(fields.envelope(actor, tool)))
+}
+
+struct SettlementFields<'a> {
+    id: &'a str,
+    digest: &'a str,
+    action: &'a str,
+    resource: &'a str,
+    state: &'a str,
+}
+
+impl<'a> SettlementFields<'a> {
+    fn parse(value: &'a Value) -> Result<Self, &'static str> {
+        Ok(Self {
+            id: required(value, FIELDS[0])?,
+            digest: required(value, FIELDS[1])?,
+            action: required(value, FIELDS[2])?,
+            resource: required(value, FIELDS[3])?,
+            state: required(value, FIELDS[4])?,
+        })
+    }
+
+    fn validate(&self, primary_resource: &str) -> Result<(), &'static str> {
+        validate_digest(self.digest)?;
+        validate_equal(self.action, "settlement:confirmed")?;
+        validate_equal(self.resource, primary_resource)?;
+        validate_equal(self.state, "confirmed")
+    }
+
+    fn envelope(&self, actor: &str, tool: &str) -> Value {
+        json!({
+            "actor_did": actor, "tool": tool, "action": self.action,
+            "resource_id": self.resource, "resulting_state": self.state,
+            "service_receipt_id": self.id, "service_receipt_digest": self.digest,
+        })
+    }
+}

--- a/crates/kamn-mcp-server/src/dispatch.rs
+++ b/crates/kamn-mcp-server/src/dispatch.rs
@@ -1,6 +1,7 @@
 use crate::json_helpers::{escape_json, json_optional_string_field, json_required_string_field};
 use crate::registration::register_service_backed_mcp_agent;
 use kamn_agent_lib::{AgentLibError, KamnAgentHandle, KolmeProofReceipt};
+use serde_json::json;
 
 /// Backend abstraction used by MCP tool dispatch.
 pub trait McpToolBackend {
@@ -267,15 +268,19 @@ impl McpToolBackend for KamnAgentHandle {
 
     fn release_escrow(&self, escrow_id: &str, payload: &str) -> Result<String, AgentLibError> {
         let receipt = KamnAgentHandle::release_escrow_with_payload(self, escrow_id, payload)?;
-        Ok(format!(
-            r#"{{"actor_did":"{}","escrow_id":"{}","state":"{}","receipt_id":"{}","receipt_digest":"{}","action":"{}"}}"#,
-            escape_json(self.identity().did().as_str()),
-            escape_json(receipt.escrow_id.as_str()),
-            escape_json(receipt.state.as_str()),
-            escape_json(receipt.receipt_id.as_str()),
-            escape_json(receipt.receipt_digest.as_str()),
-            escape_json(receipt.action.as_str()),
-        ))
+        let mut result = json!({
+            "actor_did": self.identity().did().as_str(), "escrow_id": receipt.escrow_id,
+            "state": receipt.state, "receipt_id": receipt.receipt_id,
+            "receipt_digest": receipt.receipt_digest, "action": receipt.action,
+        });
+        if let Some(settlement) = receipt.settlement_receipt {
+            result["settlement_receipt_id"] = json!(settlement.receipt_id);
+            result["settlement_receipt_digest"] = json!(settlement.receipt_digest);
+            result["settlement_receipt_action"] = json!(settlement.action);
+            result["settlement_receipt_resource_id"] = json!(settlement.resource_id);
+            result["settlement_receipt_state"] = json!(settlement.state);
+        }
+        Ok(result.to_string())
     }
 
     fn health(&self) -> Result<String, AgentLibError> {

--- a/crates/kamn-mcp-server/tests/authority_receipt_contract.rs
+++ b/crates/kamn-mcp-server/tests/authority_receipt_contract.rs
@@ -56,9 +56,6 @@ macro_rules! unsupported_backend_methods {
         fn fund_escrow(&self, _: &str) -> Result<String, AgentLibError> {
             unsupported()
         }
-        fn release_escrow(&self, _: &str, _: &str) -> Result<String, AgentLibError> {
-            unsupported()
-        }
         fn health(&self) -> Result<String, AgentLibError> {
             unsupported()
         }
@@ -101,6 +98,12 @@ impl McpToolBackend for AuthorityBackend {
         Ok(format!(r#"{{"task_id":"{task_id}","state":"completed"}}"#))
     }
 
+    fn release_escrow(&self, escrow_id: &str, _: &str) -> Result<String, AgentLibError> {
+        Ok(format!(
+            r#"{{"actor_did":"kamn:did:agent:test","escrow_id":"{escrow_id}","state":"release-authorized","receipt_id":"escrow-transition-receipt-1","receipt_digest":"{DIGEST}","action":"escrow:release-authorize","settlement_receipt_id":"settlement-intent-1","settlement_receipt_digest":"{DIGEST}","settlement_receipt_action":"settlement:confirmed","settlement_receipt_resource_id":"{escrow_id}","settlement_receipt_state":"confirmed"}}"#
+        ))
+    }
+
     unsupported_backend_methods!();
 }
 
@@ -135,6 +138,17 @@ fn mutation_result_is_wrapped_as_service_authority_v1() {
     assert!(response.contains(r#""service_receipt_id":"task-transition-receipt-1""#));
     let digest_field = format!(r#""service_receipt_digest":"{DIGEST}""#);
     assert!(response.contains(digest_field.as_str()));
+}
+
+#[test]
+fn finalized_release_wraps_distinct_settlement_receipt_authority() {
+    let response = dispatch_tool_request_json(
+        &AuthorityBackend,
+        r#"{"id":"settled","tool":"release_escrow","escrow_id":"escrow-1","payload":"{}"}"#,
+    )
+    .expect("dispatch should return an envelope");
+    assert!(response.contains(r#""action":"settlement:confirmed""#));
+    assert!(response.contains(r#""service_receipt_id":"settlement-intent-1""#));
 }
 
 #[test]

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/support.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/support.rs
@@ -21,7 +21,7 @@ pub(super) use request_support::{
 pub(super) use solana_asset_movement_support::{
     assert_persisted_solana_signature_metadata, assert_released_escrow_has_durable_authority,
     assert_released_escrow_has_settlement_authority,
-    assert_released_escrow_has_solana_signature_metadata, assert_replayed_release_authority,
+    assert_released_escrow_has_solana_signature_metadata, assert_replayed_live_release,
     build_live_solana_asset_movement_context, fund_and_release_live_escrow, fund_live_escrow,
     release_live_escrow_across_restart, release_live_escrow_twice, settlement_tx_signature,
     AssetMovementHarness, LiveSolanaAssetMovementContext, LiveSolanaAssetMovementParams,

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/support.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/support.rs
@@ -21,10 +21,9 @@ pub(super) use request_support::{
 pub(super) use solana_asset_movement_support::{
     assert_persisted_solana_signature_metadata, assert_released_escrow_has_durable_authority,
     assert_released_escrow_has_solana_signature_metadata, assert_replayed_release_authority,
-    build_live_solana_asset_movement_context,
-    fund_and_release_live_escrow, fund_live_escrow, release_live_escrow_across_restart,
-    release_live_escrow_twice, settlement_tx_signature, AssetMovementHarness,
-    LiveSolanaAssetMovementContext, LiveSolanaAssetMovementParams,
+    build_live_solana_asset_movement_context, fund_and_release_live_escrow, fund_live_escrow,
+    release_live_escrow_across_restart, release_live_escrow_twice, settlement_tx_signature,
+    AssetMovementHarness, LiveSolanaAssetMovementContext, LiveSolanaAssetMovementParams,
 };
 pub(super) use state_support::{
     build_task_escrow_snapshot, set_state_file_env, state_hash, unique_named_state_file,

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/support.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/support.rs
@@ -20,6 +20,7 @@ pub(super) use request_support::{
 };
 pub(super) use solana_asset_movement_support::{
     assert_persisted_solana_signature_metadata, assert_released_escrow_has_durable_authority,
+    assert_released_escrow_has_settlement_authority,
     assert_released_escrow_has_solana_signature_metadata, assert_replayed_release_authority,
     build_live_solana_asset_movement_context, fund_and_release_live_escrow, fund_live_escrow,
     release_live_escrow_across_restart, release_live_escrow_twice, settlement_tx_signature,

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/support.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/support.rs
@@ -19,8 +19,9 @@ pub(super) use request_support::{
     release_escrow, release_escrow_response, release_escrow_response_with_key, SignedRequest,
 };
 pub(super) use solana_asset_movement_support::{
-    assert_persisted_solana_signature_metadata,
-    assert_released_escrow_has_solana_signature_metadata, build_live_solana_asset_movement_context,
+    assert_persisted_solana_signature_metadata, assert_released_escrow_has_durable_authority,
+    assert_released_escrow_has_solana_signature_metadata, assert_replayed_release_authority,
+    build_live_solana_asset_movement_context,
     fund_and_release_live_escrow, fund_live_escrow, release_live_escrow_across_restart,
     release_live_escrow_twice, settlement_tx_signature, AssetMovementHarness,
     LiveSolanaAssetMovementContext, LiveSolanaAssetMovementParams,

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/support/solana_asset_movement_support.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/support/solana_asset_movement_support.rs
@@ -1,7 +1,8 @@
 use super::super::super::*;
 use super::{
     accept_task, build_task_escrow_snapshot, complete_task, create_task, fund_escrow,
-    release_escrow, set_state_file_env, unique_named_state_file,
+    read_state_json, release_escrow, release_escrow_response, set_state_file_env,
+    unique_named_state_file,
 };
 use crate::service_api_endpoint::ServiceApiSnapshot;
 use solana_sdk::signer::keypair::{write_keypair_file, Keypair};
@@ -15,7 +16,7 @@ mod context;
 pub(crate) use assertions::{
     assert_persisted_solana_signature_metadata, assert_released_escrow_has_durable_authority,
     assert_released_escrow_has_settlement_authority,
-    assert_released_escrow_has_solana_signature_metadata, assert_replayed_release_authority,
+    assert_released_escrow_has_solana_signature_metadata, assert_replayed_live_release,
     cleanup_solana_settlement_fixture, cleanup_state_file, settlement_tx_signature,
 };
 pub(crate) use context::{

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/support/solana_asset_movement_support.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/support/solana_asset_movement_support.rs
@@ -14,6 +14,7 @@ mod context;
 
 pub(crate) use assertions::{
     assert_persisted_solana_signature_metadata, assert_released_escrow_has_durable_authority,
+    assert_released_escrow_has_settlement_authority,
     assert_released_escrow_has_solana_signature_metadata, assert_replayed_release_authority,
     cleanup_solana_settlement_fixture, cleanup_state_file, settlement_tx_signature,
 };

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/support/solana_asset_movement_support.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/support/solana_asset_movement_support.rs
@@ -13,7 +13,7 @@ mod assertions;
 mod context;
 
 pub(crate) use assertions::{
-    assert_persisted_solana_signature_metadata,
+    assert_persisted_solana_signature_metadata, assert_released_escrow_has_durable_authority,
     assert_released_escrow_has_solana_signature_metadata, cleanup_solana_settlement_fixture,
     cleanup_state_file, settlement_tx_signature,
 };

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/support/solana_asset_movement_support.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/support/solana_asset_movement_support.rs
@@ -14,8 +14,8 @@ mod context;
 
 pub(crate) use assertions::{
     assert_persisted_solana_signature_metadata, assert_released_escrow_has_durable_authority,
-    assert_released_escrow_has_solana_signature_metadata, cleanup_solana_settlement_fixture,
-    cleanup_state_file, settlement_tx_signature,
+    assert_released_escrow_has_solana_signature_metadata, assert_replayed_release_authority,
+    cleanup_solana_settlement_fixture, cleanup_state_file, settlement_tx_signature,
 };
 pub(crate) use context::{
     build_live_solana_asset_movement_context, release_live_escrow_across_restart,

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/support/solana_asset_movement_support/assertions.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/support/solana_asset_movement_support/assertions.rs
@@ -2,14 +2,14 @@ use super::SolanaSettlementFixture;
 use super::Value;
 
 pub(crate) fn assert_released_escrow_has_solana_signature_metadata(released_escrow: &Value) {
-    assert_eq!(released_escrow["state"], "released");
+    assert_eq!(released_escrow["state"], "release-authorized");
     assert_eq!(released_escrow["settlement_network"], "solana:devnet");
     assert_eq!(released_escrow["settlement_commitment"], "finalized");
     assert_base58ish_signature(settlement_tx_signature(released_escrow));
 }
 
 pub(crate) fn assert_released_escrow_has_durable_authority(released_escrow: &Value) {
-    assert_eq!(released_escrow["state"], "released");
+    assert_eq!(released_escrow["state"], "release-authorized");
     assert_eq!(released_escrow["action"], "escrow:release-authorize");
     assert!(released_escrow["receipt_id"]
         .as_str()

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/support/solana_asset_movement_support/assertions.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/support/solana_asset_movement_support/assertions.rs
@@ -19,6 +19,13 @@ pub(crate) fn assert_released_escrow_has_durable_authority(released_escrow: &Val
         .is_some_and(|value| value.starts_with("sha256:")));
 }
 
+pub(crate) fn assert_replayed_release_authority(first: &Value, second: &Value) {
+    assert_released_escrow_has_durable_authority(first);
+    assert_released_escrow_has_durable_authority(second);
+    assert_eq!(first["receipt_id"], second["receipt_id"]);
+    assert_eq!(first["receipt_digest"], second["receipt_digest"]);
+}
+
 pub(crate) fn assert_persisted_solana_signature_metadata(state_json: &Value, escrow_id: &str) {
     let persisted = &state_json["escrows"][escrow_id];
     assert_eq!(persisted["state"], "released");

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/support/solana_asset_movement_support/assertions.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/support/solana_asset_movement_support/assertions.rs
@@ -8,6 +8,17 @@ pub(crate) fn assert_released_escrow_has_solana_signature_metadata(released_escr
     assert_base58ish_signature(settlement_tx_signature(released_escrow));
 }
 
+pub(crate) fn assert_released_escrow_has_durable_authority(released_escrow: &Value) {
+    assert_eq!(released_escrow["state"], "released");
+    assert_eq!(released_escrow["action"], "escrow:release-authorize");
+    assert!(released_escrow["receipt_id"]
+        .as_str()
+        .is_some_and(|value| value.starts_with("escrow-transition-receipt-")));
+    assert!(released_escrow["receipt_digest"]
+        .as_str()
+        .is_some_and(|value| value.starts_with("sha256:")));
+}
+
 pub(crate) fn assert_persisted_solana_signature_metadata(state_json: &Value, escrow_id: &str) {
     let persisted = &state_json["escrows"][escrow_id];
     assert_eq!(persisted["state"], "released");

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/support/solana_asset_movement_support/assertions.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/support/solana_asset_movement_support/assertions.rs
@@ -19,11 +19,39 @@ pub(crate) fn assert_released_escrow_has_durable_authority(released_escrow: &Val
         .is_some_and(|value| value.starts_with("sha256:")));
 }
 
+pub(crate) fn assert_released_escrow_has_settlement_authority(released_escrow: &Value) {
+    assert_eq!(
+        released_escrow["settlement_receipt_action"],
+        "settlement:confirmed"
+    );
+    assert_eq!(released_escrow["settlement_receipt_state"], "confirmed");
+    assert_eq!(
+        released_escrow["settlement_receipt_resource_id"],
+        released_escrow["escrow_id"]
+    );
+    assert!(released_escrow["settlement_receipt_id"]
+        .as_str()
+        .is_some_and(|value| value.starts_with("settlement-intent-")));
+    assert!(released_escrow["settlement_receipt_digest"]
+        .as_str()
+        .is_some_and(|value| value.starts_with("sha256:")));
+}
+
 pub(crate) fn assert_replayed_release_authority(first: &Value, second: &Value) {
     assert_released_escrow_has_durable_authority(first);
     assert_released_escrow_has_durable_authority(second);
+    assert_released_escrow_has_settlement_authority(first);
+    assert_released_escrow_has_settlement_authority(second);
     assert_eq!(first["receipt_id"], second["receipt_id"]);
     assert_eq!(first["receipt_digest"], second["receipt_digest"]);
+    assert_eq!(
+        first["settlement_receipt_id"],
+        second["settlement_receipt_id"]
+    );
+    assert_eq!(
+        first["settlement_receipt_digest"],
+        second["settlement_receipt_digest"]
+    );
 }
 
 pub(crate) fn assert_persisted_solana_signature_metadata(state_json: &Value, escrow_id: &str) {

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/support/solana_asset_movement_support/assertions.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/support/solana_asset_movement_support/assertions.rs
@@ -1,5 +1,5 @@
 use super::SolanaSettlementFixture;
-use super::Value;
+use super::{read_state_json, release_escrow_response, LiveSolanaAssetMovementContext, Value};
 
 pub(crate) fn assert_released_escrow_has_solana_signature_metadata(released_escrow: &Value) {
     assert_eq!(released_escrow["state"], "release-authorized");
@@ -51,6 +51,44 @@ pub(crate) fn assert_replayed_release_authority(first: &Value, second: &Value) {
     assert_eq!(
         first["settlement_receipt_digest"],
         second["settlement_receipt_digest"]
+    );
+}
+
+pub(crate) fn assert_replayed_live_release(
+    context: &LiveSolanaAssetMovementContext,
+    first: &Value,
+    second: &Value,
+) {
+    assert_eq!(
+        settlement_tx_signature(first),
+        settlement_tx_signature(second)
+    );
+    assert_replayed_release_authority(first, second);
+    let escrow_id = first["escrow_id"].as_str().expect("escrow ID");
+    assert_tampered_settlement_authority_rejected(context, escrow_id);
+}
+
+pub(crate) fn assert_tampered_settlement_authority_rejected(
+    context: &LiveSolanaAssetMovementContext,
+    escrow_id: &str,
+) {
+    let mut state = read_state_json(context.harness.state_file.as_path());
+    state["settlement_intents"][escrow_id]["actor_did"] = serde_json::json!("kamn:did:tampered");
+    std::fs::write(
+        context.harness.state_file.as_path(),
+        serde_json::to_vec(&state).expect("tampered state should serialize"),
+    )
+    .expect("tampered state should persist");
+    let response = release_escrow_response(
+        &context.harness.snapshot,
+        context.harness.bind_addr.as_str(),
+        context.harness.caller_did,
+        115,
+        escrow_id,
+    );
+    assert!(
+        response.contains("SETTLEMENT_RECEIPT_INVALID"),
+        "{response}"
     );
 }
 

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_solana_asset_movement_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_solana_asset_movement_contract_tests.rs
@@ -1,6 +1,6 @@
 use super::super::*;
 use super::support::{
-    assert_persisted_solana_signature_metadata,
+    assert_persisted_solana_signature_metadata, assert_released_escrow_has_durable_authority,
     assert_released_escrow_has_solana_signature_metadata, build_live_solana_asset_movement_context,
     build_task_escrow_snapshot, fund_and_release_live_escrow, fund_live_escrow, read_state_json,
     release_escrow_response, release_live_escrow_across_restart, release_live_escrow_twice,
@@ -99,6 +99,7 @@ fn integration_service_api_endpoint_live_solana_asset_movement_release_persists_
     let state_json = read_state_json(context.harness.state_file.as_path());
 
     assert_released_escrow_has_solana_signature_metadata(&released_escrow);
+    assert_released_escrow_has_durable_authority(&released_escrow);
     assert_eq!(released_escrow["claim_scope"], "devnet-backed");
     assert_persisted_solana_signature_metadata(&state_json, escrow_id.as_str());
 }
@@ -152,6 +153,10 @@ fn integration_service_api_endpoint_live_solana_asset_movement_release_is_idempo
         settlement_tx_signature(&second),
         "repeated release must keep the same Solana transaction signature"
     );
+    assert_released_escrow_has_durable_authority(&first);
+    assert_released_escrow_has_durable_authority(&second);
+    assert_eq!(first["receipt_id"], second["receipt_id"]);
+    assert_eq!(first["receipt_digest"], second["receipt_digest"]);
 }
 
 #[test]

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_solana_asset_movement_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_solana_asset_movement_contract_tests.rs
@@ -104,7 +104,7 @@ fn integration_service_api_endpoint_live_solana_asset_movement_release_persists_
 }
 
 #[test]
-fn integration_live_settlement_persists_prepared_intent_before_adapter_submission() {
+fn integration_live_settlement_persists_submitted_intent_before_adapter_submission() {
     let _env = acquire_service_api_test_env();
     let _override_guard =
         crate::service_api_endpoint::set_test_live_solana_settlement_override(true);
@@ -123,8 +123,8 @@ fn integration_live_settlement_persists_prepared_intent_before_adapter_submissio
     fund_and_release_live_escrow(&context.harness, 131, 133, 23);
 
     assert!(
-        crate::service_api_endpoint::test_live_settlement_observed_prepared_intent(),
-        "settlement intent must be durable before adapter submission"
+        crate::service_api_endpoint::test_live_settlement_observed_submitted_intent(),
+        "submitted intent and one attempt must be durable before adapter submission"
     );
 }
 

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_solana_asset_movement_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_solana_asset_movement_contract_tests.rs
@@ -1,9 +1,10 @@
 use super::super::*;
 use super::support::{
     assert_persisted_solana_signature_metadata, assert_released_escrow_has_durable_authority,
-    assert_released_escrow_has_solana_signature_metadata, build_live_solana_asset_movement_context,
-    build_task_escrow_snapshot, fund_and_release_live_escrow, fund_live_escrow, read_state_json,
-    release_escrow_response, release_live_escrow_across_restart, release_live_escrow_twice,
+    assert_released_escrow_has_solana_signature_metadata, assert_replayed_release_authority,
+    build_live_solana_asset_movement_context, build_task_escrow_snapshot,
+    fund_and_release_live_escrow, fund_live_escrow, read_state_json, release_escrow_response,
+    release_live_escrow_across_restart, release_live_escrow_twice,
     set_live_solana_bridge_rpc_url_env, settlement_tx_signature, LiveSolanaAssetMovementParams,
 };
 
@@ -153,10 +154,7 @@ fn integration_service_api_endpoint_live_solana_asset_movement_release_is_idempo
         settlement_tx_signature(&second),
         "repeated release must keep the same Solana transaction signature"
     );
-    assert_released_escrow_has_durable_authority(&first);
-    assert_released_escrow_has_durable_authority(&second);
-    assert_eq!(first["receipt_id"], second["receipt_id"]);
-    assert_eq!(first["receipt_digest"], second["receipt_digest"]);
+    assert_replayed_release_authority(&first, &second);
 }
 
 #[test]

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_solana_asset_movement_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_solana_asset_movement_contract_tests.rs
@@ -1,6 +1,7 @@
 use super::super::*;
 use super::support::{
     assert_persisted_solana_signature_metadata, assert_released_escrow_has_durable_authority,
+    assert_released_escrow_has_settlement_authority,
     assert_released_escrow_has_solana_signature_metadata, assert_replayed_release_authority,
     build_live_solana_asset_movement_context, build_task_escrow_snapshot,
     fund_and_release_live_escrow, fund_live_escrow, read_state_json, release_escrow_response,
@@ -101,6 +102,7 @@ fn integration_service_api_endpoint_live_solana_asset_movement_release_persists_
 
     assert_released_escrow_has_solana_signature_metadata(&released_escrow);
     assert_released_escrow_has_durable_authority(&released_escrow);
+    assert_released_escrow_has_settlement_authority(&released_escrow);
     assert_eq!(released_escrow["claim_scope"], "devnet-backed");
     assert_persisted_solana_signature_metadata(&state_json, escrow_id.as_str());
 }

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_solana_asset_movement_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_solana_asset_movement_contract_tests.rs
@@ -2,7 +2,7 @@ use super::super::*;
 use super::support::{
     assert_persisted_solana_signature_metadata, assert_released_escrow_has_durable_authority,
     assert_released_escrow_has_settlement_authority,
-    assert_released_escrow_has_solana_signature_metadata, assert_replayed_release_authority,
+    assert_released_escrow_has_solana_signature_metadata, assert_replayed_live_release,
     build_live_solana_asset_movement_context, build_task_escrow_snapshot,
     fund_and_release_live_escrow, fund_live_escrow, read_state_json, release_escrow_response,
     release_live_escrow_across_restart, release_live_escrow_twice,
@@ -150,13 +150,7 @@ fn integration_service_api_endpoint_live_solana_asset_movement_release_is_idempo
         amount_lamports: 17,
     });
     let (first, second) = release_live_escrow_twice(&context.harness, 111, 113, 114, 17);
-
-    assert_eq!(
-        settlement_tx_signature(&first),
-        settlement_tx_signature(&second),
-        "repeated release must keep the same Solana transaction signature"
-    );
-    assert_replayed_release_authority(&first, &second);
+    assert_replayed_live_release(&context, &first, &second);
 }
 
 #[test]

--- a/crates/kamn-node/src/service_api_endpoint.rs
+++ b/crates/kamn-node/src/service_api_endpoint.rs
@@ -97,7 +97,7 @@ pub(crate) use live_settlement_dispatch::{
     set_test_live_solana_settlement_ambiguous_after_submit,
     set_test_live_solana_settlement_evidence_mismatch, set_test_live_solana_settlement_expired,
     set_test_live_solana_settlement_override, set_test_live_solana_settlement_reconcile_confirmed,
-    test_live_settlement_observed_prepared_intent, test_live_solana_settlement_submission_count,
+    test_live_settlement_observed_submitted_intent, test_live_solana_settlement_submission_count,
 };
 
 pub(crate) const DEFAULT_SERVICE_API_MAX_REQUESTS: u64 = 1;

--- a/crates/kamn-node/src/service_api_endpoint/escrow_models.rs
+++ b/crates/kamn-node/src/service_api_endpoint/escrow_models.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct ServiceApiEscrowStatusBody {
     pub(crate) escrow_id: String,
     pub(crate) state: String,
@@ -29,6 +29,16 @@ pub(crate) struct ServiceApiEscrowStatusBody {
     pub(crate) receipt_digest: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) action: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) settlement_receipt_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) settlement_receipt_digest: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) settlement_receipt_action: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) settlement_receipt_resource_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) settlement_receipt_state: Option<String>,
     #[serde(flatten)]
     pub(crate) settlement: ServiceApiSettlementMetadata,
 }

--- a/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch.rs
+++ b/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch.rs
@@ -26,8 +26,9 @@ pub(super) fn submit_or_reconcile_live_settlement(
     config: &LiveSolanaSettlementConfig,
     prepared: &PreparedLiveSettlement,
     escrow_id: &str,
+    before_submit: &mut dyn FnMut() -> Result<(), String>,
 ) -> Result<LiveSettlementEvidence, String> {
-    transport::submit_or_reconcile_live_settlement(config, prepared, escrow_id)
+    transport::submit_or_reconcile_live_settlement(config, prepared, escrow_id, before_submit)
 }
 
 #[cfg(test)]

--- a/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch.rs
+++ b/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch.rs
@@ -35,5 +35,5 @@ pub(crate) use test_support::{
     set_test_live_solana_settlement_ambiguous_after_submit,
     set_test_live_solana_settlement_evidence_mismatch, set_test_live_solana_settlement_expired,
     set_test_live_solana_settlement_override, set_test_live_solana_settlement_reconcile_confirmed,
-    test_live_settlement_observed_prepared_intent, test_live_solana_settlement_submission_count,
+    test_live_settlement_observed_submitted_intent, test_live_solana_settlement_submission_count,
 };

--- a/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch/test_support.rs
+++ b/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch/test_support.rs
@@ -4,7 +4,7 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Mutex, OnceLock};
 
 static TEST_LIVE_SOLANA_SETTLEMENT_OVERRIDE: OnceLock<Mutex<bool>> = OnceLock::new();
-static OBSERVED_PREPARED_INTENT: AtomicBool = AtomicBool::new(false);
+static OBSERVED_SUBMITTED_INTENT: AtomicBool = AtomicBool::new(false);
 static AMBIGUOUS_AFTER_SUBMIT: AtomicBool = AtomicBool::new(false);
 static RECONCILE_CONFIRMED: AtomicBool = AtomicBool::new(false);
 static SUBMISSION_COUNT: AtomicU64 = AtomicU64::new(0);
@@ -27,7 +27,7 @@ pub(crate) fn set_test_live_solana_settlement_override(
     let previous_ambiguous = AMBIGUOUS_AFTER_SUBMIT.swap(false, Ordering::SeqCst);
     let previous_expired = EXPIRED.swap(false, Ordering::SeqCst);
     *guard = enabled;
-    OBSERVED_PREPARED_INTENT.store(false, Ordering::SeqCst);
+    OBSERVED_SUBMITTED_INTENT.store(false, Ordering::SeqCst);
     RECONCILE_CONFIRMED.store(false, Ordering::SeqCst);
     SUBMISSION_COUNT.store(0, Ordering::SeqCst);
     EVIDENCE_MISMATCH.store(false, Ordering::SeqCst);
@@ -94,7 +94,7 @@ pub(crate) fn maybe_submit_test_live_settlement(
     {
         return None;
     }
-    OBSERVED_PREPARED_INTENT.store(prepared_intent_exists(escrow_id), Ordering::SeqCst);
+    OBSERVED_SUBMITTED_INTENT.store(submitted_intent_exists(escrow_id), Ordering::SeqCst);
     if RECONCILE_CONFIRMED.load(Ordering::SeqCst) {
         return Some(Ok(success_evidence(config, prepared)));
     }
@@ -126,8 +126,8 @@ fn success_evidence(
     }
 }
 
-pub(crate) fn test_live_settlement_observed_prepared_intent() -> bool {
-    OBSERVED_PREPARED_INTENT.load(Ordering::SeqCst)
+pub(crate) fn test_live_settlement_observed_submitted_intent() -> bool {
+    OBSERVED_SUBMITTED_INTENT.load(Ordering::SeqCst)
 }
 
 impl Drop for TestLiveSolanaSettlementOverrideGuard {
@@ -145,7 +145,7 @@ fn override_state() -> &'static Mutex<bool> {
     TEST_LIVE_SOLANA_SETTLEMENT_OVERRIDE.get_or_init(|| Mutex::new(false))
 }
 
-fn prepared_intent_exists(escrow_id: &str) -> bool {
+fn submitted_intent_exists(escrow_id: &str) -> bool {
     let Ok(path) = std::env::var("KAMN_SERVICE_API_STATE_FILE") else {
         return false;
     };
@@ -158,7 +158,9 @@ fn prepared_intent_exists(escrow_id: &str) -> bool {
     state["settlement_intents"]
         .as_object()
         .and_then(|intents| intents.get(escrow_id))
-        .is_some_and(|intent| intent["state"] == "prepared")
+        .is_some_and(|intent| {
+            intent["state"] == "submitted" && intent["submission_attempt_count"] == 1
+        })
 }
 
 fn deterministic_signature(seed: &str) -> String {

--- a/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch/test_support.rs
+++ b/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch/test_support.rs
@@ -87,6 +87,7 @@ pub(crate) fn maybe_submit_test_live_settlement(
     config: &LiveSolanaSettlementConfig,
     prepared: &PreparedLiveSettlement,
     escrow_id: &str,
+    before_submit: &mut dyn FnMut() -> Result<(), String>,
 ) -> Option<Result<LiveSettlementEvidence, String>> {
     if !*override_state()
         .lock()
@@ -94,13 +95,16 @@ pub(crate) fn maybe_submit_test_live_settlement(
     {
         return None;
     }
-    OBSERVED_SUBMITTED_INTENT.store(submitted_intent_exists(escrow_id), Ordering::SeqCst);
     if RECONCILE_CONFIRMED.load(Ordering::SeqCst) {
         return Some(Ok(success_evidence(config, prepared)));
     }
     if EXPIRED.load(Ordering::SeqCst) {
         return Some(Err("SETTLEMENT_TRANSACTION_EXPIRED".to_owned()));
     }
+    if let Err(error) = before_submit() {
+        return Some(Err(error));
+    }
+    OBSERVED_SUBMITTED_INTENT.store(submitted_intent_exists(escrow_id), Ordering::SeqCst);
     SUBMISSION_COUNT.fetch_add(1, Ordering::SeqCst);
     if AMBIGUOUS_AFTER_SUBMIT.load(Ordering::SeqCst) {
         return Some(Err("SETTLEMENT_OUTCOME_AMBIGUOUS".to_owned()));

--- a/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch/test_support.rs
+++ b/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch/test_support.rs
@@ -89,10 +89,7 @@ pub(crate) fn maybe_submit_test_live_settlement(
     escrow_id: &str,
     before_submit: &mut dyn FnMut() -> Result<(), String>,
 ) -> Option<Result<LiveSettlementEvidence, String>> {
-    if !*override_state()
-        .lock()
-        .expect("override lock should not poison")
-    {
+    if !test_override_enabled() {
         return None;
     }
     if RECONCILE_CONFIRMED.load(Ordering::SeqCst) {
@@ -110,6 +107,12 @@ pub(crate) fn maybe_submit_test_live_settlement(
         return Some(Err("SETTLEMENT_OUTCOME_AMBIGUOUS".to_owned()));
     }
     Some(Ok(success_evidence(config, prepared)))
+}
+
+fn test_override_enabled() -> bool {
+    *override_state()
+        .lock()
+        .expect("override lock should not poison")
 }
 
 fn success_evidence(

--- a/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch/transport.rs
+++ b/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch/transport.rs
@@ -31,14 +31,18 @@ pub(super) fn submit_or_reconcile_live_settlement(
     config: &LiveSolanaSettlementConfig,
     prepared: &PreparedLiveSettlement,
     escrow_id: &str,
+    before_submit: &mut dyn FnMut() -> Result<(), String>,
 ) -> Result<LiveSettlementEvidence, String> {
     #[cfg(test)]
-    if let Some(result) =
-        super::test_support::maybe_submit_test_live_settlement(config, prepared, escrow_id)
-    {
+    if let Some(result) = super::test_support::maybe_submit_test_live_settlement(
+        config,
+        prepared,
+        escrow_id,
+        before_submit,
+    ) {
         return result;
     }
-    submit_or_reconcile_live_settlement_via_rpc(config, prepared, escrow_id)
+    submit_or_reconcile_live_settlement_via_rpc(config, prepared, escrow_id, before_submit)
 }
 
 fn prepare_live_settlement_via_rpc(
@@ -71,6 +75,7 @@ fn submit_or_reconcile_live_settlement_via_rpc(
     config: &LiveSolanaSettlementConfig,
     prepared: &PreparedLiveSettlement,
     escrow_id: &str,
+    before_submit: &mut dyn FnMut() -> Result<(), String>,
 ) -> Result<LiveSettlementEvidence, String> {
     let (transaction, expected_signature) = validated_transaction(config, prepared, escrow_id)?;
     let client = settlement_rpc_client(config);
@@ -78,6 +83,7 @@ fn submit_or_reconcile_live_settlement_via_rpc(
         return Ok(settlement_evidence(config, prepared));
     }
     require_resubmittable_blockhash(blockhash_is_valid(&client, &transaction, config)?)?;
+    before_submit()?;
     let signature = submit_live_settlement_transaction(&client, &transaction)?;
     require_expected_signature(&signature, prepared)?;
     let confirmed = confirm_live_settlement_signature(&client, &signature, config)?;

--- a/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch/transport_tests.rs
+++ b/crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch/transport_tests.rs
@@ -1,5 +1,6 @@
 use super::transaction::{build_escrow_bound_transaction, validate_persisted_transaction};
 use super::*;
+use solana_commitment_config::CommitmentConfig;
 use solana_sdk::{hash::Hash, pubkey::Pubkey, signature::Keypair};
 
 #[test]
@@ -49,4 +50,42 @@ fn persisted_transaction_integrity_rejects_tampering() {
     let error = validate_persisted_transaction(json.as_str(), expected.as_str())
         .expect_err("tampering must fail");
     assert!(error.contains("integrity"));
+}
+
+#[test]
+fn persistence_failure_prevents_settlement_submission() {
+    let _guard = super::super::test_support::set_test_live_solana_settlement_override(true);
+    let config = test_config();
+    let prepared = super::super::test_support::maybe_prepare_test_live_settlement(
+        &config,
+        "escrow-persist-failure",
+    )
+    .expect("test override")
+    .expect("prepared settlement");
+    let mut reject = || Err("SETTLEMENT_SUBMISSION_PERSISTENCE_FAILED: injected".to_owned());
+
+    let error = submit_or_reconcile_live_settlement(
+        &config,
+        &prepared,
+        "escrow-persist-failure",
+        &mut reject,
+    )
+    .expect_err("persistence failure must prevent submission");
+
+    assert!(error.starts_with("SETTLEMENT_SUBMISSION_PERSISTENCE_FAILED"));
+    assert_eq!(
+        super::super::test_support::test_live_solana_settlement_submission_count(),
+        0
+    );
+}
+
+fn test_config() -> LiveSolanaSettlementConfig {
+    LiveSolanaSettlementConfig {
+        rpc_url: "http://127.0.0.1:1".to_owned(),
+        keypair_file: "unused".to_owned(),
+        recipient_pubkey: Pubkey::new_unique(),
+        lamports: 1,
+        commitment: CommitmentConfig::finalized(),
+        commitment_label: "finalized".to_owned(),
+    }
 }

--- a/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops.rs
@@ -145,12 +145,12 @@ impl ServiceApiMessageStore {
         }))
     }
 
-    pub(crate) fn get_escrow_status(
+    pub(crate) fn get_released_escrow_status(
         &mut self,
         escrow_id: &str,
     ) -> Result<Option<ServiceApiEscrowStatusBody>, String> {
         self.refresh_from_disk()?;
-        settlement::status_response(&self.snapshot, escrow_id)
+        settlement::released_response(&self.snapshot, escrow_id)
     }
 
     pub(crate) fn release_escrow(

--- a/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops.rs
@@ -150,10 +150,7 @@ impl ServiceApiMessageStore {
         escrow_id: &str,
     ) -> Result<Option<ServiceApiEscrowStatusBody>, String> {
         self.refresh_from_disk()?;
-        let Some(record) = self.snapshot.escrows.get(escrow_id) else {
-            return Ok(None);
-        };
-        Ok(Some(escrow_status_response(record)))
+        settlement::status_response(&self.snapshot, escrow_id)
     }
 
     pub(crate) fn release_escrow(

--- a/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops.rs
@@ -68,6 +68,10 @@ impl ServiceApiMessageStore {
         settlement_intent::mark_ambiguous(self, escrow_id)
     }
 
+    pub(crate) fn mark_settlement_submitted(&mut self, escrow_id: &str) -> Result<(), String> {
+        settlement_intent::mark_submitted(self, escrow_id)
+    }
+
     pub(crate) fn mark_settlement_failed(
         &mut self,
         escrow_id: &str,

--- a/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/escrow_lifecycle.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/escrow_lifecycle.rs
@@ -1,5 +1,5 @@
 use super::super::super::*;
-use super::settlement::{escrow_status_response, next_escrow_id};
+use super::settlement::{escrow_status_response, next_escrow_id, status_response_with_receipt};
 
 mod agreement;
 mod receipt;

--- a/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/escrow_lifecycle.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/escrow_lifecycle.rs
@@ -1,5 +1,5 @@
 use super::super::super::*;
-use super::settlement::{escrow_status_response, next_escrow_id, status_response_with_receipt};
+use super::settlement::{escrow_status_response, next_escrow_id, receipt_status_response};
 
 mod agreement;
 mod receipt;

--- a/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/escrow_lifecycle/receipt.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/escrow_lifecycle/receipt.rs
@@ -52,10 +52,10 @@ pub(super) fn response(
     record: &ServiceApiPersistedEscrowRecord,
     receipt: Option<&ServiceApiEscrowTransitionReceiptRecord>,
 ) -> ServiceApiEscrowStatusBody {
-    let mut response = escrow_status_response(record);
-    response.receipt_id = receipt.map(|value| value.receipt_id.clone());
-    response.receipt_digest = receipt.map(authority_digest::escrow);
-    response.action = receipt.map(|value| value.action.clone());
+    let mut response = receipt.map_or_else(
+        || escrow_status_response(record),
+        |value| status_response_with_receipt(record, value),
+    );
     if let Some(receipt) = receipt {
         response.state = receipt.resulting_state.clone();
     }

--- a/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/escrow_lifecycle/receipt.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/escrow_lifecycle/receipt.rs
@@ -52,14 +52,10 @@ pub(super) fn response(
     record: &ServiceApiPersistedEscrowRecord,
     receipt: Option<&ServiceApiEscrowTransitionReceiptRecord>,
 ) -> ServiceApiEscrowStatusBody {
-    let mut response = receipt.map_or_else(
+    receipt.map_or_else(
         || escrow_status_response(record),
-        |value| status_response_with_receipt(record, value),
-    );
-    if let Some(receipt) = receipt {
-        response.state = receipt.resulting_state.clone();
-    }
-    response
+        |value| receipt_status_response(record, value),
+    )
 }
 
 fn required(value: &Option<String>) -> Result<String, EscrowLifecycleError> {

--- a/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/settlement.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/settlement.rs
@@ -48,6 +48,61 @@ pub(super) fn escrow_status_response(
     }
 }
 
+pub(super) fn status_response(
+    snapshot: &ServiceApiPersistedMessageStoreSnapshot,
+    escrow_id: &str,
+) -> Result<Option<ServiceApiEscrowStatusBody>, String> {
+    let Some(record) = snapshot.escrows.get(escrow_id) else {
+        return Ok(None);
+    };
+    if record.state != "released" {
+        return Ok(Some(escrow_status_response(record)));
+    }
+    let receipt = release_authority_receipt(snapshot, escrow_id)?;
+    Ok(Some(released_status_response(record, receipt)))
+}
+
+pub(super) fn release_authority_receipt<'a>(
+    snapshot: &'a ServiceApiPersistedMessageStoreSnapshot,
+    escrow_id: &str,
+) -> Result<&'a ServiceApiEscrowTransitionReceiptRecord, String> {
+    snapshot
+        .escrow_transition_receipts
+        .iter()
+        .find(|receipt| {
+            receipt.escrow_id == escrow_id && receipt.action == "escrow:release-authorize"
+        })
+        .ok_or_else(|| "ESCROW_RECEIPT_MISSING: release authorization receipt missing".to_owned())
+}
+
+pub(super) fn released_status_response(
+    record: &ServiceApiPersistedEscrowRecord,
+    receipt: &ServiceApiEscrowTransitionReceiptRecord,
+) -> ServiceApiEscrowStatusBody {
+    let mut response = escrow_status_response(record);
+    response.receipt_id = Some(receipt.receipt_id.clone());
+    response.receipt_digest = Some(authority_digest::escrow(receipt));
+    response.action = Some(receipt.action.clone());
+    response
+}
+
+pub(super) fn release_with_metadata(
+    snapshot: &mut ServiceApiPersistedMessageStoreSnapshot,
+    escrow_id: &str,
+    settlement: &ServiceApiSettlementMetadata,
+) -> Result<Option<ServiceApiEscrowStatusBody>, String> {
+    if !snapshot.escrows.contains_key(escrow_id) {
+        return Ok(None);
+    }
+    let receipt = release_authority_receipt(snapshot, escrow_id)?.clone();
+    let record = snapshot
+        .escrows
+        .get_mut(escrow_id)
+        .ok_or_else(|| "settlement escrow missing during release".to_owned())?;
+    release_escrow_record(record, Some(settlement));
+    Ok(Some(released_status_response(record, &receipt)))
+}
+
 fn escrow_claim_scope(record: &ServiceApiPersistedEscrowRecord) -> &'static str {
     if record.settlement.settlement_tx_signature.is_some()
         && record.settlement.settlement_network.as_deref() == Some("solana:devnet")

--- a/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/settlement.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/settlement.rs
@@ -59,7 +59,7 @@ pub(super) fn status_response(
         return Ok(Some(escrow_status_response(record)));
     }
     let receipt = release_authority_receipt(snapshot, escrow_id)?;
-    Ok(Some(released_status_response(record, receipt)))
+    Ok(Some(status_response_with_receipt(record, receipt)))
 }
 
 pub(super) fn release_authority_receipt<'a>(
@@ -75,7 +75,7 @@ pub(super) fn release_authority_receipt<'a>(
         .ok_or_else(|| "ESCROW_RECEIPT_MISSING: release authorization receipt missing".to_owned())
 }
 
-pub(super) fn released_status_response(
+pub(super) fn status_response_with_receipt(
     record: &ServiceApiPersistedEscrowRecord,
     receipt: &ServiceApiEscrowTransitionReceiptRecord,
 ) -> ServiceApiEscrowStatusBody {
@@ -100,7 +100,7 @@ pub(super) fn release_with_metadata(
         .get_mut(escrow_id)
         .ok_or_else(|| "settlement escrow missing during release".to_owned())?;
     release_escrow_record(record, Some(settlement));
-    Ok(Some(released_status_response(record, &receipt)))
+    Ok(Some(status_response_with_receipt(record, &receipt)))
 }
 
 fn escrow_claim_scope(record: &ServiceApiPersistedEscrowRecord) -> &'static str {

--- a/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/settlement.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/settlement.rs
@@ -48,7 +48,7 @@ pub(super) fn escrow_status_response(
     }
 }
 
-pub(super) fn status_response(
+pub(super) fn released_response(
     snapshot: &ServiceApiPersistedMessageStoreSnapshot,
     escrow_id: &str,
 ) -> Result<Option<ServiceApiEscrowStatusBody>, String> {
@@ -56,10 +56,10 @@ pub(super) fn status_response(
         return Ok(None);
     };
     if record.state != "released" {
-        return Ok(Some(escrow_status_response(record)));
+        return Ok(None);
     }
     let receipt = release_authority_receipt(snapshot, escrow_id)?;
-    Ok(Some(status_response_with_receipt(record, receipt)))
+    Ok(Some(receipt_status_response(record, receipt)))
 }
 
 pub(super) fn release_authority_receipt<'a>(
@@ -86,6 +86,15 @@ pub(super) fn status_response_with_receipt(
     response
 }
 
+pub(super) fn receipt_status_response(
+    record: &ServiceApiPersistedEscrowRecord,
+    receipt: &ServiceApiEscrowTransitionReceiptRecord,
+) -> ServiceApiEscrowStatusBody {
+    let mut response = status_response_with_receipt(record, receipt);
+    response.state = receipt.resulting_state.clone();
+    response
+}
+
 pub(super) fn release_with_metadata(
     snapshot: &mut ServiceApiPersistedMessageStoreSnapshot,
     escrow_id: &str,
@@ -100,7 +109,7 @@ pub(super) fn release_with_metadata(
         .get_mut(escrow_id)
         .ok_or_else(|| "settlement escrow missing during release".to_owned())?;
     release_escrow_record(record, Some(settlement));
-    Ok(Some(status_response_with_receipt(record, &receipt)))
+    Ok(Some(receipt_status_response(record, &receipt)))
 }
 
 fn escrow_claim_scope(record: &ServiceApiPersistedEscrowRecord) -> &'static str {

--- a/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/settlement.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/settlement.rs
@@ -45,6 +45,7 @@ pub(super) fn escrow_status_response(
         receipt_digest: None,
         action: None,
         settlement: record.settlement.clone(),
+        ..ServiceApiEscrowStatusBody::default()
     }
 }
 
@@ -59,7 +60,8 @@ pub(super) fn released_response(
         return Ok(None);
     }
     let receipt = release_authority_receipt(snapshot, escrow_id)?;
-    Ok(Some(receipt_status_response(record, receipt)))
+    let intent = confirmed_settlement_intent(snapshot, escrow_id)?;
+    Ok(Some(settled_status_response(record, receipt, intent)))
 }
 
 pub(super) fn release_authority_receipt<'a>(
@@ -95,6 +97,33 @@ pub(super) fn receipt_status_response(
     response
 }
 
+fn settled_status_response(
+    record: &ServiceApiPersistedEscrowRecord,
+    receipt: &ServiceApiEscrowTransitionReceiptRecord,
+    intent: &ServiceApiSettlementIntentRecord,
+) -> ServiceApiEscrowStatusBody {
+    let mut response = receipt_status_response(record, receipt);
+    response.settlement_receipt_id = Some(intent.settlement_intent_id.clone());
+    response.settlement_receipt_digest = Some(authority_digest::settlement(intent));
+    response.settlement_receipt_action = Some("settlement:confirmed".to_owned());
+    response.settlement_receipt_resource_id = Some(intent.escrow_id.clone());
+    response.settlement_receipt_state = Some(intent.state.clone());
+    response
+}
+
+fn confirmed_settlement_intent<'a>(
+    snapshot: &'a ServiceApiPersistedMessageStoreSnapshot,
+    escrow_id: &str,
+) -> Result<&'a ServiceApiSettlementIntentRecord, String> {
+    snapshot
+        .settlement_intents
+        .get(escrow_id)
+        .filter(|intent| intent.state == "confirmed" && intent.escrow_id == escrow_id)
+        .ok_or_else(|| {
+            "SETTLEMENT_RECEIPT_MISSING: confirmed settlement receipt missing".to_owned()
+        })
+}
+
 pub(super) fn release_with_metadata(
     snapshot: &mut ServiceApiPersistedMessageStoreSnapshot,
     escrow_id: &str,
@@ -104,12 +133,13 @@ pub(super) fn release_with_metadata(
         return Ok(None);
     }
     let receipt = release_authority_receipt(snapshot, escrow_id)?.clone();
+    let intent = confirmed_settlement_intent(snapshot, escrow_id)?.clone();
     let record = snapshot
         .escrows
         .get_mut(escrow_id)
         .ok_or_else(|| "settlement escrow missing during release".to_owned())?;
     release_escrow_record(record, Some(settlement));
-    Ok(Some(receipt_status_response(record, &receipt)))
+    Ok(Some(settled_status_response(record, &receipt, &intent)))
 }
 
 fn escrow_claim_scope(record: &ServiceApiPersistedEscrowRecord) -> &'static str {

--- a/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/settlement.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/settlement.rs
@@ -61,7 +61,7 @@ pub(super) fn released_response(
     }
     let receipt = release_authority_receipt(snapshot, escrow_id)?;
     let intent = confirmed_settlement_intent(snapshot, escrow_id)?;
-    Ok(Some(settled_status_response(record, receipt, intent)))
+    Ok(Some(settled_status_response(record, receipt, intent)?))
 }
 
 pub(super) fn release_authority_receipt<'a>(
@@ -101,14 +101,33 @@ fn settled_status_response(
     record: &ServiceApiPersistedEscrowRecord,
     receipt: &ServiceApiEscrowTransitionReceiptRecord,
     intent: &ServiceApiSettlementIntentRecord,
-) -> ServiceApiEscrowStatusBody {
+) -> Result<ServiceApiEscrowStatusBody, String> {
+    validate_settlement_receipt_binding(record, intent)?;
     let mut response = receipt_status_response(record, receipt);
     response.settlement_receipt_id = Some(intent.settlement_intent_id.clone());
     response.settlement_receipt_digest = Some(authority_digest::settlement(intent));
     response.settlement_receipt_action = Some("settlement:confirmed".to_owned());
     response.settlement_receipt_resource_id = Some(intent.escrow_id.clone());
     response.settlement_receipt_state = Some(intent.state.clone());
-    response
+    Ok(response)
+}
+
+fn validate_settlement_receipt_binding(
+    escrow: &ServiceApiPersistedEscrowRecord,
+    intent: &ServiceApiSettlementIntentRecord,
+) -> Result<(), String> {
+    let valid = escrow.release_authority_did.as_deref() == Some(intent.actor_did.as_str())
+        && escrow.settlement.settlement_tx_signature.as_deref()
+            == Some(intent.expected_signature.as_str())
+        && escrow.settlement.settlement_receipt_hash.as_deref()
+            == Some(intent.expected_signature.as_str())
+        && escrow.settlement.settlement_network.as_deref() == Some(intent.network.as_str())
+        && escrow.settlement.settlement_commitment.as_deref() == Some("finalized")
+        && escrow.amount_lamports == Some(intent.amount_lamports)
+        && intent.network == "solana:devnet";
+    valid
+        .then_some(())
+        .ok_or_else(|| "SETTLEMENT_RECEIPT_INVALID: settlement receipt binding mismatch".to_owned())
 }
 
 fn confirmed_settlement_intent<'a>(
@@ -139,7 +158,7 @@ pub(super) fn release_with_metadata(
         .get_mut(escrow_id)
         .ok_or_else(|| "settlement escrow missing during release".to_owned())?;
     release_escrow_record(record, Some(settlement));
-    Ok(Some(settled_status_response(record, &receipt, &intent)))
+    Ok(Some(settled_status_response(record, &receipt, &intent)?))
 }
 
 fn escrow_claim_scope(record: &ServiceApiPersistedEscrowRecord) -> &'static str {

--- a/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/settlement_intent.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/settlement_intent.rs
@@ -187,9 +187,5 @@ fn release_without_refresh(
     escrow_id: &str,
     settlement: &ServiceApiSettlementMetadata,
 ) -> Result<Option<ServiceApiEscrowStatusBody>, String> {
-    let Some(record) = store.snapshot.escrows.get_mut(escrow_id) else {
-        return Ok(None);
-    };
-    super::settlement::release_escrow_record(record, Some(settlement));
-    Ok(Some(super::settlement::escrow_status_response(record)))
+    super::settlement::release_with_metadata(&mut store.snapshot, escrow_id, settlement)
 }

--- a/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/settlement_intent.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/settlement_intent.rs
@@ -90,6 +90,21 @@ pub(super) fn mark_failed(
     store.persist()
 }
 
+pub(super) fn mark_submitted(
+    store: &mut ServiceApiMessageStore,
+    escrow_id: &str,
+) -> Result<(), String> {
+    store.refresh_from_disk()?;
+    let intent = store
+        .snapshot
+        .settlement_intents
+        .get_mut(escrow_id)
+        .ok_or_else(|| "settlement intent missing during submit".to_owned())?;
+    intent.state = "submitted".to_owned();
+    record_submission(intent);
+    store.persist()
+}
+
 fn record_submission(intent: &mut ServiceApiSettlementIntentRecord) {
     intent.submission_attempt_count = intent.submission_attempt_count.max(1);
 }

--- a/crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/mutations/update_routes/state_routes_release/live_settlement.rs
+++ b/crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/mutations/update_routes/state_routes_release/live_settlement.rs
@@ -1,10 +1,11 @@
+use super::super::super::super::persistence_error as service_persistence_error;
 use super::*;
 
 mod errors;
 mod release_authority;
+mod submission;
 use errors::{
     invalid_release_key, settlement_evidence_mismatch_error, settlement_intent_conflict_error,
-    settlement_outcome_ambiguous_error, settlement_transaction_expired_error,
 };
 
 type ReleaseResult = Result<Result<Option<ServiceApiEscrowStatusBody>, String>, Box<Response>>;
@@ -43,11 +44,9 @@ fn released_escrow(
     store: &mut ServiceApiMessageStore,
     escrow_id: &str,
 ) -> Result<Option<ServiceApiEscrowStatusBody>, Box<Response>> {
-    let existing = store.get_escrow_status(escrow_id).map_err(|error| {
-        Box::new(super::super::super::super::persistence_error(
-            error.as_str(),
-        ))
-    })?;
+    let existing = store
+        .get_escrow_status(escrow_id)
+        .map_err(persistence_error)?;
     Ok(existing.filter(|payload| payload.state == "released"))
 }
 
@@ -78,50 +77,17 @@ fn submit(
             .mark_settlement_submitted(escrow_id)
             .map_err(|error| format!("SETTLEMENT_SUBMISSION_PERSISTENCE_FAILED: {error}"))
     };
-    match live_settlement_dispatch::submit_or_reconcile_live_settlement(
+    let result = live_settlement_dispatch::submit_or_reconcile_live_settlement(
         config,
         prepared,
         escrow_id,
         &mut persist,
-    ) {
-        Ok(evidence) => Ok(evidence),
-        Err(error) if error.starts_with("SETTLEMENT_SUBMISSION_PERSISTENCE_FAILED") => {
-            Err(persistence_error(error))
-        }
-        Err(error) if error.starts_with("SETTLEMENT_OUTCOME_AMBIGUOUS") => {
-            persist_ambiguous(store, escrow_id)?;
-            Err(Box::new(settlement_outcome_ambiguous_error()))
-        }
-        Err(error) if error == "SETTLEMENT_TRANSACTION_EXPIRED" => {
-            persist_expired(store, escrow_id)?;
-            Err(Box::new(settlement_transaction_expired_error()))
-        }
-        Err(error) => Err(Box::new(live_settlement_evidence_error(error.as_str()))),
-    }
-}
-
-fn persist_ambiguous(
-    store: &mut ServiceApiMessageStore,
-    escrow_id: &str,
-) -> Result<(), Box<Response>> {
-    store
-        .mark_settlement_outcome_ambiguous(escrow_id)
-        .map_err(persistence_error)
-}
-
-fn persist_expired(
-    store: &mut ServiceApiMessageStore,
-    escrow_id: &str,
-) -> Result<(), Box<Response>> {
-    store
-        .mark_settlement_expired(escrow_id)
-        .map_err(persistence_error)
+    );
+    submission::handle(store, escrow_id, result)
 }
 
 fn persistence_error(error: String) -> Box<Response> {
-    Box::new(super::super::super::super::persistence_error(
-        error.as_str(),
-    ))
+    Box::new(service_persistence_error(error.as_str()))
 }
 
 fn validate_evidence(
@@ -136,11 +102,7 @@ fn validate_evidence(
     }
     store
         .mark_settlement_failed(escrow_id, "SETTLEMENT_EVIDENCE_MISMATCH")
-        .map_err(|error| {
-            Box::new(super::super::super::super::persistence_error(
-                error.as_str(),
-            ))
-        })?;
+        .map_err(persistence_error)?;
     Err(Box::new(settlement_evidence_mismatch_error()))
 }
 
@@ -162,11 +124,9 @@ fn resolve_prepared(
     config: &LiveSolanaSettlementConfig,
     escrow_id: &str,
 ) -> Result<PreparedLiveSettlement, Box<Response>> {
-    let existing = store.get_settlement_intent(escrow_id).map_err(|error| {
-        Box::new(super::super::super::super::persistence_error(
-            error.as_str(),
-        ))
-    })?;
+    let existing = store
+        .get_settlement_intent(escrow_id)
+        .map_err(persistence_error)?;
     if let Some(intent) = existing {
         return Ok(prepared_from_intent(intent));
     }

--- a/crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/mutations/update_routes/state_routes_release/live_settlement.rs
+++ b/crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/mutations/update_routes/state_routes_release/live_settlement.rs
@@ -73,9 +73,21 @@ fn submit(
     prepared: &PreparedLiveSettlement,
     escrow_id: &str,
 ) -> Result<LiveSettlementEvidence, Box<Response>> {
-    match live_settlement_dispatch::submit_or_reconcile_live_settlement(config, prepared, escrow_id)
-    {
+    let mut persist = || {
+        store
+            .mark_settlement_submitted(escrow_id)
+            .map_err(|error| format!("SETTLEMENT_SUBMISSION_PERSISTENCE_FAILED: {error}"))
+    };
+    match live_settlement_dispatch::submit_or_reconcile_live_settlement(
+        config,
+        prepared,
+        escrow_id,
+        &mut persist,
+    ) {
         Ok(evidence) => Ok(evidence),
+        Err(error) if error.starts_with("SETTLEMENT_SUBMISSION_PERSISTENCE_FAILED") => {
+            Err(persistence_error(error))
+        }
         Err(error) if error.starts_with("SETTLEMENT_OUTCOME_AMBIGUOUS") => {
             persist_ambiguous(store, escrow_id)?;
             Err(Box::new(settlement_outcome_ambiguous_error()))

--- a/crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/mutations/update_routes/state_routes_release/live_settlement.rs
+++ b/crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/mutations/update_routes/state_routes_release/live_settlement.rs
@@ -45,9 +45,9 @@ fn released_escrow(
     escrow_id: &str,
 ) -> Result<Option<ServiceApiEscrowStatusBody>, Box<Response>> {
     let existing = store
-        .get_escrow_status(escrow_id)
+        .get_released_escrow_status(escrow_id)
         .map_err(persistence_error)?;
-    Ok(existing.filter(|payload| payload.state == "released"))
+    Ok(existing)
 }
 
 fn persist_intent(

--- a/crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/mutations/update_routes/state_routes_release/live_settlement/submission.rs
+++ b/crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/mutations/update_routes/state_routes_release/live_settlement/submission.rs
@@ -1,0 +1,42 @@
+use super::errors::{settlement_outcome_ambiguous_error, settlement_transaction_expired_error};
+use super::*;
+
+pub(super) fn handle(
+    store: &mut ServiceApiMessageStore,
+    escrow_id: &str,
+    result: Result<LiveSettlementEvidence, String>,
+) -> Result<LiveSettlementEvidence, Box<Response>> {
+    match result {
+        Ok(evidence) => Ok(evidence),
+        Err(error) if error.starts_with("SETTLEMENT_SUBMISSION_PERSISTENCE_FAILED") => {
+            Err(persistence_error(error))
+        }
+        Err(error) if error.starts_with("SETTLEMENT_OUTCOME_AMBIGUOUS") => {
+            persist_ambiguous(store, escrow_id)?;
+            Err(Box::new(settlement_outcome_ambiguous_error()))
+        }
+        Err(error) if error == "SETTLEMENT_TRANSACTION_EXPIRED" => {
+            persist_expired(store, escrow_id)?;
+            Err(Box::new(settlement_transaction_expired_error()))
+        }
+        Err(error) => Err(Box::new(live_settlement_evidence_error(error.as_str()))),
+    }
+}
+
+fn persist_ambiguous(
+    store: &mut ServiceApiMessageStore,
+    escrow_id: &str,
+) -> Result<(), Box<Response>> {
+    store
+        .mark_settlement_outcome_ambiguous(escrow_id)
+        .map_err(persistence_error)
+}
+
+fn persist_expired(
+    store: &mut ServiceApiMessageStore,
+    escrow_id: &str,
+) -> Result<(), Box<Response>> {
+    store
+        .mark_settlement_expired(escrow_id)
+        .map_err(persistence_error)
+}

--- a/crates/kamn-node/src/service_api_endpoint/payload.rs
+++ b/crates/kamn-node/src/service_api_endpoint/payload.rs
@@ -270,6 +270,11 @@ pub(super) fn render_service_api_endpoint_response(
                 receipt_id: None,
                 receipt_digest: None,
                 action: None,
+                settlement_receipt_id: None,
+                settlement_receipt_digest: None,
+                settlement_receipt_action: None,
+                settlement_receipt_resource_id: None,
+                settlement_receipt_state: None,
                 settlement: ServiceApiSettlementMetadata::default(),
             };
             return ServiceApiEndpointResponse {
@@ -295,6 +300,11 @@ pub(super) fn render_service_api_endpoint_response(
                 receipt_id: None,
                 receipt_digest: None,
                 action: None,
+                settlement_receipt_id: None,
+                settlement_receipt_digest: None,
+                settlement_receipt_action: None,
+                settlement_receipt_resource_id: None,
+                settlement_receipt_state: None,
                 settlement: ServiceApiSettlementMetadata::default(),
             };
             return ServiceApiEndpointResponse {

--- a/crates/kamn-sdk/src/service.rs
+++ b/crates/kamn-sdk/src/service.rs
@@ -18,6 +18,8 @@ mod service_models;
 mod service_request_auth;
 #[path = "service_response.rs"]
 mod service_response;
+#[path = "service_settlement_receipt.rs"]
+mod service_settlement_receipt;
 #[path = "service_websocket.rs"]
 mod service_websocket;
 pub use self::service_auth_crypto::{
@@ -26,7 +28,7 @@ pub use self::service_auth_crypto::{
     service_verify_signature_with_public_key,
 };
 use self::service_authority::profile_commitment;
-pub use self::service_authority_models::ServiceTaskTransitionReceipt;
+pub use self::service_authority_models::{ServiceSettlementReceipt, ServiceTaskTransitionReceipt};
 pub(crate) use self::service_client::service_client_bridge_misc_routes::agent_search_payload;
 use self::service_client::HttpResponse;
 pub use self::service_client::ServiceApiClient;
@@ -50,6 +52,7 @@ use self::service_response::{
     expect_status, json_string_array_field, json_string_field, json_u64_field,
     map_non_success_response, parse_http_response, status_from_header,
 };
+use self::service_settlement_receipt::parse_settlement_receipt;
 use self::service_websocket::parse_unmasked_text_frame_payload;
 
 const REQUEST_TIMEOUT_SECONDS_DEFAULT: u64 = 2;

--- a/crates/kamn-sdk/src/service_authority_models.rs
+++ b/crates/kamn-sdk/src/service_authority_models.rs
@@ -12,3 +12,18 @@ pub struct ServiceTaskTransitionReceipt {
     /// Canonical durable receipt action.
     pub action: String,
 }
+
+/// Durable settlement receipt returned with a finalized escrow release.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ServiceSettlementReceipt {
+    /// Settlement intent receipt identifier.
+    pub receipt_id: String,
+    /// Digest of the durable settlement intent.
+    pub receipt_digest: String,
+    /// Canonical settlement receipt action.
+    pub action: String,
+    /// Escrow identifier bound by the settlement receipt.
+    pub resource_id: String,
+    /// Durable settlement intent state.
+    pub state: String,
+}

--- a/crates/kamn-sdk/src/service_client.rs
+++ b/crates/kamn-sdk/src/service_client.rs
@@ -123,12 +123,14 @@ impl ServiceApiClient {
 
 pub(super) fn parse_escrow_status(body: &str) -> Result<ServiceEscrowStatus, SdkError> {
     let (receipt_id, receipt_digest) = receipt_fields(body)?;
+    let escrow_id = json_string_field(body, "escrow_id")?;
+    let settlement_receipt = parse_settlement_receipt(body, escrow_id.as_str())?;
     Ok(ServiceEscrowStatus {
-        escrow_id: json_string_field(body, "escrow_id")?,
+        escrow_id,
         state: json_string_field(body, "state")?,
         receipt_id,
         receipt_digest,
         action: json_string_field(body, "action")?,
-        settlement_receipt: parse_settlement_receipt(body)?,
+        settlement_receipt,
     })
 }

--- a/crates/kamn-sdk/src/service_client.rs
+++ b/crates/kamn-sdk/src/service_client.rs
@@ -2,7 +2,7 @@ use super::parse_unmasked_text_frame_payload;
 use super::service_authority::receipt_fields;
 use super::{
     json_string_field, json_u64_field, map_non_success_response, parse_http_response,
-    status_from_header,
+    parse_settlement_receipt, status_from_header,
 };
 use super::{
     read_response_bytes, read_response_text, render_auth_headers, validate_http_header_value,
@@ -129,5 +129,6 @@ pub(super) fn parse_escrow_status(body: &str) -> Result<ServiceEscrowStatus, Sdk
         receipt_id,
         receipt_digest,
         action: json_string_field(body, "action")?,
+        settlement_receipt: parse_settlement_receipt(body)?,
     })
 }

--- a/crates/kamn-sdk/src/service_models.rs
+++ b/crates/kamn-sdk/src/service_models.rs
@@ -81,6 +81,8 @@ pub struct ServiceEscrowStatus {
     pub receipt_digest: String,
     /// Canonical durable receipt action.
     pub action: String,
+    /// Distinct durable settlement receipt for finalized live releases.
+    pub settlement_receipt: Option<ServiceSettlementReceipt>,
 }
 
 /// Parsed response for `POST /v1/content/register`.
@@ -184,3 +186,4 @@ pub struct ServiceRouteEvent {
     /// Event sequence identifier.
     pub sequence: u64,
 }
+use super::ServiceSettlementReceipt;

--- a/crates/kamn-sdk/src/service_settlement_receipt.rs
+++ b/crates/kamn-sdk/src/service_settlement_receipt.rs
@@ -1,0 +1,41 @@
+use super::{SdkError, ServiceSettlementReceipt};
+use serde_json::Value;
+
+const FIELDS: [&str; 5] = [
+    "settlement_receipt_id",
+    "settlement_receipt_digest",
+    "settlement_receipt_action",
+    "settlement_receipt_resource_id",
+    "settlement_receipt_state",
+];
+
+pub(super) fn parse_settlement_receipt(
+    body: &str,
+) -> Result<Option<ServiceSettlementReceipt>, SdkError> {
+    let root = serde_json::from_str::<Value>(body).map_err(|_| malformed())?;
+    if FIELDS.iter().all(|field| root.get(field).is_none()) {
+        return Ok(None);
+    }
+    Ok(Some(ServiceSettlementReceipt {
+        receipt_id: field(&root, FIELDS[0])?,
+        receipt_digest: field(&root, FIELDS[1])?,
+        action: field(&root, FIELDS[2])?,
+        resource_id: field(&root, FIELDS[3])?,
+        state: field(&root, FIELDS[4])?,
+    }))
+}
+
+fn field(root: &Value, name: &str) -> Result<String, SdkError> {
+    root.get(name)
+        .and_then(Value::as_str)
+        .map(str::to_owned)
+        .ok_or_else(incomplete)
+}
+
+fn malformed() -> SdkError {
+    SdkError::TransportFailure("service response payload was not valid json")
+}
+
+fn incomplete() -> SdkError {
+    SdkError::TransportFailure("service response settlement receipt was incomplete")
+}

--- a/crates/kamn-sdk/src/service_settlement_receipt.rs
+++ b/crates/kamn-sdk/src/service_settlement_receipt.rs
@@ -11,18 +11,39 @@ const FIELDS: [&str; 5] = [
 
 pub(super) fn parse_settlement_receipt(
     body: &str,
+    expected_resource: &str,
 ) -> Result<Option<ServiceSettlementReceipt>, SdkError> {
     let root = serde_json::from_str::<Value>(body).map_err(|_| malformed())?;
     if FIELDS.iter().all(|field| root.get(field).is_none()) {
         return Ok(None);
     }
-    Ok(Some(ServiceSettlementReceipt {
+    let receipt = ServiceSettlementReceipt {
         receipt_id: field(&root, FIELDS[0])?,
         receipt_digest: field(&root, FIELDS[1])?,
         action: field(&root, FIELDS[2])?,
         resource_id: field(&root, FIELDS[3])?,
         state: field(&root, FIELDS[4])?,
-    }))
+    };
+    validate(&receipt, expected_resource)?;
+    Ok(Some(receipt))
+}
+
+fn validate(receipt: &ServiceSettlementReceipt, expected_resource: &str) -> Result<(), SdkError> {
+    let digest = receipt.receipt_digest.strip_prefix("sha256:");
+    let digest_valid = digest.is_some_and(|value| {
+        value.len() == 64
+            && value
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    });
+    if digest_valid
+        && receipt.action == "settlement:confirmed"
+        && receipt.resource_id == expected_resource
+        && receipt.state == "confirmed"
+    {
+        return Ok(());
+    }
+    Err(invalid())
 }
 
 fn field(root: &Value, name: &str) -> Result<String, SdkError> {
@@ -38,4 +59,67 @@ fn malformed() -> SdkError {
 
 fn incomplete() -> SdkError {
     SdkError::TransportFailure("service response settlement receipt was incomplete")
+}
+
+fn invalid() -> SdkError {
+    SdkError::TransportFailure("service response settlement receipt was invalid")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn absent_settlement_receipt_remains_optional() {
+        assert_eq!(
+            parse_settlement_receipt(r#"{"escrow_id":"escrow-1"}"#, "escrow-1"),
+            Ok(None)
+        );
+    }
+
+    #[test]
+    fn complete_settlement_receipt_is_preserved() {
+        let body = complete_receipt(
+            "settlement:confirmed",
+            "escrow-1",
+            "confirmed",
+            &"a".repeat(64),
+        );
+        let receipt = parse_settlement_receipt(&body, "escrow-1")
+            .expect("receipt should parse")
+            .expect("receipt");
+        assert_eq!(receipt.receipt_id, "intent-1");
+        assert_eq!(receipt.resource_id, "escrow-1");
+    }
+
+    #[test]
+    fn partial_settlement_receipt_fails_closed() {
+        let error = parse_settlement_receipt(r#"{"settlement_receipt_id":"intent-1"}"#, "escrow-1")
+            .expect_err("partial receipt must fail");
+        assert!(error
+            .to_string()
+            .contains("settlement receipt was incomplete"));
+    }
+
+    #[test]
+    fn invalid_settlement_receipt_bindings_fail_closed() {
+        let digest = "a".repeat(64);
+        assert_invalid_receipt("settlement:failed", "escrow-1", "confirmed", &digest);
+        assert_invalid_receipt("settlement:confirmed", "escrow-2", "confirmed", &digest);
+        assert_invalid_receipt("settlement:confirmed", "escrow-1", "pending", &digest);
+        assert_invalid_receipt("settlement:confirmed", "escrow-1", "confirmed", "abc");
+    }
+
+    fn assert_invalid_receipt(action: &str, resource: &str, state: &str, digest: &str) {
+        let body = complete_receipt(action, resource, state, digest);
+        let error = parse_settlement_receipt(&body, "escrow-1")
+            .expect_err("invalid settlement authority must fail");
+        assert!(error.to_string().contains("settlement receipt was invalid"));
+    }
+
+    fn complete_receipt(action: &str, resource: &str, state: &str, digest: &str) -> String {
+        format!(
+            r#"{{"settlement_receipt_id":"intent-1","settlement_receipt_digest":"sha256:{digest}","settlement_receipt_action":"{action}","settlement_receipt_resource_id":"{resource}","settlement_receipt_state":"{state}"}}"#
+        )
+    }
 }

--- a/specs/7141-ambiguous-live-settlement-reconciliation.md
+++ b/specs/7141-ambiguous-live-settlement-reconciliation.md
@@ -49,6 +49,8 @@ give the canonical MCP SDK enough time to receive finalized settlement responses
   second submission.
 - The Pi extension strips the SDK timeout while constructing the MCP child environment,
   causing the MCP server to retain the two-second SDK default.
+- The Pi extension's MCP request timer remains at ten seconds even when the MCP SDK is
+  configured with the longer canonical timeout.
 - Conflicting actor, idempotency key, signature, recipient, amount, network, or evidence.
 
 ## Acceptance Criteria
@@ -65,6 +67,8 @@ give the canonical MCP SDK enough time to receive finalized settlement responses
   timeout budget without changing the SDK-wide default.
 - [ ] The Pi extension forwards that timeout to the MCP server while continuing to strip
   credentials, custody configuration, and unrelated parent environment values.
+- [ ] The persistent MCP session request timer is no shorter than the forwarded SDK
+  timeout, so the extension does not terminate an in-flight settlement first.
 - [ ] Regression tests cover write-ahead ordering, callback failure, ambiguous retry,
   confirmed reconciliation, and canonical timeout propagation.
 - [ ] The fresh-checkout canonical demo and standalone verifier pass with one transfer.

--- a/specs/7141-ambiguous-live-settlement-reconciliation.md
+++ b/specs/7141-ambiguous-live-settlement-reconciliation.md
@@ -73,34 +73,34 @@ give the canonical MCP SDK enough time to receive finalized settlement responses
 
 ## Acceptance Criteria
 
-- [ ] The live adapter invokes a durable write-ahead callback immediately before its one
+- [x] The live adapter invokes a durable write-ahead callback immediately before its one
   broadcast call.
-- [ ] The callback persists `state == "submitted"` and exactly one submission attempt.
-- [ ] Callback persistence failure prevents broadcast and hard-fails the release.
-- [ ] Ambiguous, successful, and reconciled outcomes retain exactly one durable attempt.
-- [ ] Retry queries the expected signature before blockhash validation or resubmission and
+- [x] The callback persists `state == "submitted"` and exactly one submission attempt.
+- [x] Callback persistence failure prevents broadcast and hard-fails the release.
+- [x] Ambiguous, successful, and reconciled outcomes retain exactly one durable attempt.
+- [x] Retry queries the expected signature before blockhash validation or resubmission and
   never broadcasts when that signature is already confirmed.
-- [ ] Expired transactions fail closed without a new broadcast.
-- [ ] The canonical Pi/MCP child environment sets the SDK timeout from the supervisor RPC
+- [x] Expired transactions fail closed without a new broadcast.
+- [x] The canonical Pi/MCP child environment sets the SDK timeout from the supervisor RPC
   timeout budget without changing the SDK-wide default.
-- [ ] The Pi extension forwards that timeout to the MCP server while continuing to strip
+- [x] The Pi extension forwards that timeout to the MCP server while continuing to strip
   credentials, custody configuration, and unrelated parent environment values.
-- [ ] The persistent MCP session request timer is no shorter than the forwarded SDK
+- [x] The persistent MCP session request timer is no shorter than the forwarded SDK
   timeout, so the extension does not terminate an in-flight settlement first.
-- [ ] Successful and idempotently replayed live release responses include the same
+- [x] Successful and idempotently replayed live release responses include the same
   durable `escrow:release-authorize` receipt ID and digest with the receipt-bound
   `release-authorized` state, while durable escrow state remains `released`.
-- [ ] Solana signature, receipt hash, network, and commitment remain separate settlement
+- [x] Solana signature, receipt hash, network, and commitment remain separate settlement
   metadata; the authorization digest is not relabeled as a settlement digest.
-- [ ] Successful and idempotently replayed live release responses also include the same
+- [x] Successful and idempotently replayed live release responses also include the same
   durable `settlement:confirmed` receipt ID and digest with `confirmed` state, distinct
   from the release-authorization receipt and Solana metadata.
-- [ ] MCP validates and records both receipt authorities from the release response, and
+- [x] MCP validates and records both receipt authorities from the release response, and
   Pi requires the role-scoped service receipt sequence to equal the persisted participant
   projection without client-side synthesis or ambient projection trust.
-- [ ] Pi/MCP service authority and the persisted projection agree on the release receipt's
+- [x] Pi/MCP service authority and the persisted projection agree on the release receipt's
   `release-authorized` resulting state without client-side normalization.
-- [ ] Regression tests cover write-ahead ordering, callback failure, ambiguous retry,
+- [x] Regression tests cover write-ahead ordering, callback failure, ambiguous retry,
   confirmed reconciliation, and canonical timeout propagation.
 - [ ] The fresh-checkout canonical demo and standalone verifier pass with one transfer.
 - [ ] Formatting, strict Clippy, focused tests, `make check`, and relevant CI pass.
@@ -115,6 +115,10 @@ give the canonical MCP SDK enough time to receive finalized settlement responses
 - `crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/mutations/update_routes/state_routes_release/live_settlement.rs`
 - `crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/`
 - `crates/kamn-e2e-harness/src/agent_transaction_evidence.rs`
+- `crates/kamn-e2e-harness/src/agent_transaction_receipt_chain.rs`
+- `crates/kamn-e2e-harness/src/mvp_demo/pi_transaction_actor_authority.rs`
+- `crates/kamn-e2e-harness/src/mvp_demo/runtime_receipt_chain.rs`
+- `crates/kamn-e2e-harness/tests/support/service_authority_fixture.rs`
 - Focused harness configuration tests.
 - `.pi/extensions/kamn-mvp/mcp-session.ts`
 - `.pi/extensions/kamn-mvp/mcp-session.test.ts`
@@ -144,6 +148,9 @@ give the canonical MCP SDK enough time to receive finalized settlement responses
 - A confirmed settlement missing its durable settlement intent receipt returns
   `SETTLEMENT_RECEIPT_MISSING`; MCP and Pi reject partial authority rather than dropping
   the projected settlement entry.
+- A settlement receipt whose actor, signature, hash, network, commitment, amount, action,
+  resource, state, digest, or envelope binding drifts returns
+  `SETTLEMENT_RECEIPT_INVALID` or the boundary-specific authority error.
 
 ## Test Plan
 
@@ -188,3 +195,25 @@ give the canonical MCP SDK enough time to receive finalized settlement responses
 - Run formatting, strict Clippy, touched Rust size policy, and `make check`.
 - From a detached fresh `origin/main` worktree, run the canonical demo followed by the
   standalone verifier and reconcile exactly one finalized transfer.
+
+## Verification Evidence
+
+- The single detached-worktree attempt at `9b4c33e49` transferred exactly `1,000,000`
+  lamports, persisted a `confirmed` settlement intent with
+  `submission_attempt_count == 1`, and left the escrow durably `released` with finalized
+  Solana metadata. The recipient is retired and was not reused.
+- That attempt stopped at `PI_SERVICE_AUTHORITY_MISMATCH` after settlement because the
+  Rust proof verifier still excluded the settlement receipt even though Pi and the
+  durable chain contained it. The regression at `90fd16d29` reproduced that exact error.
+- At `b9a980755`, a read-only replay of the captured state and actor artifacts generated
+  `/private/tmp/kamn-7141-replayed-proof-b9a980755-retry2/latest/proof/report.json` with
+  `execution_surface == "live-service-persisted-receipt"`, six portable service receipts,
+  and a finalized settlement. The standalone verifier returned `PASS` against all three
+  captured actor artifacts without another submission.
+- Focused verification passed: 4 SDK settlement parser tests, 3 MCP settlement authority
+  tests, 6 node settlement tests, 64 Pi tests, 261 harness unit tests, strict workspace
+  Clippy, rustfmt, diff checks, and the touched-Rust size policy.
+- The full harness run remains non-clean on an unrelated project-local Pi extension
+  marker contract that expects `KAMN_MVP_LIVE_MCP_BINARY` in the split extension entry
+  file. The broader workspace also retains pre-existing governance/policy failures, so
+  the two repository-wide acceptance boxes above remain open pending their own fixes.

--- a/specs/7141-ambiguous-live-settlement-reconciliation.md
+++ b/specs/7141-ambiguous-live-settlement-reconciliation.md
@@ -26,6 +26,9 @@ give the canonical MCP SDK enough time to receive finalized settlement responses
 - A confirmed settlement response carrying the durable `escrow:release-authorize`
   receipt identity and its `release-authorized` resulting state alongside separate
   Solana settlement metadata and a durably `released` escrow.
+- The same response carrying the durable `settlement:confirmed` receipt identity and
+  digest as distinct service authority, so Pi can match the complete participant
+  projection without promoting transport provenance or projection data into authority.
 - A canonical MCP SDK request timeout that is no shorter than the supervisor RPC budget.
 
 ## Boundaries And Non-Goals
@@ -59,6 +62,11 @@ give the canonical MCP SDK enough time to receive finalized settlement responses
   digest, or action and therefore cannot satisfy the SDK authority contract.
 - A finalized response labels the authorization receipt's resulting state as `released`,
   overstating what the durable receipt digest binds and diverging from projection state.
+- A finalized or replayed response omits the durable `settlement:confirmed` receipt, so
+  MCP records only mutation authority while the participant projection contains an
+  additional settlement entry.
+- Pi accepts a projected settlement receipt that was not delivered as validated MCP
+  service authority.
 - A released escrow has no durable `escrow:release-authorize` receipt; the response must
   hard-fail instead of fabricating client-local evidence.
 - Conflicting actor, idempotency key, signature, recipient, amount, network, or evidence.
@@ -84,6 +92,12 @@ give the canonical MCP SDK enough time to receive finalized settlement responses
   `release-authorized` state, while durable escrow state remains `released`.
 - [ ] Solana signature, receipt hash, network, and commitment remain separate settlement
   metadata; the authorization digest is not relabeled as a settlement digest.
+- [ ] Successful and idempotently replayed live release responses also include the same
+  durable `settlement:confirmed` receipt ID and digest with `confirmed` state, distinct
+  from the release-authorization receipt and Solana metadata.
+- [ ] MCP validates and records both receipt authorities from the release response, and
+  Pi requires the role-scoped service receipt sequence to equal the persisted participant
+  projection without client-side synthesis or ambient projection trust.
 - [ ] Pi/MCP service authority and the persisted projection agree on the release receipt's
   `release-authorized` resulting state without client-side normalization.
 - [ ] Regression tests cover write-ahead ordering, callback failure, ambiguous retry,
@@ -104,6 +118,9 @@ give the canonical MCP SDK enough time to receive finalized settlement responses
 - Focused harness configuration tests.
 - `.pi/extensions/kamn-mvp/mcp-session.ts`
 - `.pi/extensions/kamn-mvp/mcp-session.test.ts`
+- `.pi/extensions/kamn-mvp/mcp-authority.ts`
+- `.pi/extensions/kamn-mvp/pi-service-authority-evidence.ts`
+- `crates/kamn-mcp-server/src/authority.rs`
 - `crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/settlement.rs`
 
 ## Error Semantics
@@ -119,6 +136,9 @@ give the canonical MCP SDK enough time to receive finalized settlement responses
   authority receipt is allowed.
 - A released escrow missing its durable release-authorization receipt returns
   `ESCROW_RECEIPT_MISSING`; no receipt is synthesized during response serialization.
+- A confirmed settlement missing its durable settlement intent receipt returns
+  `SETTLEMENT_RECEIPT_MISSING`; MCP and Pi reject partial authority rather than dropping
+  the projected settlement entry.
 
 ## Test Plan
 
@@ -133,6 +153,9 @@ give the canonical MCP SDK enough time to receive finalized settlement responses
   its credential and custody allowlist.
 - Require finalized and replayed live releases to expose one stable durable authorization
   receipt ID, digest, action, and receipt-bound state in the SDK response shape.
+- Require finalized and replayed live releases to expose one stable durable settlement
+  receipt ID and digest, and require MCP/Pi authority to preserve it as the fourth
+  Agent A receipt that matches the participant projection.
 
 ### GREEN
 
@@ -143,6 +166,8 @@ give the canonical MCP SDK enough time to receive finalized settlement responses
 - Add canonical SDK timeout propagation to the Pi/MCP runtime environment.
 - Resolve the already-persisted release-authorization receipt when serializing finalized
   and replayed live release responses, including its actual resulting state.
+- Resolve the confirmed settlement intent when serializing those responses and preserve
+  its receipt identity through MCP validation and Pi actor evidence.
 
 ### REFACTOR
 

--- a/specs/7141-ambiguous-live-settlement-reconciliation.md
+++ b/specs/7141-ambiguous-live-settlement-reconciliation.md
@@ -23,8 +23,9 @@ give the canonical MCP SDK enough time to receive finalized settlement responses
   signed transaction reaches the Solana broadcast call.
 - A retry path that queries the expected signature before considering resubmission.
 - One confirmed/released durable result with the expected signature and receipt hash.
-- A confirmed/released response carrying the durable `escrow:release-authorize`
-  receipt identity alongside the separate Solana settlement metadata.
+- A confirmed settlement response carrying the durable `escrow:release-authorize`
+  receipt identity and its `release-authorized` resulting state alongside separate
+  Solana settlement metadata and a durably `released` escrow.
 - A canonical MCP SDK request timeout that is no shorter than the supervisor RPC budget.
 
 ## Boundaries And Non-Goals
@@ -56,6 +57,8 @@ give the canonical MCP SDK enough time to receive finalized settlement responses
   configured with the longer canonical timeout.
 - A finalized or replayed release response omits the durable authorization receipt ID,
   digest, or action and therefore cannot satisfy the SDK authority contract.
+- A finalized response labels the authorization receipt's resulting state as `released`,
+  overstating what the durable receipt digest binds and diverging from projection state.
 - A released escrow has no durable `escrow:release-authorize` receipt; the response must
   hard-fail instead of fabricating client-local evidence.
 - Conflicting actor, idempotency key, signature, recipient, amount, network, or evidence.
@@ -77,9 +80,12 @@ give the canonical MCP SDK enough time to receive finalized settlement responses
 - [ ] The persistent MCP session request timer is no shorter than the forwarded SDK
   timeout, so the extension does not terminate an in-flight settlement first.
 - [ ] Successful and idempotently replayed live release responses include the same
-  durable `escrow:release-authorize` receipt ID and digest while reporting `released`.
+  durable `escrow:release-authorize` receipt ID and digest with the receipt-bound
+  `release-authorized` state, while durable escrow state remains `released`.
 - [ ] Solana signature, receipt hash, network, and commitment remain separate settlement
   metadata; the authorization digest is not relabeled as a settlement digest.
+- [ ] Pi/MCP service authority and the persisted projection agree on the release receipt's
+  `release-authorized` resulting state without client-side normalization.
 - [ ] Regression tests cover write-ahead ordering, callback failure, ambiguous retry,
   confirmed reconciliation, and canonical timeout propagation.
 - [ ] The fresh-checkout canonical demo and standalone verifier pass with one transfer.
@@ -126,7 +132,7 @@ give the canonical MCP SDK enough time to receive finalized settlement responses
 - Require the Pi extension MCP spawn environment to retain that timeout without widening
   its credential and custody allowlist.
 - Require finalized and replayed live releases to expose one stable durable authorization
-  receipt ID, digest, and action in the SDK response shape.
+  receipt ID, digest, action, and receipt-bound state in the SDK response shape.
 
 ### GREEN
 
@@ -136,7 +142,7 @@ give the canonical MCP SDK enough time to receive finalized settlement responses
   ordering.
 - Add canonical SDK timeout propagation to the Pi/MCP runtime environment.
 - Resolve the already-persisted release-authorization receipt when serializing finalized
-  and replayed live release responses.
+  and replayed live release responses, including its actual resulting state.
 
 ### REFACTOR
 

--- a/specs/7141-ambiguous-live-settlement-reconciliation.md
+++ b/specs/7141-ambiguous-live-settlement-reconciliation.md
@@ -121,6 +121,10 @@ give the canonical MCP SDK enough time to receive finalized settlement responses
 - `.pi/extensions/kamn-mvp/mcp-authority.ts`
 - `.pi/extensions/kamn-mvp/pi-service-authority-evidence.ts`
 - `crates/kamn-mcp-server/src/authority.rs`
+- `crates/kamn-mcp-server/src/dispatch.rs`
+- `crates/kamn-sdk/src/service_client.rs`
+- `crates/kamn-sdk/src/service_models.rs`
+- `crates/kamn-node/src/service_api_endpoint/escrow_models.rs`
 - `crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/settlement.rs`
 
 ## Error Semantics

--- a/specs/7141-ambiguous-live-settlement-reconciliation.md
+++ b/specs/7141-ambiguous-live-settlement-reconciliation.md
@@ -47,6 +47,8 @@ give the canonical MCP SDK enough time to receive finalized settlement responses
 - Persistence fails immediately before broadcast; the transaction must not be submitted.
 - A callback or adapter failure is translated into a structured hard failure without a
   second submission.
+- The Pi extension strips the SDK timeout while constructing the MCP child environment,
+  causing the MCP server to retain the two-second SDK default.
 - Conflicting actor, idempotency key, signature, recipient, amount, network, or evidence.
 
 ## Acceptance Criteria
@@ -61,6 +63,8 @@ give the canonical MCP SDK enough time to receive finalized settlement responses
 - [ ] Expired transactions fail closed without a new broadcast.
 - [ ] The canonical Pi/MCP child environment sets the SDK timeout from the supervisor RPC
   timeout budget without changing the SDK-wide default.
+- [ ] The Pi extension forwards that timeout to the MCP server while continuing to strip
+  credentials, custody configuration, and unrelated parent environment values.
 - [ ] Regression tests cover write-ahead ordering, callback failure, ambiguous retry,
   confirmed reconciliation, and canonical timeout propagation.
 - [ ] The fresh-checkout canonical demo and standalone verifier pass with one transfer.
@@ -77,6 +81,8 @@ give the canonical MCP SDK enough time to receive finalized settlement responses
 - `crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/`
 - `crates/kamn-e2e-harness/src/agent_transaction_evidence.rs`
 - Focused harness configuration tests.
+- `.pi/extensions/kamn-mvp/mcp-session.ts`
+- `.pi/extensions/kamn-mvp/mcp-session.test.ts`
 
 ## Error Semantics
 
@@ -99,6 +105,8 @@ give the canonical MCP SDK enough time to receive finalized settlement responses
 - Inject write-ahead callback failure and prove the adapter submission count remains zero.
 - Require the canonical child environment to propagate an SDK timeout derived from the
   configured supervisor RPC timeout.
+- Require the Pi extension MCP spawn environment to retain that timeout without widening
+  its credential and custody allowlist.
 
 ### GREEN
 

--- a/specs/7141-ambiguous-live-settlement-reconciliation.md
+++ b/specs/7141-ambiguous-live-settlement-reconciliation.md
@@ -1,0 +1,124 @@
+# Issue #7141: Reconcile Ambiguous Live Settlement Before Retry
+
+## Objective
+
+Prevent a lost or truncated release response from making an accepted Solana transfer
+look unsubmitted in durable service state. Persist one submission attempt immediately
+before broadcast, reconcile the deterministic expected signature before any retry, and
+give the canonical MCP SDK enough time to receive finalized settlement responses.
+
+## Inputs And Outputs
+
+### Inputs
+
+- A persisted `prepared` settlement intent containing the signed transaction and expected
+  signature.
+- A live Solana settlement configuration using finalized devnet confirmation.
+- A canonical Pi/MCP escrow-release request with a stable idempotency key.
+- The canonical supervisor RPC timeout budget.
+
+### Outputs
+
+- A durable `submitted` settlement intent with `submission_attempt_count == 1` before the
+  signed transaction reaches the Solana broadcast call.
+- A retry path that queries the expected signature before considering resubmission.
+- One confirmed/released durable result with the expected signature and receipt hash.
+- A canonical MCP SDK request timeout that is no shorter than the supervisor RPC budget.
+
+## Boundaries And Non-Goals
+
+- Do not change transaction construction, deterministic signatures, finalized RPC
+  verification, settlement receipt authority, or idempotency keys.
+- Do not add dependencies, chains, mainnet behavior, production custody, or a second
+  settlement path.
+- Do not retry the live transfer observed while diagnosing #7141.
+- Do not weaken failure handling when the signature is absent, failed, expired, or bound
+  to different settlement terms.
+- Do not change the SDK's general two-second default; configure the longer timeout only
+  for the canonical agent-transaction child environment.
+
+## Failure Modes
+
+- The process exits after broadcast but before confirmation or final persistence.
+- The client times out and closes the HTTP connection while Solana confirmation is still
+  running.
+- A retry sees `submitted` durable state and the expected signature is already finalized.
+- A retry sees no signature and the persisted blockhash is valid or expired.
+- Persistence fails immediately before broadcast; the transaction must not be submitted.
+- A callback or adapter failure is translated into a structured hard failure without a
+  second submission.
+- Conflicting actor, idempotency key, signature, recipient, amount, network, or evidence.
+
+## Acceptance Criteria
+
+- [ ] The live adapter invokes a durable write-ahead callback immediately before its one
+  broadcast call.
+- [ ] The callback persists `state == "submitted"` and exactly one submission attempt.
+- [ ] Callback persistence failure prevents broadcast and hard-fails the release.
+- [ ] Ambiguous, successful, and reconciled outcomes retain exactly one durable attempt.
+- [ ] Retry queries the expected signature before blockhash validation or resubmission and
+  never broadcasts when that signature is already confirmed.
+- [ ] Expired transactions fail closed without a new broadcast.
+- [ ] The canonical Pi/MCP child environment sets the SDK timeout from the supervisor RPC
+  timeout budget without changing the SDK-wide default.
+- [ ] Regression tests cover write-ahead ordering, callback failure, ambiguous retry,
+  confirmed reconciliation, and canonical timeout propagation.
+- [ ] The fresh-checkout canonical demo and standalone verifier pass with one transfer.
+- [ ] Formatting, strict Clippy, focused tests, `make check`, and relevant CI pass.
+
+## Files To Touch
+
+- `crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch.rs`
+- `crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch/transport.rs`
+- `crates/kamn-node/src/service_api_endpoint/live_settlement_dispatch/test_support.rs`
+- `crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops.rs`
+- `crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/settlement_intent.rs`
+- `crates/kamn-node/src/service_api_endpoint/middleware_impl/http_routes/mutations/update_routes/state_routes_release/live_settlement.rs`
+- `crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/`
+- `crates/kamn-e2e-harness/src/agent_transaction_evidence.rs`
+- Focused harness configuration tests.
+
+## Error Semantics
+
+- Write-ahead persistence failure returns the existing service persistence error and does
+  not call the settlement transport.
+- Confirmed expected signatures return canonical settlement evidence without broadcast.
+- Ambiguous submission or confirmation returns `SETTLEMENT_OUTCOME_AMBIGUOUS` after the
+  durable attempt marker exists.
+- Expired transactions return `SETTLEMENT_TRANSACTION_EXPIRED` without broadcast.
+- Conflicts retain `SETTLEMENT_INTENT_CONFLICT` or `SETTLEMENT_AGREEMENT_MISMATCH`.
+- MCP and SDK boundaries return a complete structured error; no silent fallback or local
+  authority receipt is allowed.
+
+## Test Plan
+
+### RED
+
+- Require the test adapter to observe durable `submitted` state and attempt count one at
+  its simulated broadcast boundary.
+- Inject write-ahead callback failure and prove the adapter submission count remains zero.
+- Require the canonical child environment to propagate an SDK timeout derived from the
+  configured supervisor RPC timeout.
+
+### GREEN
+
+- Add a one-shot pre-broadcast callback to settlement submission/reconciliation.
+- Persist the submitted state and attempt count through the message store callback.
+- Thread the callback through real and test dispatch without changing reconciliation
+  ordering.
+- Add canonical SDK timeout propagation to the Pi/MCP runtime environment.
+
+### REFACTOR
+
+- Keep transport, durable intent transitions, route error translation, and supervisor
+  environment calculation in their existing single-purpose modules.
+- Keep functions at or below 25 lines and touched files at or below 200 lines.
+- Remove duplicate attempt mutation while preserving monotonic state transitions.
+
+### INTEGRATION
+
+- Run focused settlement transport, persistence, ambiguous retry, and agent-transaction
+  environment contracts.
+- Run formatting, strict Clippy, touched Rust size policy, and `make check`.
+- From a detached fresh `origin/main` worktree, run the canonical demo followed by the
+  standalone verifier and reconcile exactly one finalized transfer.

--- a/specs/7141-ambiguous-live-settlement-reconciliation.md
+++ b/specs/7141-ambiguous-live-settlement-reconciliation.md
@@ -124,6 +124,7 @@ give the canonical MCP SDK enough time to receive finalized settlement responses
 - `crates/kamn-mcp-server/src/dispatch.rs`
 - `crates/kamn-sdk/src/service_client.rs`
 - `crates/kamn-sdk/src/service_models.rs`
+- `crates/kamn-sdk/src/service_settlement_receipt.rs`
 - `crates/kamn-node/src/service_api_endpoint/escrow_models.rs`
 - `crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/settlement.rs`
 

--- a/specs/7141-ambiguous-live-settlement-reconciliation.md
+++ b/specs/7141-ambiguous-live-settlement-reconciliation.md
@@ -23,12 +23,15 @@ give the canonical MCP SDK enough time to receive finalized settlement responses
   signed transaction reaches the Solana broadcast call.
 - A retry path that queries the expected signature before considering resubmission.
 - One confirmed/released durable result with the expected signature and receipt hash.
+- A confirmed/released response carrying the durable `escrow:release-authorize`
+  receipt identity alongside the separate Solana settlement metadata.
 - A canonical MCP SDK request timeout that is no shorter than the supervisor RPC budget.
 
 ## Boundaries And Non-Goals
 
 - Do not change transaction construction, deterministic signatures, finalized RPC
-  verification, settlement receipt authority, or idempotency keys.
+  verification, the existing `escrow:release-authorize` authority action, or
+  idempotency keys.
 - Do not add dependencies, chains, mainnet behavior, production custody, or a second
   settlement path.
 - Do not retry the live transfer observed while diagnosing #7141.
@@ -51,6 +54,10 @@ give the canonical MCP SDK enough time to receive finalized settlement responses
   causing the MCP server to retain the two-second SDK default.
 - The Pi extension's MCP request timer remains at ten seconds even when the MCP SDK is
   configured with the longer canonical timeout.
+- A finalized or replayed release response omits the durable authorization receipt ID,
+  digest, or action and therefore cannot satisfy the SDK authority contract.
+- A released escrow has no durable `escrow:release-authorize` receipt; the response must
+  hard-fail instead of fabricating client-local evidence.
 - Conflicting actor, idempotency key, signature, recipient, amount, network, or evidence.
 
 ## Acceptance Criteria
@@ -69,6 +76,10 @@ give the canonical MCP SDK enough time to receive finalized settlement responses
   credentials, custody configuration, and unrelated parent environment values.
 - [ ] The persistent MCP session request timer is no shorter than the forwarded SDK
   timeout, so the extension does not terminate an in-flight settlement first.
+- [ ] Successful and idempotently replayed live release responses include the same
+  durable `escrow:release-authorize` receipt ID and digest while reporting `released`.
+- [ ] Solana signature, receipt hash, network, and commitment remain separate settlement
+  metadata; the authorization digest is not relabeled as a settlement digest.
 - [ ] Regression tests cover write-ahead ordering, callback failure, ambiguous retry,
   confirmed reconciliation, and canonical timeout propagation.
 - [ ] The fresh-checkout canonical demo and standalone verifier pass with one transfer.
@@ -87,6 +98,7 @@ give the canonical MCP SDK enough time to receive finalized settlement responses
 - Focused harness configuration tests.
 - `.pi/extensions/kamn-mvp/mcp-session.ts`
 - `.pi/extensions/kamn-mvp/mcp-session.test.ts`
+- `crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/settlement.rs`
 
 ## Error Semantics
 
@@ -99,6 +111,8 @@ give the canonical MCP SDK enough time to receive finalized settlement responses
 - Conflicts retain `SETTLEMENT_INTENT_CONFLICT` or `SETTLEMENT_AGREEMENT_MISMATCH`.
 - MCP and SDK boundaries return a complete structured error; no silent fallback or local
   authority receipt is allowed.
+- A released escrow missing its durable release-authorization receipt returns
+  `ESCROW_RECEIPT_MISSING`; no receipt is synthesized during response serialization.
 
 ## Test Plan
 
@@ -111,6 +125,8 @@ give the canonical MCP SDK enough time to receive finalized settlement responses
   configured supervisor RPC timeout.
 - Require the Pi extension MCP spawn environment to retain that timeout without widening
   its credential and custody allowlist.
+- Require finalized and replayed live releases to expose one stable durable authorization
+  receipt ID, digest, and action in the SDK response shape.
 
 ### GREEN
 
@@ -119,6 +135,8 @@ give the canonical MCP SDK enough time to receive finalized settlement responses
 - Thread the callback through real and test dispatch without changing reconciliation
   ordering.
 - Add canonical SDK timeout propagation to the Pi/MCP runtime environment.
+- Resolve the already-persisted release-authorization receipt when serializing finalized
+  and replayed live release responses.
 
 ### REFACTOR
 


### PR DESCRIPTION
## Human Summary

- Persist live settlement attempts before broadcast and reconcile the deterministic signature before any retry.
- Carry distinct release-authorization and settlement-confirmation receipt authority through the service, SDK, MCP, Pi actor evidence, and Rust proof verifier.
- Fail closed on partial, malformed, legacy, or drifted receipt bindings instead of trusting ambient actor or projection evidence.
- Preserve one finalized transfer: the verifier repair was validated by read-only replay, not another submission.

## Testing

- `CARGO_TARGET_DIR=/tmp/kamn-node-target cargo test -p kamn-sdk --lib service_settlement_receipt` (4 passed)
- `CARGO_TARGET_DIR=/tmp/kamn-node-target cargo test -p kamn-mcp-server --lib authority::settlement` (3 passed)
- `CARGO_TARGET_DIR=/tmp/kamn-node-target cargo test -p kamn-node --bin kamn-node task_escrow_solana_asset_movement_contract_tests` (6 passed)
- `node --test .pi/extensions/kamn-mvp/*.test.ts` (64 passed)
- `CARGO_TARGET_DIR=/tmp/kamn-node-target cargo test -p kamn-e2e-harness --lib` (261 passed)
- `CARGO_TARGET_DIR=/tmp/kamn-node-target cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo fmt --all -- --check`
- Touched-Rust size policy: GO, no offending files or functions
- Live devnet: one 1,000,000-lamport transfer finalized; persisted intent confirmed with attempt count 1
- Read-only finalizer replay generated a `live-service-persisted-receipt` report; standalone verifier returned `PASS` against all three captured actor artifacts

## Notes for Reviewers

Issue: Closes #7141

Spec: `specs/7141-ambiguous-live-settlement-reconciliation.md`

The first proof attempt exposed the stale Rust three-receipt verifier after the transfer finalized. Commit `90fd16d29` reproduces that exact `PI_SERVICE_AUTHORITY_MISMATCH`; `b9a980755` unifies the verifier with the six-entry durable chain. No second transfer was submitted.

The full harness run remains non-clean on an unrelated project-local Pi extension marker contract, and the broader workspace retains pre-existing governance/policy failures. Focused authority suites, strict Clippy, size policy, and required PR checks are the merge authority for this issue.

shell_loc_delta_actual: 0
rust_loc_delta_actual: 0
shell_to_rust_ratio_delta_actual: 0.0
shell_surface_ratio_target_status: neutral