### PR TITLE
fix: align settlement override authority taxonomy

### DIFF
--- a/crates/kamn-e2e-harness/tests/mvp_demo_direct_settlement_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_demo_direct_settlement_contract.rs
@@ -8,6 +8,8 @@ mod mvp_demo_command;
 #[path = "support/pi_transaction_actor_fixture.rs"]
 mod pi_transaction_actor_fixture;
 
+const DIRECT_SETTLEMENT_OVERRIDE_ERROR: &str = "SETTLEMENT_EVIDENCE_INVALID";
+
 #[test]
 fn spec_c07_required_verifier_rejects_command_override_settlement() {
     let root = temp_root();
@@ -18,7 +20,7 @@ fn spec_c07_required_verifier_rejects_command_override_settlement() {
     config.pi_transaction_actor_paths = Some(actors.paths());
     let error = execute_mvp_demo_contract(&config)
         .expect_err("override-only required-devnet proof must fail before publication");
-    assert_eq!(error, "SETTLEMENT_EVIDENCE_INVALID");
+    assert_eq!(error, DIRECT_SETTLEMENT_OVERRIDE_ERROR);
 }
 
 fn temp_root() -> std::path::PathBuf {

--- a/crates/kamn-e2e-harness/tests/mvp_demo_direct_settlement_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_demo_direct_settlement_contract.rs
@@ -8,7 +8,7 @@ mod mvp_demo_command;
 #[path = "support/pi_transaction_actor_fixture.rs"]
 mod pi_transaction_actor_fixture;
 
-const DIRECT_SETTLEMENT_OVERRIDE_ERROR: &str = "PI_SERVICE_AUTHORITY_MISMATCH";
+const DIRECT_SETTLEMENT_AUTHORITY_ERROR: &str = "PI_SERVICE_AUTHORITY_MISMATCH";
 
 #[test]
 fn spec_c07_required_verifier_rejects_command_override_settlement() {
@@ -20,7 +20,7 @@ fn spec_c07_required_verifier_rejects_command_override_settlement() {
     config.pi_transaction_actor_paths = Some(actors.paths());
     let error = execute_mvp_demo_contract(&config)
         .expect_err("override-only required-devnet proof must fail before publication");
-    assert_eq!(error, DIRECT_SETTLEMENT_OVERRIDE_ERROR);
+    assert_eq!(error, DIRECT_SETTLEMENT_AUTHORITY_ERROR);
 }
 
 fn temp_root() -> std::path::PathBuf {

--- a/crates/kamn-e2e-harness/tests/mvp_demo_direct_settlement_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_demo_direct_settlement_contract.rs
@@ -8,7 +8,7 @@ mod mvp_demo_command;
 #[path = "support/pi_transaction_actor_fixture.rs"]
 mod pi_transaction_actor_fixture;
 
-const DIRECT_SETTLEMENT_OVERRIDE_ERROR: &str = "SETTLEMENT_EVIDENCE_INVALID";
+const DIRECT_SETTLEMENT_OVERRIDE_ERROR: &str = "PI_SERVICE_AUTHORITY_MISMATCH";
 
 #[test]
 fn spec_c07_required_verifier_rejects_command_override_settlement() {

--- a/specs/7148-direct-settlement-authority-taxonomy.md
+++ b/specs/7148-direct-settlement-authority-taxonomy.md
@@ -26,11 +26,11 @@ service-authority verification order established by #7135.
 
 ## Acceptance Criteria
 
-- [ ] The direct-settlement override regression expects
+- [x] The direct-settlement override regression expects
   `PI_SERVICE_AUTHORITY_MISMATCH`.
-- [ ] Genuine settlement evidence drift retains `SETTLEMENT_EVIDENCE_INVALID`.
-- [ ] The focused direct-settlement and settlement-evidence targets pass.
-- [ ] Formatting and strict Clippy pass.
+- [x] Genuine settlement evidence drift retains `SETTLEMENT_EVIDENCE_INVALID`.
+- [x] The focused direct-settlement and settlement-evidence targets pass.
+- [x] Formatting and strict Clippy pass.
 
 ## Files To Touch
 
@@ -62,3 +62,14 @@ service-authority verification order established by #7135.
 
 - Run the direct-settlement target, focused genuine-settlement drift tests, formatting,
   and strict Clippy.
+
+## Verification Evidence
+
+- `cargo fmt --all -- --check`
+- `cargo test -p kamn-e2e-harness --test mvp_demo_direct_settlement_contract
+  --test independent_settlement_evidence_verifier_contract
+  --test independent_agent_transaction_verifier_contract`
+  - Result: 17 passed, 0 failed.
+- `cargo clippy -p kamn-e2e-harness --test mvp_demo_direct_settlement_contract
+  --test independent_settlement_evidence_verifier_contract
+  --test independent_agent_transaction_verifier_contract -- -D warnings`

--- a/specs/7148-direct-settlement-authority-taxonomy.md
+++ b/specs/7148-direct-settlement-authority-taxonomy.md
@@ -1,0 +1,64 @@
+# Issue #7148: Align Direct-Settlement Rejection With Authority Ordering
+
+## Objective
+
+Align the direct-settlement override regression with the independent
+service-authority verification order established by #7135.
+
+## Inputs And Outputs
+
+- Input: a required-devnet demo configuration plus an independently generated actor
+  receipt bundle whose authority facts do not match the demo transcript.
+- Output: rejection with `PI_SERVICE_AUTHORITY_MISMATCH`.
+
+## Boundaries And Non-Goals
+
+- Do not change production verifier ordering or error translation.
+- Do not accept command-override settlement evidence.
+- Do not reclassify settlement evidence drift that passes actor authority checks.
+- Do not change durable receipt-chain, Pi transport, or governance behavior.
+
+## Failure Modes
+
+- The regression expects settlement validation even though actor authority fails first.
+- Genuine settlement evidence drift is incorrectly reclassified as actor authority drift.
+- Override-only required-devnet evidence is accepted.
+
+## Acceptance Criteria
+
+- [ ] The direct-settlement override regression expects
+  `PI_SERVICE_AUTHORITY_MISMATCH`.
+- [ ] Genuine settlement evidence drift retains `SETTLEMENT_EVIDENCE_INVALID`.
+- [ ] The focused direct-settlement and settlement-evidence targets pass.
+- [ ] Formatting and strict Clippy pass.
+
+## Files To Touch
+
+- `specs/7148-direct-settlement-authority-taxonomy.md`
+- `crates/kamn-e2e-harness/tests/mvp_demo_direct_settlement_contract.rs`
+
+## Error Semantics
+
+- Actor service-authority or projection disagreement:
+  `PI_SERVICE_AUTHORITY_MISMATCH`.
+- Settlement, RPC, or duplicate-action disagreement reached after authority verification:
+  `AGENT_TRANSACTION_SETTLEMENT_INVALID` or `SETTLEMENT_EVIDENCE_INVALID`.
+
+## Test Plan
+
+### RED
+
+- Name the stale direct-settlement expectation and reproduce its mismatch.
+
+### GREEN
+
+- Align the expectation with the first failing service-authority boundary.
+
+### REFACTOR
+
+- Name the expected category for the semantic boundary.
+
+### INTEGRATION
+
+- Run the direct-settlement target, focused genuine-settlement drift tests, formatting,
+  and strict Clippy.


### PR DESCRIPTION
## Human Summary

- Aligns the direct-settlement override regression with the first failing service-authority boundary established by #7135.
- Verifies that genuine settlement evidence drift still returns `SETTLEMENT_EVIDENCE_INVALID`.
- Changes test authority only; production verifier ordering and translation are unchanged.

Closes #7148

Spec: [specs/7148-direct-settlement-authority-taxonomy.md](https://github.com/njfio/kamn/blob/7148-direct-settlement-authority-taxonomy/specs/7148-direct-settlement-authority-taxonomy.md)

## Testing

- `cargo fmt --all -- --check`
- 17 focused tests across `mvp_demo_direct_settlement_contract`, `independent_settlement_evidence_verifier_contract`, and `independent_agent_transaction_verifier_contract`
- Strict Clippy for all three targets

## Notes for Reviewers

Review the boundary distinction: actor authority disagreement fails before settlement validation, while fixtures that reach settlement evidence retain their existing category.