### PR TITLE
docs: synchronize authority closeout proof index

### DIFF
--- a/crates/kamn-node/tests/runtime_proof_index_authority_closeout_contract.rs
+++ b/crates/kamn-node/tests/runtime_proof_index_authority_closeout_contract.rs
@@ -2,6 +2,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 const INDEX_PATH: &str = "docs/validation/current-proven-runtime-slices.md";
+const EXTERNAL_SECTION: &str = "## External Evidence That Is Not a Proven Runtime Slice";
 const PROVEN_MARKERS: &[&str] = &[
     "docs/validation/live-chain-backed-bridge-finality-slice.md",
     "docs/validation/bridge-authorized-escrow-settlement-slice.md",
@@ -10,7 +11,7 @@ const PROVEN_MARKERS: &[&str] = &[
     "composes live finality with deterministic service and adapter contracts",
 ];
 const EXTERNAL_MARKERS: &[&str] = &[
-    "## External Evidence That Is Not a Proven Runtime Slice",
+    EXTERNAL_SECTION,
     "docs/validation/external-a2a-x402-receipt-authority-probe.md",
     "FAIL",
     "BLOCKED",
@@ -28,14 +29,13 @@ fn authority_closeout_artifacts_are_indexed_with_bounded_claims() {
 #[test]
 fn external_probe_is_outside_the_proven_runtime_section() {
     let index = read_workspace_file(INDEX_PATH);
-    let remains = marker_position(&index, "## What Remains Unproven");
-    let external = marker_position(
-        &index,
-        "## External Evidence That Is Not a Proven Runtime Slice",
-    );
+    assert_marker_follows(&index, EXTERNAL_SECTION, "## What Remains Unproven");
+}
+
+fn assert_marker_follows(doc: &str, marker: &str, predecessor: &str) {
     assert!(
-        external > remains,
-        "external probe section must follow the proven-runtime section"
+        marker_position(doc, marker) > marker_position(doc, predecessor),
+        "{marker} must follow {predecessor}"
     );
 }
 

--- a/crates/kamn-node/tests/runtime_proof_index_authority_closeout_contract.rs
+++ b/crates/kamn-node/tests/runtime_proof_index_authority_closeout_contract.rs
@@ -1,0 +1,67 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const INDEX_PATH: &str = "docs/validation/current-proven-runtime-slices.md";
+const PROVEN_MARKERS: &[&str] = &[
+    "docs/validation/live-chain-backed-bridge-finality-slice.md",
+    "docs/validation/bridge-authorized-escrow-settlement-slice.md",
+    "reuses the finalized bridge transfer",
+    "docs/validation/authoritative-live-settlement-driver-parity-slice.md",
+    "composes live finality with deterministic service and adapter contracts",
+];
+const EXTERNAL_MARKERS: &[&str] = &[
+    "## External Evidence That Is Not a Proven Runtime Slice",
+    "docs/validation/external-a2a-x402-receipt-authority-probe.md",
+    "FAIL",
+    "BLOCKED",
+    "no approval response",
+    "no settlement response",
+];
+
+#[test]
+fn authority_closeout_artifacts_are_indexed_with_bounded_claims() {
+    let index = read_workspace_file(INDEX_PATH);
+    assert_contains_all(&index, PROVEN_MARKERS);
+    assert_contains_all(&index, EXTERNAL_MARKERS);
+}
+
+#[test]
+fn external_probe_is_outside_the_proven_runtime_section() {
+    let index = read_workspace_file(INDEX_PATH);
+    let remains = marker_position(&index, "## What Remains Unproven");
+    let external = marker_position(
+        &index,
+        "## External Evidence That Is Not a Proven Runtime Slice",
+    );
+    assert!(
+        external > remains,
+        "external probe section must follow the proven-runtime section"
+    );
+}
+
+fn marker_position(doc: &str, marker: &str) -> usize {
+    doc.find(marker)
+        .unwrap_or_else(|| panic!("runtime proof index missing marker: {marker}"))
+}
+
+fn assert_contains_all(doc: &str, markers: &[&str]) {
+    for marker in markers {
+        assert!(
+            doc.contains(marker),
+            "runtime proof index missing marker: {marker}"
+        );
+    }
+}
+
+fn read_workspace_file(relative_path: &str) -> String {
+    let path = workspace_root().join(relative_path);
+    fs::read_to_string(&path)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", path.display()))
+}
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("workspace root should resolve")
+}

--- a/docs/validation/current-proven-runtime-slices.md
+++ b/docs/validation/current-proven-runtime-slices.md
@@ -35,6 +35,10 @@ This index summarizes the runtime behavior that current `main` proves today thro
   - proves the live Solana-backed bridge evidence lane reaches the presence-mode websocket surface
 - live chain-backed bridge finality slice: `docs/validation/live-chain-backed-bridge-finality-slice.md`
   - proves one bounded finalized Solana devnet bridge receipt with independent RPC verification and restart-safe reconciliation
+- bridge-authorized escrow settlement slice: `docs/validation/bridge-authorized-escrow-settlement-slice.md`
+  - proves one bounded release whose authority is a matching finalized bridge receipt; release reuses the finalized bridge transfer and does not submit a second settlement transaction
+- authoritative live settlement driver parity slice: `docs/validation/authoritative-live-settlement-driver-parity-slice.md`
+  - proves SDK-direct, CLI-scripted, and MCP-agent surfaces preserve the same service-issued settlement authority; this composes live finality with deterministic service and adapter contracts rather than claiming three funded live transfers
 - live escrow settlement slice: `docs/validation/live-escrow-settlement-slice.md`
   - proves one bounded live escrow settlement execution lane through external-execution `sdk-direct` S-05
 - live escrow CLI parity slice: `docs/validation/live-escrow-cli-parity-slice.md`
@@ -54,6 +58,11 @@ This index summarizes the runtime behavior that current `main` proves today thro
 - generalized external settlement beyond one bounded Solana devnet asset-movement lane
 - broad multi-driver live economic-settlement parity
 - global fault tolerance under arbitrary partitions
+
+## External Evidence That Is Not a Proven Runtime Slice
+- external A2A x402 receipt-authority probe: `docs/validation/external-a2a-x402-receipt-authority-probe.md`
+  - records a bounded `FAIL` because the observed challenge did not bind a request digest, nonce, challenge ID, or absolute expiry
+  - settlement visibility remains `BLOCKED`: no approval response and no settlement response were observed, and no signed retry or payment was attempted
 
 ## How To Use This Index
 Start here when evaluating what KAMN actually demonstrates on current `main`. Then follow the linked runbooks to the exact test commands and operator evidence for each slice.

--- a/specs/7169-runtime-proof-index-authority-closeout.md
+++ b/specs/7169-runtime-proof-index-authority-closeout.md
@@ -39,16 +39,16 @@ Outputs:
 
 ## Acceptance Criteria
 
-- [ ] The index links the #7160 live finality runbook with bounded wording.
-- [ ] The index links the #7163 bridge-authorized settlement runbook and states
+- [x] The index links the #7160 live finality runbook with bounded wording.
+- [x] The index links the #7163 bridge-authorized settlement runbook and states
       that release reuses the finalized bridge transfer.
-- [ ] The index links the #7161 authority-parity runbook and preserves its
+- [x] The index links the #7161 authority-parity runbook and preserves its
       composed-proof limitation.
-- [ ] The index links the #7162 probe in a separate non-proof section with FAIL,
+- [x] The index links the #7162 probe in a separate non-proof section with FAIL,
       BLOCKED, no-approval, and no-settlement boundaries.
-- [ ] A focused Rust docs contract fails when a link, classification boundary,
+- [x] A focused Rust docs contract fails when a link, classification boundary,
       or critical claim marker is removed.
-- [ ] Targeted tests, formatting, and lint/static checks pass.
+- [x] Targeted tests, formatting, and lint/static checks pass.
 
 ## Files To Touch
 
@@ -80,3 +80,16 @@ Refactor:
 Integration:
 - Run both proof-index contracts against the real workspace documentation.
 - Verify every indexed path exists on the final tree.
+
+## Implementation Evidence
+
+- The canonical index links all three bounded KAMN authority slices under
+  `What Is Currently Proven`.
+- The bridge-authorized entry states that release reuses the finalized bridge
+  transfer and does not submit another settlement transaction.
+- The adapter-parity entry identifies the composed live/deterministic proof and
+  rejects a three-funded-transfer interpretation.
+- The external probe is in a later non-proof section with `FAIL`, `BLOCKED`,
+  no-approval, and no-settlement markers.
+- The focused authority-closeout and existing runtime-index contracts pass
+  against the same workspace documentation.

--- a/specs/7169-runtime-proof-index-authority-closeout.md
+++ b/specs/7169-runtime-proof-index-authority-closeout.md
@@ -1,0 +1,82 @@
+# 7169 Runtime Proof Index Authority Closeout
+
+## Objective
+
+Synchronize the canonical runtime-proof index with the four validation
+artifacts merged by the settlement-authority closeout while keeping failed or
+blocked external observations separate from proven KAMN runtime behavior.
+
+## Inputs / Outputs
+
+Inputs:
+- the #7160 live chain-backed bridge finality runbook
+- the #7163 bridge-authorized escrow settlement runbook
+- the #7161 authoritative SDK, CLI, and MCP parity runbook
+- the #7162 external A2A/x402 receipt-authority probe
+
+Outputs:
+- bounded entries for the three proven KAMN slices
+- a separate external evidence section for the failed and blocked probe
+- a hard-fail documentation contract covering links and claim boundaries
+
+## Boundaries / Non-Goals
+
+- Do not rerun or claim another funded transaction.
+- Do not change runtime, adapter, protocol, or public API behavior.
+- Do not present the external probe as KAMN service authority or a successful
+  settlement.
+- Do not claim generalized settlement, mainnet custody, consensus, or
+  production readiness.
+- Do not add dependencies or modify CI.
+
+## Failure Modes
+
+- The index omits a merged authority runbook.
+- Bridge-authorized release is described as a second transfer.
+- Adapter parity is presented as three independent funded live transfers.
+- The external FAIL/BLOCKED probe appears inside the proven-runtime section.
+- The external probe loses its no-approval or no-settlement boundary.
+
+## Acceptance Criteria
+
+- [ ] The index links the #7160 live finality runbook with bounded wording.
+- [ ] The index links the #7163 bridge-authorized settlement runbook and states
+      that release reuses the finalized bridge transfer.
+- [ ] The index links the #7161 authority-parity runbook and preserves its
+      composed-proof limitation.
+- [ ] The index links the #7162 probe in a separate non-proof section with FAIL,
+      BLOCKED, no-approval, and no-settlement boundaries.
+- [ ] A focused Rust docs contract fails when a link, classification boundary,
+      or critical claim marker is removed.
+- [ ] Targeted tests, formatting, and lint/static checks pass.
+
+## Files To Touch
+
+- `specs/7169-runtime-proof-index-authority-closeout.md`
+- `docs/validation/current-proven-runtime-slices.md`
+- `crates/kamn-node/tests/runtime_proof_index_authority_closeout_contract.rs`
+
+## Error Semantics
+
+The documentation contract must fail with a marker-specific assertion when a
+required runbook or bounded-claim phrase is absent. It must also fail if the
+external probe appears before the end of the proven-runtime section.
+
+## Test Plan
+
+Red:
+- Add a contract requiring all four links and their bounded markers.
+- Assert that the external probe appears only after the proven-runtime section.
+- Run the focused contract and record the expected failure.
+
+Green:
+- Add the minimum index entries and separate external evidence section.
+- Run the focused contract until it passes.
+
+Refactor:
+- Keep marker lists and section-order checks small and self-documenting.
+- Run formatting, Clippy, and the existing runtime-proof index contract.
+
+Integration:
+- Run both proof-index contracts against the real workspace documentation.
+- Verify every indexed path exists on the final tree.


### PR DESCRIPTION
## Human Summary

- Adds the merged bridge-authorized settlement and SDK/CLI/MCP authority-parity slices to the canonical runtime-proof index.
- Keeps the external A2A/x402 probe in a separate non-proof section because it recorded `FAIL`/`BLOCKED`, with no approval or settlement response.
- Adds a focused docs contract that locks the links, bounded claims, and section classification.
- Updates the issue spec with the final verification evidence.

Closes #7169

Spec: [`specs/7169-runtime-proof-index-authority-closeout.md`](https://github.com/njfio/kamn/blob/7169-runtime-proof-index-authority-closeout/specs/7169-runtime-proof-index-authority-closeout.md)

## Testing

- `cargo test -p kamn-node --test runtime_proof_index_authority_closeout_contract --test runtime_proof_index_contract`
- `cargo fmt --all -- --check`
- `cargo clippy -p kamn-node --test runtime_proof_index_authority_closeout_contract -- -D warnings`
- Verified all four indexed validation paths exist.
- `git diff --check`

## Notes for Reviewers

This change updates proof discoverability only. It does not rerun a funded transaction or change runtime behavior. The external x402 observation remains evidence of a peer-authority gap, not a proven KAMN capability.

## AI Agent Details

- Preserves the issue/spec/RED/GREEN/refactor/integration commit arc.
- RED evidence: the new contract failed on both absent bridge-authority markers and the missing external-evidence section before the index update.
- No dependencies, CI configuration, public APIs, database schemas, or shell surfaces changed.