### PR TITLE
docs: publish canonical Pi/MCP authority proof

### DIFF
--- a/crates/kamn-e2e-harness/tests/pi_mcp_service_authority_evidence_contract.rs
+++ b/crates/kamn-e2e-harness/tests/pi_mcp_service_authority_evidence_contract.rs
@@ -51,12 +51,7 @@ fn evidence_binds_finalized_single_transfer() {
 #[test]
 fn evidence_is_secret_safe_and_claim_bounded() {
     let content = read_evidence();
-    for forbidden in FORBIDDEN {
-        assert!(
-            !content.contains(forbidden),
-            "forbidden marker: {forbidden}"
-        );
-    }
+    assert_absent_all(&content, FORBIDDEN);
     assert_contains_all(
         &content,
         &[
@@ -80,6 +75,12 @@ fn assert_contains_all(content: &str, markers: &[&str]) {
             content.contains(marker),
             "{EVIDENCE} missing marker: {marker}"
         );
+    }
+}
+
+fn assert_absent_all(content: &str, markers: &[&str]) {
+    for marker in markers {
+        assert!(!content.contains(marker), "forbidden marker: {marker}");
     }
 }
 

--- a/crates/kamn-e2e-harness/tests/pi_mcp_service_authority_evidence_contract.rs
+++ b/crates/kamn-e2e-harness/tests/pi_mcp_service_authority_evidence_contract.rs
@@ -1,0 +1,88 @@
+use std::path::PathBuf;
+
+const EVIDENCE: &str =
+    "docs/validation/evidence/7126-fresh-checkout-pi-mcp-service-authority.md";
+const FORBIDDEN: &[&str] = &[
+    "/Users/",
+    "/private/",
+    "PRIVATE KEY",
+    "secret=",
+    "KAMN_MVP_LIVE_MCP_AGENT_A_KEY_FILE=",
+];
+
+#[test]
+fn evidence_binds_fresh_checkout_and_canonical_commands() {
+    require(&[
+        "source_commit: 732b1d59027724632af16c4073ca4f1cbe27db31",
+        "clone_state: fresh",
+        "inherited_kamn_state: false",
+        "run_id: run-63361-1784859146830",
+        "make demo-agent-transaction: GO",
+        "standalone_verifier: PASS",
+        "children_exited_before_verifier: true",
+    ]);
+}
+
+#[test]
+fn evidence_binds_service_authority_and_actor_views() {
+    require(&[
+        "authority_schema: kamn.mcp.authority-receipt.v1",
+        "receipt_chain_schema: kamn.service.receipt-chain.v1",
+        "execution_surface: live-service-persisted-receipt",
+        "agent_a_view: participant-private",
+        "agent_b_view: participant-private",
+        "agent_c_view: restricted-public",
+        "agent_c_participant_private_field_count: 0",
+    ]);
+}
+
+#[test]
+fn evidence_binds_finalized_single_transfer() {
+    require(&[
+        "settlement_commitment: finalized",
+        "amount_lamports: 1000000",
+        "transfer_count: 1",
+        "retry_duplicate_count: 0",
+        "rpc_verification: GO",
+        "receipt_chain_commitment: sha256:",
+        "service_receipt_commitment: sha256:",
+    ]);
+}
+
+#[test]
+fn evidence_is_secret_safe_and_claim_bounded() {
+    let content = read_evidence();
+    for forbidden in FORBIDDEN {
+        assert!(!content.contains(forbidden), "forbidden marker: {forbidden}");
+    }
+    assert_contains_all(
+        &content,
+        &[
+            "not production readiness",
+            "not mainnet",
+            "not custody",
+            "not broad bridge finality",
+            "not generalized external settlement",
+            "devnet test tokens",
+        ],
+    );
+}
+
+fn require(markers: &[&str]) {
+    assert_contains_all(&read_evidence(), markers);
+}
+
+fn assert_contains_all(content: &str, markers: &[&str]) {
+    for marker in markers {
+        assert!(content.contains(marker), "{EVIDENCE} missing marker: {marker}");
+    }
+}
+
+fn read_evidence() -> String {
+    std::fs::read_to_string(repo_root().join(EVIDENCE))
+        .unwrap_or_else(|error| panic!("{EVIDENCE} should be readable: {error}"))
+}
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..")
+}

--- a/crates/kamn-e2e-harness/tests/pi_mcp_service_authority_evidence_contract.rs
+++ b/crates/kamn-e2e-harness/tests/pi_mcp_service_authority_evidence_contract.rs
@@ -1,7 +1,6 @@
 use std::path::PathBuf;
 
-const EVIDENCE: &str =
-    "docs/validation/evidence/7126-fresh-checkout-pi-mcp-service-authority.md";
+const EVIDENCE: &str = "docs/validation/evidence/7126-fresh-checkout-pi-mcp-service-authority.md";
 const FORBIDDEN: &[&str] = &[
     "/Users/",
     "/private/",
@@ -53,7 +52,10 @@ fn evidence_binds_finalized_single_transfer() {
 fn evidence_is_secret_safe_and_claim_bounded() {
     let content = read_evidence();
     for forbidden in FORBIDDEN {
-        assert!(!content.contains(forbidden), "forbidden marker: {forbidden}");
+        assert!(
+            !content.contains(forbidden),
+            "forbidden marker: {forbidden}"
+        );
     }
     assert_contains_all(
         &content,
@@ -74,7 +76,10 @@ fn require(markers: &[&str]) {
 
 fn assert_contains_all(content: &str, markers: &[&str]) {
     for marker in markers {
-        assert!(content.contains(marker), "{EVIDENCE} missing marker: {marker}");
+        assert!(
+            content.contains(marker),
+            "{EVIDENCE} missing marker: {marker}"
+        );
     }
 }
 

--- a/crates/kamn-node/tests/pi_mcp_service_receipt_authority_slice_contract.rs
+++ b/crates/kamn-node/tests/pi_mcp_service_receipt_authority_slice_contract.rs
@@ -1,0 +1,60 @@
+use std::path::{Path, PathBuf};
+
+const RUNBOOK: &str = "docs/validation/pi-mcp-service-receipt-authority-slice.md";
+const INDEX: &str = "docs/validation/current-proven-runtime-slices.md";
+const RUNBOOK_MARKERS: &[&str] = &[
+    "# Pi/MCP Service-Receipt Authority Slice",
+    "make demo-agent-transaction",
+    "kamn.mcp.authority-receipt.v1",
+    "kamn.service.receipt-chain.v1",
+    "task:create -> task:accept -> escrow:fund -> task:complete",
+    "escrow:release-authorize -> settlement:confirmed",
+    "live-service-persisted-receipt",
+    "standalone verifier",
+    "not production readiness",
+    "not broad bridge finality",
+    "not generalized external settlement",
+];
+const INDEX_MARKERS: &[&str] = &[
+    "Pi/MCP service-receipt authority slice: `docs/validation/pi-mcp-service-receipt-authority-slice.md`",
+    "proves one bounded three-role Pi/MCP transaction",
+    "durable service receipts",
+    "`make demo-agent-transaction`",
+];
+
+#[test]
+fn pi_mcp_service_receipt_authority_runbook_is_bounded() {
+    assert_contains_all(
+        &read_workspace_file(RUNBOOK),
+        RUNBOOK_MARKERS,
+        "Pi/MCP authority runbook",
+    );
+}
+
+#[test]
+fn runtime_proof_index_includes_pi_mcp_authority_slice() {
+    assert_contains_all(
+        &read_workspace_file(INDEX),
+        INDEX_MARKERS,
+        "runtime proof index",
+    );
+}
+
+fn assert_contains_all(content: &str, markers: &[&str], label: &str) {
+    for marker in markers {
+        assert!(content.contains(marker), "{label} missing marker: {marker}");
+    }
+}
+
+fn read_workspace_file(relative_path: &str) -> String {
+    let path = workspace_root().join(relative_path);
+    std::fs::read_to_string(&path)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", path.display()))
+}
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("workspace root should resolve")
+}

--- a/docs/validation/current-proven-runtime-slices.md
+++ b/docs/validation/current-proven-runtime-slices.md
@@ -43,6 +43,8 @@ This index summarizes the runtime behavior that current `main` proves today thro
   - proves one bounded external-chain-backed escrow settlement lane
 - solana devnet asset-movement slice: `docs/validation/solana-devnet-asset-movement-slice.md`
   - proves one bounded live Solana devnet asset-movement lane
+- Pi/MCP service-receipt authority slice: `docs/validation/pi-mcp-service-receipt-authority-slice.md`
+  - `make demo-agent-transaction` proves one bounded three-role Pi/MCP transaction whose canonical authority comes from durable service receipts
 
 ## What Remains Unproven
 - broad production readiness

--- a/docs/validation/evidence/7126-fresh-checkout-pi-mcp-service-authority.md
+++ b/docs/validation/evidence/7126-fresh-checkout-pi-mcp-service-authority.md
@@ -1,0 +1,72 @@
+# 7126 Fresh-Checkout Pi/MCP Service Authority Evidence
+
+## Provenance
+
+- source_commit: 732b1d59027724632af16c4073ca4f1cbe27db31
+- clone_source: origin/main
+- clone_state: fresh
+- inherited_target: false
+- inherited_kamn_state: false
+- run_id: run-63361-1784859146830
+- make demo-agent-transaction: GO
+- standalone_verifier: PASS
+- children_exited_before_verifier: true
+
+## Service Authority
+
+- authority_schema: kamn.mcp.authority-receipt.v1
+- receipt_chain_schema: kamn.service.receipt-chain.v1
+- execution_surface: live-service-persisted-receipt
+- receipt_chain_commitment: sha256:eff3a939e3e3ba09d7ac33038d83a4a8c4ad190737f81a3d13ac8e7e8a67cf4e
+- service_receipt_commitment: sha256:618ebbe47a8520daba9399034d082324c82e73f30fe1360c5709617a4ee76e90
+- ordered_actions: task:create, task:accept, escrow:fund, task:complete,
+  escrow:release-authorize, settlement:confirmed
+- agent_a_view: participant-private
+- agent_b_view: participant-private
+- agent_c_view: restricted-public
+- agent_c_participant_private_field_count: 0
+
+All three actor observations bind the same task, transaction, escrow, finalized
+signature, receipt-chain commitment, and public commitment. Their report-bound
+observation receipt digests remain distinct.
+
+## Independent Solana Evidence
+
+- network: solana:devnet
+- settlement_commitment: finalized
+- settlement_tx_signature:
+  2VkJPvLPjK34KJd2LK294reNc1xFZdNif4P7wsB7VBA8vC1hnm5QrrSuxMJUJDsdGHBDiucvAUyRoanmveBiTBuq
+- finalized_slot: 478456906
+- transaction_error: null
+- fee_lamports: 5000
+- amount_lamports: 1000000
+- recipient_balance_before_lamports: 9000000
+- recipient_balance_after_lamports: 10000000
+- recipient_balance_delta_lamports: 1000000
+- transfer_count: 1
+- retry_duplicate_count: 0
+- rpc_verification: GO
+- explorer:
+  https://explorer.solana.com/tx/2VkJPvLPjK34KJd2LK294reNc1xFZdNif4P7wsB7VBA8vC1hnm5QrrSuxMJUJDsdGHBDiucvAUyRoanmveBiTBuq?cluster=devnet
+
+## Hygiene
+
+- transcript_sha256:
+  3d58a6768e24bdb0d326861f8a41aded6e49c323251181b05701b03ef050cd0d
+- transcript_and_proof_hygiene_scan: PASS
+- generated_agent_secret_scan: PASS
+
+This note contains no key material, environment values, transient checkout
+paths, or participant-private payloads.
+
+## Claim Boundary
+
+This proves one local KAMN three-agent transaction backed by durable service
+authority and one finalized Solana devnet test-token transfer.
+
+- not production readiness
+- not mainnet
+- not custody
+- not broad bridge finality
+- not generalized external settlement
+- devnet test tokens have no real economic value

--- a/docs/validation/pi-mcp-service-receipt-authority-slice.md
+++ b/docs/validation/pi-mcp-service-receipt-authority-slice.md
@@ -1,0 +1,76 @@
+# Pi/MCP Service-Receipt Authority Slice
+
+This runbook documents one bounded canonical three-role transaction on merged
+`main`. Its authority comes from service-persisted receipts collected through
+three independent Pi-driven MCP actors, not from actor-authored local evidence.
+
+## What This Proves
+
+- `make demo-agent-transaction` runs the canonical transaction path.
+- Each mutation response uses `kamn.mcp.authority-receipt.v1`.
+- The durable transcript uses `kamn.service.receipt-chain.v1`.
+- The receipt order is:
+  `task:create -> task:accept -> escrow:fund -> task:complete` followed by
+  `escrow:release-authorize -> settlement:confirmed`.
+- All three actors bind the same task, transaction, escrow, finalized
+  settlement signature, receipt-chain commitment, and public commitment.
+- Agent A and Agent B retain participant-private views while Agent C receives a
+  restricted-public view with zero participant-private fields.
+- Settlement evidence uses `live-service-persisted-receipt` and is reconciled
+  against independent finalized Solana devnet RPC evidence.
+- A standalone verifier runs after the Pi, MCP, node, and supervisor children
+  exit and recomputes the durable authority and settlement bindings.
+
+## What This Does Not Prove
+
+- not production readiness
+- not mainnet or custody safety
+- not real economic value beyond Solana devnet test tokens
+- not broad bridge finality
+- not generalized external settlement
+- not multi-authority release or Byzantine consensus
+
+## Stable Regression Commands
+
+```bash
+cargo test -p kamn-e2e-harness \
+  --test mvp_demo_runtime_receipt_chain_contract -- --nocapture
+cargo test -p kamn-e2e-harness \
+  --test agent_transaction_demo_success_contract -- --nocapture
+cargo test -p kamn-e2e-harness \
+  --test independent_agent_transaction_verifier_contract -- --nocapture
+cargo test -p kamn-node \
+  --test pi_mcp_service_receipt_authority_slice_contract -- --nocapture
+```
+
+## Live Command
+
+From a fresh checkout with the documented required Solana devnet
+configuration:
+
+```bash
+make demo-agent-transaction
+cargo run -p kamn-e2e-harness -- \
+  verify-mvp-demo --report .kamn/demo/latest/proof/report.json
+```
+
+The command must report `GO`, and the post-child standalone verifier must report
+`PASS`. A required devnet run hard-fails when persisted service authority,
+receipt-chain membership, transaction binding, or independent RPC evidence is
+missing or inconsistent.
+
+## Published Evidence
+
+The secret-safe fresh-checkout proof is recorded at
+`docs/validation/evidence/7126-fresh-checkout-pi-mcp-service-authority.md`.
+That note identifies the exact merged source commit, run ID, commitments, and
+finalized transaction facts without retaining keys, environment values,
+transient paths, or participant-private payloads.
+
+## Interpretation
+
+This is one executable bounded proof of service-backed Pi/MCP transaction
+authority. It is stronger than an ambient actor-evidence claim because the
+verifier recomputes membership in the durable ordered service receipt chain and
+binds the finalized settlement to the same transaction. It remains a devnet
+evaluation slice, not a production or generalized settlement guarantee.

--- a/specs/7159-pi-mcp-service-receipt-authority-proof-index.md
+++ b/specs/7159-pi-mcp-service-receipt-authority-proof-index.md
@@ -1,0 +1,95 @@
+# 7159 Pi/MCP Service-Receipt Authority Proof Index
+
+## Objective
+
+Publish one bounded, operator-readable proof slice for the canonical
+`make demo-agent-transaction` path and index it from the current runtime proof
+catalog without expanding the claims already proven by issue #7126.
+
+## Inputs / Outputs
+
+Inputs:
+- the merged canonical demo behavior on commit
+  `732b1d59027724632af16c4073ca4f1cbe27db31`
+- the fresh-checkout run `run-63361-1784859146830`
+- existing executable Pi/MCP authority and receipt-chain contracts
+
+Outputs:
+- a dedicated validation runbook
+- a redacted fresh-checkout evidence note
+- one proof-index entry
+- hard-fail Rust documentation contracts for the slice and evidence note
+
+## Boundaries / Non-Goals
+
+- Do not change runtime behavior.
+- Do not reuse the #7123 command-override rehearsal as service-authority proof.
+- Do not claim production readiness, mainnet custody, broad bridge finality,
+  generalized external settlement, or multi-authority release.
+- Do not publish secrets, environment values, key material, transient absolute
+  paths, or private actor receipt payloads.
+- Do not represent a bounded Solana devnet transfer as real economic value.
+
+## Failure Modes
+
+- The runtime proof index omits the canonical demo command or dedicated runbook.
+- The runbook omits service authority, receipt-chain membership, settlement
+  binding, or independent post-child verification.
+- The evidence note does not identify the exact source commit and fresh run.
+- The evidence note leaks secret-bearing material or transient paths.
+- The published proof overstates its runtime, custody, bridge, or settlement
+  boundaries.
+- A stale command-override artifact is presented as persisted service authority.
+
+## Acceptance Criteria
+
+- [ ] The runtime proof index links the dedicated Pi/MCP authority slice and
+      names `make demo-agent-transaction`.
+- [ ] The indexed claim is limited to one three-role Pi/MCP transaction whose
+      authority comes from durable service receipts.
+- [ ] The runbook identifies `kamn.mcp.authority-receipt.v1`,
+      `kamn.service.receipt-chain.v1`, the ordered service actions, shared public
+      commitments, actor-view boundaries, finalized settlement reconciliation,
+      and a standalone verifier after child exit.
+- [ ] The evidence note binds the exact merged commit, fresh run ID, canonical
+      command result, verifier result, receipt commitments, finalized devnet
+      transaction facts, one transfer, and zero retry duplicates.
+- [ ] The evidence note contains no secrets, key material, environment values,
+      or transient absolute paths.
+- [ ] Focused Rust contracts fail if required proof anchors or non-claims drift.
+- [ ] Existing canonical demo and runtime proof-index contracts remain green.
+
+## Files To Touch
+
+- `specs/7159-pi-mcp-service-receipt-authority-proof-index.md`
+- `docs/validation/pi-mcp-service-receipt-authority-slice.md`
+- `docs/validation/evidence/7126-fresh-checkout-pi-mcp-service-authority.md`
+- `docs/validation/current-proven-runtime-slices.md`
+- `crates/kamn-node/tests/pi_mcp_service_receipt_authority_slice_contract.rs`
+- `crates/kamn-e2e-harness/tests/pi_mcp_service_authority_evidence_contract.rs`
+
+## Error Semantics
+
+The proof contracts use hard assertions with a marker-specific failure message.
+Missing files, missing anchors, stale execution-surface language, leaked path
+markers, or missing non-claims fail the test. There is no fallback proof source.
+
+## Test Plan
+
+Red:
+- Add the slice contract before the runbook and index entry exist.
+- Add the evidence contract before the evidence note exists.
+- Run each focused target and capture the expected failures.
+
+Green:
+- Add the dedicated runbook, redacted evidence note, and proof-index entry.
+- Re-run both focused contracts.
+
+Refactor:
+- Remove duplicated prose where a stable link or evidence table is clearer.
+- Verify file and function size, formatting, names, and boundary language.
+
+Integration:
+- Run `runtime_proof_index_contract`.
+- Run the existing canonical demo runbook and authority contracts.
+- Run the touched crate test targets and formatting checks.


### PR DESCRIPTION
## Human Summary

- Adds a dedicated proof slice for the canonical three-role Pi/MCP transaction backed by durable service receipts.
- Publishes the secret-safe fresh-checkout #7126 evidence and links it from the current runtime proof index.
- Adds hard-fail contracts so service authority, finalized single-transfer evidence, privacy boundaries, and non-claims cannot silently drift.
- Changes no production runtime behavior.

## Testing

- `cargo test -p kamn-node --test runtime_proof_index_contract -- --nocapture`
- `cargo test -p kamn-node --test pi_mcp_service_receipt_authority_slice_contract -- --nocapture`
- `cargo test -p kamn-e2e-harness --test pi_mcp_service_authority_evidence_contract -- --nocapture`
- `cargo test -p kamn-e2e-harness --test mvp_evaluator_demo_runbook_contract -- --nocapture`
- `cargo test -p kamn-e2e-harness --test mvp_demo_runtime_receipt_chain_contract -- --nocapture`
- `cargo test -p kamn-e2e-harness --test agent_transaction_demo_success_contract -- --nocapture`
- `cargo test -p kamn-e2e-harness --test independent_agent_transaction_verifier_contract -- --nocapture`
- Focused Clippy for both new contracts with `-D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

## Notes for Reviewers

The published live facts come from the final fresh-checkout proof on merged commit `732b1d59027724632af16c4073ca4f1cbe27db31`. The older #7123 command-override rehearsal is intentionally not used as service-authority evidence.

Closes #7159
