### PR TITLE
docs: record external x402 authority probe

### DIFF
--- a/crates/kamn-e2e-harness/tests/external_a2a_x402_receipt_authority_contract.rs
+++ b/crates/kamn-e2e-harness/tests/external_a2a_x402_receipt_authority_contract.rs
@@ -36,7 +36,10 @@ fn failed_verdict_is_supported_by_observed_challenge() {
         false
     );
     assert_eq!(boolean(&evidence, "/challenge/nonce_observed"), false);
-    assert_eq!(boolean(&evidence, "/challenge/challenge_id_observed"), false);
+    assert_eq!(
+        boolean(&evidence, "/challenge/challenge_id_observed"),
+        false
+    );
     assert_eq!(boolean(&evidence, "/approval/observed"), false);
     assert_eq!(boolean(&evidence, "/settlement/observed"), false);
     assert_eq!(boolean(&evidence, "/service_result/observed"), false);
@@ -70,7 +73,10 @@ fn runbook_reports_evidence_boundaries() {
         "not KAMN service authority",
         "not production readiness",
     ] {
-        assert!(runbook.contains(marker), "{RUNBOOK} missing marker: {marker}");
+        assert!(
+            runbook.contains(marker),
+            "{RUNBOOK} missing marker: {marker}"
+        );
     }
 }
 

--- a/crates/kamn-e2e-harness/tests/external_a2a_x402_receipt_authority_contract.rs
+++ b/crates/kamn-e2e-harness/tests/external_a2a_x402_receipt_authority_contract.rs
@@ -30,19 +30,18 @@ fn discovery_and_challenge_payment_terms_are_consistent() {
 fn failed_verdict_is_supported_by_observed_challenge() {
     let evidence = read_json();
     assert_eq!(text(&evidence, "/verdict"), "FAIL");
-    assert_eq!(boolean(&evidence, "/challenge/observed"), true);
-    assert_eq!(
-        boolean(&evidence, "/challenge/request_body_digest_observed"),
-        false
+    assert!(boolean(&evidence, "/challenge/observed"));
+    assert_false_paths(
+        &evidence,
+        &[
+            "/challenge/request_body_digest_observed",
+            "/challenge/nonce_observed",
+            "/challenge/challenge_id_observed",
+            "/approval/observed",
+            "/settlement/observed",
+            "/service_result/observed",
+        ],
     );
-    assert_eq!(boolean(&evidence, "/challenge/nonce_observed"), false);
-    assert_eq!(
-        boolean(&evidence, "/challenge/challenge_id_observed"),
-        false
-    );
-    assert_eq!(boolean(&evidence, "/approval/observed"), false);
-    assert_eq!(boolean(&evidence, "/settlement/observed"), false);
-    assert_eq!(boolean(&evidence, "/service_result/observed"), false);
     assert!(text(&evidence, "/verdict_reason").contains("request binding"));
     assert!(text(&evidence, "/settlement_visibility").contains("no-funds"));
 }
@@ -50,9 +49,14 @@ fn failed_verdict_is_supported_by_observed_challenge() {
 #[test]
 fn evidence_preserves_no_funds_and_secret_safe_boundary() {
     let evidence = read_json();
-    assert_eq!(boolean(&evidence, "/safety/funds_spent"), false);
-    assert_eq!(boolean(&evidence, "/safety/credentials_used"), false);
-    assert_eq!(boolean(&evidence, "/safety/mark_paid_called"), false);
+    assert_false_paths(
+        &evidence,
+        &[
+            "/safety/funds_spent",
+            "/safety/credentials_used",
+            "/safety/mark_paid_called",
+        ],
+    );
     let raw = serde_json::to_string(&evidence).expect("evidence should serialize");
     for forbidden in ["private_key", "authorization", "payment-signature"] {
         assert!(!raw.to_lowercase().contains(forbidden), "found {forbidden}");
@@ -86,6 +90,12 @@ fn assert_equal_paths(value: &Value, left: &str, right: &str) {
         value.pointer(right),
         "mismatched evidence paths: {left} and {right}"
     );
+}
+
+fn assert_false_paths(value: &Value, paths: &[&str]) {
+    for path in paths {
+        assert!(!boolean(value, path), "expected false at {path}");
+    }
 }
 
 fn text<'a>(value: &'a Value, path: &str) -> &'a str {

--- a/crates/kamn-e2e-harness/tests/external_a2a_x402_receipt_authority_contract.rs
+++ b/crates/kamn-e2e-harness/tests/external_a2a_x402_receipt_authority_contract.rs
@@ -1,0 +1,104 @@
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+use std::path::PathBuf;
+
+const EVIDENCE: &str = "docs/validation/evidence/7162-external-a2a-x402-observation.json";
+const RUNBOOK: &str = "docs/validation/external-a2a-x402-receipt-authority-probe.md";
+
+#[test]
+fn observed_request_digest_is_recomputable() {
+    let evidence = read_json();
+    let body = text(&evidence, "/request/canonical_body");
+    let expected = format!("sha256:{:x}", Sha256::digest(body.as_bytes()));
+    assert_eq!(text(&evidence, "/request/body_sha256"), expected);
+}
+
+#[test]
+fn discovery_and_challenge_payment_terms_are_consistent() {
+    let evidence = read_json();
+    for field in ["network", "asset", "pay_to"] {
+        assert_equal_paths(
+            &evidence,
+            &format!("/discovery/{field}"),
+            &format!("/challenge/{field}"),
+        );
+    }
+    assert_equal_paths(&evidence, "/discovery/price_usd", "/challenge/amount_usd");
+}
+
+#[test]
+fn blocked_verdict_is_supported_by_observed_stages() {
+    let evidence = read_json();
+    assert_eq!(text(&evidence, "/verdict"), "BLOCKED");
+    assert_eq!(boolean(&evidence, "/challenge/observed"), true);
+    assert_eq!(boolean(&evidence, "/approval/observed"), false);
+    assert_eq!(boolean(&evidence, "/settlement/observed"), false);
+    assert_eq!(boolean(&evidence, "/service_result/observed"), false);
+    assert!(text(&evidence, "/verdict_reason").contains("no-funds"));
+}
+
+#[test]
+fn evidence_preserves_no_funds_and_secret_safe_boundary() {
+    let evidence = read_json();
+    assert_eq!(boolean(&evidence, "/safety/funds_spent"), false);
+    assert_eq!(boolean(&evidence, "/safety/credentials_used"), false);
+    assert_eq!(boolean(&evidence, "/safety/mark_paid_called"), false);
+    let raw = serde_json::to_string(&evidence).expect("evidence should serialize");
+    for forbidden in ["private_key", "authorization", "payment-signature"] {
+        assert!(!raw.to_lowercase().contains(forbidden), "found {forbidden}");
+    }
+}
+
+#[test]
+fn runbook_reports_evidence_boundaries() {
+    let runbook = read_file(RUNBOOK);
+    for marker in [
+        "# External A2A x402 Receipt-Authority Probe",
+        "Verdict: BLOCKED",
+        "unpaid x402 challenge",
+        "request body digest",
+        "no approval response was observed",
+        "no settlement response was observed",
+        "not KAMN service authority",
+        "not production readiness",
+    ] {
+        assert!(runbook.contains(marker), "{RUNBOOK} missing marker: {marker}");
+    }
+}
+
+fn assert_equal_paths(value: &Value, left: &str, right: &str) {
+    assert_eq!(
+        value.pointer(left),
+        value.pointer(right),
+        "mismatched evidence paths: {left} and {right}"
+    );
+}
+
+fn text<'a>(value: &'a Value, path: &str) -> &'a str {
+    value
+        .pointer(path)
+        .and_then(Value::as_str)
+        .unwrap_or_else(|| panic!("expected string at {path}"))
+}
+
+fn boolean(value: &Value, path: &str) -> bool {
+    value
+        .pointer(path)
+        .and_then(Value::as_bool)
+        .unwrap_or_else(|| panic!("expected bool at {path}"))
+}
+
+fn read_json() -> Value {
+    serde_json::from_str(&read_file(EVIDENCE))
+        .unwrap_or_else(|error| panic!("{EVIDENCE} should contain JSON: {error}"))
+}
+
+fn read_file(relative: &str) -> String {
+    let path = repo_root().join(relative);
+    std::fs::read_to_string(&path)
+        .unwrap_or_else(|error| panic!("{} should be readable: {error}", path.display()))
+}
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..")
+}

--- a/crates/kamn-e2e-harness/tests/external_a2a_x402_receipt_authority_contract.rs
+++ b/crates/kamn-e2e-harness/tests/external_a2a_x402_receipt_authority_contract.rs
@@ -27,14 +27,21 @@ fn discovery_and_challenge_payment_terms_are_consistent() {
 }
 
 #[test]
-fn blocked_verdict_is_supported_by_observed_stages() {
+fn failed_verdict_is_supported_by_observed_challenge() {
     let evidence = read_json();
-    assert_eq!(text(&evidence, "/verdict"), "BLOCKED");
+    assert_eq!(text(&evidence, "/verdict"), "FAIL");
     assert_eq!(boolean(&evidence, "/challenge/observed"), true);
+    assert_eq!(
+        boolean(&evidence, "/challenge/request_body_digest_observed"),
+        false
+    );
+    assert_eq!(boolean(&evidence, "/challenge/nonce_observed"), false);
+    assert_eq!(boolean(&evidence, "/challenge/challenge_id_observed"), false);
     assert_eq!(boolean(&evidence, "/approval/observed"), false);
     assert_eq!(boolean(&evidence, "/settlement/observed"), false);
     assert_eq!(boolean(&evidence, "/service_result/observed"), false);
-    assert!(text(&evidence, "/verdict_reason").contains("no-funds"));
+    assert!(text(&evidence, "/verdict_reason").contains("request binding"));
+    assert!(text(&evidence, "/settlement_visibility").contains("no-funds"));
 }
 
 #[test]
@@ -54,9 +61,10 @@ fn runbook_reports_evidence_boundaries() {
     let runbook = read_file(RUNBOOK);
     for marker in [
         "# External A2A x402 Receipt-Authority Probe",
-        "Verdict: BLOCKED",
+        "Verdict: FAIL",
         "unpaid x402 challenge",
         "request body digest",
+        "no nonce or challenge ID",
         "no approval response was observed",
         "no settlement response was observed",
         "not KAMN service authority",

--- a/docs/validation/evidence/7162-external-a2a-x402-observation.json
+++ b/docs/validation/evidence/7162-external-a2a-x402-observation.json
@@ -1,0 +1,59 @@
+{
+  "schema_version": "kamn.external-a2a-x402-observation.v1",
+  "observed_at_utc": "2026-07-24T02:52:35.735Z",
+  "endpoint": "https://a2a.elonsusk.com/x402/file.deliver",
+  "discovery": {
+    "agent_card_sha256": "sha256:c89c74feb8579e90e74d040658c238bcaf6c7206c0e5d6a3ffe1370f1687c4b5",
+    "x402_manifest_sha256": "sha256:2deb0ad8a89bc3475f93943387a3e52ca0cc9e51da8870b73ff6c489a1b7fa1c",
+    "openapi_sha256": "sha256:96c2e4e514cce819f4f03ed7ce565f11ee30f9fc8ab5f82a8a0718104cede3a8",
+    "x402_version": 2,
+    "flow": ["challenge", "sign", "retry", "settle"],
+    "network": "solana:demo",
+    "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+    "pay_to": "51XM6Q4W5RwCHD1BDkbpoRDZDYgyfgGb2UkekuzT8GPC",
+    "price_usd": 0.02
+  },
+  "request": {
+    "method": "POST",
+    "path": "/x402/file.deliver",
+    "canonical_body": "{\"prompt\":\"KAMN no-funds receipt-authority conformance probe\"}",
+    "body_sha256": "sha256:11393458e0b4957d114dbc79a4452d67b1b78241206fc320b626c9b31826066b"
+  },
+  "challenge": {
+    "observed": true,
+    "http_status": 402,
+    "x402_version": 2,
+    "network": "solana:demo",
+    "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+    "pay_to": "51XM6Q4W5RwCHD1BDkbpoRDZDYgyfgGb2UkekuzT8GPC",
+    "amount_atomic": "20000",
+    "amount_usd": 0.02,
+    "max_timeout_seconds": 120,
+    "challenge_body_sha256": "sha256:1d322cc5548e1566422b8237868ee25019791047f81443fb7181ebc757d34dd6",
+    "request_body_digest_observed": false,
+    "nonce_observed": false,
+    "challenge_id_observed": false,
+    "expiry_timestamp_observed": false
+  },
+  "approval": {
+    "observed": false,
+    "reason": "Unsigned challenge only; no demo or production signature was sent."
+  },
+  "settlement": {
+    "observed": false,
+    "reason": "Signed retry was outside the no-funds and no-credentials boundary."
+  },
+  "service_result": {
+    "observed": false,
+    "reason": "The service result is gated behind the unperformed signed retry."
+  },
+  "verdict": "FAIL",
+  "verdict_reason": "The observed challenge has payment terms but no request binding, nonce, challenge ID, or expiry timestamp.",
+  "settlement_visibility": "BLOCKED by the no-funds and no-credentials boundary.",
+  "safety": {
+    "funds_spent": false,
+    "credentials_used": false,
+    "mark_paid_called": false,
+    "signed_retry_sent": false
+  }
+}

--- a/docs/validation/external-a2a-x402-receipt-authority-probe.md
+++ b/docs/validation/external-a2a-x402-receipt-authority-probe.md
@@ -1,0 +1,84 @@
+# External A2A x402 Receipt-Authority Probe
+
+## Verdict: FAIL
+
+The bounded probe observed a valid unpaid x402 challenge, but it did not observe
+a request body digest, nonce, challenge ID, or expiry timestamp in that
+challenge. The advertised signing hint names a nonce without supplying one.
+The challenge therefore does not expose enough information to bind an approval
+or later settlement to this exact request.
+
+Settlement visibility is separately `BLOCKED`: no signed retry, payment, real
+wallet, credential, or invoice action was permitted by this probe.
+
+## Scope
+
+- Public peer: `https://a2a.elonsusk.com`
+- Endpoint: `POST /x402/file.deliver`
+- Observation time: `2026-07-24T02:52:35.735Z`
+- One unsigned request with no payment or authorization material
+- Normalized evidence:
+  `docs/validation/evidence/7162-external-a2a-x402-observation.json`
+
+## Observed Exchange
+
+1. Public agent-card, x402 manifest, and OpenAPI bytes returned HTTP `200`.
+2. The request used a fixed canonical JSON body and a locally recomputed
+   request body digest.
+3. The service returned HTTP `402` and payment terms for `solana:demo`.
+4. Network, asset, payee, and USD amount matched public discovery.
+5. The challenge exposed no nonce or challenge ID, no request body digest, and
+   no absolute expiry timestamp.
+6. No approval response was observed.
+7. No settlement response was observed.
+8. No service result was observed.
+
+In exact terms, no approval response was observed; no settlement response was observed.
+
+The hashes in the evidence fixture are observer-computed integrity markers.
+They are not issuer receipts and are not KAMN service authority.
+
+## Authority Criteria
+
+A passing peer-authority exchange would need to make these bindings
+independently verifiable:
+
+- request payload to quote or challenge
+- challenge terms to a stable nonce, identifier, and expiry
+- approval to request, challenge, payer, payee, asset, network, and amount
+- settlement to the approved challenge and an authoritative chain transaction
+- service result to the same settlement receipt
+
+The observed challenge satisfies payment-term consistency but not the first two
+bindings. Later stages cannot repair an approval that was not tied to a unique
+request and challenge.
+
+## Operator Command
+
+The live request is intentionally a single unsigned POST:
+
+```text
+POST https://a2a.elonsusk.com/x402/file.deliver
+content-type: application/json
+
+{"prompt":"KAMN no-funds receipt-authority conformance probe"}
+```
+
+Expected safe response:
+
+- HTTP `402`
+- x402 version `2`
+- demo-network payment terms
+- no signed retry and no side-effecting service result
+
+## What This Does Not Prove
+
+- not KAMN service authority
+- not successful approval or settlement
+- not payment correctness or one-transfer idempotence
+- not production readiness
+- not mainnet safety, custody, or economic finality
+- not security of the external service
+
+The result applies only to the exact public exchange and response shape observed
+at the timestamp above.

--- a/specs/7162-external-a2a-x402-receipt-authority-probe.md
+++ b/specs/7162-external-a2a-x402-receipt-authority-probe.md
@@ -1,0 +1,97 @@
+# 7162 External A2A x402 Receipt-Authority Probe
+
+## Objective
+
+Determine whether the supplied public A2A/x402 contractor exposes
+independently verifiable bindings across request, payment challenge, approval,
+settlement, and service result without spending funds or using credentials.
+
+## Inputs / Outputs
+
+Inputs:
+- `https://a2a.elonsusk.com/.well-known/agent-card.json`
+- `https://a2a.elonsusk.com/.well-known/x402.json`
+- `https://a2a.elonsusk.com/openapi.json`
+- an unpaid request to one advertised x402 endpoint
+- an optional documented demo-only approval that cannot move real assets
+
+Outputs:
+- a redacted protocol observation fixture
+- a deterministic conformance verdict
+- an operator-readable validation note
+- an opt-in live no-funds probe
+
+## Boundaries / Non-Goals
+
+- Do not pay an invoice or invoke `mark-paid`.
+- Do not use a real wallet, private key, API token, or production credential.
+- Do not claim external assertions are KAMN service authority.
+- Do not claim the external service is secure, production-ready, or compliant
+  beyond the exact observed exchange.
+- Do not retain arbitrary service output or personal information.
+- Do not require live network access for offline regression tests.
+
+## Failure Modes
+
+- Discovery and challenge disagree on network, asset, amount, or payee.
+- A challenge lacks a stable request, quote, or payment-requirement identifier.
+- Approval is not bound to the challenge and original request.
+- Settlement is not bound to approval, challenge, request, and service result.
+- A digest is present but cannot be recomputed from defined canonical fields.
+- The service returns only ambient actor evidence or opaque assertions.
+- The no-funds boundary prevents observing settlement.
+- A captured artifact includes secrets or authorization material.
+
+## Verdict Semantics
+
+- `PASS`: every required stage is observed and joined by recomputable
+  cryptographic bindings or an equivalent independently verifiable proof.
+- `FAIL`: an observed stage omits, contradicts, or breaks a required binding.
+- `BLOCKED`: settlement cannot be observed without crossing the no-funds or
+  no-credentials boundary. Discovery and challenge findings remain reportable.
+
+## Acceptance Criteria
+
+- [ ] Public discovery and challenge response shapes are captured with UTC
+      timestamps and secret-safe redaction.
+- [ ] The validator checks request, quote/challenge, approval, settlement,
+      service result, payer, payee, asset, network, and amount bindings.
+- [ ] Any claimed digest is recomputed from explicitly defined canonical fields.
+- [ ] The live probe performs no payment and uses no production credential.
+- [ ] Missing evidence yields `FAIL` or `BLOCKED`, never inferred trust.
+- [ ] The validation note records observed evidence and exact non-claims.
+- [ ] Offline contract tests remain deterministic without network access.
+
+## Files To Touch
+
+- `specs/7162-external-a2a-x402-receipt-authority-probe.md`
+- `docs/validation/external-a2a-x402-receipt-authority-probe.md`
+- `docs/validation/evidence/7162-external-a2a-x402-observation.json`
+- `crates/kamn-e2e-harness/tests/external_a2a_x402_receipt_authority_contract.rs`
+
+## Error Semantics
+
+The offline validator hard-fails malformed fixtures, inconsistent discovery and
+challenge fields, invalid digest encodings, or a verdict unsupported by the
+observed stages. Network errors in the opt-in live probe produce `BLOCKED` with
+an explicit reason; they never fall back to a passing fixture.
+
+## Test Plan
+
+Red:
+- Add a focused contract requiring the evidence fixture and validation note.
+- Confirm it fails before either artifact exists.
+
+Green:
+- Perform the bounded live discovery and unpaid challenge.
+- Store only the normalized, redacted observations.
+- Add the validation note with the evidence-supported verdict.
+- Make the focused offline contract pass.
+
+Refactor:
+- Keep canonical field and digest checks centralized in the focused contract.
+- Remove redundant raw response fields and verify secret hygiene.
+
+Integration:
+- Re-run the no-funds live request and compare invariant protocol fields.
+- Run the focused offline contract and the existing authority contracts.


### PR DESCRIPTION
## Human Summary

- Records one no-funds unsigned x402 challenge against the supplied external A2A contractor.
- Classifies receipt authority as `FAIL` because the observed challenge omits a request digest, nonce, challenge ID, and absolute expiry.
- Stores only normalized fields and observer-computed hashes; no payment header, credential, signature, or private material is retained.
- Adds an offline deterministic contract and keeps settlement visibility explicitly `BLOCKED` by the no-funds boundary.

## Testing

- Manual live check: one unsigned `POST https://a2a.elonsusk.com/x402/file.deliver`, observed HTTP `402`; no signed retry or payment.
- `cargo test -p kamn-e2e-harness --test external_a2a_x402_receipt_authority_contract -- --nocapture`
- `cargo test -p kamn-mcp-server --test authority_receipt_contract -- --nocapture`
- `cargo clippy -p kamn-e2e-harness --test external_a2a_x402_receipt_authority_contract -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

## Notes for Reviewers

The verdict applies only to the exact exchange observed at `2026-07-24T02:52:35.735Z`. Observer-computed hashes are integrity markers, not issuer receipts and not KAMN service authority. Approval, settlement, replay, and service-result stages were not exercised because they cross the no-funds boundary.

Closes #7162
