### PR TITLE
[7156] Bind MCP release settlement authority

### DIFF
--- a/crates/kamn-mcp-server/tests/tool_dispatch_contract.rs
+++ b/crates/kamn-mcp-server/tests/tool_dispatch_contract.rs
@@ -130,9 +130,7 @@ impl McpToolBackend for TestBackend {
     }
 
     fn release_escrow(&self, escrow_id: &str, _payload: &str) -> Result<String, AgentLibError> {
-        Ok(format!(
-            r#"{{"actor_did":"kamn:did:agent:test","escrow_id":"{escrow_id}","state":"release-authorized","receipt_id":"escrow-release","receipt_digest":"{DIGEST}","action":"escrow:release-authorize","settlement_receipt_id":"settlement-intent-1","settlement_receipt_digest":"{DIGEST}","settlement_receipt_action":"settlement:confirmed","settlement_receipt_resource_id":"{escrow_id}","settlement_receipt_state":"confirmed"}}"#
-        ))
+        Ok(bound_release_authority(escrow_id))
     }
 
     fn health(&self) -> Result<String, AgentLibError> {
@@ -153,6 +151,12 @@ impl McpToolBackend for TestBackend {
             r#"{{"message_id":"{message_id}","tx_hash":"{tx_hash}","block_height":{block_height},"finality":"{finality}","verified":{verified}}}"#
         ))
     }
+}
+
+fn bound_release_authority(escrow_id: &str) -> String {
+    format!(
+        r#"{{"actor_did":"kamn:did:agent:test","escrow_id":"{escrow_id}","state":"release-authorized","receipt_id":"escrow-release","receipt_digest":"{DIGEST}","action":"escrow:release-authorize","settlement_receipt_id":"settlement-intent-1","settlement_receipt_digest":"{DIGEST}","settlement_receipt_action":"settlement:confirmed","settlement_receipt_resource_id":"{escrow_id}","settlement_receipt_state":"confirmed"}}"#
+    )
 }
 
 #[test]

--- a/crates/kamn-mcp-server/tests/tool_dispatch_contract.rs
+++ b/crates/kamn-mcp-server/tests/tool_dispatch_contract.rs
@@ -290,8 +290,16 @@ fn spec_c05_mcp_dispatch_executes_task_and_escrow_tools_with_structured_success(
         "release should succeed: {release}"
     );
     assert!(
-        release.contains(r#""state":"released""#),
-        "release payload should include state: {release}"
+        release.contains(r#""state":"release-authorized""#),
+        "release payload should include authorized state: {release}"
+    );
+    assert!(
+        release.contains(r#""resulting_state":"release-authorized""#),
+        "release authority should remain pre-settlement: {release}"
+    );
+    assert!(
+        release.contains(r#""action":"settlement:confirmed""#),
+        "release should include confirmed settlement authority: {release}"
     );
 }
 

--- a/crates/kamn-mcp-server/tests/tool_dispatch_contract.rs
+++ b/crates/kamn-mcp-server/tests/tool_dispatch_contract.rs
@@ -131,7 +131,7 @@ impl McpToolBackend for TestBackend {
 
     fn release_escrow(&self, escrow_id: &str, _payload: &str) -> Result<String, AgentLibError> {
         Ok(format!(
-            r#"{{"actor_did":"kamn:did:agent:test","escrow_id":"{escrow_id}","state":"released","receipt_id":"escrow-release","receipt_digest":"{DIGEST}","action":"escrow:release-authorize"}}"#
+            r#"{{"actor_did":"kamn:did:agent:test","escrow_id":"{escrow_id}","state":"release-authorized","receipt_id":"escrow-release","receipt_digest":"{DIGEST}","action":"escrow:release-authorize","settlement_receipt_id":"settlement-intent-1","settlement_receipt_digest":"{DIGEST}","settlement_receipt_action":"settlement:confirmed","settlement_receipt_resource_id":"{escrow_id}","settlement_receipt_state":"confirmed"}}"#
         ))
     }
 

--- a/specs/7156-bound-mcp-settlement-authority.md
+++ b/specs/7156-bound-mcp-settlement-authority.md
@@ -1,0 +1,66 @@
+# Issue #7156: Bind MCP Settlement Authority Fixture
+
+## Objective
+
+Align the MCP `release_escrow` dispatch success fixture with the service-backed
+settlement receipt authority contract.
+
+## Inputs And Outputs
+
+- Input: a release authorization service receipt plus a distinct confirmed settlement
+  service receipt.
+- Output: a successful MCP authority envelope that preserves both receipt authorities.
+
+## Boundaries And Non-Goals
+
+- Do not change production authority parsing or verification.
+- Do not weaken missing, malformed, partial, tampered, or released-state rejection.
+- Do not change public MCP tool schemas or error codes.
+- Do not change escrow, Pi, runtime receipt-chain, or governance behavior.
+
+## Failure Modes
+
+- The success fixture reports the terminal `released` state as primary authority.
+- The success fixture omits confirmed settlement receipt fields.
+- The settlement receipt resource differs from the requested escrow.
+- Negative authority cases begin passing.
+
+## Acceptance Criteria
+
+- [ ] The release success fixture reports `release-authorized` primary state.
+- [ ] The fixture includes a distinct `settlement:confirmed` service receipt.
+- [ ] The successful response retains the release-authorized service result.
+- [ ] Existing negative authority cases remain rejected.
+- [ ] The complete tool-dispatch and authority-receipt targets pass.
+- [ ] Formatting and strict Clippy pass.
+
+## Files To Touch
+
+- `specs/7156-bound-mcp-settlement-authority.md`
+- `crates/kamn-mcp-server/tests/tool_dispatch_contract.rs`
+
+## Error Semantics
+
+- Complete bound release and settlement authority succeeds.
+- Missing, malformed, partial, tampered, mismatched, or terminal primary authority
+  returns `MCP_AUTHORITY_RECEIPT_MISSING` or `MCP_AUTHORITY_RECEIPT_INVALID`.
+
+## Test Plan
+
+### RED
+
+- Isolate the stale release success fixture and reproduce
+  `MCP_AUTHORITY_RECEIPT_INVALID`.
+
+### GREEN
+
+- Bind the fixture to release authorization and confirmed settlement receipts.
+
+### REFACTOR
+
+- Extract the bound release fixture if needed to keep the backend readable.
+
+### INTEGRATION
+
+- Run the complete tool-dispatch and authority-receipt targets, formatting, strict
+  Clippy, and the full workspace gate.

--- a/specs/7156-bound-mcp-settlement-authority.md
+++ b/specs/7156-bound-mcp-settlement-authority.md
@@ -27,12 +27,12 @@ settlement receipt authority contract.
 
 ## Acceptance Criteria
 
-- [ ] The release success fixture reports `release-authorized` primary state.
-- [ ] The fixture includes a distinct `settlement:confirmed` service receipt.
-- [ ] The successful response retains the release-authorized service result.
-- [ ] Existing negative authority cases remain rejected.
-- [ ] The complete tool-dispatch and authority-receipt targets pass.
-- [ ] Formatting and strict Clippy pass.
+- [x] The release success fixture reports `release-authorized` primary state.
+- [x] The fixture includes a distinct `settlement:confirmed` service receipt.
+- [x] The successful response retains the release-authorized service result.
+- [x] Existing negative authority cases remain rejected.
+- [x] The complete tool-dispatch and authority-receipt targets pass.
+- [x] Formatting and strict Clippy pass.
 
 ## Files To Touch
 
@@ -64,3 +64,10 @@ settlement receipt authority contract.
 
 - Run the complete tool-dispatch and authority-receipt targets, formatting, strict
   Clippy, and the full workspace gate.
+
+## Verification Evidence
+
+- `cargo fmt --all -- --check`
+- `cargo test -p kamn-mcp-server --test tool_dispatch_contract --test authority_receipt_contract`
+  passed 14 tests.
+- `cargo clippy -p kamn-mcp-server --test tool_dispatch_contract --test authority_receipt_contract -- -D warnings`


### PR DESCRIPTION
## Human Summary

- Updates the MCP release_escrow success fixture to use release authorization as primary authority.
- Adds the distinct confirmed settlement service receipt required by the current verifier.
- Preserves production verification, public tool schemas, and negative authority behavior.

Closes #7156

Spec: [specs/7156-bound-mcp-settlement-authority.md](https://github.com/njfio/kamn/blob/7156-bound-mcp-settlement-authority/specs/7156-bound-mcp-settlement-authority.md)
Issue: https://github.com/njfio/kamn/issues/7156

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p kamn-mcp-server --test tool_dispatch_contract --test authority_receipt_contract` (14 passed)
- `cargo clippy -p kamn-mcp-server --test tool_dispatch_contract --test authority_receipt_contract -- -D warnings`

## Notes for Reviewers

The review boundary is test authority data only. The production verifier remains fail-closed and unchanged.