### PR TITLE
test: migrate Pi actor authority taxonomy

### DIFF
--- a/crates/kamn-e2e-harness/tests/mvp_demo_pi_transaction_actor_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_demo_pi_transaction_actor_contract.rs
@@ -4,76 +4,70 @@ use kamn_e2e_harness::verify_pi_transaction_actor_paths;
 mod pi_transaction_actor_fixture;
 use pi_transaction_actor_fixture::{sha, ActorFixture, Overrides};
 
-const PROCESS_OR_IDENTITY_ERROR: &str = "PI_ACTOR_";
+const SERVICE_AUTHORITY_ERROR: &str = "PI_SERVICE_AUTHORITY_MISMATCH";
+const TRANSPORT_PROVENANCE_ERROR: &str = "PI_TRANSPORT_PROVENANCE_INVALID";
 
 #[test]
 fn spec_c01_rust_verifier_accepts_three_runtime_bound_pi_actors() {
     let fixture = ActorFixture::new();
-    write_actor_fixture(&fixture, Overrides::default());
+    fixture.write_bound_v2_all();
 
     let summary = verify_pi_transaction_actor_paths(&fixture.paths())
         .expect("three independent actor artifacts should verify");
-    assert!(summary.contains("task-live-7099"));
-    assert!(summary.contains("escrow-live-7099"));
-    assert!(summary.contains("devnet-signature-7099"));
+    assert!(summary.contains(r#""receipt_chain_commitment":"sha256:"#));
+    assert!(summary.contains(r#""public_commitment":"sha256:"#));
 }
 #[test]
 fn spec_c02_rust_verifier_rejects_reused_process_and_identity() {
-    for overrides in [
-        Overrides {
-            agent_c_pid: 101,
-            ..Overrides::default()
-        },
-        Overrides {
-            agent_c_did: "kamn:did:a",
-            ..Overrides::default()
-        },
+    for (overrides, expected) in [
+        (
+            Overrides {
+                agent_c_pid: 101,
+                ..Overrides::default()
+            },
+            TRANSPORT_PROVENANCE_ERROR,
+        ),
+        (
+            Overrides {
+                agent_c_did: "kamn:did:a",
+                ..Overrides::default()
+            },
+            SERVICE_AUTHORITY_ERROR,
+        ),
     ] {
         let fixture = ActorFixture::new();
         write_actor_fixture(&fixture, overrides);
         let error = verify_pi_transaction_actor_paths(&fixture.paths())
             .expect_err("reused actor identity must fail");
-        assert!(error.contains(PROCESS_OR_IDENTITY_ERROR));
+        assert_eq!(error, expected);
     }
 }
 
 #[test]
 fn spec_c03_rust_verifier_rejects_runtime_privacy_and_shared_fact_drift() {
-    for (overrides, code) in [
-        (
-            Overrides {
-                agent_c_projection: sha('f'),
-                ..Overrides::default()
-            },
-            "PI_TRANSACTION_FACT_MISMATCH",
-        ),
-        (
-            Overrides {
-                agent_c_private: Some(sha('e')),
-                ..Overrides::default()
-            },
-            "PI_VERIFIER_PRIVATE_LEAK",
-        ),
-        (
-            Overrides {
-                agent_b_escrow: "escrow-other",
-                ..Overrides::default()
-            },
-            "PI_TRANSACTION_FACT_MISMATCH",
-        ),
-        (
-            Overrides {
-                agent_a_handoff_authorized: true,
-                ..Overrides::default()
-            },
-            "PI_HANDOFF_AUTHORIZATION_FORBIDDEN",
-        ),
+    for overrides in [
+        Overrides {
+            agent_c_projection: sha('f'),
+            ..Overrides::default()
+        },
+        Overrides {
+            agent_c_private: Some(sha('e')),
+            ..Overrides::default()
+        },
+        Overrides {
+            agent_b_escrow: "escrow-other",
+            ..Overrides::default()
+        },
+        Overrides {
+            agent_a_handoff_authorized: true,
+            ..Overrides::default()
+        },
     ] {
         let fixture = ActorFixture::new();
         write_actor_fixture(&fixture, overrides);
         let error = verify_pi_transaction_actor_paths(&fixture.paths())
             .expect_err("tampered actor evidence must fail");
-        assert!(error.contains(code), "unexpected error: {error}");
+        assert_eq!(error, SERVICE_AUTHORITY_ERROR);
     }
 }
 
@@ -98,5 +92,5 @@ fn spec_c04_rust_verifier_rejects_missing_operation_and_type_confusion() {
 }
 
 fn write_actor_fixture(fixture: &ActorFixture, overrides: Overrides) {
-    fixture.write_all(overrides);
+    fixture.write_bound_v2(overrides);
 }

--- a/crates/kamn-e2e-harness/tests/mvp_demo_pi_transaction_actor_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_demo_pi_transaction_actor_contract.rs
@@ -36,7 +36,7 @@ fn spec_c02_rust_verifier_rejects_reused_process_and_identity() {
         ),
     ] {
         let fixture = ActorFixture::new();
-        write_actor_fixture(&fixture, overrides);
+        write_bound_actor_fixture(&fixture, overrides);
         let error = verify_pi_transaction_actor_paths(&fixture.paths())
             .expect_err("reused actor identity must fail");
         assert_eq!(error, expected);
@@ -64,7 +64,7 @@ fn spec_c03_rust_verifier_rejects_runtime_privacy_and_shared_fact_drift() {
         },
     ] {
         let fixture = ActorFixture::new();
-        write_actor_fixture(&fixture, overrides);
+        write_bound_actor_fixture(&fixture, overrides);
         let error = verify_pi_transaction_actor_paths(&fixture.paths())
             .expect_err("tampered actor evidence must fail");
         assert_eq!(error, SERVICE_AUTHORITY_ERROR);
@@ -84,13 +84,13 @@ fn spec_c04_rust_verifier_rejects_missing_operation_and_type_confusion() {
         },
     ] {
         let fixture = ActorFixture::new();
-        write_actor_fixture(&fixture, overrides);
+        write_bound_actor_fixture(&fixture, overrides);
         let error = verify_pi_transaction_actor_paths(&fixture.paths())
             .expect_err("incomplete or type-confused actor evidence must fail");
         assert!(error.contains("PI_"), "unexpected error: {error}");
     }
 }
 
-fn write_actor_fixture(fixture: &ActorFixture, overrides: Overrides) {
+fn write_bound_actor_fixture(fixture: &ActorFixture, overrides: Overrides) {
     fixture.write_bound_v2(overrides);
 }

--- a/crates/kamn-e2e-harness/tests/mvp_demo_pi_transaction_actor_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_demo_pi_transaction_actor_contract.rs
@@ -3,10 +3,13 @@ use kamn_e2e_harness::verify_pi_transaction_actor_paths;
 #[path = "support/pi_transaction_actor_fixture.rs"]
 mod pi_transaction_actor_fixture;
 use pi_transaction_actor_fixture::{sha, ActorFixture, Overrides};
+
+const PROCESS_OR_IDENTITY_ERROR: &str = "PI_ACTOR_";
+
 #[test]
 fn spec_c01_rust_verifier_accepts_three_runtime_bound_pi_actors() {
     let fixture = ActorFixture::new();
-    fixture.write_all(Overrides::default());
+    write_actor_fixture(&fixture, Overrides::default());
 
     let summary = verify_pi_transaction_actor_paths(&fixture.paths())
         .expect("three independent actor artifacts should verify");
@@ -27,10 +30,10 @@ fn spec_c02_rust_verifier_rejects_reused_process_and_identity() {
         },
     ] {
         let fixture = ActorFixture::new();
-        fixture.write_all(overrides);
+        write_actor_fixture(&fixture, overrides);
         let error = verify_pi_transaction_actor_paths(&fixture.paths())
             .expect_err("reused actor identity must fail");
-        assert!(error.contains("PI_ACTOR_"));
+        assert!(error.contains(PROCESS_OR_IDENTITY_ERROR));
     }
 }
 
@@ -67,7 +70,7 @@ fn spec_c03_rust_verifier_rejects_runtime_privacy_and_shared_fact_drift() {
         ),
     ] {
         let fixture = ActorFixture::new();
-        fixture.write_all(overrides);
+        write_actor_fixture(&fixture, overrides);
         let error = verify_pi_transaction_actor_paths(&fixture.paths())
             .expect_err("tampered actor evidence must fail");
         assert!(error.contains(code), "unexpected error: {error}");
@@ -87,9 +90,13 @@ fn spec_c04_rust_verifier_rejects_missing_operation_and_type_confusion() {
         },
     ] {
         let fixture = ActorFixture::new();
-        fixture.write_all(overrides);
+        write_actor_fixture(&fixture, overrides);
         let error = verify_pi_transaction_actor_paths(&fixture.paths())
             .expect_err("incomplete or type-confused actor evidence must fail");
         assert!(error.contains("PI_"), "unexpected error: {error}");
     }
+}
+
+fn write_actor_fixture(fixture: &ActorFixture, overrides: Overrides) {
+    fixture.write_all(overrides);
 }

--- a/specs/7152-pi-actor-authority-taxonomy.md
+++ b/specs/7152-pi-actor-authority-taxonomy.md
@@ -1,0 +1,68 @@
+# Issue #7152: Migrate Pi Actor Contract To Authority Taxonomy
+
+## Objective
+
+Migrate the Pi transaction actor contract from pre-#7135 fixture and error assumptions
+to transaction-bound v2 authority and exact verifier categories.
+
+## Inputs And Outputs
+
+- Input: bound v2 actor artifacts with optional process, identity, projection, privacy,
+  shared-fact, authorization, operation, or type drift.
+- Output: success for coherent authority and exact fail-closed categories for drift.
+
+## Boundaries And Non-Goals
+
+- Do not change production verifier behavior or ordering.
+- Do not accept unbound, v1, or client-local authority.
+- Do not change settlement, durable receipt-chain, Pi transport, or governance code.
+
+## Failure Modes
+
+- The success case uses generic unbound v2 evidence.
+- Process reuse is conflated with service-authority drift.
+- Identity, projection, privacy, shared-fact, or authorization drift uses obsolete
+  pre-authority categories.
+- Missing or type-confused operations are accepted.
+
+## Acceptance Criteria
+
+- [ ] The valid path uses transaction-bound v2 actor evidence.
+- [ ] Duplicate process returns `PI_TRANSPORT_PROVENANCE_INVALID`.
+- [ ] Identity, projection, privacy, shared-fact, and authorization drift return
+  `PI_SERVICE_AUTHORITY_MISMATCH`.
+- [ ] Missing operation and type confusion remain fail-closed.
+- [ ] The complete four-case target passes.
+- [ ] Formatting and strict Clippy pass.
+
+## Files To Touch
+
+- `specs/7152-pi-actor-authority-taxonomy.md`
+- `crates/kamn-e2e-harness/tests/mvp_demo_pi_transaction_actor_contract.rs`
+
+## Error Semantics
+
+- Actor service authority or projection disagreement:
+  `PI_SERVICE_AUTHORITY_MISMATCH`.
+- Actor process or transport provenance disagreement:
+  `PI_TRANSPORT_PROVENANCE_INVALID`.
+- Missing, malformed, or type-confused actor operations fail with the owning `PI_*`
+  boundary and are never accepted.
+
+## Test Plan
+
+### RED
+
+- Name the existing fixture and category assumptions and reproduce the three failures.
+
+### GREEN
+
+- Use bound v2 fixtures and exact service-authority/transport categories.
+
+### REFACTOR
+
+- Centralize bound fixture verification helpers within the target.
+
+### INTEGRATION
+
+- Run the complete target, formatting, strict Clippy, and adjacent authority contracts.

--- a/specs/7152-pi-actor-authority-taxonomy.md
+++ b/specs/7152-pi-actor-authority-taxonomy.md
@@ -27,13 +27,13 @@ to transaction-bound v2 authority and exact verifier categories.
 
 ## Acceptance Criteria
 
-- [ ] The valid path uses transaction-bound v2 actor evidence.
-- [ ] Duplicate process returns `PI_TRANSPORT_PROVENANCE_INVALID`.
-- [ ] Identity, projection, privacy, shared-fact, and authorization drift return
+- [x] The valid path uses transaction-bound v2 actor evidence.
+- [x] Duplicate process returns `PI_TRANSPORT_PROVENANCE_INVALID`.
+- [x] Identity, projection, privacy, shared-fact, and authorization drift return
   `PI_SERVICE_AUTHORITY_MISMATCH`.
-- [ ] Missing operation and type confusion remain fail-closed.
-- [ ] The complete four-case target passes.
-- [ ] Formatting and strict Clippy pass.
+- [x] Missing operation and type confusion remain fail-closed.
+- [x] The complete four-case target passes.
+- [x] Formatting and strict Clippy pass.
 
 ## Files To Touch
 
@@ -66,3 +66,14 @@ to transaction-bound v2 authority and exact verifier categories.
 ### INTEGRATION
 
 - Run the complete target, formatting, strict Clippy, and adjacent authority contracts.
+
+## Verification Evidence
+
+- `cargo fmt --all -- --check`
+- `cargo test -p kamn-e2e-harness --test mvp_demo_pi_transaction_actor_contract
+  --test mvp_demo_pi_service_authority_contract`
+  - Result: 6 passed, 0 failed.
+- `cargo clippy -p kamn-e2e-harness --test mvp_demo_pi_transaction_actor_contract
+  --test mvp_demo_pi_service_authority_contract -- -D warnings`
+- A broader runtime receipt-chain target run exposed a separate unbound success fixture;
+  that target is outside this issue and remains fail-closed.


### PR DESCRIPTION
## Human Summary

- Migrates the Pi actor contract to transaction-bound v2 fixtures.
- Separates duplicate-process transport provenance from service-authority drift.
- Replaces raw settlement-fact success assertions with privacy-preserving commitment assertions.
- Changes tests only; production verifier behavior is unchanged.

Closes #7152

Spec: [specs/7152-pi-actor-authority-taxonomy.md](https://github.com/njfio/kamn/blob/7152-pi-actor-authority-taxonomy/specs/7152-pi-actor-authority-taxonomy.md)

## Testing

- `cargo fmt --all -- --check`
- Six cases across `mvp_demo_pi_transaction_actor_contract` and `mvp_demo_pi_service_authority_contract`
- Strict Clippy for both targets

## Notes for Reviewers

Review the exact taxonomy split and the commitment-only success assertions. A separate runtime receipt-chain success fixture remains fail-closed and is not folded into this issue.