### PR TITLE
fix: align legacy authority rejection taxonomy

### DIFF
--- a/crates/kamn-e2e-harness/tests/mvp_demo_command_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_demo_command_contract.rs
@@ -18,6 +18,8 @@ mod mvp_demo_command;
 mod pi_transaction_actor_fixture;
 use pi_transaction_actor_fixture::{ActorFixture, Overrides};
 
+const LEGACY_TRANSCRIPT_RUNTIME_ACTOR_ERROR: &str = "RECEIPT_CHAIN_INVALID";
+
 #[test]
 fn spec_c01_parser_accepts_demo_mvp_with_output_root() {
     let parsed = parse_command_args(["demo-mvp", "--output-root", "/tmp/kamn-demo"])
@@ -190,7 +192,7 @@ fn spec_c11_verifier_rejects_legacy_transcript_with_runtime_actors() {
         pi_transaction_actor_paths: Some(actors.paths()),
     })
     .expect_err("runtime actors must not validate a generated transcript");
-    assert_eq!(error, "RECEIPT_CHAIN_INVALID");
+    assert_eq!(error, LEGACY_TRANSCRIPT_RUNTIME_ACTOR_ERROR);
 }
 
 #[test]

--- a/crates/kamn-e2e-harness/tests/mvp_demo_command_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_demo_command_contract.rs
@@ -18,7 +18,7 @@ mod mvp_demo_command;
 mod pi_transaction_actor_fixture;
 use pi_transaction_actor_fixture::{ActorFixture, Overrides};
 
-const LEGACY_TRANSCRIPT_RUNTIME_ACTOR_ERROR: &str = "RECEIPT_CHAIN_INVALID";
+const LEGACY_TRANSCRIPT_RUNTIME_ACTOR_ERROR: &str = "PI_SERVICE_AUTHORITY_MISMATCH";
 
 #[test]
 fn spec_c01_parser_accepts_demo_mvp_with_output_root() {

--- a/crates/kamn-e2e-harness/tests/mvp_demo_command_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_demo_command_contract.rs
@@ -18,7 +18,7 @@ mod mvp_demo_command;
 mod pi_transaction_actor_fixture;
 use pi_transaction_actor_fixture::{ActorFixture, Overrides};
 
-const LEGACY_TRANSCRIPT_RUNTIME_ACTOR_ERROR: &str = "PI_SERVICE_AUTHORITY_MISMATCH";
+const LEGACY_TRANSCRIPT_AUTHORITY_ERROR: &str = "PI_SERVICE_AUTHORITY_MISMATCH";
 
 #[test]
 fn spec_c01_parser_accepts_demo_mvp_with_output_root() {
@@ -192,7 +192,7 @@ fn spec_c11_verifier_rejects_legacy_transcript_with_runtime_actors() {
         pi_transaction_actor_paths: Some(actors.paths()),
     })
     .expect_err("runtime actors must not validate a generated transcript");
-    assert_eq!(error, LEGACY_TRANSCRIPT_RUNTIME_ACTOR_ERROR);
+    assert_eq!(error, LEGACY_TRANSCRIPT_AUTHORITY_ERROR);
 }
 
 #[test]

--- a/specs/7146-service-authority-error-taxonomy.md
+++ b/specs/7146-service-authority-error-taxonomy.md
@@ -1,0 +1,63 @@
+# Issue #7146: Align Legacy Transcript Rejection With Service-Authority Taxonomy
+
+## Objective
+
+Align the legacy transcript/runtime actor regression with the independent
+service-authority error semantics introduced by #7135.
+
+## Inputs And Outputs
+
+- Input: a generated legacy transcript and independent runtime actor artifacts.
+- Output: rejection with `PI_SERVICE_AUTHORITY_MISMATCH`.
+
+## Boundaries And Non-Goals
+
+- Do not change verifier execution order or production error translation.
+- Do not accept legacy or client-local authority.
+- Do not change durable receipt-chain verification.
+- Do not change governance-ratio policy or submit a live settlement.
+
+## Failure Modes
+
+- A stale test expects the downstream receipt-chain category even though independent
+  actor authority fails first.
+- Receipt-chain corruption is incorrectly reclassified as actor authority drift.
+- Legacy evidence is accepted.
+
+## Acceptance Criteria
+
+- [ ] Legacy transcript/runtime actor disagreement expects
+  `PI_SERVICE_AUTHORITY_MISMATCH`.
+- [ ] Receipt-chain rebuild corruption retains `RECEIPT_CHAIN_INVALID`.
+- [ ] The complete `mvp_demo_command_contract` target passes.
+- [ ] Formatting and strict Clippy pass.
+
+## Files To Touch
+
+- `specs/7146-service-authority-error-taxonomy.md`
+- `crates/kamn-e2e-harness/tests/mvp_demo_command_contract.rs`
+
+## Error Semantics
+
+- Actor service-authority or projection disagreement:
+  `PI_SERVICE_AUTHORITY_MISMATCH`.
+- Durable chain parsing, ordering, digest, or commitment disagreement:
+  `SERVICE_RECEIPT_CHAIN_INVALID` or its verifier boundary projection.
+
+## Test Plan
+
+### RED
+
+- Reproduce the current assertion mismatch on `main`.
+
+### GREEN
+
+- Align the stale expectation with the documented service-authority category.
+
+### REFACTOR
+
+- Name the expected category locally so the boundary is explicit.
+
+### INTEGRATION
+
+- Run the full command-contract target, formatting, and strict Clippy.

--- a/specs/7146-service-authority-error-taxonomy.md
+++ b/specs/7146-service-authority-error-taxonomy.md
@@ -26,11 +26,11 @@ service-authority error semantics introduced by #7135.
 
 ## Acceptance Criteria
 
-- [ ] Legacy transcript/runtime actor disagreement expects
+- [x] Legacy transcript/runtime actor disagreement expects
   `PI_SERVICE_AUTHORITY_MISMATCH`.
-- [ ] Receipt-chain rebuild corruption retains `RECEIPT_CHAIN_INVALID`.
-- [ ] The complete `mvp_demo_command_contract` target passes.
-- [ ] Formatting and strict Clippy pass.
+- [x] Receipt-chain rebuild corruption retains `RECEIPT_CHAIN_INVALID`.
+- [x] The complete `mvp_demo_command_contract` target passes.
+- [x] Formatting and strict Clippy pass.
 
 ## Files To Touch
 
@@ -61,3 +61,10 @@ service-authority error semantics introduced by #7135.
 ### INTEGRATION
 
 - Run the full command-contract target, formatting, and strict Clippy.
+
+## Verification Evidence
+
+- `cargo fmt --all -- --check`
+- `cargo test -p kamn-e2e-harness --test mvp_demo_command_contract`
+  - Result: 12 passed, 0 failed.
+- `cargo clippy -p kamn-e2e-harness --test mvp_demo_command_contract -- -D warnings`


### PR DESCRIPTION
## Human Summary

- Aligns the legacy transcript/runtime actor regression with the service-authority mismatch category established by #7135.
- Keeps durable receipt-chain corruption classified separately.
- Changes test authority only; production verifier ordering and translation are unchanged.

Closes #7146

Spec: [specs/7146-service-authority-error-taxonomy.md](https://github.com/njfio/kamn/blob/7146-service-authority-error-taxonomy/specs/7146-service-authority-error-taxonomy.md)

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p kamn-e2e-harness --test mvp_demo_command_contract` (12 passed)
- `cargo clippy -p kamn-e2e-harness --test mvp_demo_command_contract -- -D warnings`

## Notes for Reviewers

The review boundary is the distinction between actor service authority (`PI_SERVICE_AUTHORITY_MISMATCH`) and durable receipt-chain validation. No production path changed.