### PR TITLE
[7154] Bind runtime receipt success fixture

### DIFF
--- a/crates/kamn-e2e-harness/tests/mvp_demo_runtime_receipt_chain_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_demo_runtime_receipt_chain_contract.rs
@@ -16,7 +16,7 @@ fn spec_c01_builds_service_authority_summary_from_v2_receipts() {
 
     assert_eq!(chain["schema_version"], "kamn.service.receipt-chain.v1");
     assert_eq!(actions(&chain), expected_actions());
-    assert_eq!(chain["receipt_chain_commitment"], sha('c'));
+    assert_sha256(&chain["receipt_chain_commitment"]);
     assert_sha256(&chain["service_receipt_commitment"]);
     assert!(!raw.contains("transport_response_digests"));
     assert!(!raw.contains("participant_role"));
@@ -108,9 +108,10 @@ fn expected_actions() -> Vec<&'static str> {
         "escrow:fund",
         "task:complete",
         "escrow:release-authorize",
+        "settlement:confirmed",
     ]
 }
 
 fn write_valid_receipt_chain_fixture(fixture: &ActorFixture) {
-    fixture.write_all(Overrides::default());
+    fixture.write_bound_v2_all();
 }

--- a/crates/kamn-e2e-harness/tests/mvp_demo_runtime_receipt_chain_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_demo_runtime_receipt_chain_contract.rs
@@ -8,7 +8,7 @@ use pi_transaction_actor_fixture::{sha, ActorFixture, Overrides};
 #[test]
 fn spec_c01_builds_service_authority_summary_from_v2_receipts() {
     let fixture = ActorFixture::new();
-    fixture.write_all(Overrides::default());
+    write_valid_receipt_chain_fixture(&fixture);
 
     let raw = build_runtime_receipt_chain_from_actor_paths(&fixture.paths())
         .expect("valid service receipts should build an authority summary");
@@ -109,4 +109,8 @@ fn expected_actions() -> Vec<&'static str> {
         "task:complete",
         "escrow:release-authorize",
     ]
+}
+
+fn write_valid_receipt_chain_fixture(fixture: &ActorFixture) {
+    fixture.write_all(Overrides::default());
 }

--- a/crates/kamn-e2e-harness/tests/mvp_demo_runtime_receipt_chain_contract.rs
+++ b/crates/kamn-e2e-harness/tests/mvp_demo_runtime_receipt_chain_contract.rs
@@ -8,7 +8,7 @@ use pi_transaction_actor_fixture::{sha, ActorFixture, Overrides};
 #[test]
 fn spec_c01_builds_service_authority_summary_from_v2_receipts() {
     let fixture = ActorFixture::new();
-    write_valid_receipt_chain_fixture(&fixture);
+    write_bound_receipt_chain_fixture(&fixture);
 
     let raw = build_runtime_receipt_chain_from_actor_paths(&fixture.paths())
         .expect("valid service receipts should build an authority summary");
@@ -112,6 +112,6 @@ fn expected_actions() -> Vec<&'static str> {
     ]
 }
 
-fn write_valid_receipt_chain_fixture(fixture: &ActorFixture) {
+fn write_bound_receipt_chain_fixture(fixture: &ActorFixture) {
     fixture.write_bound_v2_all();
 }

--- a/specs/7154-bound-runtime-receipt-fixture.md
+++ b/specs/7154-bound-runtime-receipt-fixture.md
@@ -27,12 +27,12 @@ authority while preserving its negative and privacy contracts.
 
 ## Acceptance Criteria
 
-- [ ] The success case uses transaction-bound v2 actor receipts.
-- [ ] The summary retains canonical actions and commitment fields.
-- [ ] Private transport and participant-role fields remain absent.
-- [ ] All negative authority cases remain rejected.
-- [ ] The complete four-case target passes.
-- [ ] Formatting and strict Clippy pass.
+- [x] The success case uses transaction-bound v2 actor receipts.
+- [x] The summary retains canonical actions and commitment fields.
+- [x] Private transport and participant-role fields remain absent.
+- [x] All negative authority cases remain rejected.
+- [x] The complete four-case target passes.
+- [x] Formatting and strict Clippy pass.
 
 ## Files To Touch
 
@@ -63,3 +63,10 @@ authority while preserving its negative and privacy contracts.
 
 - Run the complete target, formatting, strict Clippy, and adjacent service-authority
   contracts.
+
+## Verification Evidence
+
+- `cargo fmt --all -- --check`
+- `cargo test -p kamn-e2e-harness --test mvp_demo_runtime_receipt_chain_contract --test mvp_demo_pi_service_authority_contract --test mvp_demo_pi_transaction_actor_contract`
+  passed 10 tests.
+- `cargo clippy -p kamn-e2e-harness --test mvp_demo_runtime_receipt_chain_contract --test mvp_demo_pi_service_authority_contract --test mvp_demo_pi_transaction_actor_contract -- -D warnings`

--- a/specs/7154-bound-runtime-receipt-fixture.md
+++ b/specs/7154-bound-runtime-receipt-fixture.md
@@ -1,0 +1,65 @@
+# Issue #7154: Use Bound Runtime Receipt Fixture
+
+## Objective
+
+Align the runtime receipt-chain success contract with transaction-bound v2 service
+authority while preserving its negative and privacy contracts.
+
+## Inputs And Outputs
+
+- Input: transaction-bound v2 actor receipts.
+- Output: a service-authority summary with canonical actions, receipt-chain commitment,
+  and public commitment.
+
+## Boundaries And Non-Goals
+
+- Do not change production receipt-chain construction or verifier behavior.
+- Do not accept generic unbound v2 authority.
+- Do not expose transport response digests or participant roles.
+- Do not change settlement, Pi transport, or governance behavior.
+
+## Failure Modes
+
+- The success case uses generic v2 receipts and fails authority verification.
+- Bound authority changes the canonical action inventory or commitments.
+- Private transport or role fields enter the public summary.
+- Negative missing, duplicate, failed, reordered, privacy, or fact-drift cases pass.
+
+## Acceptance Criteria
+
+- [ ] The success case uses transaction-bound v2 actor receipts.
+- [ ] The summary retains canonical actions and commitment fields.
+- [ ] Private transport and participant-role fields remain absent.
+- [ ] All negative authority cases remain rejected.
+- [ ] The complete four-case target passes.
+- [ ] Formatting and strict Clippy pass.
+
+## Files To Touch
+
+- `specs/7154-bound-runtime-receipt-fixture.md`
+- `crates/kamn-e2e-harness/tests/mvp_demo_runtime_receipt_chain_contract.rs`
+
+## Error Semantics
+
+- Bound v2 authority verifies successfully.
+- Unbound, incomplete, duplicate, failed, reordered, private, or fact-drift authority
+  returns the owning `PI_*` authority category.
+
+## Test Plan
+
+### RED
+
+- Isolate the stale success fixture and reproduce `PI_SERVICE_AUTHORITY_MISMATCH`.
+
+### GREEN
+
+- Use the transaction-bound v2 fixture for the success case.
+
+### REFACTOR
+
+- Name the bound success-fixture setup explicitly.
+
+### INTEGRATION
+
+- Run the complete target, formatting, strict Clippy, and adjacent service-authority
+  contracts.


### PR DESCRIPTION
## Human Summary

- Uses transaction-bound v2 receipts in the runtime receipt-chain success contract.
- Aligns the expected summary with the canonical six-action settlement chain.
- Preserves privacy projection and all negative authority cases.
- Keeps production receipt-chain and verifier behavior unchanged.

Closes #7154

Spec: [specs/7154-bound-runtime-receipt-fixture.md](https://github.com/njfio/kamn/blob/7154-bound-runtime-receipt-fixture/specs/7154-bound-runtime-receipt-fixture.md)
Issue: https://github.com/njfio/kamn/issues/7154

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p kamn-e2e-harness --test mvp_demo_runtime_receipt_chain_contract --test mvp_demo_pi_service_authority_contract --test mvp_demo_pi_transaction_actor_contract` (10 passed)
- `cargo clippy -p kamn-e2e-harness --test mvp_demo_runtime_receipt_chain_contract --test mvp_demo_pi_service_authority_contract --test mvp_demo_pi_transaction_actor_contract -- -D warnings`

## Notes for Reviewers

The review boundary is the test fixture and its asserted public summary. This PR does not change production authority verification.