### PR TITLE
fix: repair the Pi extension claim contract

### DIFF
--- a/crates/kamn-e2e-harness/tests/mvp_demo_agent_harness_claim_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_demo_agent_harness_claim_contract.rs
@@ -14,6 +14,20 @@ use std::path::Path;
 use std::process::Command;
 use support::*;
 
+const PI_EXTENSION_SOURCES: &[&str] = &[
+    ".pi/extensions/kamn-mvp/index.ts",
+    ".pi/extensions/kamn-mvp/evidence.ts",
+    ".pi/extensions/kamn-mvp/actor-receipts.ts",
+    ".pi/extensions/kamn-mvp/live-mcp-tools.ts",
+    ".pi/extensions/kamn-mvp/live-transaction-tools.ts",
+    ".pi/extensions/kamn-mvp/pi-transaction-tools.ts",
+    ".pi/extensions/kamn-mvp/mcp-session.ts",
+    ".pi/extensions/kamn-mvp/live-task-workflow.ts",
+    ".pi/extensions/kamn-mvp/live-task-coordination.ts",
+    ".pi/extensions/kamn-mvp/live-task-coordination-tools.ts",
+    ".pi/extensions/kamn-mvp/restricted-task-observation.ts",
+];
+
 #[test]
 fn spec_c01_direct_report_without_agent_harness_still_passes() {
     let root = temp_root("direct");
@@ -186,6 +200,14 @@ fn spec_c08_project_local_pi_extension_registers_kamn_tools() {
 }
 
 #[test]
+fn spec_c08_pi_extension_inventory_includes_delegated_mcp_config() {
+    assert!(
+        PI_EXTENSION_SOURCES.contains(&".pi/extensions/kamn-mvp/mcp-session-config.ts"),
+        "Pi extension source inventory must include delegated MCP configuration"
+    );
+}
+
+#[test]
 fn spec_c22_cli_verifies_direct_pi_evidence_without_mutating_report() {
     let root = canonical_run_root("direct-pi-evidence", "run-7074");
     let report_json = direct_report_with_three_agent_claim(&root);
@@ -245,24 +267,14 @@ fn command_output(output: &std::process::Output) -> String {
 }
 
 fn pi_extension_source() -> String {
-    [
-        ".pi/extensions/kamn-mvp/index.ts",
-        ".pi/extensions/kamn-mvp/evidence.ts",
-        ".pi/extensions/kamn-mvp/actor-receipts.ts",
-        ".pi/extensions/kamn-mvp/live-mcp-tools.ts",
-        ".pi/extensions/kamn-mvp/live-transaction-tools.ts",
-        ".pi/extensions/kamn-mvp/pi-transaction-tools.ts",
-        ".pi/extensions/kamn-mvp/mcp-session.ts",
-        ".pi/extensions/kamn-mvp/live-task-workflow.ts",
-        ".pi/extensions/kamn-mvp/live-task-coordination.ts",
-        ".pi/extensions/kamn-mvp/live-task-coordination-tools.ts",
-        ".pi/extensions/kamn-mvp/restricted-task-observation.ts",
-    ]
-    .map(|path| {
-        std::fs::read_to_string(workspace_root().join(path))
-            .unwrap_or_else(|_| panic!("KAMN Pi extension file should exist: {path}"))
-    })
-    .join("\n")
+    PI_EXTENSION_SOURCES
+        .iter()
+        .map(|path| {
+            std::fs::read_to_string(workspace_root().join(path))
+                .unwrap_or_else(|_| panic!("KAMN Pi extension file should exist: {path}"))
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 fn workspace_root() -> &'static Path {

--- a/crates/kamn-e2e-harness/tests/mvp_demo_agent_harness_claim_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_demo_agent_harness_claim_contract.rs
@@ -1,5 +1,7 @@
 #[path = "mvp_demo_agent_harness_claim_contract/canonical_observation_receipts_contract.rs"]
 mod canonical_observation_receipts_contract;
+#[path = "mvp_demo_agent_harness_claim_contract/pi_extension_claim_contract.rs"]
+mod pi_extension_claim_contract;
 #[path = "mvp_demo_agent_harness_claim_contract/support.rs"]
 mod support;
 #[path = "mvp_demo_agent_harness_claim_contract/three_agent_actor_receipts_contract.rs"]
@@ -13,21 +15,6 @@ use kamn_e2e_harness::{execute_mvp_demo_contract, execute_verify_mvp_demo_contra
 use std::path::Path;
 use std::process::Command;
 use support::*;
-
-const PI_EXTENSION_SOURCES: &[&str] = &[
-    ".pi/extensions/kamn-mvp/index.ts",
-    ".pi/extensions/kamn-mvp/evidence.ts",
-    ".pi/extensions/kamn-mvp/actor-receipts.ts",
-    ".pi/extensions/kamn-mvp/live-mcp-tools.ts",
-    ".pi/extensions/kamn-mvp/live-transaction-tools.ts",
-    ".pi/extensions/kamn-mvp/pi-transaction-tools.ts",
-    ".pi/extensions/kamn-mvp/mcp-session.ts",
-    ".pi/extensions/kamn-mvp/mcp-session-config.ts",
-    ".pi/extensions/kamn-mvp/live-task-workflow.ts",
-    ".pi/extensions/kamn-mvp/live-task-coordination.ts",
-    ".pi/extensions/kamn-mvp/live-task-coordination-tools.ts",
-    ".pi/extensions/kamn-mvp/restricted-task-observation.ts",
-];
 
 #[test]
 fn spec_c01_direct_report_without_agent_harness_still_passes() {
@@ -134,81 +121,6 @@ fn spec_c07_markdown_report_surfaces_agent_harness_evidence() {
 }
 
 #[test]
-fn spec_c08_project_local_pi_extension_registers_kamn_tools() {
-    let source = pi_extension_source();
-
-    for marker in [
-        "kamn_verify_mvp_report",
-        "agentHarnessEvidencePath",
-        "--agent-harness-evidence",
-        "kamn_inspect_mvp_report_boundaries",
-        "kamn_write_agent_harness_evidence",
-        "kamn_run_demo_mvp_with_agent_evidence",
-        "three_agent_boundary",
-        "three_agent_actor_rehearsal",
-        "three_agent_actor_tool_receipts",
-        "three_agent_actor_observation_receipts",
-        "kamn_agent_a_register",
-        "kamn_agent_a_invoke_transaction",
-        "kamn_agent_b_register",
-        "kamn_agent_b_accept_task",
-        "kamn_agent_c_verify_three_agent_proof",
-        "invoke_transaction",
-        "accept_task",
-        "kamn_live_agent_a_register",
-        "kamn_live_agent_a_query_profile",
-        "query_agent_profile",
-        "session_shutdown",
-        "KAMN_MVP_LIVE_MCP_BINARY",
-        "KAMN_MVP_LIVE_MCP_AGENT_A_KEY_FILE",
-        "kamn_live_agent_b_register",
-        "kamn_live_agent_a_create_task",
-        "kamn_live_agent_b_accept_task",
-        "kamn_live_agent_a_query_task",
-        "kamn_live_agent_b_query_task",
-        "kamn_live_agent_a_fund_escrow",
-        "kamn_live_agent_a_release_escrow",
-        "kamn_live_agent_a_query_participant_projection",
-        "kamn_live_agent_b_complete_task",
-        "kamn_live_agent_b_query_participant_projection",
-        "kamn_live_agent_c_register",
-        "kamn_live_agent_c_receive_task_handoff",
-        "kamn_live_agent_c_query_verifier_projection",
-        "kamn_live_agent_a_write_transaction_evidence",
-        "kamn_live_agent_b_write_transaction_evidence",
-        "kamn_live_agent_c_write_transaction_evidence",
-        "kamn_live_verify_pi_transaction_actors",
-        "KAMN_MVP_LIVE_MCP_AGENT_B_NAME",
-        "KAMN_MVP_LIVE_MCP_AGENT_B_KEY_FILE",
-        "KAMN_MVP_LIVE_MCP_AGENT_C_NAME",
-        "KAMN_MVP_LIVE_MCP_AGENT_C_KEY_FILE",
-        "real local-only task lifecycle",
-        "kamn_live_agent_a_publish_task_handoff",
-        "kamn_live_agent_b_receive_task_handoff",
-        "kamn_live_agent_a_wait_for_task_acceptance",
-        "kamn_live_agent_b_write_task_receipt",
-        "kamn_live_verify_independent_actor_receipts",
-        "KAMN_MVP_LIVE_TASK_HANDOFF_FILE",
-        "KAMN_MVP_LIVE_TASK_AGENT_A_RECEIPT_FILE",
-        "KAMN_MVP_LIVE_TASK_AGENT_B_RECEIPT_FILE",
-        "real local-only independent Pi actors",
-        "kamn_live_agent_c_verify_restricted_task_observation",
-        "KAMN_MVP_LIVE_TASK_AGENT_C_OBSERVATION_FILE",
-        "real local-only independent Agent C artifact observation",
-    ] {
-        assert!(source.contains(marker), "missing Pi tool marker: {marker}");
-    }
-}
-
-#[test]
-fn spec_c08_pi_extension_inventory_includes_delegated_mcp_config() {
-    assert!(
-        PI_EXTENSION_SOURCES.contains(&".pi/extensions/kamn-mvp/mcp-session-config.ts"),
-        "Pi extension source inventory must include delegated MCP configuration"
-    );
-}
-
-#[test]
 fn spec_c22_cli_verifies_direct_pi_evidence_without_mutating_report() {
     let root = canonical_run_root("direct-pi-evidence", "run-7074");
     let report_json = direct_report_with_three_agent_claim(&root);
@@ -265,23 +177,4 @@ fn command_output(output: &std::process::Output) -> String {
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     )
-}
-
-fn pi_extension_source() -> String {
-    PI_EXTENSION_SOURCES
-        .iter()
-        .map(|path| {
-            std::fs::read_to_string(workspace_root().join(path))
-                .unwrap_or_else(|_| panic!("KAMN Pi extension file should exist: {path}"))
-        })
-        .collect::<Vec<_>>()
-        .join("\n")
-}
-
-fn workspace_root() -> &'static Path {
-    Path::new(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .expect("crate should live under crates/")
-        .parent()
-        .expect("workspace root should contain crates/")
 }

--- a/crates/kamn-e2e-harness/tests/mvp_demo_agent_harness_claim_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_demo_agent_harness_claim_contract.rs
@@ -22,6 +22,7 @@ const PI_EXTENSION_SOURCES: &[&str] = &[
     ".pi/extensions/kamn-mvp/live-transaction-tools.ts",
     ".pi/extensions/kamn-mvp/pi-transaction-tools.ts",
     ".pi/extensions/kamn-mvp/mcp-session.ts",
+    ".pi/extensions/kamn-mvp/mcp-session-config.ts",
     ".pi/extensions/kamn-mvp/live-task-workflow.ts",
     ".pi/extensions/kamn-mvp/live-task-coordination.ts",
     ".pi/extensions/kamn-mvp/live-task-coordination-tools.ts",

--- a/crates/kamn-e2e-harness/tests/mvp_demo_agent_harness_claim_contract/pi_extension_claim_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_demo_agent_harness_claim_contract/pi_extension_claim_contract.rs
@@ -1,0 +1,114 @@
+use std::path::Path;
+
+const DELEGATED_MCP_CONFIG: &str = ".pi/extensions/kamn-mvp/mcp-session-config.ts";
+const PI_EXTENSION_SOURCES: &[&str] = &[
+    ".pi/extensions/kamn-mvp/index.ts",
+    ".pi/extensions/kamn-mvp/evidence.ts",
+    ".pi/extensions/kamn-mvp/actor-receipts.ts",
+    ".pi/extensions/kamn-mvp/live-mcp-tools.ts",
+    ".pi/extensions/kamn-mvp/live-transaction-tools.ts",
+    ".pi/extensions/kamn-mvp/pi-transaction-tools.ts",
+    ".pi/extensions/kamn-mvp/mcp-session.ts",
+    DELEGATED_MCP_CONFIG,
+    ".pi/extensions/kamn-mvp/live-task-workflow.ts",
+    ".pi/extensions/kamn-mvp/live-task-coordination.ts",
+    ".pi/extensions/kamn-mvp/live-task-coordination-tools.ts",
+    ".pi/extensions/kamn-mvp/restricted-task-observation.ts",
+];
+const PI_EXTENSION_MARKERS: &[&str] = &[
+    "kamn_verify_mvp_report",
+    "agentHarnessEvidencePath",
+    "--agent-harness-evidence",
+    "kamn_inspect_mvp_report_boundaries",
+    "kamn_write_agent_harness_evidence",
+    "kamn_run_demo_mvp_with_agent_evidence",
+    "three_agent_boundary",
+    "three_agent_actor_rehearsal",
+    "three_agent_actor_tool_receipts",
+    "three_agent_actor_observation_receipts",
+    "kamn_agent_a_register",
+    "kamn_agent_a_invoke_transaction",
+    "kamn_agent_b_register",
+    "kamn_agent_b_accept_task",
+    "kamn_agent_c_verify_three_agent_proof",
+    "invoke_transaction",
+    "accept_task",
+    "kamn_live_agent_a_register",
+    "kamn_live_agent_a_query_profile",
+    "query_agent_profile",
+    "session_shutdown",
+    "KAMN_MVP_LIVE_MCP_BINARY",
+    "KAMN_MVP_LIVE_MCP_AGENT_A_KEY_FILE",
+    "kamn_live_agent_b_register",
+    "kamn_live_agent_a_create_task",
+    "kamn_live_agent_b_accept_task",
+    "kamn_live_agent_a_query_task",
+    "kamn_live_agent_b_query_task",
+    "kamn_live_agent_a_fund_escrow",
+    "kamn_live_agent_a_release_escrow",
+    "kamn_live_agent_a_query_participant_projection",
+    "kamn_live_agent_b_complete_task",
+    "kamn_live_agent_b_query_participant_projection",
+    "kamn_live_agent_c_register",
+    "kamn_live_agent_c_receive_task_handoff",
+    "kamn_live_agent_c_query_verifier_projection",
+    "kamn_live_agent_a_write_transaction_evidence",
+    "kamn_live_agent_b_write_transaction_evidence",
+    "kamn_live_agent_c_write_transaction_evidence",
+    "kamn_live_verify_pi_transaction_actors",
+    "KAMN_MVP_LIVE_MCP_AGENT_B_NAME",
+    "KAMN_MVP_LIVE_MCP_AGENT_B_KEY_FILE",
+    "KAMN_MVP_LIVE_MCP_AGENT_C_NAME",
+    "KAMN_MVP_LIVE_MCP_AGENT_C_KEY_FILE",
+    "real local-only task lifecycle",
+    "kamn_live_agent_a_publish_task_handoff",
+    "kamn_live_agent_b_receive_task_handoff",
+    "kamn_live_agent_a_wait_for_task_acceptance",
+    "kamn_live_agent_b_write_task_receipt",
+    "kamn_live_verify_independent_actor_receipts",
+    "KAMN_MVP_LIVE_TASK_HANDOFF_FILE",
+    "KAMN_MVP_LIVE_TASK_AGENT_A_RECEIPT_FILE",
+    "KAMN_MVP_LIVE_TASK_AGENT_B_RECEIPT_FILE",
+    "real local-only independent Pi actors",
+    "kamn_live_agent_c_verify_restricted_task_observation",
+    "KAMN_MVP_LIVE_TASK_AGENT_C_OBSERVATION_FILE",
+    "real local-only independent Agent C artifact observation",
+];
+
+#[test]
+fn spec_c08_project_local_pi_extension_registers_kamn_tools() {
+    let source = pi_extension_source();
+
+    for marker in PI_EXTENSION_MARKERS {
+        assert!(source.contains(marker), "missing Pi tool marker: {marker}");
+    }
+}
+
+#[test]
+fn spec_c08_pi_extension_inventory_includes_delegated_mcp_config() {
+    assert!(
+        PI_EXTENSION_SOURCES.contains(&DELEGATED_MCP_CONFIG),
+        "Pi extension source inventory must include delegated MCP configuration"
+    );
+}
+
+fn pi_extension_source() -> String {
+    PI_EXTENSION_SOURCES
+        .iter()
+        .map(|path| read_extension_source(path))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn read_extension_source(path: &str) -> String {
+    std::fs::read_to_string(workspace_root().join(path))
+        .unwrap_or_else(|_| panic!("KAMN Pi extension file should exist: {path}"))
+}
+
+fn workspace_root() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("crate should live under crates/")
+        .parent()
+        .expect("workspace root should contain crates/")
+}

--- a/specs/7143-pi-extension-claim-contract.md
+++ b/specs/7143-pi-extension-claim-contract.md
@@ -40,12 +40,12 @@ tool boundary.
 
 ## Acceptance Criteria
 
-- [ ] The source inventory includes
+- [x] The source inventory includes
   `.pi/extensions/kamn-mvp/mcp-session-config.ts`.
-- [ ] The contract asserts that the delegated module path remains in the inventory.
-- [ ] `spec_c08_project_local_pi_extension_registers_kamn_tools` passes.
-- [ ] The complete `mvp_demo_agent_harness_claim_contract` test target passes.
-- [ ] No production Pi extension source changes.
+- [x] The contract asserts that the delegated module path remains in the inventory.
+- [x] `spec_c08_project_local_pi_extension_registers_kamn_tools` passes.
+- [x] The complete `mvp_demo_agent_harness_claim_contract` test target passes.
+- [x] No production Pi extension source changes.
 
 ## Files To Touch
 
@@ -83,3 +83,11 @@ tool boundary.
 
 - Run the real `kamn-e2e-harness` claim-contract integration test target from a clean
   checkout.
+
+## Verification Evidence
+
+- `cargo fmt --all -- --check`
+- `cargo clippy -p kamn-e2e-harness --tests -- -D warnings`
+- `cargo test -p kamn-e2e-harness --test mvp_demo_agent_harness_claim_contract`
+  passes all 24 tests.
+- Both touched Rust test files remain below 200 lines.

--- a/specs/7143-pi-extension-claim-contract.md
+++ b/specs/7143-pi-extension-claim-contract.md
@@ -1,0 +1,85 @@
+# Issue #7143: Repair Pi Extension Claim Contract After MCP Module Split
+
+## Objective
+
+Restore the project-local Pi extension claim contract after live MCP configuration was
+extracted into its own TypeScript module. The contract must inspect the delegated
+configuration source before asserting the environment markers that define the live MCP
+tool boundary.
+
+## Inputs And Outputs
+
+### Inputs
+
+- The explicit project-local KAMN MVP Pi extension source inventory.
+- `.pi/extensions/kamn-mvp/mcp-session-config.ts`.
+- The live MCP environment marker assertions in
+  `spec_c08_project_local_pi_extension_registers_kamn_tools`.
+
+### Outputs
+
+- A source bundle that includes the delegated MCP session configuration module.
+- A passing Pi extension marker contract on current `main`.
+- A regression assertion that binds the source inventory to the delegated module path.
+
+## Boundaries And Non-Goals
+
+- Do not change Pi runtime behavior, tool registration, or MCP session semantics.
+- Do not add dependencies or discover extension files dynamically.
+- Do not change public APIs or environment-variable requirements.
+- Do not resolve repository-wide governance-ratio or unrelated #7126 closeout gates.
+- Do not perform another live devnet settlement.
+
+## Failure Modes
+
+- The claim contract omits a delegated TypeScript module and falsely reports that a
+  required runtime marker is missing.
+- The delegated module is renamed or removed without updating the explicit contract
+  inventory.
+- A missing source file is silently ignored instead of failing the contract.
+
+## Acceptance Criteria
+
+- [ ] The source inventory includes
+  `.pi/extensions/kamn-mvp/mcp-session-config.ts`.
+- [ ] The contract asserts that the delegated module path remains in the inventory.
+- [ ] `spec_c08_project_local_pi_extension_registers_kamn_tools` passes.
+- [ ] The complete `mvp_demo_agent_harness_claim_contract` test target passes.
+- [ ] No production Pi extension source changes.
+
+## Files To Touch
+
+- `specs/7143-pi-extension-claim-contract.md`
+- `crates/kamn-e2e-harness/tests/mvp_demo_agent_harness_claim_contract.rs`
+
+## Error Semantics
+
+- Missing inventoried source files continue to panic with the exact missing path.
+- Missing tool markers continue to panic with the exact missing marker.
+- No fallback, directory-wide discovery, or ignored read error is allowed.
+
+## Test Plan
+
+### RED
+
+- Reproduce the inherited failure for
+  `spec_c08_project_local_pi_extension_registers_kamn_tools`, which reports the missing
+  `KAMN_MVP_LIVE_MCP_BINARY` marker.
+- Add a contract assertion requiring the delegated MCP configuration path in the source
+  inventory; verify that it fails before the inventory is updated.
+
+### GREEN
+
+- Add `mcp-session-config.ts` to the explicit source inventory.
+- Run the focused marker test and the complete claim-contract test target.
+
+### REFACTOR
+
+- Keep the source inventory explicit, ordered with the related MCP session modules, and
+  free of duplicated path literals.
+- Run formatting and Clippy for the touched Rust test target.
+
+### INTEGRATION
+
+- Run the real `kamn-e2e-harness` claim-contract integration test target from a clean
+  checkout.


### PR DESCRIPTION
## Human Summary

- Repairs the project-local Pi claim contract after MCP session configuration moved into its own TypeScript module.
- Adds a regression that binds the explicit source inventory to the delegated MCP configuration path.
- Moves the Pi-specific assertions into a focused submodule so both touched Rust test files stay below 200 lines.
- Changes verification code only; production Pi runtime behavior and public APIs are unchanged.

Closes #7143
Parent: #7126
Spec: [`specs/7143-pi-extension-claim-contract.md`](https://github.com/njfio/kamn/blob/7143-pi-extension-claim-contract/specs/7143-pi-extension-claim-contract.md)

## Testing

- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/tmp/kamn-7143-target cargo clippy -p kamn-e2e-harness --tests -- -D warnings`
- `CARGO_TARGET_DIR=/tmp/kamn-7143-target cargo test -p kamn-e2e-harness --test mvp_demo_agent_harness_claim_contract` (24 passed)
- RED proof: `spec_c08_pi_extension_inventory_includes_delegated_mcp_config` failed before the source inventory was repaired.

## Notes for Reviewers

Repository-wide `make check`, `make test`, pre-push, mutation gates, and any additional live devnet settlement remain separate #7126 closeout work. This PR does not claim those gates.

## AI Agent Details

- `pi_extension_claim_contract.rs` owns the explicit Pi TypeScript source and marker inventories.
- Missing source files and markers continue to fail loudly with their exact paths or marker names.
- The branch preserves spec, RED, GREEN, refactor, and integration commits.