### PR TITLE
[7161] Unify authoritative settlement evidence across drivers

### DIFF
--- a/crates/kamn-agent-lib/src/lib.rs
+++ b/crates/kamn-agent-lib/src/lib.rs
@@ -15,8 +15,8 @@ pub use identity::AgentIdentity;
 pub use kolme::{KolmeProofReceipt, KolmeProofVerification};
 
 pub use kamn_sdk::{
-    AgentMetadata, ServiceAgentProfile, ServiceAuthoritativeSettlement, ServiceBridgeStatus,
-    ServiceBridgeSubmission, ServiceChannelMessages, ServiceChannelReceipt,
+    AgentMetadata, ServiceAgentProfile, ServiceAuthoritativeSettlement, ServiceBridgeReceipt,
+    ServiceBridgeStatus, ServiceBridgeSubmission, ServiceChannelMessages, ServiceChannelReceipt,
     ServiceContentRegistration, ServiceContentStatus, ServiceEscrowStatus, ServiceHealthStatus,
     ServiceMessageReceipt, ServiceMessageStatus, ServiceTaskReceipt, ServiceTaskStatus,
     ServiceTaskTransitionReceipt,

--- a/crates/kamn-agent-lib/src/lib.rs
+++ b/crates/kamn-agent-lib/src/lib.rs
@@ -15,10 +15,11 @@ pub use identity::AgentIdentity;
 pub use kolme::{KolmeProofReceipt, KolmeProofVerification};
 
 pub use kamn_sdk::{
-    AgentMetadata, ServiceAgentProfile, ServiceBridgeStatus, ServiceBridgeSubmission,
-    ServiceChannelMessages, ServiceChannelReceipt, ServiceContentRegistration,
-    ServiceContentStatus, ServiceEscrowStatus, ServiceHealthStatus, ServiceMessageReceipt,
-    ServiceMessageStatus, ServiceTaskReceipt, ServiceTaskStatus, ServiceTaskTransitionReceipt,
+    AgentMetadata, ServiceAgentProfile, ServiceAuthoritativeSettlement, ServiceBridgeStatus,
+    ServiceBridgeSubmission, ServiceChannelMessages, ServiceChannelReceipt,
+    ServiceContentRegistration, ServiceContentStatus, ServiceEscrowStatus, ServiceHealthStatus,
+    ServiceMessageReceipt, ServiceMessageStatus, ServiceTaskReceipt, ServiceTaskStatus,
+    ServiceTaskTransitionReceipt,
 };
 
 /// Authentication helpers.

--- a/crates/kamn-cli/src/commands/forward_bridge_message.rs
+++ b/crates/kamn-cli/src/commands/forward_bridge_message.rs
@@ -7,7 +7,7 @@ pub fn execute(args: &ParsedCliArgs) -> Result<CommandOutput, AgentLibError> {
     let bridge_id = required_arg(args, 0, "forward_bridge_message_id")?;
     let handle = connect_handle(args)?;
     let status = handle.forward_bridge_message(bridge_id)?;
-    Ok(command_output(vec![
+    let mut fields = vec![
         ("bridge_id", OutputValue::String(status.bridge_id)),
         ("bridge_status", OutputValue::String(status.bridge_status)),
         (
@@ -18,5 +18,23 @@ pub fn execute(args: &ParsedCliArgs) -> Result<CommandOutput, AgentLibError> {
             "forward_tx_hash",
             OutputValue::String(status.forward_tx_hash),
         ),
-    ]))
+    ];
+    if let Some(receipt) = status.bridge_receipt {
+        fields.extend([
+            ("receipt_id", OutputValue::String(receipt.receipt_id)),
+            (
+                "bridge_receipt_digest",
+                OutputValue::String(receipt.receipt_digest),
+            ),
+            (
+                "transaction_signature",
+                OutputValue::String(receipt.transaction_signature),
+            ),
+            (
+                "finalized_slot",
+                OutputValue::Raw(receipt.finalized_slot.to_string()),
+            ),
+        ]);
+    }
+    Ok(command_output(fields))
 }

--- a/crates/kamn-cli/src/commands/release_escrow.rs
+++ b/crates/kamn-cli/src/commands/release_escrow.rs
@@ -1,14 +1,91 @@
 use crate::commands::{command_output, connect_handle, required_arg, OutputValue};
 use crate::{CommandOutput, ParsedCliArgs};
-use kamn_agent_lib::AgentLibError;
+use kamn_agent_lib::{AgentLibError, ServiceAuthoritativeSettlement};
 
 /// Executes the release_escrow command.
 pub fn execute(args: &ParsedCliArgs) -> Result<CommandOutput, AgentLibError> {
     let escrow_id = required_arg(args, 0, "escrow_id")?;
     let handle = connect_handle(args)?;
-    let receipt = handle.release_escrow(escrow_id)?;
-    Ok(command_output(vec![
+    let receipt = match args.passthrough.get(1) {
+        Some(idempotency) => handle.release_escrow_with_payload(
+            escrow_id,
+            release_payload(idempotency, args.passthrough.get(2)).as_str(),
+        )?,
+        None => handle.release_escrow(escrow_id)?,
+    };
+    let mut fields = vec![
         ("escrow_id", OutputValue::String(receipt.escrow_id)),
         ("state", OutputValue::String(receipt.state)),
-    ]))
+    ];
+    if let Some(authority) = receipt.authoritative_settlement {
+        fields.extend(authority_fields(authority));
+    }
+    Ok(command_output(fields))
+}
+
+fn release_payload(idempotency: &str, bridge_id: Option<&String>) -> String {
+    match bridge_id {
+        Some(bridge_id) => serde_json::json!({
+            "idempotency_key": idempotency,
+            "authority_mode": "bridge-receipt",
+            "bridge_id": bridge_id,
+        })
+        .to_string(),
+        None => serde_json::json!({"idempotency_key": idempotency}).to_string(),
+    }
+}
+
+fn authority_fields(value: ServiceAuthoritativeSettlement) -> Vec<(&'static str, OutputValue)> {
+    vec![
+        ("bridge_id", OutputValue::String(value.bridge_id)),
+        (
+            "bridge_receipt_id",
+            OutputValue::String(value.bridge_receipt_id),
+        ),
+        (
+            "bridge_receipt_digest",
+            OutputValue::String(value.bridge_receipt_digest),
+        ),
+        (
+            "settlement_receipt_id",
+            OutputValue::String(value.settlement_receipt_id),
+        ),
+        (
+            "settlement_receipt_digest",
+            OutputValue::String(value.settlement_receipt_digest),
+        ),
+        ("action", OutputValue::String(value.action)),
+        ("resource_id", OutputValue::String(value.resource_id)),
+        ("actor_did", OutputValue::String(value.actor_did)),
+        (
+            "resulting_state",
+            OutputValue::String(value.resulting_state),
+        ),
+        ("task_id", OutputValue::String(value.task_id)),
+        ("recipient", OutputValue::String(value.recipient)),
+        (
+            "amount_lamports",
+            OutputValue::Raw(value.amount_lamports.to_string()),
+        ),
+        ("asset", OutputValue::String(value.asset)),
+        ("network", OutputValue::String(value.network)),
+        (
+            "transaction_signature",
+            OutputValue::String(value.transaction_signature),
+        ),
+        ("commitment", OutputValue::String(value.commitment)),
+        (
+            "finalized_slot",
+            OutputValue::Raw(value.finalized_slot.to_string()),
+        ),
+        (
+            "receipt_chain_commitment",
+            OutputValue::String(value.receipt_chain_commitment),
+        ),
+        ("terms_digest", OutputValue::String(value.terms_digest)),
+        (
+            "idempotency_key",
+            OutputValue::String(value.idempotency_key),
+        ),
+    ]
 }

--- a/crates/kamn-e2e-harness/src/drivers/authoritative_settlement_observation.rs
+++ b/crates/kamn-e2e-harness/src/drivers/authoritative_settlement_observation.rs
@@ -1,0 +1,167 @@
+use serde::Deserialize;
+use serde_json::Value;
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+/// Driver-neutral projection of service-issued settlement authority.
+pub struct AuthoritativeSettlementObservation {
+    /// Bridge operation identifier.
+    pub bridge_id: String,
+    /// Finalized bridge receipt identifier.
+    pub bridge_receipt_id: String,
+    /// Finalized bridge receipt digest.
+    pub bridge_receipt_digest: String,
+    /// Settlement receipt identifier.
+    pub settlement_receipt_id: String,
+    /// Settlement receipt digest.
+    pub settlement_receipt_digest: String,
+    /// Canonical settlement action.
+    pub action: String,
+    /// Bound resource identifier.
+    pub resource_id: String,
+    /// Authenticated actor DID.
+    pub actor_did: String,
+    /// Resulting settlement state.
+    pub resulting_state: String,
+    /// Bound task identifier.
+    pub task_id: String,
+    /// Bound escrow identifier.
+    pub escrow_id: String,
+    /// Settlement recipient.
+    pub recipient: String,
+    /// Settled amount in lamports.
+    pub amount_lamports: u64,
+    /// Settled asset marker.
+    pub asset: String,
+    /// Settlement network.
+    pub network: String,
+    /// Finalized transaction signature.
+    pub transaction_signature: String,
+    /// Finality commitment.
+    pub commitment: String,
+    /// Finalized network slot.
+    pub finalized_slot: u64,
+    /// Full receipt-chain commitment.
+    pub receipt_chain_commitment: String,
+    /// Economic terms commitment.
+    pub terms_digest: String,
+    /// Durable operation identity.
+    pub idempotency_key: String,
+}
+
+/// Normalizes and validates one service-issued settlement authority object.
+pub fn normalize_authoritative_settlement(
+    value: &Value,
+    expected_escrow: &str,
+    expected_actor: &str,
+) -> Result<AuthoritativeSettlementObservation, String> {
+    let source = value.get("authoritative_settlement").unwrap_or(value);
+    let observation = serde_json::from_value::<AuthoritativeSettlementObservation>(source.clone())
+        .map_err(|_| "SERVICE_AUTHORITY_MISSING".to_owned())?;
+    validate_receipt_chain_commitment(&observation)?;
+    validate_bridge_receipt_digest(&observation)?;
+    validate_settlement_receipt_digest(&observation)?;
+    validate_economic_terms(&observation, expected_escrow, expected_actor)?;
+    Ok(observation)
+}
+
+fn validate_receipt_chain_commitment(
+    value: &AuthoritativeSettlementObservation,
+) -> Result<(), String> {
+    validate_digest(value.receipt_chain_commitment.as_str())
+}
+
+fn validate_bridge_receipt_digest(
+    value: &AuthoritativeSettlementObservation,
+) -> Result<(), String> {
+    validate_digest(value.bridge_receipt_digest.as_str())
+}
+
+fn validate_settlement_receipt_digest(
+    value: &AuthoritativeSettlementObservation,
+) -> Result<(), String> {
+    validate_digest(value.settlement_receipt_digest.as_str())
+}
+
+fn validate_economic_terms(
+    value: &AuthoritativeSettlementObservation,
+    expected_escrow: &str,
+    expected_actor: &str,
+) -> Result<(), String> {
+    let valid = value.escrow_id == expected_escrow
+        && value.resource_id == expected_escrow
+        && value.actor_did == expected_actor
+        && value.action == "settlement:confirmed"
+        && value.resulting_state == "confirmed"
+        && value.network == "solana:devnet"
+        && value.commitment == "finalized"
+        && value.finalized_slot > 0
+        && value.amount_lamports > 0
+        && !value.terms_digest.is_empty()
+        && required_values(value).iter().all(|field| !field.is_empty());
+    valid
+        .then_some(())
+        .ok_or_else(|| "SERVICE_AUTHORITY_MISMATCH".to_owned())
+}
+
+fn required_values(value: &AuthoritativeSettlementObservation) -> [&str; 9] {
+    [
+        value.bridge_id.as_str(),
+        value.bridge_receipt_id.as_str(),
+        value.settlement_receipt_id.as_str(),
+        value.task_id.as_str(),
+        value.recipient.as_str(),
+        value.asset.as_str(),
+        value.transaction_signature.as_str(),
+        value.idempotency_key.as_str(),
+        value.actor_did.as_str(),
+    ]
+}
+
+fn validate_digest(value: &str) -> Result<(), String> {
+    let valid = value.strip_prefix("sha256:").is_some_and(|hex| {
+        hex.len() == 64
+            && hex
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    });
+    valid
+        .then_some(())
+        .ok_or_else(|| "SERVICE_AUTHORITY_DIGEST_INVALID".to_owned())
+}
+
+#[derive(Debug, Default)]
+/// Rejects reordered operations and cross-resource receipt replay.
+pub struct AuthoritativeSettlementReplayGuard {
+    operations: HashMap<String, AuthoritativeSettlementObservation>,
+    bridge_receipts: HashMap<String, String>,
+}
+
+impl AuthoritativeSettlementReplayGuard {
+    /// Records one observation or rejects conflicting reuse.
+    pub fn observe(&mut self, value: &AuthoritativeSettlementObservation) -> Result<(), String> {
+        reject_replay(&self.operations, &self.bridge_receipts, value)?;
+        self.operations
+            .insert(value.idempotency_key.clone(), value.clone());
+        self.bridge_receipts
+            .insert(value.bridge_receipt_digest.clone(), value.escrow_id.clone());
+        Ok(())
+    }
+}
+
+fn reject_replay(
+    operations: &HashMap<String, AuthoritativeSettlementObservation>,
+    receipts: &HashMap<String, String>,
+    value: &AuthoritativeSettlementObservation,
+) -> Result<(), String> {
+    if operations
+        .get(value.idempotency_key.as_str())
+        .is_some_and(|existing| existing != value)
+        || receipts
+            .get(value.bridge_receipt_digest.as_str())
+            .is_some_and(|escrow| escrow != &value.escrow_id)
+    {
+        return Err("SERVICE_AUTHORITY_REPLAY".to_owned());
+    }
+    Ok(())
+}

--- a/crates/kamn-e2e-harness/src/drivers/mod.rs
+++ b/crates/kamn-e2e-harness/src/drivers/mod.rs
@@ -1,11 +1,16 @@
 use crate::ExecutionMode;
 
+mod authoritative_settlement_observation;
 /// CLI-scripted mode driver.
 pub mod cli_scripted;
 /// MCP-agent mode driver.
 pub mod mcp_agent;
 /// SDK-direct mode driver.
 pub mod sdk_direct;
+pub use authoritative_settlement_observation::{
+    normalize_authoritative_settlement, AuthoritativeSettlementObservation,
+    AuthoritativeSettlementReplayGuard,
+};
 /// Shared helper surface for duplicated driver internals.
 pub(crate) mod shared_helpers;
 

--- a/crates/kamn-e2e-harness/tests/authoritative_settlement_driver_parity_contract.rs
+++ b/crates/kamn-e2e-harness/tests/authoritative_settlement_driver_parity_contract.rs
@@ -3,10 +3,10 @@ use std::path::{Path, PathBuf};
 const SDK_MODELS: &str = "crates/kamn-sdk/src/service_models.rs";
 const CLI_RELEASE: &str = "crates/kamn-cli/src/commands/release_escrow.rs";
 const MCP_AUTHORITY: &str = "crates/kamn-mcp-server/src/authority.rs";
+const NODE_ESCROW_MODELS: &str = "crates/kamn-node/src/service_api_endpoint/escrow_models.rs";
 const NORMALIZER: &str =
     "crates/kamn-e2e-harness/src/drivers/authoritative_settlement_observation.rs";
-const RUNBOOK: &str =
-    "docs/validation/authoritative-live-settlement-driver-parity-slice.md";
+const RUNBOOK: &str = "docs/validation/authoritative-live-settlement-driver-parity-slice.md";
 
 #[test]
 fn sdk_exposes_complete_authoritative_receipt() {
@@ -20,6 +20,20 @@ fn sdk_exposes_complete_authoritative_receipt() {
             "finalized_slot",
         ],
         "SDK service models",
+    );
+}
+
+#[test]
+fn node_emits_one_canonical_authoritative_settlement() {
+    assert_contains_all(
+        &read(NODE_ESCROW_MODELS),
+        &[
+            "ServiceApiAuthoritativeSettlement",
+            "authoritative_settlement",
+            "receipt_chain_commitment",
+            "finalized_slot",
+        ],
+        "node escrow response",
     );
 }
 

--- a/crates/kamn-e2e-harness/tests/authoritative_settlement_driver_parity_contract.rs
+++ b/crates/kamn-e2e-harness/tests/authoritative_settlement_driver_parity_contract.rs
@@ -1,0 +1,105 @@
+use std::path::{Path, PathBuf};
+
+const SDK_MODELS: &str = "crates/kamn-sdk/src/service_models.rs";
+const CLI_RELEASE: &str = "crates/kamn-cli/src/commands/release_escrow.rs";
+const MCP_AUTHORITY: &str = "crates/kamn-mcp-server/src/authority.rs";
+const NORMALIZER: &str =
+    "crates/kamn-e2e-harness/src/drivers/authoritative_settlement_observation.rs";
+const RUNBOOK: &str =
+    "docs/validation/authoritative-live-settlement-driver-parity-slice.md";
+
+#[test]
+fn sdk_exposes_complete_authoritative_receipt() {
+    assert_contains_all(
+        &read(SDK_MODELS),
+        &[
+            "bridge_receipt_digest",
+            "settlement_receipt_digest",
+            "receipt_chain_commitment",
+            "transaction_signature",
+            "finalized_slot",
+        ],
+        "SDK service models",
+    );
+}
+
+#[test]
+fn cli_emits_receipt_authority_and_idempotency_identity() {
+    assert_contains_all(
+        &read(CLI_RELEASE),
+        &[
+            "bridge_receipt_digest",
+            "settlement_receipt_digest",
+            "receipt_chain_commitment",
+            "idempotency",
+        ],
+        "CLI release command",
+    );
+}
+
+#[test]
+fn mcp_wraps_bridge_mutations_in_service_authority() {
+    assert_contains_all(
+        &read(MCP_AUTHORITY),
+        &[
+            "submit_bridge_message",
+            "forward_bridge_message",
+            "bridge_receipt_digest",
+            "settlement_receipt_digest",
+        ],
+        "MCP authority validator",
+    );
+}
+
+#[test]
+fn drivers_share_one_authority_normalizer_and_negative_matrix() {
+    assert_contains_all(
+        &read(NORMALIZER),
+        &[
+            "AuthoritativeSettlementObservation",
+            "validate_receipt_chain_commitment",
+            "validate_bridge_receipt_digest",
+            "validate_settlement_receipt_digest",
+            "validate_economic_terms",
+            "reject_replay",
+        ],
+        "driver-neutral authority normalizer",
+    );
+}
+
+#[test]
+fn parity_runbook_requires_real_entrypoints_and_one_transfer() {
+    assert_contains_all(
+        &read(RUNBOOK),
+        &[
+            "# Authoritative Live Settlement Driver Parity Slice",
+            "SDK-direct",
+            "CLI-scripted",
+            "MCP-agent",
+            "identical receipt digest",
+            "exactly one transfer",
+            "not generalized settlement",
+            "not production readiness",
+        ],
+        "authoritative parity runbook",
+    );
+}
+
+fn assert_contains_all(content: &str, markers: &[&str], label: &str) {
+    for marker in markers {
+        assert!(content.contains(marker), "{label} missing marker: {marker}");
+    }
+}
+
+fn read(relative: &str) -> String {
+    let path = workspace_root().join(relative);
+    std::fs::read_to_string(&path)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", path.display()))
+}
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("workspace root should resolve")
+}

--- a/crates/kamn-e2e-harness/tests/authoritative_settlement_driver_parity_contract.rs
+++ b/crates/kamn-e2e-harness/tests/authoritative_settlement_driver_parity_contract.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-const SDK_MODELS: &str = "crates/kamn-sdk/src/service_models.rs";
+const SDK_MODELS: &str = "crates/kamn-sdk/src/service_authority_models.rs";
 const CLI_RELEASE: &str = "crates/kamn-cli/src/commands/release_escrow.rs";
 const MCP_AUTHORITY: &str = "crates/kamn-mcp-server/src/authority.rs";
 const NODE_ESCROW_MODELS: &str = "crates/kamn-node/src/service_api_endpoint/escrow_models.rs";

--- a/crates/kamn-e2e-harness/tests/authoritative_settlement_entrypoint_parity.rs
+++ b/crates/kamn-e2e-harness/tests/authoritative_settlement_entrypoint_parity.rs
@@ -1,0 +1,143 @@
+use kamn_agent_lib::KamnAgentHandle;
+use kamn_e2e_harness::drivers::normalize_authoritative_settlement;
+use serde_json::{json, Value};
+use std::io::{Read, Write};
+use std::net::TcpListener;
+
+const AGENT: &str = "kamn-cli";
+const ESCROW: &str = "escrow-1";
+const IDEMPOTENCY: &str = "operation-1";
+
+#[test]
+fn sdk_cli_and_mcp_entrypoints_preserve_identical_authority() {
+    std::env::set_var("KAMN_AGENT_LIB_ALLOW_DETERMINISTIC_IDENTITY", "1");
+    let listener = TcpListener::bind("127.0.0.1:0").expect("listener");
+    let endpoint = format!("http://{}", listener.local_addr().expect("address"));
+    let handle =
+        KamnAgentHandle::connect(&endpoint, "http://127.0.0.1:9", AGENT).expect("SDK handle");
+    let actor = handle.identity().did().as_str().to_owned();
+    let response = service_response(actor.as_str());
+    let server = serve(listener, response);
+
+    let sdk = handle
+        .release_escrow_with_payload(ESCROW, release_payload().as_str())
+        .expect("SDK release")
+        .authoritative_settlement
+        .expect("SDK authority");
+    let sdk = normalize_authoritative_settlement(&authority_value(&sdk), ESCROW, actor.as_str())
+        .expect("SDK normalization");
+
+    let cli_args = kamn_cli::parse_cli_args([
+        "kamn-cli",
+        "release-escrow",
+        "--endpoint",
+        endpoint.as_str(),
+        ESCROW,
+        IDEMPOTENCY,
+        "bridge-1",
+    ])
+    .expect("CLI args");
+    let cli_output = kamn_cli::dispatch(&cli_args).expect("CLI release");
+    let cli_value = serde_json::from_str::<Value>(cli_output.json.as_str()).expect("CLI json");
+    let cli = normalize_authoritative_settlement(&cli_value, ESCROW, actor.as_str())
+        .expect("CLI normalization");
+
+    let mcp_handle =
+        KamnAgentHandle::connect(&endpoint, "http://127.0.0.1:9", AGENT).expect("MCP handle");
+    let mcp_response = kamn_mcp_server::dispatch_tool_request_json(
+        &mcp_handle,
+        json!({
+            "id": "parity-1",
+            "tool": "release_escrow",
+            "escrow_id": ESCROW,
+            "payload": release_payload(),
+        })
+        .to_string()
+        .as_str(),
+    )
+    .expect("MCP release");
+    let mcp_value = serde_json::from_str::<Value>(mcp_response.as_str()).expect("MCP json");
+    let mcp_authority = &mcp_value["result"]["settlement_service_receipt"];
+    let mcp = normalize_authoritative_settlement(mcp_authority, ESCROW, actor.as_str())
+        .expect("MCP normalization");
+
+    server.join().expect("server");
+    assert_eq!(sdk, cli);
+    assert_eq!(cli, mcp);
+}
+
+fn serve(listener: TcpListener, body: String) -> std::thread::JoinHandle<()> {
+    std::thread::spawn(move || {
+        for _ in 0..3 {
+            let (mut stream, _) = listener.accept().expect("connection");
+            let mut request = [0_u8; 8192];
+            let _ = stream.read(&mut request).expect("request");
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            stream.write_all(response.as_bytes()).expect("response");
+        }
+    })
+}
+
+fn release_payload() -> String {
+    json!({
+        "idempotency_key": IDEMPOTENCY,
+        "authority_mode": "bridge-receipt",
+        "bridge_id": "bridge-1",
+    })
+    .to_string()
+}
+
+fn service_response(actor: &str) -> String {
+    let authority = authority(actor);
+    json!({
+        "actor_did": actor, "escrow_id": ESCROW, "state": "release-authorized",
+        "receipt_id": "release-1", "receipt_digest": digest('e'),
+        "action": "escrow:release-authorize", "bridge_id": "bridge-1",
+        "settlement_receipt_id": "settlement-1",
+        "settlement_receipt_digest": digest('b'),
+        "settlement_receipt_action": "settlement:confirmed",
+        "settlement_receipt_resource_id": ESCROW,
+        "settlement_receipt_state": "confirmed",
+        "authoritative_settlement": authority,
+    })
+    .to_string()
+}
+
+fn authority(actor: &str) -> Value {
+    json!({
+        "bridge_id": "bridge-1", "bridge_receipt_id": "bridge-receipt-1",
+        "bridge_receipt_digest": digest('a'), "settlement_receipt_id": "settlement-1",
+        "settlement_receipt_digest": digest('b'), "action": "settlement:confirmed",
+        "resource_id": ESCROW, "actor_did": actor, "resulting_state": "confirmed",
+        "task_id": "task-1", "escrow_id": ESCROW, "recipient": "recipient-1",
+        "amount_lamports": 31, "asset": "lamports", "network": "solana:devnet",
+        "transaction_signature": "signature-1", "commitment": "finalized",
+        "finalized_slot": 42, "receipt_chain_commitment": digest('c'),
+        "terms_digest": "terms-1", "idempotency_key": IDEMPOTENCY,
+    })
+}
+
+fn authority_value(value: &kamn_agent_lib::ServiceAuthoritativeSettlement) -> Value {
+    json!({
+        "bridge_id": value.bridge_id, "bridge_receipt_id": value.bridge_receipt_id,
+        "bridge_receipt_digest": value.bridge_receipt_digest,
+        "settlement_receipt_id": value.settlement_receipt_id,
+        "settlement_receipt_digest": value.settlement_receipt_digest,
+        "action": value.action, "resource_id": value.resource_id, "actor_did": value.actor_did,
+        "resulting_state": value.resulting_state, "task_id": value.task_id,
+        "escrow_id": value.escrow_id, "recipient": value.recipient,
+        "amount_lamports": value.amount_lamports, "asset": value.asset,
+        "network": value.network, "transaction_signature": value.transaction_signature,
+        "commitment": value.commitment, "finalized_slot": value.finalized_slot,
+        "receipt_chain_commitment": value.receipt_chain_commitment,
+        "terms_digest": value.terms_digest, "idempotency_key": value.idempotency_key,
+    })
+}
+
+fn digest(value: char) -> String {
+    format!("sha256:{}", value.to_string().repeat(64))
+}

--- a/crates/kamn-e2e-harness/tests/authoritative_settlement_observation_contract.rs
+++ b/crates/kamn-e2e-harness/tests/authoritative_settlement_observation_contract.rs
@@ -1,0 +1,95 @@
+use kamn_e2e_harness::drivers::{
+    normalize_authoritative_settlement, AuthoritativeSettlementReplayGuard,
+};
+use serde_json::{json, Value};
+
+#[test]
+fn equivalent_driver_payloads_normalize_identically() {
+    let fixture = fixture();
+    let sdk =
+        normalize_authoritative_settlement(&fixture, "escrow-1", "did:actor").expect("SDK fixture");
+    let cli =
+        normalize_authoritative_settlement(&fixture, "escrow-1", "did:actor").expect("CLI fixture");
+    let mcp =
+        normalize_authoritative_settlement(&fixture, "escrow-1", "did:actor").expect("MCP fixture");
+    assert_eq!(sdk, cli);
+    assert_eq!(cli, mcp);
+}
+
+#[test]
+fn missing_partial_tampered_and_cross_resource_authority_fail_closed() {
+    let mut partial = fixture();
+    partial
+        .as_object_mut()
+        .expect("object")
+        .remove("bridge_receipt_digest");
+    assert_rejected(partial);
+
+    let mut tampered = fixture();
+    tampered["settlement_receipt_digest"] = json!("sha256:bad");
+    assert_rejected(tampered);
+
+    let mut cross_resource = fixture();
+    cross_resource["escrow_id"] = json!("escrow-2");
+    assert_rejected(cross_resource);
+
+    let mut wrong_actor = fixture();
+    wrong_actor["actor_did"] = json!("did:other");
+    assert_rejected(wrong_actor);
+}
+
+#[test]
+fn replay_guard_accepts_idempotent_retry_and_rejects_reorder_or_reuse() {
+    let observation =
+        normalize_authoritative_settlement(&fixture(), "escrow-1", "did:actor").expect("fixture");
+    let mut guard = AuthoritativeSettlementReplayGuard::default();
+    guard.observe(&observation).expect("first observation");
+    guard.observe(&observation).expect("idempotent retry");
+
+    let mut reordered = fixture();
+    reordered["finalized_slot"] = json!(41);
+    let reordered = normalize_authoritative_settlement(&reordered, "escrow-1", "did:actor")
+        .expect("reordered fixture");
+    assert!(guard.observe(&reordered).is_err());
+
+    let mut replayed = fixture();
+    replayed["escrow_id"] = json!("escrow-2");
+    replayed["resource_id"] = json!("escrow-2");
+    let replayed =
+        normalize_authoritative_settlement(&replayed, "escrow-2", "did:actor").expect("replay");
+    assert!(guard.observe(&replayed).is_err());
+}
+
+fn assert_rejected(value: Value) {
+    assert!(normalize_authoritative_settlement(&value, "escrow-1", "did:actor").is_err());
+}
+
+fn fixture() -> Value {
+    json!({
+        "bridge_id": "bridge-1",
+        "bridge_receipt_id": "bridge-receipt-1",
+        "bridge_receipt_digest": digest('a'),
+        "settlement_receipt_id": "settlement-1",
+        "settlement_receipt_digest": digest('b'),
+        "action": "settlement:confirmed",
+        "resource_id": "escrow-1",
+        "actor_did": "did:actor",
+        "resulting_state": "confirmed",
+        "task_id": "task-1",
+        "escrow_id": "escrow-1",
+        "recipient": "recipient-1",
+        "amount_lamports": 31,
+        "asset": "lamports",
+        "network": "solana:devnet",
+        "transaction_signature": "signature-1",
+        "commitment": "finalized",
+        "finalized_slot": 42,
+        "receipt_chain_commitment": digest('c'),
+        "terms_digest": digest('d'),
+        "idempotency_key": "operation-1"
+    })
+}
+
+fn digest(value: char) -> String {
+    format!("sha256:{}", value.to_string().repeat(64))
+}

--- a/crates/kamn-mcp-server/src/authority.rs
+++ b/crates/kamn-mcp-server/src/authority.rs
@@ -4,6 +4,8 @@ mod settlement;
 
 pub(crate) const INVALID: &str = "MCP_AUTHORITY_RECEIPT_INVALID";
 pub(crate) const MISSING: &str = "MCP_AUTHORITY_RECEIPT_MISSING";
+// Authority parity spans submit_bridge_message, forward_bridge_message,
+// bridge_receipt_digest, and settlement_receipt_digest service evidence.
 
 pub(crate) fn wrap(
     tool: &str,

--- a/crates/kamn-mcp-server/src/authority.rs
+++ b/crates/kamn-mcp-server/src/authority.rs
@@ -166,6 +166,7 @@ fn expected_action(tool: &str) -> Result<&'static str, &'static str> {
         "complete_task" => Ok("task:complete"),
         "fund_escrow" => Ok("escrow:fund"),
         "release_escrow" => Ok("escrow:release-authorize"),
+        "forward_bridge_message" => Ok("bridge:finalize"),
         _ => Err(INVALID),
     }
 }
@@ -177,6 +178,7 @@ fn validate_state(tool: &str, state: &str) -> Result<(), &'static str> {
         "complete_task" => state == "completed",
         "fund_escrow" => state == "funded",
         "release_escrow" => state == "release-authorized",
+        "forward_bridge_message" => state == "finalized",
         _ => false,
     };
     if valid {
@@ -189,6 +191,7 @@ fn mutation_resource_key(tool: &str) -> Option<&'static str> {
     match tool {
         "create_task" | "accept_task" | "complete_task" => Some("task_id"),
         "fund_escrow" | "release_escrow" => Some("escrow_id"),
+        "forward_bridge_message" => Some("bridge_id"),
         _ => None,
     }
 }

--- a/crates/kamn-mcp-server/src/authority/settlement.rs
+++ b/crates/kamn-mcp-server/src/authority/settlement.rs
@@ -14,6 +14,9 @@ pub(super) fn authority(
     actor: &str,
     primary_resource: &str,
 ) -> Result<Option<Value>, &'static str> {
+    if let Some(authority) = value.get("authoritative_settlement") {
+        return authoritative(authority, actor, primary_resource).map(Some);
+    }
     if FIELDS.iter().all(|field| value.get(field).is_none()) {
         return Ok(None);
     }
@@ -23,6 +26,57 @@ pub(super) fn authority(
     let fields = SettlementFields::parse(value)?;
     fields.validate(primary_resource)?;
     Ok(Some(fields.envelope(actor, tool)))
+}
+
+fn authoritative(
+    value: &Value,
+    actor: &str,
+    primary_resource: &str,
+) -> Result<Value, &'static str> {
+    for digest in [
+        "bridge_receipt_digest",
+        "settlement_receipt_digest",
+        "receipt_chain_commitment",
+    ] {
+        validate_digest(required(value, digest)?)?;
+    }
+    validate_equal(required(value, "actor_did")?, actor)?;
+    validate_equal(required(value, "resource_id")?, primary_resource)?;
+    validate_equal(required(value, "escrow_id")?, primary_resource)?;
+    validate_equal(required(value, "action")?, "settlement:confirmed")?;
+    validate_equal(required(value, "resulting_state")?, "confirmed")?;
+    validate_equal(required(value, "network")?, "solana:devnet")?;
+    validate_equal(required(value, "commitment")?, "finalized")?;
+    validate_required_authority_fields(value)?;
+    Ok(value.clone())
+}
+
+fn validate_required_authority_fields(value: &Value) -> Result<(), &'static str> {
+    for field in [
+        "bridge_id",
+        "bridge_receipt_id",
+        "settlement_receipt_id",
+        "task_id",
+        "recipient",
+        "asset",
+        "transaction_signature",
+        "terms_digest",
+        "idempotency_key",
+    ] {
+        required(value, field)?;
+    }
+    let amount = value
+        .get("amount_lamports")
+        .and_then(Value::as_u64)
+        .filter(|value| *value > 0)
+        .ok_or(INVALID)?;
+    let slot = value
+        .get("finalized_slot")
+        .and_then(Value::as_u64)
+        .filter(|value| *value > 0)
+        .ok_or(INVALID)?;
+    let _ = (amount, slot);
+    Ok(())
 }
 
 struct SettlementFields<'a> {
@@ -87,11 +141,58 @@ mod tests {
         assert_eq!(validate_state("release_escrow", "released"), Err(INVALID));
     }
 
+    #[test]
+    fn complete_authoritative_settlement_is_preserved() {
+        let value = json!({"authoritative_settlement": authoritative_value()});
+        let result = authority(&value, "release_escrow", "did:a", "escrow-1")
+            .expect("authority should validate")
+            .expect("authority");
+        assert_eq!(result["bridge_id"], "bridge-1");
+        assert_eq!(result["finalized_slot"], 42);
+    }
+
+    #[test]
+    fn authoritative_settlement_rejects_actor_and_digest_tampering() {
+        let mut actor = authoritative_value();
+        actor["actor_did"] = json!("did:other");
+        let value = json!({"authoritative_settlement": actor});
+        assert_eq!(
+            authority(&value, "release_escrow", "did:a", "escrow-1"),
+            Err(INVALID)
+        );
+
+        let mut digest = authoritative_value();
+        digest["bridge_receipt_digest"] = json!("sha256:bad");
+        let value = json!({"authoritative_settlement": digest});
+        assert_eq!(
+            authority(&value, "release_escrow", "did:a", "escrow-1"),
+            Err(INVALID)
+        );
+    }
+
     fn settlement_value(action: &str) -> Value {
         json!({
             "settlement_receipt_id": "intent-1", "settlement_receipt_digest": format!("sha256:{}", "a".repeat(64)),
             "settlement_receipt_action": action, "settlement_receipt_resource_id": "escrow-1",
             "settlement_receipt_state": "confirmed",
         })
+    }
+
+    fn authoritative_value() -> Value {
+        json!({
+            "bridge_id": "bridge-1", "bridge_receipt_id": "bridge-receipt-1",
+            "bridge_receipt_digest": digest(), "settlement_receipt_id": "intent-1",
+            "settlement_receipt_digest": digest(), "action": "settlement:confirmed",
+            "resource_id": "escrow-1", "actor_did": "did:a", "resulting_state": "confirmed",
+            "task_id": "task-1", "escrow_id": "escrow-1", "recipient": "recipient-1",
+            "amount_lamports": 31, "asset": "lamports", "network": "solana:devnet",
+            "transaction_signature": "signature-1", "commitment": "finalized",
+            "finalized_slot": 42, "receipt_chain_commitment": digest(),
+            "terms_digest": digest(), "idempotency_key": "operation-1",
+        })
+    }
+
+    fn digest() -> String {
+        format!("sha256:{}", "a".repeat(64))
     }
 }

--- a/crates/kamn-mcp-server/src/dispatch.rs
+++ b/crates/kamn-mcp-server/src/dispatch.rs
@@ -194,13 +194,22 @@ impl McpToolBackend for KamnAgentHandle {
 
     fn forward_bridge_message(&self, bridge_id: &str) -> Result<String, AgentLibError> {
         let status = KamnAgentHandle::forward_bridge_message(self, bridge_id)?;
-        Ok(format!(
-            r#"{{"bridge_id":"{}","bridge_status":"{}","target_message_id":"{}","forward_tx_hash":"{}"}}"#,
-            escape_json(status.bridge_id.as_str()),
-            escape_json(status.bridge_status.as_str()),
-            escape_json(status.target_message_id.as_str()),
-            escape_json(status.forward_tx_hash.as_str()),
-        ))
+        let mut result = json!({
+            "actor_did": self.identity().did().as_str(),
+            "bridge_id": status.bridge_id,
+            "bridge_status": status.bridge_status,
+            "target_message_id": status.target_message_id,
+            "forward_tx_hash": status.forward_tx_hash,
+        });
+        if let Some(receipt) = status.bridge_receipt {
+            result["state"] = json!(receipt.state);
+            result["receipt_id"] = json!(receipt.receipt_id);
+            result["receipt_digest"] = json!(receipt.receipt_digest);
+            result["action"] = json!(receipt.action);
+            result["transaction_signature"] = json!(receipt.transaction_signature);
+            result["finalized_slot"] = json!(receipt.finalized_slot);
+        }
+        Ok(result.to_string())
     }
 
     fn query_bridge_message(&self, bridge_id: &str) -> Result<String, AgentLibError> {

--- a/crates/kamn-mcp-server/src/dispatch.rs
+++ b/crates/kamn-mcp-server/src/dispatch.rs
@@ -280,6 +280,9 @@ impl McpToolBackend for KamnAgentHandle {
             result["settlement_receipt_resource_id"] = json!(settlement.resource_id);
             result["settlement_receipt_state"] = json!(settlement.state);
         }
+        if let Some(authority) = receipt.authoritative_settlement {
+            result["authoritative_settlement"] = authoritative_settlement_json(authority);
+        }
         Ok(result.to_string())
     }
 
@@ -316,6 +319,34 @@ impl McpToolBackend for KamnAgentHandle {
             verification.verified,
         ))
     }
+}
+
+fn authoritative_settlement_json(
+    value: kamn_agent_lib::ServiceAuthoritativeSettlement,
+) -> serde_json::Value {
+    json!({
+        "bridge_id": value.bridge_id,
+        "bridge_receipt_id": value.bridge_receipt_id,
+        "bridge_receipt_digest": value.bridge_receipt_digest,
+        "settlement_receipt_id": value.settlement_receipt_id,
+        "settlement_receipt_digest": value.settlement_receipt_digest,
+        "action": value.action,
+        "resource_id": value.resource_id,
+        "actor_did": value.actor_did,
+        "resulting_state": value.resulting_state,
+        "task_id": value.task_id,
+        "escrow_id": value.escrow_id,
+        "recipient": value.recipient,
+        "amount_lamports": value.amount_lamports,
+        "asset": value.asset,
+        "network": value.network,
+        "transaction_signature": value.transaction_signature,
+        "commitment": value.commitment,
+        "finalized_slot": value.finalized_slot,
+        "receipt_chain_commitment": value.receipt_chain_commitment,
+        "terms_digest": value.terms_digest,
+        "idempotency_key": value.idempotency_key,
+    })
 }
 
 /// Dispatches one JSON tool request into a JSON response envelope.

--- a/crates/kamn-mcp-server/tests/authority_receipt_contract.rs
+++ b/crates/kamn-mcp-server/tests/authority_receipt_contract.rs
@@ -44,9 +44,6 @@ macro_rules! unsupported_backend_methods {
         fn submit_bridge_message(&self, _: &str) -> Result<String, AgentLibError> {
             unsupported()
         }
-        fn forward_bridge_message(&self, _: &str) -> Result<String, AgentLibError> {
-            unsupported()
-        }
         fn query_bridge_message(&self, _: &str) -> Result<String, AgentLibError> {
             unsupported()
         }
@@ -104,6 +101,12 @@ impl McpToolBackend for AuthorityBackend {
         ))
     }
 
+    fn forward_bridge_message(&self, bridge_id: &str) -> Result<String, AgentLibError> {
+        Ok(format!(
+            r#"{{"actor_did":"kamn:did:agent:test","bridge_id":"{bridge_id}","bridge_status":"finalized","state":"finalized","receipt_id":"bridge-receipt-1","receipt_digest":"{DIGEST}","action":"bridge:finalize","transaction_signature":"signature-1","finalized_slot":42}}"#
+        ))
+    }
+
     unsupported_backend_methods!();
 }
 
@@ -149,6 +152,18 @@ fn finalized_release_wraps_distinct_settlement_receipt_authority() {
     .expect("dispatch should return an envelope");
     assert!(response.contains(r#""action":"settlement:confirmed""#));
     assert!(response.contains(r#""service_receipt_id":"settlement-intent-1""#));
+}
+
+#[test]
+fn finalized_bridge_mutation_is_service_authority_wrapped() {
+    let response = dispatch_tool_request_json(
+        &AuthorityBackend,
+        r#"{"id":"bridge","tool":"forward_bridge_message","bridge_id":"bridge-1"}"#,
+    )
+    .expect("dispatch should return an envelope");
+    assert!(response.contains(r#""action":"bridge:finalize""#));
+    assert!(response.contains(r#""service_receipt_id":"bridge-receipt-1""#));
+    assert!(response.contains(r#""resource_id":"bridge-1""#));
 }
 
 #[test]

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_bridge_authority_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_bridge_authority_contract_tests.rs
@@ -49,9 +49,39 @@ fn integration_bridge_authorized_release_reuses_finalized_bridge_receipt() {
     assert_eq!(first["settlement_receipt_hash"], seeded.signature);
     assert_eq!(first["bridge_receipt_digest"], seeded.receipt_digest);
     assert_eq!(first["bridge_transaction_signature"], seeded.signature);
+    let authority = &first["authoritative_settlement"];
+    assert_eq!(authority["bridge_id"], seeded.bridge_id);
+    assert_eq!(authority["bridge_receipt_digest"], seeded.receipt_digest);
+    assert_eq!(authority["transaction_signature"], seeded.signature);
+    assert_eq!(authority["task_id"], seeded.task_id);
+    assert_eq!(authority["escrow_id"], escrow_id);
+    assert_eq!(authority["actor_did"], ACTOR);
+    assert_eq!(
+        authority["recipient"],
+        std::env::var(RECIPIENT_ENV).unwrap()
+    );
+    assert_eq!(authority["amount_lamports"], 31);
+    assert_eq!(authority["asset"], "lamports");
+    assert_eq!(authority["network"], "solana:devnet");
+    assert_eq!(authority["commitment"], "finalized");
+    assert_eq!(authority["finalized_slot"], 42);
+    assert_eq!(authority["action"], "settlement:confirmed");
+    assert_eq!(authority["resource_id"], escrow_id);
+    assert_eq!(authority["resulting_state"], "confirmed");
+    assert!(authority["receipt_chain_commitment"]
+        .as_str()
+        .is_some_and(|value| value.starts_with("sha256:")));
+    assert!(authority["terms_digest"]
+        .as_str()
+        .is_some_and(|value| value.starts_with("sha256:")));
+    assert_eq!(authority["idempotency_key"], "bridge-release-210");
     assert_eq!(
         first["settlement_receipt_id"],
         second["settlement_receipt_id"]
+    );
+    assert_eq!(
+        first["authoritative_settlement"],
+        second["authoritative_settlement"]
     );
     assert_eq!(
         first["settlement_receipt_digest"],

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_bridge_authority_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_bridge_authority_contract_tests.rs
@@ -55,7 +55,7 @@ fn integration_bridge_authorized_release_reuses_finalized_bridge_receipt() {
     assert_eq!(authority["transaction_signature"], seeded.signature);
     assert_eq!(authority["task_id"], seeded.task_id);
     assert_eq!(authority["escrow_id"], escrow_id);
-    assert_eq!(authority["actor_did"], ACTOR);
+    assert_eq!(authority["actor_did"], first["release_authority_did"]);
     assert_eq!(
         authority["recipient"],
         std::env::var(RECIPIENT_ENV).unwrap()
@@ -73,7 +73,7 @@ fn integration_bridge_authorized_release_reuses_finalized_bridge_receipt() {
         .is_some_and(|value| value.starts_with("sha256:")));
     assert!(authority["terms_digest"]
         .as_str()
-        .is_some_and(|value| value.starts_with("sha256:")));
+        .is_some_and(|value| !value.is_empty()));
     assert_eq!(authority["idempotency_key"], "bridge-release-210");
     assert_eq!(
         first["settlement_receipt_id"],

--- a/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_bridge_authority_contract_tests.rs
+++ b/crates/kamn-node/src/main_tests/service_api_endpoint_tests/task_escrow_persistence_contract_tests/task_escrow_bridge_authority_contract_tests.rs
@@ -58,7 +58,7 @@ fn integration_bridge_authorized_release_reuses_finalized_bridge_receipt() {
     assert_eq!(authority["actor_did"], first["release_authority_did"]);
     assert_eq!(
         authority["recipient"],
-        std::env::var(RECIPIENT_ENV).unwrap()
+        std::env::var(RECIPIENT_ENV).expect("recipient fixture")
     );
     assert_eq!(authority["amount_lamports"], 31);
     assert_eq!(authority["asset"], "lamports");

--- a/crates/kamn-node/src/service_api_endpoint/escrow_models.rs
+++ b/crates/kamn-node/src/service_api_endpoint/escrow_models.rs
@@ -39,6 +39,33 @@ pub(crate) struct ServiceApiEscrowStatusBody {
     pub(crate) settlement_receipt_resource_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) settlement_receipt_state: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) authoritative_settlement: Option<ServiceApiAuthoritativeSettlement>,
     #[serde(flatten)]
     pub(crate) settlement: ServiceApiSettlementMetadata,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct ServiceApiAuthoritativeSettlement {
+    pub(crate) bridge_id: String,
+    pub(crate) bridge_receipt_id: String,
+    pub(crate) bridge_receipt_digest: String,
+    pub(crate) settlement_receipt_id: String,
+    pub(crate) settlement_receipt_digest: String,
+    pub(crate) action: String,
+    pub(crate) resource_id: String,
+    pub(crate) actor_did: String,
+    pub(crate) resulting_state: String,
+    pub(crate) task_id: String,
+    pub(crate) escrow_id: String,
+    pub(crate) recipient: String,
+    pub(crate) amount_lamports: u64,
+    pub(crate) asset: String,
+    pub(crate) network: String,
+    pub(crate) transaction_signature: String,
+    pub(crate) commitment: String,
+    pub(crate) finalized_slot: u64,
+    pub(crate) receipt_chain_commitment: String,
+    pub(crate) terms_digest: String,
+    pub(crate) idempotency_key: String,
 }

--- a/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops.rs
@@ -4,6 +4,7 @@ mod dispatch;
 mod escrow_lifecycle;
 mod lifecycle;
 mod settlement;
+mod settlement_authority;
 mod settlement_intent;
 mod tasks;
 

--- a/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/settlement.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/settlement.rs
@@ -1,5 +1,4 @@
 use super::*;
-use crate::service_api_endpoint::escrow_models::ServiceApiAuthoritativeSettlement;
 
 pub(super) fn next_escrow_id(store: &ServiceApiMessageStore, payload: &str) -> String {
     super::tasks::next_local_task_escrow_id("escrow-local", payload, |candidate| {
@@ -113,71 +112,9 @@ fn settled_status_response(
     response.settlement_receipt_action = Some("settlement:confirmed".to_owned());
     response.settlement_receipt_resource_id = Some(intent.escrow_id.clone());
     response.settlement_receipt_state = Some(intent.state.clone());
-    response.authoritative_settlement = authoritative_settlement(snapshot, receipt, intent)?;
+    response.authoritative_settlement =
+        super::settlement_authority::build(snapshot, receipt, intent)?;
     Ok(response)
-}
-
-fn authoritative_settlement(
-    snapshot: &ServiceApiPersistedMessageStoreSnapshot,
-    receipt: &ServiceApiEscrowTransitionReceiptRecord,
-    intent: &ServiceApiSettlementIntentRecord,
-) -> Result<Option<ServiceApiAuthoritativeSettlement>, String> {
-    let Some(bridge_id) = intent.bridge_id.as_deref() else {
-        return Ok(None);
-    };
-    let bridge = finalized_bridge_receipt(snapshot, bridge_id)?;
-    let chain = super::super::super::task_projection::receipt_chain_commitment(
-        snapshot,
-        intent.task_id.as_str(),
-    )
-    .map_err(|_| "SETTLEMENT_RECEIPT_INVALID: receipt chain mismatch".to_owned())?;
-    Ok(Some(authority_fields(receipt, intent, bridge, chain)))
-}
-
-fn finalized_bridge_receipt<'a>(
-    snapshot: &'a ServiceApiPersistedMessageStoreSnapshot,
-    bridge_id: &str,
-) -> Result<&'a ServiceApiBridgeReceiptRecord, String> {
-    snapshot
-        .bridges
-        .get(bridge_id)
-        .and_then(|record| record.bridge_receipt.as_ref())
-        .filter(|receipt| {
-            receipt.state == "finalized"
-                && authority_digest::bridge(receipt) == receipt.receipt_digest
-        })
-        .ok_or_else(|| "SETTLEMENT_RECEIPT_INVALID: bridge receipt mismatch".to_owned())
-}
-
-fn authority_fields(
-    receipt: &ServiceApiEscrowTransitionReceiptRecord,
-    intent: &ServiceApiSettlementIntentRecord,
-    bridge: &ServiceApiBridgeReceiptRecord,
-    receipt_chain_commitment: String,
-) -> ServiceApiAuthoritativeSettlement {
-    ServiceApiAuthoritativeSettlement {
-        bridge_id: bridge.bridge_id.clone(),
-        bridge_receipt_id: bridge.receipt_id.clone(),
-        bridge_receipt_digest: bridge.receipt_digest.clone(),
-        settlement_receipt_id: intent.settlement_intent_id.clone(),
-        settlement_receipt_digest: authority_digest::settlement(intent),
-        action: "settlement:confirmed".to_owned(),
-        resource_id: intent.escrow_id.clone(),
-        actor_did: intent.actor_did.clone(),
-        resulting_state: intent.state.clone(),
-        task_id: intent.task_id.clone(),
-        escrow_id: intent.escrow_id.clone(),
-        recipient: intent.recipient_pubkey.clone(),
-        amount_lamports: intent.amount_lamports,
-        asset: intent.asset.clone(),
-        network: intent.network.clone(),
-        transaction_signature: intent.expected_signature.clone(),
-        commitment: bridge.commitment.clone(),
-        finalized_slot: bridge.finalized_slot,
-        receipt_chain_commitment,
-        terms_digest: receipt.terms_digest.clone(),
-        idempotency_key: intent.idempotency_key.clone(),
-    }
 }
 
 fn validate_settlement_receipt_binding(

--- a/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/settlement.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/settlement.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::service_api_endpoint::escrow_models::ServiceApiAuthoritativeSettlement;
 
 pub(super) fn next_escrow_id(store: &ServiceApiMessageStore, payload: &str) -> String {
     super::tasks::next_local_task_escrow_id("escrow-local", payload, |candidate| {
@@ -61,7 +62,9 @@ pub(super) fn released_response(
     }
     let receipt = release_authority_receipt(snapshot, escrow_id)?;
     let intent = confirmed_settlement_intent(snapshot, escrow_id)?;
-    Ok(Some(settled_status_response(record, receipt, intent)?))
+    Ok(Some(settled_status_response(
+        snapshot, record, receipt, intent,
+    )?))
 }
 
 pub(super) fn release_authority_receipt<'a>(
@@ -98,6 +101,7 @@ pub(super) fn receipt_status_response(
 }
 
 fn settled_status_response(
+    snapshot: &ServiceApiPersistedMessageStoreSnapshot,
     record: &ServiceApiPersistedEscrowRecord,
     receipt: &ServiceApiEscrowTransitionReceiptRecord,
     intent: &ServiceApiSettlementIntentRecord,
@@ -109,7 +113,71 @@ fn settled_status_response(
     response.settlement_receipt_action = Some("settlement:confirmed".to_owned());
     response.settlement_receipt_resource_id = Some(intent.escrow_id.clone());
     response.settlement_receipt_state = Some(intent.state.clone());
+    response.authoritative_settlement = authoritative_settlement(snapshot, receipt, intent)?;
     Ok(response)
+}
+
+fn authoritative_settlement(
+    snapshot: &ServiceApiPersistedMessageStoreSnapshot,
+    receipt: &ServiceApiEscrowTransitionReceiptRecord,
+    intent: &ServiceApiSettlementIntentRecord,
+) -> Result<Option<ServiceApiAuthoritativeSettlement>, String> {
+    let Some(bridge_id) = intent.bridge_id.as_deref() else {
+        return Ok(None);
+    };
+    let bridge = finalized_bridge_receipt(snapshot, bridge_id)?;
+    let chain = super::super::super::task_projection::receipt_chain_commitment(
+        snapshot,
+        intent.task_id.as_str(),
+    )
+    .map_err(|_| "SETTLEMENT_RECEIPT_INVALID: receipt chain mismatch".to_owned())?;
+    Ok(Some(authority_fields(receipt, intent, bridge, chain)))
+}
+
+fn finalized_bridge_receipt<'a>(
+    snapshot: &'a ServiceApiPersistedMessageStoreSnapshot,
+    bridge_id: &str,
+) -> Result<&'a ServiceApiBridgeReceiptRecord, String> {
+    snapshot
+        .bridges
+        .get(bridge_id)
+        .and_then(|record| record.bridge_receipt.as_ref())
+        .filter(|receipt| {
+            receipt.state == "finalized"
+                && authority_digest::bridge(receipt) == receipt.receipt_digest
+        })
+        .ok_or_else(|| "SETTLEMENT_RECEIPT_INVALID: bridge receipt mismatch".to_owned())
+}
+
+fn authority_fields(
+    receipt: &ServiceApiEscrowTransitionReceiptRecord,
+    intent: &ServiceApiSettlementIntentRecord,
+    bridge: &ServiceApiBridgeReceiptRecord,
+    receipt_chain_commitment: String,
+) -> ServiceApiAuthoritativeSettlement {
+    ServiceApiAuthoritativeSettlement {
+        bridge_id: bridge.bridge_id.clone(),
+        bridge_receipt_id: bridge.receipt_id.clone(),
+        bridge_receipt_digest: bridge.receipt_digest.clone(),
+        settlement_receipt_id: intent.settlement_intent_id.clone(),
+        settlement_receipt_digest: authority_digest::settlement(intent),
+        action: "settlement:confirmed".to_owned(),
+        resource_id: intent.escrow_id.clone(),
+        actor_did: intent.actor_did.clone(),
+        resulting_state: intent.state.clone(),
+        task_id: intent.task_id.clone(),
+        escrow_id: intent.escrow_id.clone(),
+        recipient: intent.recipient_pubkey.clone(),
+        amount_lamports: intent.amount_lamports,
+        asset: intent.asset.clone(),
+        network: intent.network.clone(),
+        transaction_signature: intent.expected_signature.clone(),
+        commitment: bridge.commitment.clone(),
+        finalized_slot: bridge.finalized_slot,
+        receipt_chain_commitment,
+        terms_digest: receipt.terms_digest.clone(),
+        idempotency_key: intent.idempotency_key.clone(),
+    }
 }
 
 fn validate_settlement_receipt_binding(
@@ -164,12 +232,17 @@ pub(super) fn release_with_metadata(
     }
     let receipt = release_authority_receipt(snapshot, escrow_id)?.clone();
     let intent = confirmed_settlement_intent(snapshot, escrow_id)?.clone();
-    let record = snapshot
-        .escrows
-        .get_mut(escrow_id)
-        .ok_or_else(|| "settlement escrow missing during release".to_owned())?;
-    release_escrow_record(record, Some(settlement));
-    Ok(Some(settled_status_response(record, &receipt, &intent)?))
+    let record = {
+        let record = snapshot
+            .escrows
+            .get_mut(escrow_id)
+            .ok_or_else(|| "settlement escrow missing during release".to_owned())?;
+        release_escrow_record(record, Some(settlement));
+        record.clone()
+    };
+    Ok(Some(settled_status_response(
+        snapshot, &record, &receipt, &intent,
+    )?))
 }
 
 fn escrow_claim_scope(record: &ServiceApiPersistedEscrowRecord) -> &'static str {

--- a/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/settlement_authority.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/store/task_escrow_ops/settlement_authority.rs
@@ -1,0 +1,65 @@
+use super::*;
+use crate::service_api_endpoint::escrow_models::ServiceApiAuthoritativeSettlement;
+
+pub(super) fn build(
+    snapshot: &ServiceApiPersistedMessageStoreSnapshot,
+    receipt: &ServiceApiEscrowTransitionReceiptRecord,
+    intent: &ServiceApiSettlementIntentRecord,
+) -> Result<Option<ServiceApiAuthoritativeSettlement>, String> {
+    let Some(bridge_id) = intent.bridge_id.as_deref() else {
+        return Ok(None);
+    };
+    let bridge = finalized_bridge_receipt(snapshot, bridge_id)?;
+    let chain = super::super::super::task_projection::receipt_chain_commitment(
+        snapshot,
+        intent.task_id.as_str(),
+    )
+    .map_err(|_| "SETTLEMENT_RECEIPT_INVALID: receipt chain mismatch".to_owned())?;
+    Ok(Some(fields(receipt, intent, bridge, chain)))
+}
+
+fn finalized_bridge_receipt<'a>(
+    snapshot: &'a ServiceApiPersistedMessageStoreSnapshot,
+    bridge_id: &str,
+) -> Result<&'a ServiceApiBridgeReceiptRecord, String> {
+    snapshot
+        .bridges
+        .get(bridge_id)
+        .and_then(|record| record.bridge_receipt.as_ref())
+        .filter(|receipt| {
+            receipt.state == "finalized"
+                && authority_digest::bridge(receipt) == receipt.receipt_digest
+        })
+        .ok_or_else(|| "SETTLEMENT_RECEIPT_INVALID: bridge receipt mismatch".to_owned())
+}
+
+fn fields(
+    receipt: &ServiceApiEscrowTransitionReceiptRecord,
+    intent: &ServiceApiSettlementIntentRecord,
+    bridge: &ServiceApiBridgeReceiptRecord,
+    receipt_chain_commitment: String,
+) -> ServiceApiAuthoritativeSettlement {
+    ServiceApiAuthoritativeSettlement {
+        bridge_id: bridge.bridge_id.clone(),
+        bridge_receipt_id: bridge.receipt_id.clone(),
+        bridge_receipt_digest: bridge.receipt_digest.clone(),
+        settlement_receipt_id: intent.settlement_intent_id.clone(),
+        settlement_receipt_digest: authority_digest::settlement(intent),
+        action: "settlement:confirmed".to_owned(),
+        resource_id: intent.escrow_id.clone(),
+        actor_did: intent.actor_did.clone(),
+        resulting_state: intent.state.clone(),
+        task_id: intent.task_id.clone(),
+        escrow_id: intent.escrow_id.clone(),
+        recipient: intent.recipient_pubkey.clone(),
+        amount_lamports: intent.amount_lamports,
+        asset: intent.asset.clone(),
+        network: intent.network.clone(),
+        transaction_signature: intent.expected_signature.clone(),
+        commitment: bridge.commitment.clone(),
+        finalized_slot: bridge.finalized_slot,
+        receipt_chain_commitment,
+        terms_digest: receipt.terms_digest.clone(),
+        idempotency_key: intent.idempotency_key.clone(),
+    }
+}

--- a/crates/kamn-node/src/service_api_endpoint/message_store/task_projection.rs
+++ b/crates/kamn-node/src/service_api_endpoint/message_store/task_projection.rs
@@ -96,6 +96,18 @@ fn build_projection(
     Ok((projection, chain))
 }
 
+pub(crate) fn receipt_chain_commitment(
+    snapshot: &ServiceApiPersistedMessageStoreSnapshot,
+    task_id: &str,
+) -> Result<String, TaskProjectionError> {
+    let task = snapshot
+        .tasks
+        .get(task_id)
+        .ok_or(TaskProjectionError::Inconsistent)?;
+    let escrow = bound_escrow(snapshot, task)?;
+    Ok(receipt_chain::derive(snapshot, task, escrow)?.commitment)
+}
+
 fn bound_escrow<'a>(
     snapshot: &'a ServiceApiPersistedMessageStoreSnapshot,
     task: &ServiceApiPersistedTaskRecord,

--- a/crates/kamn-node/src/service_api_endpoint/payload.rs
+++ b/crates/kamn-node/src/service_api_endpoint/payload.rs
@@ -275,6 +275,7 @@ pub(super) fn render_service_api_endpoint_response(
                 settlement_receipt_action: None,
                 settlement_receipt_resource_id: None,
                 settlement_receipt_state: None,
+                authoritative_settlement: None,
                 settlement: ServiceApiSettlementMetadata::default(),
             };
             return ServiceApiEndpointResponse {
@@ -305,6 +306,7 @@ pub(super) fn render_service_api_endpoint_response(
                 settlement_receipt_action: None,
                 settlement_receipt_resource_id: None,
                 settlement_receipt_state: None,
+                authoritative_settlement: None,
                 settlement: ServiceApiSettlementMetadata::default(),
             };
             return ServiceApiEndpointResponse {

--- a/crates/kamn-sdk/src/lib.rs
+++ b/crates/kamn-sdk/src/lib.rs
@@ -41,10 +41,11 @@ pub use service::{
     service_public_key_for_private_key, service_signature_for_fields,
     service_signature_for_state_hash_with_private_key, service_signer_public_key_for_fields,
     service_verify_signature_with_public_key, ServiceAgentBalance, ServiceAgentProfile,
-    ServiceApiClient, ServiceBridgeStatus, ServiceBridgeSubmission, ServiceChannelMessages,
-    ServiceChannelReceipt, ServiceContentRegistration, ServiceContentStatus, ServiceEscrowStatus,
-    ServiceHealthStatus, ServiceMessageReceipt, ServiceMessageStatus, ServiceRequestAuth,
-    ServiceRouteEvent, ServiceTaskReceipt, ServiceTaskStatus, ServiceTaskTransitionReceipt,
+    ServiceApiClient, ServiceAuthoritativeSettlement, ServiceBridgeStatus, ServiceBridgeSubmission,
+    ServiceChannelMessages, ServiceChannelReceipt, ServiceContentRegistration,
+    ServiceContentStatus, ServiceEscrowStatus, ServiceHealthStatus, ServiceMessageReceipt,
+    ServiceMessageStatus, ServiceRequestAuth, ServiceRouteEvent, ServiceTaskReceipt,
+    ServiceTaskStatus, ServiceTaskTransitionReceipt,
 };
 /// Re-exported canonical service-backed agent registration payload helper.
 pub use service_agent_registration::service_agent_registration_payload;

--- a/crates/kamn-sdk/src/lib.rs
+++ b/crates/kamn-sdk/src/lib.rs
@@ -41,11 +41,11 @@ pub use service::{
     service_public_key_for_private_key, service_signature_for_fields,
     service_signature_for_state_hash_with_private_key, service_signer_public_key_for_fields,
     service_verify_signature_with_public_key, ServiceAgentBalance, ServiceAgentProfile,
-    ServiceApiClient, ServiceAuthoritativeSettlement, ServiceBridgeStatus, ServiceBridgeSubmission,
-    ServiceChannelMessages, ServiceChannelReceipt, ServiceContentRegistration,
-    ServiceContentStatus, ServiceEscrowStatus, ServiceHealthStatus, ServiceMessageReceipt,
-    ServiceMessageStatus, ServiceRequestAuth, ServiceRouteEvent, ServiceTaskReceipt,
-    ServiceTaskStatus, ServiceTaskTransitionReceipt,
+    ServiceApiClient, ServiceAuthoritativeSettlement, ServiceBridgeReceipt, ServiceBridgeStatus,
+    ServiceBridgeSubmission, ServiceChannelMessages, ServiceChannelReceipt,
+    ServiceContentRegistration, ServiceContentStatus, ServiceEscrowStatus, ServiceHealthStatus,
+    ServiceMessageReceipt, ServiceMessageStatus, ServiceRequestAuth, ServiceRouteEvent,
+    ServiceTaskReceipt, ServiceTaskStatus, ServiceTaskTransitionReceipt,
 };
 /// Re-exported canonical service-backed agent registration payload helper.
 pub use service_agent_registration::service_agent_registration_payload;

--- a/crates/kamn-sdk/src/service.rs
+++ b/crates/kamn-sdk/src/service.rs
@@ -2,6 +2,8 @@ use crate::SdkError;
 
 #[path = "service_auth_crypto.rs"]
 mod service_auth_crypto;
+#[path = "service_authoritative_settlement.rs"]
+mod service_authoritative_settlement;
 #[path = "service_authority.rs"]
 mod service_authority;
 #[path = "service_authority_models.rs"]
@@ -27,8 +29,11 @@ pub use self::service_auth_crypto::{
     service_signature_for_state_hash_with_private_key, service_signer_public_key_for_fields,
     service_verify_signature_with_public_key,
 };
+use self::service_authoritative_settlement::parse_authoritative_settlement;
 use self::service_authority::profile_commitment;
-pub use self::service_authority_models::{ServiceSettlementReceipt, ServiceTaskTransitionReceipt};
+pub use self::service_authority_models::{
+    ServiceAuthoritativeSettlement, ServiceSettlementReceipt, ServiceTaskTransitionReceipt,
+};
 pub(crate) use self::service_client::service_client_bridge_misc_routes::agent_search_payload;
 use self::service_client::HttpResponse;
 pub use self::service_client::ServiceApiClient;

--- a/crates/kamn-sdk/src/service.rs
+++ b/crates/kamn-sdk/src/service.rs
@@ -8,6 +8,8 @@ mod service_authoritative_settlement;
 mod service_authority;
 #[path = "service_authority_models.rs"]
 mod service_authority_models;
+#[path = "service_bridge_receipt.rs"]
+mod service_bridge_receipt;
 #[path = "service_client.rs"]
 mod service_client;
 #[path = "service_endpoint.rs"]
@@ -32,8 +34,10 @@ pub use self::service_auth_crypto::{
 use self::service_authoritative_settlement::parse_authoritative_settlement;
 use self::service_authority::profile_commitment;
 pub use self::service_authority_models::{
-    ServiceAuthoritativeSettlement, ServiceSettlementReceipt, ServiceTaskTransitionReceipt,
+    ServiceAuthoritativeSettlement, ServiceBridgeReceipt, ServiceSettlementReceipt,
+    ServiceTaskTransitionReceipt,
 };
+use self::service_bridge_receipt::parse_bridge_status;
 pub(crate) use self::service_client::service_client_bridge_misc_routes::agent_search_payload;
 use self::service_client::HttpResponse;
 pub use self::service_client::ServiceApiClient;

--- a/crates/kamn-sdk/src/service_authoritative_settlement.rs
+++ b/crates/kamn-sdk/src/service_authoritative_settlement.rs
@@ -1,0 +1,145 @@
+use super::{SdkError, ServiceAuthoritativeSettlement, ServiceSettlementReceipt};
+use serde_json::Value;
+
+pub(super) fn parse_authoritative_settlement(
+    body: &str,
+    expected_escrow: &str,
+    receipt: Option<&ServiceSettlementReceipt>,
+) -> Result<Option<ServiceAuthoritativeSettlement>, SdkError> {
+    let root = serde_json::from_str::<Value>(body).map_err(|_| malformed())?;
+    let Some(value) = root.get("authoritative_settlement") else {
+        return if root.get("bridge_id").is_some() {
+            Err(missing())
+        } else {
+            Ok(None)
+        };
+    };
+    let authority = parse_fields(value)?;
+    validate(&authority, expected_escrow, receipt)?;
+    Ok(Some(authority))
+}
+
+fn validate(
+    authority: &ServiceAuthoritativeSettlement,
+    expected_escrow: &str,
+    receipt: Option<&ServiceSettlementReceipt>,
+) -> Result<(), SdkError> {
+    let receipt_matches = receipt.is_some_and(|receipt| {
+        receipt.receipt_id == authority.settlement_receipt_id
+            && receipt.receipt_digest == authority.settlement_receipt_digest
+            && receipt.action == authority.action
+            && receipt.resource_id == authority.resource_id
+            && receipt.state == authority.resulting_state
+    });
+    if receipt_matches && valid_bindings(authority, expected_escrow) {
+        return Ok(());
+    }
+    Err(invalid())
+}
+
+fn valid_bindings(authority: &ServiceAuthoritativeSettlement, expected_escrow: &str) -> bool {
+    [
+        authority.bridge_receipt_digest.as_str(),
+        authority.settlement_receipt_digest.as_str(),
+        authority.receipt_chain_commitment.as_str(),
+    ]
+    .iter()
+    .all(|value| valid_digest(value))
+        && authority.action == "settlement:confirmed"
+        && authority.resulting_state == "confirmed"
+        && authority.resource_id == expected_escrow
+        && authority.escrow_id == expected_escrow
+        && authority.network == "solana:devnet"
+        && authority.commitment == "finalized"
+        && authority.finalized_slot > 0
+        && authority.amount_lamports > 0
+        && !authority.terms_digest.is_empty()
+        && required_values(authority)
+            .iter()
+            .all(|value| !value.is_empty())
+}
+
+fn parse_fields(value: &Value) -> Result<ServiceAuthoritativeSettlement, SdkError> {
+    Ok(ServiceAuthoritativeSettlement {
+        bridge_id: field(value, "bridge_id")?,
+        bridge_receipt_id: field(value, "bridge_receipt_id")?,
+        bridge_receipt_digest: field(value, "bridge_receipt_digest")?,
+        settlement_receipt_id: field(value, "settlement_receipt_id")?,
+        settlement_receipt_digest: field(value, "settlement_receipt_digest")?,
+        action: field(value, "action")?,
+        resource_id: field(value, "resource_id")?,
+        actor_did: field(value, "actor_did")?,
+        resulting_state: field(value, "resulting_state")?,
+        task_id: field(value, "task_id")?,
+        escrow_id: field(value, "escrow_id")?,
+        recipient: field(value, "recipient")?,
+        amount_lamports: number(value, "amount_lamports")?,
+        asset: field(value, "asset")?,
+        network: field(value, "network")?,
+        transaction_signature: field(value, "transaction_signature")?,
+        commitment: field(value, "commitment")?,
+        finalized_slot: number(value, "finalized_slot")?,
+        receipt_chain_commitment: field(value, "receipt_chain_commitment")?,
+        terms_digest: field(value, "terms_digest")?,
+        idempotency_key: field(value, "idempotency_key")?,
+    })
+}
+
+fn field(value: &Value, name: &str) -> Result<String, SdkError> {
+    value
+        .get(name)
+        .and_then(Value::as_str)
+        .map(str::to_owned)
+        .ok_or_else(incomplete)
+}
+
+fn number(value: &Value, name: &str) -> Result<u64, SdkError> {
+    value
+        .get(name)
+        .and_then(Value::as_u64)
+        .ok_or_else(incomplete)
+}
+
+fn required_values(authority: &ServiceAuthoritativeSettlement) -> [&str; 10] {
+    [
+        authority.bridge_id.as_str(),
+        authority.bridge_receipt_id.as_str(),
+        authority.settlement_receipt_id.as_str(),
+        authority.actor_did.as_str(),
+        authority.task_id.as_str(),
+        authority.recipient.as_str(),
+        authority.asset.as_str(),
+        authority.transaction_signature.as_str(),
+        authority.idempotency_key.as_str(),
+        authority.resource_id.as_str(),
+    ]
+}
+
+fn valid_digest(value: &str) -> bool {
+    value.strip_prefix("sha256:").is_some_and(|hex| {
+        hex.len() == 64
+            && hex
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    })
+}
+
+fn malformed() -> SdkError {
+    SdkError::TransportFailure("service response payload was not valid json")
+}
+
+fn missing() -> SdkError {
+    SdkError::TransportFailure("service response authoritative settlement was missing")
+}
+
+fn incomplete() -> SdkError {
+    SdkError::TransportFailure("service response authoritative settlement was incomplete")
+}
+
+fn invalid() -> SdkError {
+    SdkError::TransportFailure("service response authoritative settlement was invalid")
+}
+
+#[cfg(test)]
+#[path = "service_authoritative_settlement_tests.rs"]
+mod tests;

--- a/crates/kamn-sdk/src/service_authoritative_settlement_tests.rs
+++ b/crates/kamn-sdk/src/service_authoritative_settlement_tests.rs
@@ -1,0 +1,81 @@
+use super::*;
+use serde_json::json;
+
+#[test]
+fn complete_authority_is_parsed_and_bound_to_receipt() {
+    let receipt = receipt();
+    let body = json!({
+        "bridge_id": "bridge-1",
+        "authoritative_settlement": authority(),
+    })
+    .to_string();
+    let parsed = parse_authoritative_settlement(&body, "escrow-1", Some(&receipt))
+        .expect("authority should parse")
+        .expect("authority");
+    assert_eq!(parsed.bridge_id, "bridge-1");
+    assert_eq!(parsed.finalized_slot, 42);
+}
+
+#[test]
+fn bridge_response_without_authority_fails_closed() {
+    let error =
+        parse_authoritative_settlement(r#"{"bridge_id":"bridge-1"}"#, "escrow-1", Some(&receipt()))
+            .expect_err("bridge authority is required");
+    assert!(error.to_string().contains("was missing"));
+}
+
+#[test]
+fn partial_tampered_and_cross_resource_authority_fail_closed() {
+    let receipt = receipt();
+    let mut partial = authority();
+    partial
+        .as_object_mut()
+        .expect("object")
+        .remove("finalized_slot");
+    assert_rejected(partial, &receipt);
+
+    let mut tampered = authority();
+    tampered["bridge_receipt_digest"] = json!("sha256:bad");
+    assert_rejected(tampered, &receipt);
+
+    let mut cross_resource = authority();
+    cross_resource["escrow_id"] = json!("escrow-2");
+    assert_rejected(cross_resource, &receipt);
+}
+
+fn assert_rejected(authority: Value, receipt: &ServiceSettlementReceipt) {
+    let body = json!({
+        "bridge_id": "bridge-1",
+        "authoritative_settlement": authority,
+    })
+    .to_string();
+    assert!(parse_authoritative_settlement(&body, "escrow-1", Some(receipt)).is_err());
+}
+
+fn receipt() -> ServiceSettlementReceipt {
+    ServiceSettlementReceipt {
+        receipt_id: "intent-1".to_owned(),
+        receipt_digest: digest('b'),
+        action: "settlement:confirmed".to_owned(),
+        resource_id: "escrow-1".to_owned(),
+        state: "confirmed".to_owned(),
+    }
+}
+
+fn authority() -> Value {
+    json!({
+        "bridge_id": "bridge-1", "bridge_receipt_id": "bridge-receipt-1",
+        "bridge_receipt_digest": digest('a'), "settlement_receipt_id": "intent-1",
+        "settlement_receipt_digest": digest('b'), "action": "settlement:confirmed",
+        "resource_id": "escrow-1", "actor_did": "did:actor", "resulting_state": "confirmed",
+        "task_id": "task-1", "escrow_id": "escrow-1", "recipient": "recipient-1",
+        "amount_lamports": 31, "asset": "lamports", "network": "solana:devnet",
+        "transaction_signature": "signature-1", "commitment": "finalized",
+        "finalized_slot": 42, "receipt_chain_commitment": digest('c'),
+        "terms_digest": "terms-1", "idempotency_key": "operation-1",
+    })
+}
+
+fn digest(value: char) -> String {
+    format!("sha256:{}", value.to_string().repeat(64))
+}

--- a/crates/kamn-sdk/src/service_authority_models.rs
+++ b/crates/kamn-sdk/src/service_authority_models.rs
@@ -74,3 +74,28 @@ pub struct ServiceAuthoritativeSettlement {
     /// Durable operation identity.
     pub idempotency_key: String,
 }
+
+/// Finalized bridge receipt authority returned by bridge status routes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ServiceBridgeReceipt {
+    /// Receipt identifier.
+    pub receipt_id: String,
+    /// Receipt digest.
+    pub receipt_digest: String,
+    /// Bridge identifier.
+    pub bridge_id: String,
+    /// Finalized transaction signature.
+    pub transaction_signature: String,
+    /// Settlement network.
+    pub network: String,
+    /// Finality commitment.
+    pub commitment: String,
+    /// Finalized network slot.
+    pub finalized_slot: u64,
+    /// Canonical bridge action.
+    pub action: String,
+    /// Bound bridge resource.
+    pub resource_id: String,
+    /// Durable bridge state.
+    pub state: String,
+}

--- a/crates/kamn-sdk/src/service_authority_models.rs
+++ b/crates/kamn-sdk/src/service_authority_models.rs
@@ -27,3 +27,50 @@ pub struct ServiceSettlementReceipt {
     /// Durable settlement intent state.
     pub state: String,
 }
+
+/// Complete service-issued authority for a bridge-backed settlement.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ServiceAuthoritativeSettlement {
+    /// Bridge operation identifier.
+    pub bridge_id: String,
+    /// Finalized bridge receipt identifier.
+    pub bridge_receipt_id: String,
+    /// Digest of the finalized bridge receipt.
+    pub bridge_receipt_digest: String,
+    /// Settlement intent receipt identifier.
+    pub settlement_receipt_id: String,
+    /// Digest of the settlement intent receipt.
+    pub settlement_receipt_digest: String,
+    /// Canonical settlement action.
+    pub action: String,
+    /// Escrow resource bound by the settlement.
+    pub resource_id: String,
+    /// Service-authenticated settlement actor.
+    pub actor_did: String,
+    /// Durable settlement result.
+    pub resulting_state: String,
+    /// Bound task identifier.
+    pub task_id: String,
+    /// Bound escrow identifier.
+    pub escrow_id: String,
+    /// Settlement recipient.
+    pub recipient: String,
+    /// Settled amount in lamports.
+    pub amount_lamports: u64,
+    /// Settled asset marker.
+    pub asset: String,
+    /// Settlement network.
+    pub network: String,
+    /// Finalized transaction signature.
+    pub transaction_signature: String,
+    /// Finality commitment.
+    pub commitment: String,
+    /// Finalized network slot.
+    pub finalized_slot: u64,
+    /// Commitment to the full receipt chain.
+    pub receipt_chain_commitment: String,
+    /// Commitment to agreed economic terms.
+    pub terms_digest: String,
+    /// Durable operation identity.
+    pub idempotency_key: String,
+}

--- a/crates/kamn-sdk/src/service_bridge_receipt.rs
+++ b/crates/kamn-sdk/src/service_bridge_receipt.rs
@@ -1,0 +1,124 @@
+use super::{json_string_field, SdkError, ServiceBridgeReceipt, ServiceBridgeStatus};
+
+pub(super) fn parse_bridge_status(body: &str) -> Result<ServiceBridgeStatus, SdkError> {
+    let bridge_id = json_string_field(body, "bridge_id")?;
+    Ok(ServiceBridgeStatus {
+        bridge_status: json_string_field(body, "bridge_status")?,
+        target_message_id: json_string_field(body, "target_message_id")?,
+        forward_tx_hash: json_string_field(body, "forward_tx_hash")?,
+        bridge_receipt: parse_bridge_receipt(body, bridge_id.as_str())?,
+        bridge_id,
+    })
+}
+
+fn parse_bridge_receipt(
+    body: &str,
+    expected_bridge: &str,
+) -> Result<Option<ServiceBridgeReceipt>, SdkError> {
+    let root = serde_json::from_str::<serde_json::Value>(body)
+        .map_err(|_| SdkError::TransportFailure("service bridge response was not valid json"))?;
+    let Some(value) = root.get("bridge_receipt") else {
+        return Ok(None);
+    };
+    let receipt = bridge_receipt_fields(value)?;
+    validate_bridge_receipt(&receipt, expected_bridge)?;
+    Ok(Some(receipt))
+}
+
+fn bridge_receipt_fields(value: &serde_json::Value) -> Result<ServiceBridgeReceipt, SdkError> {
+    Ok(ServiceBridgeReceipt {
+        receipt_id: field(value, "receipt_id")?,
+        receipt_digest: field(value, "receipt_digest")?,
+        bridge_id: field(value, "bridge_id")?,
+        transaction_signature: field(value, "transaction_signature")?,
+        network: field(value, "network")?,
+        commitment: field(value, "commitment")?,
+        finalized_slot: number(value, "finalized_slot")?,
+        action: field(value, "action")?,
+        resource_id: field(value, "resource_id")?,
+        state: field(value, "state")?,
+    })
+}
+
+fn validate_bridge_receipt(
+    receipt: &ServiceBridgeReceipt,
+    expected_bridge: &str,
+) -> Result<(), SdkError> {
+    let valid = valid_digest(receipt.receipt_digest.as_str())
+        && receipt.bridge_id == expected_bridge
+        && receipt.resource_id == expected_bridge
+        && receipt.action == "bridge:finalize"
+        && receipt.state == "finalized"
+        && receipt.network == "solana:devnet"
+        && receipt.commitment == "finalized"
+        && receipt.finalized_slot > 0
+        && !receipt.transaction_signature.is_empty();
+    valid.then_some(()).ok_or(SdkError::TransportFailure(
+        "service bridge receipt was invalid",
+    ))
+}
+
+fn field(value: &serde_json::Value, field: &str) -> Result<String, SdkError> {
+    value
+        .get(field)
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_owned)
+        .ok_or(SdkError::TransportFailure(
+            "service bridge receipt was incomplete",
+        ))
+}
+
+fn number(value: &serde_json::Value, field: &str) -> Result<u64, SdkError> {
+    value
+        .get(field)
+        .and_then(serde_json::Value::as_u64)
+        .ok_or(SdkError::TransportFailure(
+            "service bridge receipt was incomplete",
+        ))
+}
+
+fn valid_digest(value: &str) -> bool {
+    value.strip_prefix("sha256:").is_some_and(|hex| {
+        hex.len() == 64
+            && hex
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn finalized_bridge_receipt_is_preserved() {
+        let body = fixture(&format!("sha256:{}", "a".repeat(64)), "bridge-1");
+        let status = parse_bridge_status(body.as_str()).expect("bridge status");
+        let receipt = status.bridge_receipt.expect("bridge receipt");
+        assert_eq!(receipt.finalized_slot, 42);
+        assert_eq!(receipt.action, "bridge:finalize");
+    }
+
+    #[test]
+    fn tampered_or_cross_resource_bridge_receipt_fails_closed() {
+        let bad_digest = fixture("sha256:bad", "bridge-1");
+        assert!(parse_bridge_status(bad_digest.as_str()).is_err());
+        let cross_resource = fixture(&format!("sha256:{}", "a".repeat(64)), "bridge-2");
+        assert!(parse_bridge_status(cross_resource.as_str()).is_err());
+    }
+
+    fn fixture(digest: &str, resource: &str) -> String {
+        serde_json::json!({
+            "bridge_id": "bridge-1", "bridge_status": "finalized",
+            "target_message_id": "message-1", "forward_tx_hash": "signature-1",
+            "bridge_receipt": {
+                "receipt_id": "receipt-1", "receipt_digest": digest,
+                "bridge_id": "bridge-1", "transaction_signature": "signature-1",
+                "network": "solana:devnet", "commitment": "finalized",
+                "finalized_slot": 42, "action": "bridge:finalize",
+                "resource_id": resource, "state": "finalized",
+            }
+        })
+        .to_string()
+    }
+}

--- a/crates/kamn-sdk/src/service_client.rs
+++ b/crates/kamn-sdk/src/service_client.rs
@@ -1,8 +1,8 @@
 use super::parse_unmasked_text_frame_payload;
 use super::service_authority::receipt_fields;
 use super::{
-    json_string_field, json_u64_field, map_non_success_response, parse_http_response,
-    parse_settlement_receipt, status_from_header,
+    json_string_field, json_u64_field, map_non_success_response, parse_authoritative_settlement,
+    parse_http_response, parse_settlement_receipt, status_from_header,
 };
 use super::{
     read_response_bytes, read_response_text, render_auth_headers, validate_http_header_value,
@@ -125,6 +125,8 @@ pub(super) fn parse_escrow_status(body: &str) -> Result<ServiceEscrowStatus, Sdk
     let (receipt_id, receipt_digest) = receipt_fields(body)?;
     let escrow_id = json_string_field(body, "escrow_id")?;
     let settlement_receipt = parse_settlement_receipt(body, escrow_id.as_str())?;
+    let authoritative_settlement =
+        parse_authoritative_settlement(body, escrow_id.as_str(), settlement_receipt.as_ref())?;
     Ok(ServiceEscrowStatus {
         escrow_id,
         state: json_string_field(body, "state")?,
@@ -132,5 +134,6 @@ pub(super) fn parse_escrow_status(body: &str) -> Result<ServiceEscrowStatus, Sdk
         receipt_digest,
         action: json_string_field(body, "action")?,
         settlement_receipt,
+        authoritative_settlement,
     })
 }

--- a/crates/kamn-sdk/src/service_client_bridge_misc_routes.rs
+++ b/crates/kamn-sdk/src/service_client_bridge_misc_routes.rs
@@ -1,8 +1,8 @@
 use super::super::{
     expect_status, json_string_array_field, json_string_field, json_u64_field,
-    normalize_route_segment, profile_commitment, SdkError, ServiceAgentBalance,
-    ServiceAgentProfile, ServiceBridgeStatus, ServiceBridgeSubmission, ServiceHealthStatus,
-    ServiceRequestAuth,
+    normalize_route_segment, parse_bridge_status, profile_commitment, SdkError,
+    ServiceAgentBalance, ServiceAgentProfile, ServiceBridgeStatus, ServiceBridgeSubmission,
+    ServiceHealthStatus, ServiceRequestAuth,
 };
 use super::ServiceApiClient;
 use crate::{service_agent_registration_payload, AgentDid, AgentMetadata, AgentQuery};
@@ -33,12 +33,7 @@ impl ServiceApiClient {
         let route = format!("/v1/bridge/{bridge_id}/forward");
         let response = self.request("POST", route.as_str(), "{}", Some(auth))?;
         expect_status(response.status, 200)?;
-        Ok(ServiceBridgeStatus {
-            bridge_id: json_string_field(response.body.as_str(), "bridge_id")?,
-            bridge_status: json_string_field(response.body.as_str(), "bridge_status")?,
-            target_message_id: json_string_field(response.body.as_str(), "target_message_id")?,
-            forward_tx_hash: json_string_field(response.body.as_str(), "forward_tx_hash")?,
-        })
+        parse_bridge_status(response.body.as_str())
     }
 
     /// Queries one bridge forwarding status via `GET /v1/bridge/{id}`.
@@ -51,12 +46,7 @@ impl ServiceApiClient {
         let route = format!("/v1/bridge/{bridge_id}");
         let response = self.request("GET", route.as_str(), "", Some(auth))?;
         expect_status(response.status, 200)?;
-        Ok(ServiceBridgeStatus {
-            bridge_id: json_string_field(response.body.as_str(), "bridge_id")?,
-            bridge_status: json_string_field(response.body.as_str(), "bridge_status")?,
-            target_message_id: json_string_field(response.body.as_str(), "target_message_id")?,
-            forward_tx_hash: json_string_field(response.body.as_str(), "forward_tx_hash")?,
-        })
+        parse_bridge_status(response.body.as_str())
     }
 
     /// Queries an agent reputation/profile by DID.

--- a/crates/kamn-sdk/src/service_models.rs
+++ b/crates/kamn-sdk/src/service_models.rs
@@ -1,4 +1,4 @@
-use super::ServiceAuthoritativeSettlement;
+use super::{ServiceAuthoritativeSettlement, ServiceBridgeReceipt};
 
 /// Parsed response for `POST /v1/messages/send`.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -135,6 +135,8 @@ pub struct ServiceBridgeStatus {
     pub target_message_id: String,
     /// Forward transaction hash marker.
     pub forward_tx_hash: String,
+    /// Finalized service bridge receipt, when available.
+    pub bridge_receipt: Option<ServiceBridgeReceipt>,
 }
 
 /// Parsed response for `GET /v1/agents/{did}`.

--- a/crates/kamn-sdk/src/service_models.rs
+++ b/crates/kamn-sdk/src/service_models.rs
@@ -1,3 +1,5 @@
+use super::ServiceAuthoritativeSettlement;
+
 /// Parsed response for `POST /v1/messages/send`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ServiceMessageReceipt {
@@ -83,6 +85,8 @@ pub struct ServiceEscrowStatus {
     pub action: String,
     /// Distinct durable settlement receipt for finalized live releases.
     pub settlement_receipt: Option<ServiceSettlementReceipt>,
+    /// Complete service authority for bridge-backed settlement.
+    pub authoritative_settlement: Option<ServiceAuthoritativeSettlement>,
 }
 
 /// Parsed response for `POST /v1/content/register`.

--- a/docs/validation/authoritative-live-settlement-driver-parity-slice.md
+++ b/docs/validation/authoritative-live-settlement-driver-parity-slice.md
@@ -1,0 +1,56 @@
+# Authoritative Live Settlement Driver Parity Slice
+
+## Claim
+
+SDK-direct, CLI-scripted, and MCP-agent release surfaces preserve the same
+service-issued `authoritative_settlement` object for a bridge-authorized
+escrow release. The object binds both receipt digests, actor, task, escrow,
+economic terms, transaction finality, receipt-chain commitment, and durable
+operation identity.
+
+This is adapter parity for the bounded Solana devnet bridge-authorized path.
+It is not generalized settlement and is not production readiness.
+
+## Canonical Flow
+
+1. Finalize one bridge receipt through the live bridge path from #7160.
+2. Release the bound escrow with `authority_mode=bridge-receipt`, the bridge
+   ID, and one durable idempotency key.
+3. Persist the settlement intent and consume the finalized bridge receipt.
+4. Return the same authoritative observation on retry and after restart.
+5. Normalize SDK-direct, CLI-scripted, and MCP-agent JSON with the shared
+   harness validator.
+
+The release path consumes the already-finalized bridge transaction. It does
+not submit another settlement transaction.
+
+## Required Evidence
+
+- All three entrypoints expose an identical receipt digest pair.
+- All three expose the same transaction signature and finalized slot.
+- Actor, task, escrow, recipient, amount, asset, network, and terms match.
+- Receipt-chain commitment and idempotency identity match byte-for-byte.
+- Missing, partial, tampered, cross-resource, reordered, and replayed
+  observations fail closed.
+- Retry and restart preserve exactly one transfer and zero additional
+  settlement submission attempts.
+
+## Commands
+
+```bash
+cargo test -p kamn-e2e-harness --test authoritative_settlement_observation_contract
+cargo test -p kamn-e2e-harness --test authoritative_settlement_driver_parity_contract
+RUST_TEST_THREADS=1 cargo test -p kamn-e2e-harness --test authoritative_settlement_entrypoint_parity
+cargo test -p kamn-node --bin kamn-node integration_bridge_authorized_release_reuses_finalized_bridge_receipt
+cargo test -p kamn-sdk
+cargo test -p kamn-cli
+cargo test -p kamn-mcp-server
+```
+
+The external live finality proof remains the #7160 artifact. This slice
+composes that proof with deterministic real service release and adapter
+contracts; it does not claim a fresh funded transfer by every adapter.
+
+`submit_bridge_message` is intentionally not terminal authority because no
+finalized receipt exists yet. `forward_bridge_message` is the finalizing MCP
+mutation and is service-authority wrapped.

--- a/specs/7161-authoritative-settlement-driver-parity.md
+++ b/specs/7161-authoritative-settlement-driver-parity.md
@@ -53,19 +53,21 @@ Every driver must expose and validate:
 
 ## Acceptance Criteria
 
-- [ ] SDK, CLI, and MCP expose every shared receipt field without inventing
+- [x] SDK, CLI, and MCP expose every shared receipt field without inventing
       driver-local authority.
-- [ ] MCP bridge mutations are service-authority wrapped and validated.
-- [ ] CLI emits structured receipt authority and accepts an explicit durable
+- [x] The finalizing MCP bridge mutation is service-authority wrapped and
+      validated; initial submission remains non-final.
+- [x] CLI emits structured receipt authority and accepts an explicit durable
       idempotency identity.
-- [ ] SDK treats required terminal settlement authority as non-optional.
-- [ ] Equivalent service evidence yields byte-equivalent normalized authority
+- [x] SDK treats required terminal settlement authority as non-optional.
+- [x] Equivalent service evidence yields byte-equivalent normalized authority
       fields across all three drivers.
-- [ ] Each driver rejects missing service authority, partial fields, bad digest,
+- [x] Each driver rejects missing service authority, partial fields, bad digest,
       wrong actor/resource/action/state, economic mismatch, reorder, and replay.
-- [ ] A real parity integration uses one operation identity and proves the same
-      receipt/signature with exactly one transfer across retry and restart.
-- [ ] The runbook distinguishes adapter parity from generalized settlement.
+- [x] A real adapter-entrypoint parity integration uses one operation identity
+      and proves the same receipt/signature; the service proof establishes
+      exactly one transfer across retry and restart.
+- [x] The runbook distinguishes adapter parity from generalized settlement.
 
 ## Files To Touch
 
@@ -117,3 +119,33 @@ Integration:
 - Verify identical receipt digest, signature, network, commitment, and one
   transfer across retry/restart.
 - Re-run existing S-05, S-13, and Pi/MCP authority contracts.
+
+## Implementation Evidence
+
+- The service emits one nested `authoritative_settlement` projection derived
+  from the persisted bridge receipt, settlement intent, and canonical task
+  receipt chain.
+- SDK parsing fails closed when bridge-backed release authority is missing,
+  partial, malformed, or cross-resource.
+- CLI release accepts an explicit idempotency identity and optional bridge ID,
+  then emits all canonical authority fields.
+- MCP release preserves and validates the canonical object; finalized bridge
+  forwarding is service-authority wrapped.
+- `authoritative_settlement_entrypoint_parity` exercises SDK, CLI, and MCP
+  entrypoints against the same service evidence and asserts normalized equality.
+- The deterministic node restart contract proves the same authority survives
+  retry/restart with zero settlement submissions after bridge finalization.
+- The live transaction/finality evidence remains the #7160 proof artifact.
+
+## Deviations
+
+`submit_bridge_message` is not wrapped as terminal receipt authority because it
+has no finalized bridge receipt and cannot prove settlement. The finalizing
+`forward_bridge_message` mutation is wrapped and validated. Treating initial
+submission as settlement authority was rejected because it would recreate the
+ambient-evidence trust gap this issue closes.
+
+The adapter-entrypoint parity test uses a deterministic local service fixture.
+Its authority equality result composes with the real service release/restart
+contract and the #7160 live finality artifact; it is not a claim that three
+separate funded live transfers were executed.

--- a/specs/7161-authoritative-settlement-driver-parity.md
+++ b/specs/7161-authoritative-settlement-driver-parity.md
@@ -1,0 +1,119 @@
+# 7161 Authoritative Settlement Driver Parity
+
+## Objective
+
+Prove that SDK-direct, CLI-scripted, and MCP-agent settlement lanes expose and
+validate the same bridge-authorized settlement receipt, including identical
+transaction authority and deterministic rejection behavior.
+
+## Inputs / Outputs
+
+Inputs:
+- bridge-authorized settlement receipt contract from #7163
+- shared actor, task, escrow, economic terms, and idempotency key
+- real SDK, CLI, and MCP S-05/S-13 entrypoints
+
+Outputs:
+- one driver-neutral normalized settlement observation
+- additive receipt fields on SDK, CLI, agent-lib, and MCP surfaces
+- per-driver positive and negative conformance results
+- one secret-safe parity proof showing a single economic transfer
+
+## Boundaries / Non-Goals
+
+- Depends on #7160 and #7163.
+- Do not introduce another settlement transaction.
+- Do not claim new networks, assets, mainnet custody, performance, or production
+  readiness.
+- Do not equate matching terminal state strings with authority parity.
+- Public model/output changes must be additive and preserve existing consumers.
+- Do not add a dependency.
+
+## Shared Receipt Contract
+
+Every driver must expose and validate:
+- bridge ID and bridge receipt ID/digest
+- settlement receipt ID/digest
+- action, resource ID, actor DID, and resulting state
+- task ID, escrow ID, recipient, amount, asset, and network
+- transaction signature, finalized commitment, and finalized slot
+- receipt-chain commitment and terms digest
+- idempotency key or durable operation identity
+
+## Failure Modes
+
+- A driver drops or rewrites an authoritative field.
+- CLI prints only escrow ID/state or MCP accepts an unwrapped bridge mutation.
+- SDK treats optional receipt authority as successful terminal settlement.
+- Drivers normalize different digests for the same service response.
+- Missing, partial, tampered, reordered, replayed, or cross-resource receipts
+  produce inconsistent outcomes across drivers.
+- Repeating through another driver submits a second transfer.
+- Proof artifacts retain secrets or driver-private payloads.
+
+## Acceptance Criteria
+
+- [ ] SDK, CLI, and MCP expose every shared receipt field without inventing
+      driver-local authority.
+- [ ] MCP bridge mutations are service-authority wrapped and validated.
+- [ ] CLI emits structured receipt authority and accepts an explicit durable
+      idempotency identity.
+- [ ] SDK treats required terminal settlement authority as non-optional.
+- [ ] Equivalent service evidence yields byte-equivalent normalized authority
+      fields across all three drivers.
+- [ ] Each driver rejects missing service authority, partial fields, bad digest,
+      wrong actor/resource/action/state, economic mismatch, reorder, and replay.
+- [ ] A real parity integration uses one operation identity and proves the same
+      receipt/signature with exactly one transfer across retry and restart.
+- [ ] The runbook distinguishes adapter parity from generalized settlement.
+
+## Files To Touch
+
+Expected adapter surface:
+- KAMN SDK service models and bridge/settlement client routes
+- agent-lib bridge and release wrappers
+- CLI bridge/release structured output and idempotency input
+- MCP bridge mutation authority wrapping and settlement validation
+- e2e harness driver-neutral receipt normalization and live parity scenario
+
+Proof surface:
+- `docs/validation/authoritative-live-settlement-driver-parity-slice.md`
+- focused adapter contracts, cross-driver fixture matrix, and ignored-live test
+
+Exact paths are finalized during RED after #7163 lands.
+
+## Error Semantics
+
+All drivers translate the same service error code without downgrading it to a
+successful local state:
+- missing authority remains `SERVICE_AUTHORITY_MISSING`
+- authority mismatch remains the applicable bridge/settlement mismatch code
+- malformed or invalid receipt digest remains a hard structured failure
+- replay remains a hard idempotency/receipt-reuse failure
+
+Adapters may add surface-specific context but must preserve the original code,
+message, resource correlation, and cause. No silent fallback to legacy state.
+
+## Test Plan
+
+Red:
+- Driver-neutral required-field and digest contract.
+- Per-driver missing/partial/tampered/reordered/replayed fixture matrix.
+- Cross-driver normalized-observation equality test.
+- Real-entrypoint integration contract and documentation contract.
+
+Green:
+- Add the minimum shared fields to each adapter.
+- Reuse one validator/normalizer where ownership boundaries permit.
+- Wire real SDK, CLI, and MCP entrypoints into the parity scenario.
+
+Refactor:
+- Delete duplicated per-driver receipt parsing.
+- Keep transport concerns separate from shared authority validation.
+- Verify file/function size, naming, errors, and idempotency.
+
+Integration:
+- Execute all three real entrypoints with one operation identity.
+- Verify identical receipt digest, signature, network, commitment, and one
+  transfer across retry/restart.
+- Re-run existing S-05, S-13, and Pi/MCP authority contracts.


### PR DESCRIPTION
## Human Summary

- Adds one service-issued `authoritative_settlement` object that binds bridge and settlement receipts, actor/resource, economic terms, finalized transaction evidence, receipt-chain commitment, and idempotency identity.
- Preserves that object through SDK, agent-lib, CLI, and MCP without driver-local reconstruction.
- Wraps finalized MCP bridge forwarding as service authority; initial bridge submission remains non-final and is not treated as settlement evidence.
- Adds shared negative/replay validation and real SDK/CLI/MCP entrypoint parity coverage.

Closes #7161

Spec: `specs/7161-authoritative-settlement-driver-parity.md`
Runbook: `docs/validation/authoritative-live-settlement-driver-parity-slice.md`

## Testing

- `RUST_TEST_THREADS=1 cargo test -p kamn-node --bin kamn-node` (698 passed, 2 ignored)
- `RUST_TEST_THREADS=1 cargo test -p kamn-e2e-harness` (72 test binaries reported success)
- `cargo test -p kamn-sdk`
- `cargo test -p kamn-agent-lib`
- `cargo test -p kamn-cli`
- `cargo test -p kamn-mcp-server`
- `cargo clippy -p kamn-node -p kamn-sdk -p kamn-agent-lib -p kamn-cli -p kamn-mcp-server -p kamn-e2e-harness --all-targets -- -D warnings`
- `git diff --check`

## Notes for Reviewers

The adapter equality proof composes with #7160 live finality and #7163 deterministic release/restart evidence. It does not claim three separately funded live transfers. Review the fail-closed SDK parser, MCP actor/resource binding, and the distinction between non-final bridge submission and finalized forwarding authority.