### PR TITLE
test: bind the valid service-authority fixture

### DIFF
--- a/crates/kamn-e2e-harness/tests/mvp_demo_pi_service_authority_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_demo_pi_service_authority_contract.rs
@@ -26,5 +26,5 @@ fn spec_c02_rejects_v1_client_local_receipt_authority() {
 }
 
 fn write_valid_service_authority_fixture(fixture: &ActorFixture) {
-    fixture.write_v2_all();
+    fixture.write_bound_v2_all();
 }

--- a/crates/kamn-e2e-harness/tests/mvp_demo_pi_service_authority_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_demo_pi_service_authority_contract.rs
@@ -7,7 +7,7 @@ use pi_transaction_actor_fixture::{ActorFixture, Overrides};
 #[test]
 fn spec_c01_accepts_role_scoped_v2_service_authority() {
     let fixture = ActorFixture::new();
-    write_valid_service_authority_fixture(&fixture);
+    write_bound_service_authority_fixture(&fixture);
 
     let summary = verify_pi_transaction_actor_paths(&fixture.paths())
         .expect("v2 service authority should verify independently");
@@ -25,6 +25,6 @@ fn spec_c02_rejects_v1_client_local_receipt_authority() {
     assert_eq!(error, "PI_SERVICE_AUTHORITY_MISMATCH");
 }
 
-fn write_valid_service_authority_fixture(fixture: &ActorFixture) {
+fn write_bound_service_authority_fixture(fixture: &ActorFixture) {
     fixture.write_bound_v2_all();
 }

--- a/crates/kamn-e2e-harness/tests/mvp_demo_pi_service_authority_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_demo_pi_service_authority_contract.rs
@@ -7,7 +7,7 @@ use pi_transaction_actor_fixture::{ActorFixture, Overrides};
 #[test]
 fn spec_c01_accepts_role_scoped_v2_service_authority() {
     let fixture = ActorFixture::new();
-    fixture.write_v2_all();
+    write_valid_service_authority_fixture(&fixture);
 
     let summary = verify_pi_transaction_actor_paths(&fixture.paths())
         .expect("v2 service authority should verify independently");
@@ -23,4 +23,8 @@ fn spec_c02_rejects_v1_client_local_receipt_authority() {
     let error = verify_pi_transaction_actor_paths(&fixture.paths())
         .expect_err("v1 Pi-local authority must not satisfy the canonical verifier");
     assert_eq!(error, "PI_SERVICE_AUTHORITY_MISMATCH");
+}
+
+fn write_valid_service_authority_fixture(fixture: &ActorFixture) {
+    fixture.write_v2_all();
 }

--- a/specs/7150-bound-service-authority-fixture.md
+++ b/specs/7150-bound-service-authority-fixture.md
@@ -26,11 +26,11 @@ fixture required by the independent verifier.
 
 ## Acceptance Criteria
 
-- [ ] The valid service-authority contract uses the transaction-bound v2 fixture.
-- [ ] The v1/client-local authority case remains rejected with
+- [x] The valid service-authority contract uses the transaction-bound v2 fixture.
+- [x] The v1/client-local authority case remains rejected with
   `PI_SERVICE_AUTHORITY_MISMATCH`.
-- [ ] The complete `mvp_demo_pi_service_authority_contract` target passes.
-- [ ] Formatting and strict Clippy pass.
+- [x] The complete `mvp_demo_pi_service_authority_contract` target passes.
+- [x] Formatting and strict Clippy pass.
 
 ## Files To Touch
 
@@ -59,3 +59,15 @@ fixture required by the independent verifier.
 ### INTEGRATION
 
 - Run the full contract target, formatting, and strict Clippy.
+
+## Verification Evidence
+
+- `cargo fmt --all -- --check`
+- `cargo test -p kamn-e2e-harness --test mvp_demo_pi_service_authority_contract
+  --test independent_service_receipt_membership_contract`
+  - Result: 3 passed, 0 failed.
+- `cargo clippy -p kamn-e2e-harness --test mvp_demo_pi_service_authority_contract
+  --test independent_service_receipt_membership_contract -- -D warnings`
+- The adjacent generated-keypair actor fixture failed twice under concurrent target
+  execution with `confirmation payer lookup failed: keypair rejected`; each exact
+  isolated rerun passed. No production or fixture-generation change is included here.

--- a/specs/7150-bound-service-authority-fixture.md
+++ b/specs/7150-bound-service-authority-fixture.md
@@ -1,0 +1,61 @@
+# Issue #7150: Use Transaction-Bound Service-Authority Fixture
+
+## Objective
+
+Align the valid service-authority success contract with the transaction-bound v2 actor
+fixture required by the independent verifier.
+
+## Inputs And Outputs
+
+- Input: three role-scoped v2 actor artifacts bound to the canonical transaction facts.
+- Output: a verified service-authority summary containing receipt-chain and public
+  commitments.
+
+## Boundaries And Non-Goals
+
+- Do not change production verifier behavior.
+- Do not accept generic unbound v2 or client-local v1 authority.
+- Do not change settlement, durable receipt-chain, Pi transport, or governance behavior.
+
+## Failure Modes
+
+- The valid-path test uses an unbound fixture and fails with
+  `PI_SERVICE_AUTHORITY_MISMATCH`.
+- Transaction binding is weakened to make the stale fixture pass.
+- The v1/client-local negative case becomes accepted.
+
+## Acceptance Criteria
+
+- [ ] The valid service-authority contract uses the transaction-bound v2 fixture.
+- [ ] The v1/client-local authority case remains rejected with
+  `PI_SERVICE_AUTHORITY_MISMATCH`.
+- [ ] The complete `mvp_demo_pi_service_authority_contract` target passes.
+- [ ] Formatting and strict Clippy pass.
+
+## Files To Touch
+
+- `specs/7150-bound-service-authority-fixture.md`
+- `crates/kamn-e2e-harness/tests/mvp_demo_pi_service_authority_contract.rs`
+
+## Error Semantics
+
+- Bound v2 authority verifies successfully.
+- Unbound, v1, or client-local authority returns `PI_SERVICE_AUTHORITY_MISMATCH`.
+
+## Test Plan
+
+### RED
+
+- Reproduce the valid-path failure with the generic v2 fixture.
+
+### GREEN
+
+- Use the transaction-bound v2 fixture for the success case.
+
+### REFACTOR
+
+- Name the fixture setup helper for the valid independent-authority boundary.
+
+### INTEGRATION
+
+- Run the full contract target, formatting, and strict Clippy.


### PR DESCRIPTION
## Human Summary

- Uses the transaction-bound v2 actor fixture for the valid independent service-authority contract.
- Preserves rejection of client-local v1 authority and durable receipt-membership enforcement.
- Changes test setup only; production verifier behavior is unchanged.

Closes #7150

Spec: [specs/7150-bound-service-authority-fixture.md](https://github.com/njfio/kamn/blob/7150-bound-service-authority-fixture/specs/7150-bound-service-authority-fixture.md)

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p kamn-e2e-harness --test mvp_demo_pi_service_authority_contract --test independent_service_receipt_membership_contract`
- Strict Clippy for both targets
- Exact isolated reruns of two load-sensitive generated-keypair actor cases passed

## Notes for Reviewers

The review focus is fixture correctness: successful independent authority must be transaction-bound. The verifier was not relaxed.