### PR TITLE
feat: verify peer receipt authority chains

### DIFF
--- a/crates/kamn-e2e-harness/src/lib.rs
+++ b/crates/kamn-e2e-harness/src/lib.rs
@@ -50,6 +50,9 @@ mod agent_transaction_supervisor;
 mod peer_receipt_authority;
 mod peer_receipt_authority_digest;
 mod peer_receipt_authority_validate;
+mod peer_receipt_authority_validate_bindings;
+mod peer_receipt_authority_validate_required;
+mod peer_receipt_authority_validate_support;
 
 /// Driver implementations for each execution mode.
 pub mod drivers;

--- a/crates/kamn-e2e-harness/src/lib.rs
+++ b/crates/kamn-e2e-harness/src/lib.rs
@@ -15,6 +15,16 @@ pub use mvp_demo::{
     execute_verify_mvp_demo_contract, verify_pi_transaction_actor_paths, LiveTaskEvidencePaths,
     MvpDemoCommandConfig, VerifyMvpDemoCommandConfig,
 };
+pub use peer_receipt_authority::{
+    PeerApprovalAuthority, PeerChallengeAuthority, PeerReceiptAuthorityAttempt,
+    PeerReceiptAuthorityError, PeerReceiptAuthorityVerdict, PeerRequestAuthority,
+    PeerResultAuthority, PeerSettlementAuthority, PeerSettlementVisibility,
+};
+pub use peer_receipt_authority_digest::{
+    peer_approval_digest, peer_challenge_digest, peer_request_digest, peer_result_digest,
+    peer_settlement_digest,
+};
+pub use peer_receipt_authority_validate::verify_peer_receipt_authority;
 
 mod agent_transaction_actor_authority;
 mod agent_transaction_demo;
@@ -37,6 +47,9 @@ mod agent_transaction_rpc_events;
 mod agent_transaction_runtime;
 mod agent_transaction_runtime_grant;
 mod agent_transaction_supervisor;
+mod peer_receipt_authority;
+mod peer_receipt_authority_digest;
+mod peer_receipt_authority_validate;
 
 /// Driver implementations for each execution mode.
 pub mod drivers;

--- a/crates/kamn-e2e-harness/src/peer_receipt_authority.rs
+++ b/crates/kamn-e2e-harness/src/peer_receipt_authority.rs
@@ -1,0 +1,158 @@
+/// Canonical request evidence supplied by a peer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PeerRequestAuthority {
+    /// Exact canonical request bytes represented as UTF-8.
+    pub canonical_body: String,
+    /// Peer-claimed request digest.
+    pub request_digest: String,
+}
+
+/// Payment challenge evidence supplied by a peer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PeerChallengeAuthority {
+    /// Digest of the challenged request.
+    pub request_digest: String,
+    /// Stable challenge identifier.
+    pub challenge_id: String,
+    /// Unique challenge nonce.
+    pub nonce: String,
+    /// Absolute Unix expiry.
+    pub expires_at_unix: u64,
+    /// Payer identity.
+    pub payer: String,
+    /// Payee identity.
+    pub payee: String,
+    /// Asset identifier.
+    pub asset: String,
+    /// Network identifier.
+    pub network: String,
+    /// Amount in the asset's minor unit.
+    pub amount_minor: u64,
+    /// Peer-claimed challenge digest.
+    pub challenge_digest: String,
+}
+
+/// Approval evidence supplied by a peer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PeerApprovalAuthority {
+    /// Digest of the approved request.
+    pub request_digest: String,
+    /// Digest of the approved challenge.
+    pub challenge_digest: String,
+    /// Stable challenge identifier.
+    pub challenge_id: String,
+    /// Approved challenge nonce.
+    pub nonce: String,
+    /// Approval Unix timestamp.
+    pub approved_at_unix: u64,
+    /// Payer identity.
+    pub payer: String,
+    /// Payee identity.
+    pub payee: String,
+    /// Asset identifier.
+    pub asset: String,
+    /// Network identifier.
+    pub network: String,
+    /// Amount in the asset's minor unit.
+    pub amount_minor: u64,
+    /// Peer-claimed approval digest.
+    pub approval_digest: String,
+}
+
+/// Authoritative settlement evidence supplied by a peer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PeerSettlementAuthority {
+    /// Digest of the settled request.
+    pub request_digest: String,
+    /// Digest of the settled challenge.
+    pub challenge_digest: String,
+    /// Digest of the settled approval.
+    pub approval_digest: String,
+    /// Authoritative settlement receipt identifier.
+    pub receipt_id: String,
+    /// Authoritative network transaction identifier.
+    pub transaction_id: String,
+    /// Settlement finalization Unix timestamp.
+    pub finalized_at_unix: u64,
+    /// Payer identity.
+    pub payer: String,
+    /// Payee identity.
+    pub payee: String,
+    /// Asset identifier.
+    pub asset: String,
+    /// Network identifier.
+    pub network: String,
+    /// Amount in the asset's minor unit.
+    pub amount_minor: u64,
+    /// Peer-claimed settlement digest.
+    pub settlement_digest: String,
+}
+
+/// Service-result evidence supplied by a peer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PeerResultAuthority {
+    /// Digest of the request producing the result.
+    pub request_digest: String,
+    /// Digest of the settlement authorizing the result.
+    pub settlement_digest: String,
+    /// Result production Unix timestamp.
+    pub produced_at_unix: u64,
+    /// Exact canonical result bytes represented as UTF-8.
+    pub canonical_result: String,
+    /// Peer-claimed result digest.
+    pub result_digest: String,
+}
+
+/// Settlement visibility of one peer observation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PeerSettlementVisibility {
+    /// Settlement evidence was observed.
+    Observed,
+    /// Settlement was intentionally not attempted or observed.
+    Blocked,
+}
+
+/// Possibly incomplete peer receipt-authority evidence.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PeerReceiptAuthorityAttempt {
+    /// Request evidence.
+    pub request: Option<PeerRequestAuthority>,
+    /// Challenge evidence.
+    pub challenge: Option<PeerChallengeAuthority>,
+    /// Approval evidence.
+    pub approval: Option<PeerApprovalAuthority>,
+    /// Settlement evidence.
+    pub settlement: Option<PeerSettlementAuthority>,
+    /// Service-result evidence.
+    pub service_result: Option<PeerResultAuthority>,
+    /// Whether settlement evidence was observable.
+    pub settlement_visibility: PeerSettlementVisibility,
+}
+
+/// Structured peer receipt-authority validation failure.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PeerReceiptAuthorityError {
+    /// Stable machine-readable error code.
+    pub code: &'static str,
+    /// Human-readable failure description.
+    pub message: String,
+    /// Failing receipt stage.
+    pub stage: &'static str,
+    /// Failing field.
+    pub field: &'static str,
+    /// Non-secret debugging context.
+    pub context: String,
+    /// Preserved underlying parsing cause when applicable.
+    pub cause: Option<String>,
+}
+
+/// Verdict for one peer receipt-authority attempt.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PeerReceiptAuthorityVerdict {
+    /// Every stage and binding validated.
+    Pass,
+    /// Evidence was observed but failed validation.
+    Fail(PeerReceiptAuthorityError),
+    /// Evidence failed validation and settlement visibility was blocked.
+    Blocked(PeerReceiptAuthorityError),
+}

--- a/crates/kamn-e2e-harness/src/peer_receipt_authority_digest.rs
+++ b/crates/kamn-e2e-harness/src/peer_receipt_authority_digest.rs
@@ -1,0 +1,92 @@
+use crate::{
+    PeerApprovalAuthority, PeerChallengeAuthority, PeerResultAuthority, PeerSettlementAuthority,
+};
+use sha2::{Digest, Sha256};
+
+/// Computes the digest of exact canonical request bytes.
+pub fn peer_request_digest(canonical_body: &str) -> String {
+    format!("sha256:{:x}", Sha256::digest(canonical_body.as_bytes()))
+}
+
+/// Computes the canonical challenge commitment.
+pub fn peer_challenge_digest(value: &PeerChallengeAuthority) -> String {
+    digest_values(
+        "kamn.peer.challenge.v1",
+        vec![
+            value.request_digest.clone(),
+            value.challenge_id.clone(),
+            value.nonce.clone(),
+            value.expires_at_unix.to_string(),
+            value.payer.clone(),
+            value.payee.clone(),
+            value.asset.clone(),
+            value.network.clone(),
+            value.amount_minor.to_string(),
+        ],
+    )
+}
+
+/// Computes the canonical approval commitment.
+pub fn peer_approval_digest(value: &PeerApprovalAuthority) -> String {
+    digest_values(
+        "kamn.peer.approval.v1",
+        vec![
+            value.request_digest.clone(),
+            value.challenge_digest.clone(),
+            value.challenge_id.clone(),
+            value.nonce.clone(),
+            value.approved_at_unix.to_string(),
+            value.payer.clone(),
+            value.payee.clone(),
+            value.asset.clone(),
+            value.network.clone(),
+            value.amount_minor.to_string(),
+        ],
+    )
+}
+
+/// Computes the canonical settlement commitment.
+pub fn peer_settlement_digest(value: &PeerSettlementAuthority) -> String {
+    digest_values(
+        "kamn.peer.settlement.v1",
+        vec![
+            value.request_digest.clone(),
+            value.challenge_digest.clone(),
+            value.approval_digest.clone(),
+            value.receipt_id.clone(),
+            value.transaction_id.clone(),
+            value.finalized_at_unix.to_string(),
+            value.payer.clone(),
+            value.payee.clone(),
+            value.asset.clone(),
+            value.network.clone(),
+            value.amount_minor.to_string(),
+        ],
+    )
+}
+
+/// Computes the canonical service-result commitment.
+pub fn peer_result_digest(value: &PeerResultAuthority) -> String {
+    digest_values(
+        "kamn.peer.result.v1",
+        vec![
+            value.request_digest.clone(),
+            value.settlement_digest.clone(),
+            value.canonical_result.clone(),
+        ],
+    )
+}
+
+fn digest_values(domain: &str, values: Vec<String>) -> String {
+    let mut hasher = Sha256::new();
+    append(&mut hasher, domain);
+    for value in values {
+        append(&mut hasher, value.as_str());
+    }
+    format!("sha256:{:x}", hasher.finalize())
+}
+
+fn append(hasher: &mut Sha256, value: &str) {
+    hasher.update((value.len() as u64).to_be_bytes());
+    hasher.update(value.as_bytes());
+}

--- a/crates/kamn-e2e-harness/src/peer_receipt_authority_validate.rs
+++ b/crates/kamn-e2e-harness/src/peer_receipt_authority_validate.rs
@@ -1,0 +1,412 @@
+use crate::{
+    peer_approval_digest, peer_challenge_digest, peer_request_digest, peer_result_digest,
+    peer_settlement_digest, PeerApprovalAuthority, PeerChallengeAuthority,
+    PeerReceiptAuthorityAttempt, PeerReceiptAuthorityError, PeerReceiptAuthorityVerdict,
+    PeerRequestAuthority, PeerResultAuthority, PeerSettlementAuthority, PeerSettlementVisibility,
+};
+
+/// Validates a complete peer receipt-authority chain.
+pub fn verify_peer_receipt_authority(
+    attempt: &PeerReceiptAuthorityAttempt,
+) -> PeerReceiptAuthorityVerdict {
+    match validate(attempt) {
+        Ok(()) => PeerReceiptAuthorityVerdict::Pass,
+        Err(error) if attempt.settlement_visibility == PeerSettlementVisibility::Blocked => {
+            PeerReceiptAuthorityVerdict::Blocked(error)
+        }
+        Err(error) => PeerReceiptAuthorityVerdict::Fail(error),
+    }
+}
+
+fn validate(attempt: &PeerReceiptAuthorityAttempt) -> Result<(), PeerReceiptAuthorityError> {
+    let request = stage(attempt.request.as_ref(), "request")?;
+    validate_request(request)?;
+    let challenge = stage(attempt.challenge.as_ref(), "challenge")?;
+    validate_challenge(request, challenge)?;
+    let approval = stage(attempt.approval.as_ref(), "approval")?;
+    validate_approval(challenge, approval)?;
+    let settlement = stage(attempt.settlement.as_ref(), "settlement")?;
+    validate_settlement(approval, settlement)?;
+    let result = stage(attempt.service_result.as_ref(), "service_result")?;
+    validate_result(request, settlement, result)
+}
+
+fn validate_request(value: &PeerRequestAuthority) -> Result<(), PeerReceiptAuthorityError> {
+    required("request", "canonical_body", value.canonical_body.as_str())?;
+    check_digest(
+        "request",
+        "request_digest",
+        value.request_digest.as_str(),
+        peer_request_digest(value.canonical_body.as_str()),
+    )
+}
+
+fn validate_challenge(
+    request: &PeerRequestAuthority,
+    value: &PeerChallengeAuthority,
+) -> Result<(), PeerReceiptAuthorityError> {
+    required_challenge_fields(value)?;
+    check_nonzero("challenge", "expires_at_unix", value.expires_at_unix)?;
+    check_nonzero("challenge", "amount_minor", value.amount_minor)?;
+    binding(
+        "challenge",
+        "request_digest",
+        &request.request_digest,
+        &value.request_digest,
+    )?;
+    check_digest(
+        "challenge",
+        "challenge_digest",
+        value.challenge_digest.as_str(),
+        peer_challenge_digest(value),
+    )
+}
+
+fn validate_approval(
+    challenge: &PeerChallengeAuthority,
+    value: &PeerApprovalAuthority,
+) -> Result<(), PeerReceiptAuthorityError> {
+    required_approval_fields(value)?;
+    check_nonzero("approval", "approved_at_unix", value.approved_at_unix)?;
+    approval_bindings(challenge, value)?;
+    if value.approved_at_unix > challenge.expires_at_unix {
+        return Err(time_error("approval", "approved_at_unix"));
+    }
+    check_digest(
+        "approval",
+        "approval_digest",
+        value.approval_digest.as_str(),
+        peer_approval_digest(value),
+    )
+}
+
+fn validate_settlement(
+    approval: &PeerApprovalAuthority,
+    value: &PeerSettlementAuthority,
+) -> Result<(), PeerReceiptAuthorityError> {
+    required_settlement_fields(value)?;
+    check_nonzero("settlement", "finalized_at_unix", value.finalized_at_unix)?;
+    settlement_bindings(approval, value)?;
+    if value.finalized_at_unix < approval.approved_at_unix {
+        return Err(time_error("settlement", "finalized_at_unix"));
+    }
+    check_digest(
+        "settlement",
+        "settlement_digest",
+        value.settlement_digest.as_str(),
+        peer_settlement_digest(value),
+    )
+}
+
+fn validate_result(
+    request: &PeerRequestAuthority,
+    settlement: &PeerSettlementAuthority,
+    value: &PeerResultAuthority,
+) -> Result<(), PeerReceiptAuthorityError> {
+    required_result_fields(value)?;
+    check_nonzero("service_result", "produced_at_unix", value.produced_at_unix)?;
+    binding(
+        "service_result",
+        "request_digest",
+        &request.request_digest,
+        &value.request_digest,
+    )?;
+    binding(
+        "service_result",
+        "settlement_digest",
+        &settlement.settlement_digest,
+        &value.settlement_digest,
+    )?;
+    if value.produced_at_unix < settlement.finalized_at_unix {
+        return Err(time_error("service_result", "produced_at_unix"));
+    }
+    check_digest(
+        "service_result",
+        "result_digest",
+        value.result_digest.as_str(),
+        peer_result_digest(value),
+    )
+}
+
+fn required_challenge_fields(
+    value: &PeerChallengeAuthority,
+) -> Result<(), PeerReceiptAuthorityError> {
+    required_fields(
+        "challenge",
+        &[
+            ("request_digest", &value.request_digest),
+            ("challenge_id", &value.challenge_id),
+            ("nonce", &value.nonce),
+            ("payer", &value.payer),
+            ("payee", &value.payee),
+            ("asset", &value.asset),
+            ("network", &value.network),
+            ("challenge_digest", &value.challenge_digest),
+        ],
+    )
+}
+
+fn required_approval_fields(
+    value: &PeerApprovalAuthority,
+) -> Result<(), PeerReceiptAuthorityError> {
+    required_fields(
+        "approval",
+        &[
+            ("request_digest", &value.request_digest),
+            ("challenge_digest", &value.challenge_digest),
+            ("challenge_id", &value.challenge_id),
+            ("nonce", &value.nonce),
+            ("payer", &value.payer),
+            ("payee", &value.payee),
+            ("asset", &value.asset),
+            ("network", &value.network),
+            ("approval_digest", &value.approval_digest),
+        ],
+    )
+}
+
+fn required_settlement_fields(
+    value: &PeerSettlementAuthority,
+) -> Result<(), PeerReceiptAuthorityError> {
+    required_fields(
+        "settlement",
+        &[
+            ("request_digest", &value.request_digest),
+            ("challenge_digest", &value.challenge_digest),
+            ("approval_digest", &value.approval_digest),
+            ("receipt_id", &value.receipt_id),
+            ("transaction_id", &value.transaction_id),
+            ("payer", &value.payer),
+            ("payee", &value.payee),
+            ("asset", &value.asset),
+            ("network", &value.network),
+            ("settlement_digest", &value.settlement_digest),
+        ],
+    )
+}
+
+fn required_result_fields(value: &PeerResultAuthority) -> Result<(), PeerReceiptAuthorityError> {
+    required_fields(
+        "service_result",
+        &[
+            ("request_digest", &value.request_digest),
+            ("settlement_digest", &value.settlement_digest),
+            ("canonical_result", &value.canonical_result),
+            ("result_digest", &value.result_digest),
+        ],
+    )
+}
+
+fn approval_bindings(
+    challenge: &PeerChallengeAuthority,
+    value: &PeerApprovalAuthority,
+) -> Result<(), PeerReceiptAuthorityError> {
+    compare_fields(
+        "approval",
+        &[
+            (
+                "request_digest",
+                &challenge.request_digest,
+                &value.request_digest,
+            ),
+            (
+                "challenge_digest",
+                &challenge.challenge_digest,
+                &value.challenge_digest,
+            ),
+            ("challenge_id", &challenge.challenge_id, &value.challenge_id),
+            ("nonce", &challenge.nonce, &value.nonce),
+        ],
+    )?;
+    compare_economics(
+        "approval",
+        challenge_terms(challenge),
+        approval_terms(value),
+    )
+}
+
+fn settlement_bindings(
+    approval: &PeerApprovalAuthority,
+    value: &PeerSettlementAuthority,
+) -> Result<(), PeerReceiptAuthorityError> {
+    compare_fields(
+        "settlement",
+        &[
+            (
+                "request_digest",
+                &approval.request_digest,
+                &value.request_digest,
+            ),
+            (
+                "challenge_digest",
+                &approval.challenge_digest,
+                &value.challenge_digest,
+            ),
+            (
+                "approval_digest",
+                &approval.approval_digest,
+                &value.approval_digest,
+            ),
+        ],
+    )?;
+    compare_economics(
+        "settlement",
+        approval_terms(approval),
+        settlement_terms(value),
+    )
+}
+
+type Terms<'a> = (&'a str, &'a str, &'a str, &'a str, u64);
+
+fn challenge_terms(value: &PeerChallengeAuthority) -> Terms<'_> {
+    (
+        &value.payer,
+        &value.payee,
+        &value.asset,
+        &value.network,
+        value.amount_minor,
+    )
+}
+
+fn approval_terms(value: &PeerApprovalAuthority) -> Terms<'_> {
+    (
+        &value.payer,
+        &value.payee,
+        &value.asset,
+        &value.network,
+        value.amount_minor,
+    )
+}
+
+fn settlement_terms(value: &PeerSettlementAuthority) -> Terms<'_> {
+    (
+        &value.payer,
+        &value.payee,
+        &value.asset,
+        &value.network,
+        value.amount_minor,
+    )
+}
+
+fn compare_economics(
+    stage: &'static str,
+    expected: Terms<'_>,
+    actual: Terms<'_>,
+) -> Result<(), PeerReceiptAuthorityError> {
+    for (field, left, right) in [
+        ("payer", expected.0, actual.0),
+        ("payee", expected.1, actual.1),
+        ("asset", expected.2, actual.2),
+        ("network", expected.3, actual.3),
+    ] {
+        binding(stage, field, left, right)?;
+    }
+    if expected.4 != actual.4 {
+        return Err(binding_error(stage, "amount_minor"));
+    }
+    Ok(())
+}
+
+fn compare_fields(
+    stage: &'static str,
+    fields: &[(&'static str, &String, &String)],
+) -> Result<(), PeerReceiptAuthorityError> {
+    for (field, expected, actual) in fields {
+        binding(stage, field, expected, actual)?;
+    }
+    Ok(())
+}
+
+fn binding(
+    stage: &'static str,
+    field: &'static str,
+    expected: &str,
+    actual: &str,
+) -> Result<(), PeerReceiptAuthorityError> {
+    (expected == actual)
+        .then_some(())
+        .ok_or_else(|| binding_error(stage, field))
+}
+
+fn check_digest(
+    stage: &'static str,
+    field: &'static str,
+    claimed: &str,
+    computed: String,
+) -> Result<(), PeerReceiptAuthorityError> {
+    if !valid_digest(claimed) {
+        return Err(error("PEER_AUTHORITY_DIGEST_INVALID", stage, field));
+    }
+    (claimed == computed)
+        .then_some(())
+        .ok_or_else(|| error("PEER_AUTHORITY_DIGEST_MISMATCH", stage, field))
+}
+
+fn valid_digest(value: &str) -> bool {
+    value.strip_prefix("sha256:").is_some_and(|hex| {
+        hex.len() == 64
+            && hex
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    })
+}
+
+fn required_fields(
+    stage: &'static str,
+    fields: &[(&'static str, &String)],
+) -> Result<(), PeerReceiptAuthorityError> {
+    for (field, value) in fields {
+        required(stage, field, value)?;
+    }
+    Ok(())
+}
+
+fn required(
+    stage: &'static str,
+    field: &'static str,
+    value: &str,
+) -> Result<(), PeerReceiptAuthorityError> {
+    (!value.is_empty())
+        .then_some(())
+        .ok_or_else(|| error("PEER_AUTHORITY_FIELD_MISSING", stage, field))
+}
+
+fn check_nonzero(
+    stage: &'static str,
+    field: &'static str,
+    value: u64,
+) -> Result<(), PeerReceiptAuthorityError> {
+    (value > 0)
+        .then_some(())
+        .ok_or_else(|| error("PEER_AUTHORITY_FIELD_MISSING", stage, field))
+}
+
+fn stage<'a, T>(
+    value: Option<&'a T>,
+    stage: &'static str,
+) -> Result<&'a T, PeerReceiptAuthorityError> {
+    value.ok_or_else(|| error("PEER_AUTHORITY_STAGE_MISSING", stage, "stage"))
+}
+
+fn binding_error(stage: &'static str, field: &'static str) -> PeerReceiptAuthorityError {
+    error("PEER_AUTHORITY_BINDING_MISMATCH", stage, field)
+}
+
+fn time_error(stage: &'static str, field: &'static str) -> PeerReceiptAuthorityError {
+    error("PEER_AUTHORITY_TIME_INVALID", stage, field)
+}
+
+fn error(
+    code: &'static str,
+    stage: &'static str,
+    field: &'static str,
+) -> PeerReceiptAuthorityError {
+    PeerReceiptAuthorityError {
+        code,
+        message: format!("{stage} authority failed at {field}"),
+        stage,
+        field,
+        context: format!("stage={stage},field={field}"),
+        cause: None,
+    }
+}

--- a/crates/kamn-e2e-harness/src/peer_receipt_authority_validate.rs
+++ b/crates/kamn-e2e-harness/src/peer_receipt_authority_validate.rs
@@ -1,3 +1,6 @@
+use crate::peer_receipt_authority_validate_bindings as bindings;
+use crate::peer_receipt_authority_validate_required as required;
+use crate::peer_receipt_authority_validate_support as support;
 use crate::{
     peer_approval_digest, peer_challenge_digest, peer_request_digest, peer_result_digest,
     peer_settlement_digest, PeerApprovalAuthority, PeerChallengeAuthority,
@@ -19,21 +22,21 @@ pub fn verify_peer_receipt_authority(
 }
 
 fn validate(attempt: &PeerReceiptAuthorityAttempt) -> Result<(), PeerReceiptAuthorityError> {
-    let request = stage(attempt.request.as_ref(), "request")?;
+    let request = required::stage(attempt.request.as_ref(), "request")?;
     validate_request(request)?;
-    let challenge = stage(attempt.challenge.as_ref(), "challenge")?;
+    let challenge = required::stage(attempt.challenge.as_ref(), "challenge")?;
     validate_challenge(request, challenge)?;
-    let approval = stage(attempt.approval.as_ref(), "approval")?;
+    let approval = required::stage(attempt.approval.as_ref(), "approval")?;
     validate_approval(challenge, approval)?;
-    let settlement = stage(attempt.settlement.as_ref(), "settlement")?;
+    let settlement = required::stage(attempt.settlement.as_ref(), "settlement")?;
     validate_settlement(approval, settlement)?;
-    let result = stage(attempt.service_result.as_ref(), "service_result")?;
+    let result = required::stage(attempt.service_result.as_ref(), "service_result")?;
     validate_result(request, settlement, result)
 }
 
 fn validate_request(value: &PeerRequestAuthority) -> Result<(), PeerReceiptAuthorityError> {
-    required("request", "canonical_body", value.canonical_body.as_str())?;
-    check_digest(
+    required::text("request", "canonical_body", value.canonical_body.as_str())?;
+    support::digest(
         "request",
         "request_digest",
         value.request_digest.as_str(),
@@ -45,16 +48,16 @@ fn validate_challenge(
     request: &PeerRequestAuthority,
     value: &PeerChallengeAuthority,
 ) -> Result<(), PeerReceiptAuthorityError> {
-    required_challenge_fields(value)?;
-    check_nonzero("challenge", "expires_at_unix", value.expires_at_unix)?;
-    check_nonzero("challenge", "amount_minor", value.amount_minor)?;
-    binding(
+    required::challenge(value)?;
+    required::nonzero("challenge", "expires_at_unix", value.expires_at_unix)?;
+    required::nonzero("challenge", "amount_minor", value.amount_minor)?;
+    bindings::field(
         "challenge",
         "request_digest",
         &request.request_digest,
         &value.request_digest,
     )?;
-    check_digest(
+    support::digest(
         "challenge",
         "challenge_digest",
         value.challenge_digest.as_str(),
@@ -66,13 +69,13 @@ fn validate_approval(
     challenge: &PeerChallengeAuthority,
     value: &PeerApprovalAuthority,
 ) -> Result<(), PeerReceiptAuthorityError> {
-    required_approval_fields(value)?;
-    check_nonzero("approval", "approved_at_unix", value.approved_at_unix)?;
-    approval_bindings(challenge, value)?;
+    required::approval(value)?;
+    required::nonzero("approval", "approved_at_unix", value.approved_at_unix)?;
+    bindings::approval(challenge, value)?;
     if value.approved_at_unix > challenge.expires_at_unix {
-        return Err(time_error("approval", "approved_at_unix"));
+        return Err(support::time("approval", "approved_at_unix"));
     }
-    check_digest(
+    support::digest(
         "approval",
         "approval_digest",
         value.approval_digest.as_str(),
@@ -84,13 +87,13 @@ fn validate_settlement(
     approval: &PeerApprovalAuthority,
     value: &PeerSettlementAuthority,
 ) -> Result<(), PeerReceiptAuthorityError> {
-    required_settlement_fields(value)?;
-    check_nonzero("settlement", "finalized_at_unix", value.finalized_at_unix)?;
-    settlement_bindings(approval, value)?;
+    required::settlement(value)?;
+    required::nonzero("settlement", "finalized_at_unix", value.finalized_at_unix)?;
+    bindings::settlement(approval, value)?;
     if value.finalized_at_unix < approval.approved_at_unix {
-        return Err(time_error("settlement", "finalized_at_unix"));
+        return Err(support::time("settlement", "finalized_at_unix"));
     }
-    check_digest(
+    support::digest(
         "settlement",
         "settlement_digest",
         value.settlement_digest.as_str(),
@@ -103,24 +106,13 @@ fn validate_result(
     settlement: &PeerSettlementAuthority,
     value: &PeerResultAuthority,
 ) -> Result<(), PeerReceiptAuthorityError> {
-    required_result_fields(value)?;
-    check_nonzero("service_result", "produced_at_unix", value.produced_at_unix)?;
-    binding(
-        "service_result",
-        "request_digest",
-        &request.request_digest,
-        &value.request_digest,
-    )?;
-    binding(
-        "service_result",
-        "settlement_digest",
-        &settlement.settlement_digest,
-        &value.settlement_digest,
-    )?;
+    required::result(value)?;
+    required::nonzero("service_result", "produced_at_unix", value.produced_at_unix)?;
+    validate_result_bindings(request, settlement, value)?;
     if value.produced_at_unix < settlement.finalized_at_unix {
-        return Err(time_error("service_result", "produced_at_unix"));
+        return Err(support::time("service_result", "produced_at_unix"));
     }
-    check_digest(
+    support::digest(
         "service_result",
         "result_digest",
         value.result_digest.as_str(),
@@ -128,285 +120,21 @@ fn validate_result(
     )
 }
 
-fn required_challenge_fields(
-    value: &PeerChallengeAuthority,
+fn validate_result_bindings(
+    request: &PeerRequestAuthority,
+    settlement: &PeerSettlementAuthority,
+    value: &PeerResultAuthority,
 ) -> Result<(), PeerReceiptAuthorityError> {
-    required_fields(
-        "challenge",
-        &[
-            ("request_digest", &value.request_digest),
-            ("challenge_id", &value.challenge_id),
-            ("nonce", &value.nonce),
-            ("payer", &value.payer),
-            ("payee", &value.payee),
-            ("asset", &value.asset),
-            ("network", &value.network),
-            ("challenge_digest", &value.challenge_digest),
-        ],
-    )
-}
-
-fn required_approval_fields(
-    value: &PeerApprovalAuthority,
-) -> Result<(), PeerReceiptAuthorityError> {
-    required_fields(
-        "approval",
-        &[
-            ("request_digest", &value.request_digest),
-            ("challenge_digest", &value.challenge_digest),
-            ("challenge_id", &value.challenge_id),
-            ("nonce", &value.nonce),
-            ("payer", &value.payer),
-            ("payee", &value.payee),
-            ("asset", &value.asset),
-            ("network", &value.network),
-            ("approval_digest", &value.approval_digest),
-        ],
-    )
-}
-
-fn required_settlement_fields(
-    value: &PeerSettlementAuthority,
-) -> Result<(), PeerReceiptAuthorityError> {
-    required_fields(
-        "settlement",
-        &[
-            ("request_digest", &value.request_digest),
-            ("challenge_digest", &value.challenge_digest),
-            ("approval_digest", &value.approval_digest),
-            ("receipt_id", &value.receipt_id),
-            ("transaction_id", &value.transaction_id),
-            ("payer", &value.payer),
-            ("payee", &value.payee),
-            ("asset", &value.asset),
-            ("network", &value.network),
-            ("settlement_digest", &value.settlement_digest),
-        ],
-    )
-}
-
-fn required_result_fields(value: &PeerResultAuthority) -> Result<(), PeerReceiptAuthorityError> {
-    required_fields(
+    bindings::field(
         "service_result",
-        &[
-            ("request_digest", &value.request_digest),
-            ("settlement_digest", &value.settlement_digest),
-            ("canonical_result", &value.canonical_result),
-            ("result_digest", &value.result_digest),
-        ],
-    )
-}
-
-fn approval_bindings(
-    challenge: &PeerChallengeAuthority,
-    value: &PeerApprovalAuthority,
-) -> Result<(), PeerReceiptAuthorityError> {
-    compare_fields(
-        "approval",
-        &[
-            (
-                "request_digest",
-                &challenge.request_digest,
-                &value.request_digest,
-            ),
-            (
-                "challenge_digest",
-                &challenge.challenge_digest,
-                &value.challenge_digest,
-            ),
-            ("challenge_id", &challenge.challenge_id, &value.challenge_id),
-            ("nonce", &challenge.nonce, &value.nonce),
-        ],
+        "request_digest",
+        &request.request_digest,
+        &value.request_digest,
     )?;
-    compare_economics(
-        "approval",
-        challenge_terms(challenge),
-        approval_terms(value),
+    bindings::field(
+        "service_result",
+        "settlement_digest",
+        &settlement.settlement_digest,
+        &value.settlement_digest,
     )
-}
-
-fn settlement_bindings(
-    approval: &PeerApprovalAuthority,
-    value: &PeerSettlementAuthority,
-) -> Result<(), PeerReceiptAuthorityError> {
-    compare_fields(
-        "settlement",
-        &[
-            (
-                "request_digest",
-                &approval.request_digest,
-                &value.request_digest,
-            ),
-            (
-                "challenge_digest",
-                &approval.challenge_digest,
-                &value.challenge_digest,
-            ),
-            (
-                "approval_digest",
-                &approval.approval_digest,
-                &value.approval_digest,
-            ),
-        ],
-    )?;
-    compare_economics(
-        "settlement",
-        approval_terms(approval),
-        settlement_terms(value),
-    )
-}
-
-type Terms<'a> = (&'a str, &'a str, &'a str, &'a str, u64);
-
-fn challenge_terms(value: &PeerChallengeAuthority) -> Terms<'_> {
-    (
-        &value.payer,
-        &value.payee,
-        &value.asset,
-        &value.network,
-        value.amount_minor,
-    )
-}
-
-fn approval_terms(value: &PeerApprovalAuthority) -> Terms<'_> {
-    (
-        &value.payer,
-        &value.payee,
-        &value.asset,
-        &value.network,
-        value.amount_minor,
-    )
-}
-
-fn settlement_terms(value: &PeerSettlementAuthority) -> Terms<'_> {
-    (
-        &value.payer,
-        &value.payee,
-        &value.asset,
-        &value.network,
-        value.amount_minor,
-    )
-}
-
-fn compare_economics(
-    stage: &'static str,
-    expected: Terms<'_>,
-    actual: Terms<'_>,
-) -> Result<(), PeerReceiptAuthorityError> {
-    for (field, left, right) in [
-        ("payer", expected.0, actual.0),
-        ("payee", expected.1, actual.1),
-        ("asset", expected.2, actual.2),
-        ("network", expected.3, actual.3),
-    ] {
-        binding(stage, field, left, right)?;
-    }
-    if expected.4 != actual.4 {
-        return Err(binding_error(stage, "amount_minor"));
-    }
-    Ok(())
-}
-
-fn compare_fields(
-    stage: &'static str,
-    fields: &[(&'static str, &String, &String)],
-) -> Result<(), PeerReceiptAuthorityError> {
-    for (field, expected, actual) in fields {
-        binding(stage, field, expected, actual)?;
-    }
-    Ok(())
-}
-
-fn binding(
-    stage: &'static str,
-    field: &'static str,
-    expected: &str,
-    actual: &str,
-) -> Result<(), PeerReceiptAuthorityError> {
-    (expected == actual)
-        .then_some(())
-        .ok_or_else(|| binding_error(stage, field))
-}
-
-fn check_digest(
-    stage: &'static str,
-    field: &'static str,
-    claimed: &str,
-    computed: String,
-) -> Result<(), PeerReceiptAuthorityError> {
-    if !valid_digest(claimed) {
-        return Err(error("PEER_AUTHORITY_DIGEST_INVALID", stage, field));
-    }
-    (claimed == computed)
-        .then_some(())
-        .ok_or_else(|| error("PEER_AUTHORITY_DIGEST_MISMATCH", stage, field))
-}
-
-fn valid_digest(value: &str) -> bool {
-    value.strip_prefix("sha256:").is_some_and(|hex| {
-        hex.len() == 64
-            && hex
-                .bytes()
-                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
-    })
-}
-
-fn required_fields(
-    stage: &'static str,
-    fields: &[(&'static str, &String)],
-) -> Result<(), PeerReceiptAuthorityError> {
-    for (field, value) in fields {
-        required(stage, field, value)?;
-    }
-    Ok(())
-}
-
-fn required(
-    stage: &'static str,
-    field: &'static str,
-    value: &str,
-) -> Result<(), PeerReceiptAuthorityError> {
-    (!value.is_empty())
-        .then_some(())
-        .ok_or_else(|| error("PEER_AUTHORITY_FIELD_MISSING", stage, field))
-}
-
-fn check_nonzero(
-    stage: &'static str,
-    field: &'static str,
-    value: u64,
-) -> Result<(), PeerReceiptAuthorityError> {
-    (value > 0)
-        .then_some(())
-        .ok_or_else(|| error("PEER_AUTHORITY_FIELD_MISSING", stage, field))
-}
-
-fn stage<'a, T>(
-    value: Option<&'a T>,
-    stage: &'static str,
-) -> Result<&'a T, PeerReceiptAuthorityError> {
-    value.ok_or_else(|| error("PEER_AUTHORITY_STAGE_MISSING", stage, "stage"))
-}
-
-fn binding_error(stage: &'static str, field: &'static str) -> PeerReceiptAuthorityError {
-    error("PEER_AUTHORITY_BINDING_MISMATCH", stage, field)
-}
-
-fn time_error(stage: &'static str, field: &'static str) -> PeerReceiptAuthorityError {
-    error("PEER_AUTHORITY_TIME_INVALID", stage, field)
-}
-
-fn error(
-    code: &'static str,
-    stage: &'static str,
-    field: &'static str,
-) -> PeerReceiptAuthorityError {
-    PeerReceiptAuthorityError {
-        code,
-        message: format!("{stage} authority failed at {field}"),
-        stage,
-        field,
-        context: format!("stage={stage},field={field}"),
-        cause: None,
-    }
 }

--- a/crates/kamn-e2e-harness/src/peer_receipt_authority_validate_bindings.rs
+++ b/crates/kamn-e2e-harness/src/peer_receipt_authority_validate_bindings.rs
@@ -1,0 +1,147 @@
+use crate::peer_receipt_authority_validate_support::error;
+use crate::{
+    PeerApprovalAuthority, PeerChallengeAuthority, PeerReceiptAuthorityError,
+    PeerSettlementAuthority,
+};
+
+type Terms<'a> = (&'a str, &'a str, &'a str, &'a str, u64);
+
+pub(crate) fn approval(
+    challenge: &PeerChallengeAuthority,
+    value: &PeerApprovalAuthority,
+) -> Result<(), PeerReceiptAuthorityError> {
+    fields("approval", &approval_fields(challenge, value))?;
+    economics(
+        "approval",
+        challenge_terms(challenge),
+        approval_terms(value),
+    )
+}
+
+pub(crate) fn settlement(
+    approval: &PeerApprovalAuthority,
+    value: &PeerSettlementAuthority,
+) -> Result<(), PeerReceiptAuthorityError> {
+    fields("settlement", &settlement_fields(approval, value))?;
+    economics(
+        "settlement",
+        approval_terms(approval),
+        settlement_terms(value),
+    )
+}
+
+fn approval_fields<'a>(
+    challenge: &'a PeerChallengeAuthority,
+    value: &'a PeerApprovalAuthority,
+) -> [(&'static str, &'a String, &'a String); 4] {
+    [
+        (
+            "request_digest",
+            &challenge.request_digest,
+            &value.request_digest,
+        ),
+        (
+            "challenge_digest",
+            &challenge.challenge_digest,
+            &value.challenge_digest,
+        ),
+        ("challenge_id", &challenge.challenge_id, &value.challenge_id),
+        ("nonce", &challenge.nonce, &value.nonce),
+    ]
+}
+
+fn settlement_fields<'a>(
+    approval: &'a PeerApprovalAuthority,
+    value: &'a PeerSettlementAuthority,
+) -> [(&'static str, &'a String, &'a String); 3] {
+    [
+        (
+            "request_digest",
+            &approval.request_digest,
+            &value.request_digest,
+        ),
+        (
+            "challenge_digest",
+            &approval.challenge_digest,
+            &value.challenge_digest,
+        ),
+        (
+            "approval_digest",
+            &approval.approval_digest,
+            &value.approval_digest,
+        ),
+    ]
+}
+
+pub(crate) fn field(
+    stage: &'static str,
+    name: &'static str,
+    expected: &str,
+    actual: &str,
+) -> Result<(), PeerReceiptAuthorityError> {
+    (expected == actual)
+        .then_some(())
+        .ok_or_else(|| mismatch(stage, name))
+}
+
+fn fields(
+    stage: &'static str,
+    values: &[(&'static str, &String, &String)],
+) -> Result<(), PeerReceiptAuthorityError> {
+    for (name, expected, actual) in values {
+        field(stage, name, expected, actual)?;
+    }
+    Ok(())
+}
+
+fn economics(
+    stage: &'static str,
+    expected: Terms<'_>,
+    actual: Terms<'_>,
+) -> Result<(), PeerReceiptAuthorityError> {
+    for (name, left, right) in [
+        ("payer", expected.0, actual.0),
+        ("payee", expected.1, actual.1),
+        ("asset", expected.2, actual.2),
+        ("network", expected.3, actual.3),
+    ] {
+        field(stage, name, left, right)?;
+    }
+    (expected.4 == actual.4)
+        .then_some(())
+        .ok_or_else(|| mismatch(stage, "amount_minor"))
+}
+
+fn challenge_terms(value: &PeerChallengeAuthority) -> Terms<'_> {
+    (
+        &value.payer,
+        &value.payee,
+        &value.asset,
+        &value.network,
+        value.amount_minor,
+    )
+}
+
+fn approval_terms(value: &PeerApprovalAuthority) -> Terms<'_> {
+    (
+        &value.payer,
+        &value.payee,
+        &value.asset,
+        &value.network,
+        value.amount_minor,
+    )
+}
+
+fn settlement_terms(value: &PeerSettlementAuthority) -> Terms<'_> {
+    (
+        &value.payer,
+        &value.payee,
+        &value.asset,
+        &value.network,
+        value.amount_minor,
+    )
+}
+
+fn mismatch(stage: &'static str, field: &'static str) -> PeerReceiptAuthorityError {
+    error("PEER_AUTHORITY_BINDING_MISMATCH", stage, field)
+}

--- a/crates/kamn-e2e-harness/src/peer_receipt_authority_validate_required.rs
+++ b/crates/kamn-e2e-harness/src/peer_receipt_authority_validate_required.rs
@@ -1,0 +1,105 @@
+use crate::peer_receipt_authority_validate_support::error;
+use crate::{
+    PeerApprovalAuthority, PeerChallengeAuthority, PeerReceiptAuthorityError, PeerResultAuthority,
+    PeerSettlementAuthority,
+};
+
+pub(crate) fn challenge(value: &PeerChallengeAuthority) -> Result<(), PeerReceiptAuthorityError> {
+    fields(
+        "challenge",
+        &[
+            ("request_digest", &value.request_digest),
+            ("challenge_id", &value.challenge_id),
+            ("nonce", &value.nonce),
+            ("payer", &value.payer),
+            ("payee", &value.payee),
+            ("asset", &value.asset),
+            ("network", &value.network),
+            ("challenge_digest", &value.challenge_digest),
+        ],
+    )
+}
+
+pub(crate) fn approval(value: &PeerApprovalAuthority) -> Result<(), PeerReceiptAuthorityError> {
+    fields(
+        "approval",
+        &[
+            ("request_digest", &value.request_digest),
+            ("challenge_digest", &value.challenge_digest),
+            ("challenge_id", &value.challenge_id),
+            ("nonce", &value.nonce),
+            ("payer", &value.payer),
+            ("payee", &value.payee),
+            ("asset", &value.asset),
+            ("network", &value.network),
+            ("approval_digest", &value.approval_digest),
+        ],
+    )
+}
+
+pub(crate) fn settlement(value: &PeerSettlementAuthority) -> Result<(), PeerReceiptAuthorityError> {
+    fields(
+        "settlement",
+        &[
+            ("request_digest", &value.request_digest),
+            ("challenge_digest", &value.challenge_digest),
+            ("approval_digest", &value.approval_digest),
+            ("receipt_id", &value.receipt_id),
+            ("transaction_id", &value.transaction_id),
+            ("payer", &value.payer),
+            ("payee", &value.payee),
+            ("asset", &value.asset),
+            ("network", &value.network),
+            ("settlement_digest", &value.settlement_digest),
+        ],
+    )
+}
+
+pub(crate) fn result(value: &PeerResultAuthority) -> Result<(), PeerReceiptAuthorityError> {
+    fields(
+        "service_result",
+        &[
+            ("request_digest", &value.request_digest),
+            ("settlement_digest", &value.settlement_digest),
+            ("canonical_result", &value.canonical_result),
+            ("result_digest", &value.result_digest),
+        ],
+    )
+}
+
+pub(crate) fn text(
+    stage: &'static str,
+    field: &'static str,
+    value: &str,
+) -> Result<(), PeerReceiptAuthorityError> {
+    (!value.is_empty())
+        .then_some(())
+        .ok_or_else(|| error("PEER_AUTHORITY_FIELD_MISSING", stage, field))
+}
+
+pub(crate) fn nonzero(
+    stage: &'static str,
+    field: &'static str,
+    value: u64,
+) -> Result<(), PeerReceiptAuthorityError> {
+    (value > 0)
+        .then_some(())
+        .ok_or_else(|| error("PEER_AUTHORITY_FIELD_MISSING", stage, field))
+}
+
+pub(crate) fn stage<'a, T>(
+    value: Option<&'a T>,
+    stage: &'static str,
+) -> Result<&'a T, PeerReceiptAuthorityError> {
+    value.ok_or_else(|| error("PEER_AUTHORITY_STAGE_MISSING", stage, "stage"))
+}
+
+fn fields(
+    stage: &'static str,
+    values: &[(&'static str, &String)],
+) -> Result<(), PeerReceiptAuthorityError> {
+    for (field, value) in values {
+        text(stage, field, value)?;
+    }
+    Ok(())
+}

--- a/crates/kamn-e2e-harness/src/peer_receipt_authority_validate_support.rs
+++ b/crates/kamn-e2e-harness/src/peer_receipt_authority_validate_support.rs
@@ -1,0 +1,43 @@
+use crate::PeerReceiptAuthorityError;
+
+pub(crate) fn digest(
+    stage: &'static str,
+    field: &'static str,
+    claimed: &str,
+    computed: String,
+) -> Result<(), PeerReceiptAuthorityError> {
+    if !valid_digest(claimed) {
+        return Err(error("PEER_AUTHORITY_DIGEST_INVALID", stage, field));
+    }
+    (claimed == computed)
+        .then_some(())
+        .ok_or_else(|| error("PEER_AUTHORITY_DIGEST_MISMATCH", stage, field))
+}
+
+pub(crate) fn time(stage: &'static str, field: &'static str) -> PeerReceiptAuthorityError {
+    error("PEER_AUTHORITY_TIME_INVALID", stage, field)
+}
+
+pub(crate) fn error(
+    code: &'static str,
+    stage: &'static str,
+    field: &'static str,
+) -> PeerReceiptAuthorityError {
+    PeerReceiptAuthorityError {
+        code,
+        message: format!("{stage} authority failed at {field}"),
+        stage,
+        field,
+        context: format!("stage={stage},field={field}"),
+        cause: None,
+    }
+}
+
+fn valid_digest(value: &str) -> bool {
+    value.strip_prefix("sha256:").is_some_and(|hex| {
+        hex.len() == 64
+            && hex
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    })
+}

--- a/crates/kamn-e2e-harness/tests/external_a2a_x402_receipt_authority_contract.rs
+++ b/crates/kamn-e2e-harness/tests/external_a2a_x402_receipt_authority_contract.rs
@@ -1,3 +1,7 @@
+use kamn_e2e_harness::{
+    verify_peer_receipt_authority, PeerChallengeAuthority, PeerReceiptAuthorityAttempt,
+    PeerReceiptAuthorityVerdict, PeerRequestAuthority, PeerSettlementVisibility,
+};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 use std::path::PathBuf;
@@ -81,6 +85,45 @@ fn runbook_reports_evidence_boundaries() {
             runbook.contains(marker),
             "{RUNBOOK} missing marker: {marker}"
         );
+    }
+}
+
+#[test]
+fn observed_exchange_remains_blocked_through_shared_verifier() {
+    let verdict = verify_peer_receipt_authority(&attempt_from_observation(&read_json()));
+    match verdict {
+        PeerReceiptAuthorityVerdict::Blocked(error) => {
+            assert_eq!(error.code, "PEER_AUTHORITY_FIELD_MISSING");
+            assert_eq!(error.stage, "challenge");
+        }
+        other => panic!("expected blocked shared-verifier verdict, got {other:?}"),
+    }
+}
+
+fn attempt_from_observation(evidence: &Value) -> PeerReceiptAuthorityAttempt {
+    PeerReceiptAuthorityAttempt {
+        request: Some(PeerRequestAuthority {
+            canonical_body: text(evidence, "/request/canonical_body").into(),
+            request_digest: text(evidence, "/request/body_sha256").into(),
+        }),
+        challenge: Some(PeerChallengeAuthority {
+            request_digest: String::new(),
+            challenge_id: String::new(),
+            nonce: String::new(),
+            expires_at_unix: 0,
+            payer: String::new(),
+            payee: text(evidence, "/challenge/pay_to").into(),
+            asset: text(evidence, "/challenge/asset").into(),
+            network: text(evidence, "/challenge/network").into(),
+            amount_minor: text(evidence, "/challenge/amount_atomic")
+                .parse()
+                .expect("challenge amount should parse"),
+            challenge_digest: String::new(),
+        }),
+        approval: None,
+        settlement: None,
+        service_result: None,
+        settlement_visibility: PeerSettlementVisibility::Blocked,
     }
 }
 

--- a/crates/kamn-e2e-harness/tests/external_a2a_x402_receipt_authority_contract.rs
+++ b/crates/kamn-e2e-harness/tests/external_a2a_x402_receipt_authority_contract.rs
@@ -106,24 +106,28 @@ fn attempt_from_observation(evidence: &Value) -> PeerReceiptAuthorityAttempt {
             canonical_body: text(evidence, "/request/canonical_body").into(),
             request_digest: text(evidence, "/request/body_sha256").into(),
         }),
-        challenge: Some(PeerChallengeAuthority {
-            request_digest: String::new(),
-            challenge_id: String::new(),
-            nonce: String::new(),
-            expires_at_unix: 0,
-            payer: String::new(),
-            payee: text(evidence, "/challenge/pay_to").into(),
-            asset: text(evidence, "/challenge/asset").into(),
-            network: text(evidence, "/challenge/network").into(),
-            amount_minor: text(evidence, "/challenge/amount_atomic")
-                .parse()
-                .expect("challenge amount should parse"),
-            challenge_digest: String::new(),
-        }),
+        challenge: Some(challenge_from_observation(evidence)),
         approval: None,
         settlement: None,
         service_result: None,
         settlement_visibility: PeerSettlementVisibility::Blocked,
+    }
+}
+
+fn challenge_from_observation(evidence: &Value) -> PeerChallengeAuthority {
+    PeerChallengeAuthority {
+        request_digest: String::new(),
+        challenge_id: String::new(),
+        nonce: String::new(),
+        expires_at_unix: 0,
+        payer: String::new(),
+        payee: text(evidence, "/challenge/pay_to").into(),
+        asset: text(evidence, "/challenge/asset").into(),
+        network: text(evidence, "/challenge/network").into(),
+        amount_minor: text(evidence, "/challenge/amount_atomic")
+            .parse()
+            .expect("challenge amount should parse"),
+        challenge_digest: String::new(),
     }
 }
 

--- a/crates/kamn-e2e-harness/tests/peer_receipt_authority_contract.rs
+++ b/crates/kamn-e2e-harness/tests/peer_receipt_authority_contract.rs
@@ -1,0 +1,172 @@
+use kamn_e2e_harness::{
+    verify_peer_receipt_authority, PeerReceiptAuthorityAttempt, PeerReceiptAuthorityVerdict,
+};
+
+#[path = "peer_receipt_authority_contract/support.rs"]
+mod support;
+
+use support::{blocked_attempt, complete_attempt, recompute_digests};
+
+#[test]
+fn complete_receipt_authority_chain_passes() {
+    assert_eq!(
+        verify_peer_receipt_authority(&complete_attempt()),
+        PeerReceiptAuthorityVerdict::Pass
+    );
+}
+
+#[test]
+fn missing_stages_and_fields_fail_closed() {
+    let mut missing_stage = complete_attempt();
+    missing_stage.approval = None;
+    assert_code(missing_stage, "PEER_AUTHORITY_STAGE_MISSING");
+
+    for mutate in missing_field_mutations() {
+        let mut attempt = complete_attempt();
+        mutate(&mut attempt);
+        assert_code(attempt, "PEER_AUTHORITY_FIELD_MISSING");
+    }
+}
+
+#[test]
+fn malformed_and_mismatched_digests_fail_closed() {
+    let mut malformed = complete_attempt();
+    malformed.request.as_mut().unwrap().request_digest = "sha256:nope".into();
+    assert_code(malformed, "PEER_AUTHORITY_DIGEST_INVALID");
+
+    for mutate in digest_mutations() {
+        let mut attempt = complete_attempt();
+        mutate(&mut attempt);
+        assert_code(attempt, "PEER_AUTHORITY_DIGEST_MISMATCH");
+    }
+}
+
+#[test]
+fn identity_and_economic_mutations_fail_closed() {
+    for mutate in binding_mutations() {
+        let mut attempt = complete_attempt();
+        mutate(&mut attempt);
+        recompute_digests(&mut attempt);
+        assert_code(attempt, "PEER_AUTHORITY_BINDING_MISMATCH");
+    }
+}
+
+#[test]
+fn expiry_and_stage_order_mutations_fail_closed() {
+    for mutate in time_mutations() {
+        let mut attempt = complete_attempt();
+        mutate(&mut attempt);
+        recompute_digests(&mut attempt);
+        assert_code(attempt, "PEER_AUTHORITY_TIME_INVALID");
+    }
+}
+
+#[test]
+fn partial_no_funds_observation_is_blocked_and_never_passes() {
+    let verdict = verify_peer_receipt_authority(&blocked_attempt());
+    match verdict {
+        PeerReceiptAuthorityVerdict::Blocked(error) => {
+            assert_eq!(error.code, "PEER_AUTHORITY_FIELD_MISSING");
+            assert_eq!(error.stage, "challenge");
+        }
+        other => panic!("expected blocked verdict, got {other:?}"),
+    }
+}
+
+fn assert_code(attempt: PeerReceiptAuthorityAttempt, expected: &str) {
+    match verify_peer_receipt_authority(&attempt) {
+        PeerReceiptAuthorityVerdict::Fail(error) | PeerReceiptAuthorityVerdict::Blocked(error) => {
+            assert_eq!(error.code, expected)
+        }
+        PeerReceiptAuthorityVerdict::Pass => panic!("expected {expected}, got pass"),
+    }
+}
+
+fn missing_field_mutations() -> Vec<fn(&mut PeerReceiptAuthorityAttempt)> {
+    vec![
+        |value| value.challenge.as_mut().unwrap().challenge_id.clear(),
+        |value| value.challenge.as_mut().unwrap().nonce.clear(),
+        |value| value.approval.as_mut().unwrap().payer.clear(),
+        |value| value.settlement.as_mut().unwrap().receipt_id.clear(),
+        |value| value.settlement.as_mut().unwrap().transaction_id.clear(),
+        |value| {
+            value
+                .service_result
+                .as_mut()
+                .unwrap()
+                .canonical_result
+                .clear()
+        },
+    ]
+}
+
+fn digest_mutations() -> Vec<fn(&mut PeerReceiptAuthorityAttempt)> {
+    vec![
+        |value| {
+            value
+                .request
+                .as_mut()
+                .unwrap()
+                .request_digest
+                .replace_range(7..8, "0")
+        },
+        |value| {
+            value
+                .challenge
+                .as_mut()
+                .unwrap()
+                .challenge_digest
+                .replace_range(7..8, "0")
+        },
+        |value| {
+            value
+                .approval
+                .as_mut()
+                .unwrap()
+                .approval_digest
+                .replace_range(7..8, "0")
+        },
+        |value| {
+            value
+                .settlement
+                .as_mut()
+                .unwrap()
+                .settlement_digest
+                .replace_range(7..8, "0")
+        },
+        |value| {
+            value
+                .service_result
+                .as_mut()
+                .unwrap()
+                .result_digest
+                .replace_range(7..8, "0")
+        },
+    ]
+}
+
+fn binding_mutations() -> Vec<fn(&mut PeerReceiptAuthorityAttempt)> {
+    vec![
+        |value| value.approval.as_mut().unwrap().request_digest = digest('f'),
+        |value| value.approval.as_mut().unwrap().challenge_id = "challenge-other".into(),
+        |value| value.approval.as_mut().unwrap().nonce = "nonce-other".into(),
+        |value| value.approval.as_mut().unwrap().payer = "did:peer:other".into(),
+        |value| value.settlement.as_mut().unwrap().payee = "wallet-other".into(),
+        |value| value.settlement.as_mut().unwrap().asset = "USDC".into(),
+        |value| value.settlement.as_mut().unwrap().network = "solana:mainnet".into(),
+        |value| value.settlement.as_mut().unwrap().amount_minor += 1,
+        |value| value.service_result.as_mut().unwrap().settlement_digest = digest('e'),
+    ]
+}
+
+fn time_mutations() -> Vec<fn(&mut PeerReceiptAuthorityAttempt)> {
+    vec![
+        |value| value.approval.as_mut().unwrap().approved_at_unix = 1_800_000_001,
+        |value| value.settlement.as_mut().unwrap().finalized_at_unix = 1_700_000_099,
+        |value| value.service_result.as_mut().unwrap().produced_at_unix = 1_700_000_199,
+    ]
+}
+
+fn digest(character: char) -> String {
+    format!("sha256:{}", character.to_string().repeat(64))
+}

--- a/crates/kamn-e2e-harness/tests/peer_receipt_authority_contract.rs
+++ b/crates/kamn-e2e-harness/tests/peer_receipt_authority_contract.rs
@@ -2,6 +2,10 @@ use kamn_e2e_harness::{
     verify_peer_receipt_authority, PeerReceiptAuthorityAttempt, PeerReceiptAuthorityVerdict,
 };
 
+#[path = "peer_receipt_authority_contract/binding_mutations.rs"]
+mod binding_mutations;
+#[path = "peer_receipt_authority_contract/mutations.rs"]
+mod mutations;
 #[path = "peer_receipt_authority_contract/support.rs"]
 mod support;
 
@@ -21,7 +25,7 @@ fn missing_stages_and_fields_fail_closed() {
     missing_stage.approval = None;
     assert_code(missing_stage, "PEER_AUTHORITY_STAGE_MISSING");
 
-    for mutate in missing_field_mutations() {
+    for mutate in mutations::missing_fields() {
         let mut attempt = complete_attempt();
         mutate(&mut attempt);
         assert_code(attempt, "PEER_AUTHORITY_FIELD_MISSING");
@@ -31,10 +35,14 @@ fn missing_stages_and_fields_fail_closed() {
 #[test]
 fn malformed_and_mismatched_digests_fail_closed() {
     let mut malformed = complete_attempt();
-    malformed.request.as_mut().unwrap().request_digest = "sha256:nope".into();
+    malformed
+        .request
+        .as_mut()
+        .expect("complete fixture stage")
+        .request_digest = "sha256:nope".into();
     assert_code(malformed, "PEER_AUTHORITY_DIGEST_INVALID");
 
-    for mutate in digest_mutations() {
+    for mutate in mutations::digests() {
         let mut attempt = complete_attempt();
         mutate(&mut attempt);
         assert_code(attempt, "PEER_AUTHORITY_DIGEST_MISMATCH");
@@ -43,7 +51,7 @@ fn malformed_and_mismatched_digests_fail_closed() {
 
 #[test]
 fn identity_and_economic_mutations_fail_closed() {
-    for mutate in binding_mutations() {
+    for mutate in binding_mutations::bindings() {
         let mut attempt = complete_attempt();
         mutate(&mut attempt);
         recompute_digests(&mut attempt);
@@ -53,7 +61,7 @@ fn identity_and_economic_mutations_fail_closed() {
 
 #[test]
 fn expiry_and_stage_order_mutations_fail_closed() {
-    for mutate in time_mutations() {
+    for mutate in binding_mutations::times() {
         let mut attempt = complete_attempt();
         mutate(&mut attempt);
         recompute_digests(&mut attempt);
@@ -80,93 +88,4 @@ fn assert_code(attempt: PeerReceiptAuthorityAttempt, expected: &str) {
         }
         PeerReceiptAuthorityVerdict::Pass => panic!("expected {expected}, got pass"),
     }
-}
-
-fn missing_field_mutations() -> Vec<fn(&mut PeerReceiptAuthorityAttempt)> {
-    vec![
-        |value| value.challenge.as_mut().unwrap().challenge_id.clear(),
-        |value| value.challenge.as_mut().unwrap().nonce.clear(),
-        |value| value.approval.as_mut().unwrap().payer.clear(),
-        |value| value.settlement.as_mut().unwrap().receipt_id.clear(),
-        |value| value.settlement.as_mut().unwrap().transaction_id.clear(),
-        |value| {
-            value
-                .service_result
-                .as_mut()
-                .unwrap()
-                .canonical_result
-                .clear()
-        },
-    ]
-}
-
-fn digest_mutations() -> Vec<fn(&mut PeerReceiptAuthorityAttempt)> {
-    vec![
-        |value| {
-            value
-                .request
-                .as_mut()
-                .unwrap()
-                .request_digest
-                .replace_range(7..8, "0")
-        },
-        |value| {
-            value
-                .challenge
-                .as_mut()
-                .unwrap()
-                .challenge_digest
-                .replace_range(7..8, "0")
-        },
-        |value| {
-            value
-                .approval
-                .as_mut()
-                .unwrap()
-                .approval_digest
-                .replace_range(7..8, "0")
-        },
-        |value| {
-            value
-                .settlement
-                .as_mut()
-                .unwrap()
-                .settlement_digest
-                .replace_range(7..8, "0")
-        },
-        |value| {
-            value
-                .service_result
-                .as_mut()
-                .unwrap()
-                .result_digest
-                .replace_range(7..8, "0")
-        },
-    ]
-}
-
-fn binding_mutations() -> Vec<fn(&mut PeerReceiptAuthorityAttempt)> {
-    vec![
-        |value| value.approval.as_mut().unwrap().request_digest = digest('f'),
-        |value| value.approval.as_mut().unwrap().challenge_id = "challenge-other".into(),
-        |value| value.approval.as_mut().unwrap().nonce = "nonce-other".into(),
-        |value| value.approval.as_mut().unwrap().payer = "did:peer:other".into(),
-        |value| value.settlement.as_mut().unwrap().payee = "wallet-other".into(),
-        |value| value.settlement.as_mut().unwrap().asset = "USDC".into(),
-        |value| value.settlement.as_mut().unwrap().network = "solana:mainnet".into(),
-        |value| value.settlement.as_mut().unwrap().amount_minor += 1,
-        |value| value.service_result.as_mut().unwrap().settlement_digest = digest('e'),
-    ]
-}
-
-fn time_mutations() -> Vec<fn(&mut PeerReceiptAuthorityAttempt)> {
-    vec![
-        |value| value.approval.as_mut().unwrap().approved_at_unix = 1_800_000_001,
-        |value| value.settlement.as_mut().unwrap().finalized_at_unix = 1_700_000_099,
-        |value| value.service_result.as_mut().unwrap().produced_at_unix = 1_700_000_199,
-    ]
-}
-
-fn digest(character: char) -> String {
-    format!("sha256:{}", character.to_string().repeat(64))
 }

--- a/crates/kamn-e2e-harness/tests/peer_receipt_authority_contract/binding_mutations.rs
+++ b/crates/kamn-e2e-harness/tests/peer_receipt_authority_contract/binding_mutations.rs
@@ -1,0 +1,28 @@
+use super::support::{approval_mut, result_mut, settlement_mut};
+use kamn_e2e_harness::PeerReceiptAuthorityAttempt;
+
+pub fn bindings() -> Vec<fn(&mut PeerReceiptAuthorityAttempt)> {
+    vec![
+        |value| approval_mut(value).request_digest = digest('f'),
+        |value| approval_mut(value).challenge_id = "challenge-other".into(),
+        |value| approval_mut(value).nonce = "nonce-other".into(),
+        |value| approval_mut(value).payer = "did:peer:other".into(),
+        |value| settlement_mut(value).payee = "wallet-other".into(),
+        |value| settlement_mut(value).asset = "USDC".into(),
+        |value| settlement_mut(value).network = "solana:mainnet".into(),
+        |value| settlement_mut(value).amount_minor += 1,
+        |value| result_mut(value).settlement_digest = digest('e'),
+    ]
+}
+
+pub fn times() -> Vec<fn(&mut PeerReceiptAuthorityAttempt)> {
+    vec![
+        |value| approval_mut(value).approved_at_unix = 1_800_000_001,
+        |value| settlement_mut(value).finalized_at_unix = 1_700_000_099,
+        |value| result_mut(value).produced_at_unix = 1_700_000_199,
+    ]
+}
+
+fn digest(character: char) -> String {
+    format!("sha256:{}", character.to_string().repeat(64))
+}

--- a/crates/kamn-e2e-harness/tests/peer_receipt_authority_contract/mutations.rs
+++ b/crates/kamn-e2e-harness/tests/peer_receipt_authority_contract/mutations.rs
@@ -1,0 +1,48 @@
+use super::support::{approval_mut, challenge_mut, request_mut, result_mut, settlement_mut};
+use kamn_e2e_harness::PeerReceiptAuthorityAttempt;
+
+pub fn missing_fields() -> Vec<fn(&mut PeerReceiptAuthorityAttempt)> {
+    vec![
+        |value| challenge_mut(value).challenge_id.clear(),
+        |value| challenge_mut(value).nonce.clear(),
+        |value| approval_mut(value).payer.clear(),
+        |value| settlement_mut(value).receipt_id.clear(),
+        |value| settlement_mut(value).transaction_id.clear(),
+        |value| result_mut(value).canonical_result.clear(),
+    ]
+}
+
+pub fn digests() -> Vec<fn(&mut PeerReceiptAuthorityAttempt)> {
+    vec![
+        corrupt_request_digest,
+        corrupt_challenge_digest,
+        corrupt_approval_digest,
+        corrupt_settlement_digest,
+        corrupt_result_digest,
+    ]
+}
+
+fn corrupt_request_digest(value: &mut PeerReceiptAuthorityAttempt) {
+    corrupt(&mut request_mut(value).request_digest);
+}
+
+fn corrupt_challenge_digest(value: &mut PeerReceiptAuthorityAttempt) {
+    corrupt(&mut challenge_mut(value).challenge_digest);
+}
+
+fn corrupt_approval_digest(value: &mut PeerReceiptAuthorityAttempt) {
+    corrupt(&mut approval_mut(value).approval_digest);
+}
+
+fn corrupt_settlement_digest(value: &mut PeerReceiptAuthorityAttempt) {
+    corrupt(&mut settlement_mut(value).settlement_digest);
+}
+
+fn corrupt_result_digest(value: &mut PeerReceiptAuthorityAttempt) {
+    corrupt(&mut result_mut(value).result_digest);
+}
+
+fn corrupt(value: &mut String) {
+    let replacement = if &value[7..8] == "0" { "1" } else { "0" };
+    value.replace_range(7..8, replacement);
+}

--- a/crates/kamn-e2e-harness/tests/peer_receipt_authority_contract/support.rs
+++ b/crates/kamn-e2e-harness/tests/peer_receipt_authority_contract/support.rs
@@ -1,0 +1,127 @@
+use kamn_e2e_harness::{
+    peer_approval_digest, peer_challenge_digest, peer_request_digest, peer_result_digest,
+    peer_settlement_digest, PeerApprovalAuthority, PeerChallengeAuthority,
+    PeerReceiptAuthorityAttempt, PeerRequestAuthority, PeerResultAuthority,
+    PeerSettlementAuthority, PeerSettlementVisibility,
+};
+
+pub fn complete_attempt() -> PeerReceiptAuthorityAttempt {
+    let request = request();
+    let challenge = challenge(request.request_digest.as_str());
+    let approval = approval(&challenge);
+    let settlement = settlement(&approval);
+    let service_result = service_result(&request, &settlement);
+    PeerReceiptAuthorityAttempt {
+        request: Some(request),
+        challenge: Some(challenge),
+        approval: Some(approval),
+        settlement: Some(settlement),
+        service_result: Some(service_result),
+        settlement_visibility: PeerSettlementVisibility::Observed,
+    }
+}
+
+pub fn blocked_attempt() -> PeerReceiptAuthorityAttempt {
+    let mut attempt = complete_attempt();
+    let challenge = attempt.challenge.as_mut().unwrap();
+    challenge.request_digest.clear();
+    challenge.challenge_id.clear();
+    challenge.nonce.clear();
+    challenge.expires_at_unix = 0;
+    attempt.approval = None;
+    attempt.settlement = None;
+    attempt.service_result = None;
+    attempt.settlement_visibility = PeerSettlementVisibility::Blocked;
+    attempt
+}
+
+pub fn recompute_digests(attempt: &mut PeerReceiptAuthorityAttempt) {
+    let request = attempt.request.as_mut().unwrap();
+    request.request_digest = peer_request_digest(request.canonical_body.as_str());
+    let challenge = attempt.challenge.as_mut().unwrap();
+    challenge.challenge_digest = peer_challenge_digest(challenge);
+    let approval = attempt.approval.as_mut().unwrap();
+    approval.approval_digest = peer_approval_digest(approval);
+    let settlement = attempt.settlement.as_mut().unwrap();
+    settlement.settlement_digest = peer_settlement_digest(settlement);
+    let result = attempt.service_result.as_mut().unwrap();
+    result.result_digest = peer_result_digest(result);
+}
+
+fn request() -> PeerRequestAuthority {
+    let canonical_body = r#"{"prompt":"deliver artifact"}"#.to_owned();
+    let request_digest = peer_request_digest(canonical_body.as_str());
+    PeerRequestAuthority {
+        canonical_body,
+        request_digest,
+    }
+}
+
+fn challenge(request_digest: &str) -> PeerChallengeAuthority {
+    let mut value = PeerChallengeAuthority {
+        request_digest: request_digest.into(),
+        challenge_id: "challenge-7171".into(),
+        nonce: "nonce-7171".into(),
+        expires_at_unix: 1_800_000_000,
+        payer: "did:peer:payer".into(),
+        payee: "wallet-payee".into(),
+        asset: "SOL".into(),
+        network: "solana:devnet".into(),
+        amount_minor: 1_000,
+        challenge_digest: String::new(),
+    };
+    value.challenge_digest = peer_challenge_digest(&value);
+    value
+}
+
+fn approval(challenge: &PeerChallengeAuthority) -> PeerApprovalAuthority {
+    let mut value = PeerApprovalAuthority {
+        request_digest: challenge.request_digest.clone(),
+        challenge_digest: challenge.challenge_digest.clone(),
+        challenge_id: challenge.challenge_id.clone(),
+        nonce: challenge.nonce.clone(),
+        approved_at_unix: 1_700_000_100,
+        payer: challenge.payer.clone(),
+        payee: challenge.payee.clone(),
+        asset: challenge.asset.clone(),
+        network: challenge.network.clone(),
+        amount_minor: challenge.amount_minor,
+        approval_digest: String::new(),
+    };
+    value.approval_digest = peer_approval_digest(&value);
+    value
+}
+
+fn settlement(approval: &PeerApprovalAuthority) -> PeerSettlementAuthority {
+    let mut value = PeerSettlementAuthority {
+        request_digest: approval.request_digest.clone(),
+        challenge_digest: approval.challenge_digest.clone(),
+        approval_digest: approval.approval_digest.clone(),
+        receipt_id: "receipt-7171".into(),
+        transaction_id: "transaction-7171".into(),
+        finalized_at_unix: 1_700_000_200,
+        payer: approval.payer.clone(),
+        payee: approval.payee.clone(),
+        asset: approval.asset.clone(),
+        network: approval.network.clone(),
+        amount_minor: approval.amount_minor,
+        settlement_digest: String::new(),
+    };
+    value.settlement_digest = peer_settlement_digest(&value);
+    value
+}
+
+fn service_result(
+    request: &PeerRequestAuthority,
+    settlement: &PeerSettlementAuthority,
+) -> PeerResultAuthority {
+    let mut value = PeerResultAuthority {
+        request_digest: request.request_digest.clone(),
+        settlement_digest: settlement.settlement_digest.clone(),
+        produced_at_unix: 1_700_000_300,
+        canonical_result: r#"{"status":"delivered"}"#.into(),
+        result_digest: String::new(),
+    };
+    value.result_digest = peer_result_digest(&value);
+    value
+}

--- a/crates/kamn-e2e-harness/tests/peer_receipt_authority_contract/support.rs
+++ b/crates/kamn-e2e-harness/tests/peer_receipt_authority_contract/support.rs
@@ -5,6 +5,35 @@ use kamn_e2e_harness::{
     PeerSettlementAuthority, PeerSettlementVisibility,
 };
 
+pub fn request_mut(value: &mut PeerReceiptAuthorityAttempt) -> &mut PeerRequestAuthority {
+    value.request.as_mut().expect("complete fixture request")
+}
+
+pub fn challenge_mut(value: &mut PeerReceiptAuthorityAttempt) -> &mut PeerChallengeAuthority {
+    value
+        .challenge
+        .as_mut()
+        .expect("complete fixture challenge")
+}
+
+pub fn approval_mut(value: &mut PeerReceiptAuthorityAttempt) -> &mut PeerApprovalAuthority {
+    value.approval.as_mut().expect("complete fixture approval")
+}
+
+pub fn settlement_mut(value: &mut PeerReceiptAuthorityAttempt) -> &mut PeerSettlementAuthority {
+    value
+        .settlement
+        .as_mut()
+        .expect("complete fixture settlement")
+}
+
+pub fn result_mut(value: &mut PeerReceiptAuthorityAttempt) -> &mut PeerResultAuthority {
+    value
+        .service_result
+        .as_mut()
+        .expect("complete fixture service result")
+}
+
 pub fn complete_attempt() -> PeerReceiptAuthorityAttempt {
     let request = request();
     let challenge = challenge(request.request_digest.as_str());
@@ -23,7 +52,7 @@ pub fn complete_attempt() -> PeerReceiptAuthorityAttempt {
 
 pub fn blocked_attempt() -> PeerReceiptAuthorityAttempt {
     let mut attempt = complete_attempt();
-    let challenge = attempt.challenge.as_mut().unwrap();
+    let challenge = attempt.challenge.as_mut().expect("complete fixture stage");
     challenge.request_digest.clear();
     challenge.challenge_id.clear();
     challenge.nonce.clear();
@@ -36,15 +65,18 @@ pub fn blocked_attempt() -> PeerReceiptAuthorityAttempt {
 }
 
 pub fn recompute_digests(attempt: &mut PeerReceiptAuthorityAttempt) {
-    let request = attempt.request.as_mut().unwrap();
+    let request = attempt.request.as_mut().expect("complete fixture stage");
     request.request_digest = peer_request_digest(request.canonical_body.as_str());
-    let challenge = attempt.challenge.as_mut().unwrap();
+    let challenge = attempt.challenge.as_mut().expect("complete fixture stage");
     challenge.challenge_digest = peer_challenge_digest(challenge);
-    let approval = attempt.approval.as_mut().unwrap();
+    let approval = attempt.approval.as_mut().expect("complete fixture stage");
     approval.approval_digest = peer_approval_digest(approval);
-    let settlement = attempt.settlement.as_mut().unwrap();
+    let settlement = attempt.settlement.as_mut().expect("complete fixture stage");
     settlement.settlement_digest = peer_settlement_digest(settlement);
-    let result = attempt.service_result.as_mut().unwrap();
+    let result = attempt
+        .service_result
+        .as_mut()
+        .expect("complete fixture stage");
     result.result_digest = peer_result_digest(result);
 }
 

--- a/specs/7171-peer-receipt-authority-verifier.md
+++ b/specs/7171-peer-receipt-authority-verifier.md
@@ -62,22 +62,22 @@ All digest strings use lowercase `sha256:` plus 64 hexadecimal characters.
 
 ## Acceptance Criteria
 
-- [ ] `kamn-e2e-harness` exports the evidence model, digest builders, verifier,
+- [x] `kamn-e2e-harness` exports the evidence model, digest builders, verifier,
       verdict, and structured error.
-- [ ] A deterministic complete synthetic chain evaluates to `Pass`.
-- [ ] Every digest is recomputed from the canonical fields defined above.
-- [ ] Missing stages and fields fail with `PEER_AUTHORITY_STAGE_MISSING` or
+- [x] A deterministic complete synthetic chain evaluates to `Pass`.
+- [x] Every digest is recomputed from the canonical fields defined above.
+- [x] Missing stages and fields fail with `PEER_AUTHORITY_STAGE_MISSING` or
       `PEER_AUTHORITY_FIELD_MISSING`.
-- [ ] Malformed and recomputation-mismatched digests fail with
+- [x] Malformed and recomputation-mismatched digests fail with
       `PEER_AUTHORITY_DIGEST_INVALID` or `PEER_AUTHORITY_DIGEST_MISMATCH`.
-- [ ] Identity and economic mutations fail with
+- [x] Identity and economic mutations fail with
       `PEER_AUTHORITY_BINDING_MISMATCH`.
-- [ ] Expiry and stage-order mutations fail with
+- [x] Expiry and stage-order mutations fail with
       `PEER_AUTHORITY_TIME_INVALID`.
-- [ ] The #7162 fixture is evaluated through the shared verifier and remains
+- [x] The #7162 fixture is evaluated through the shared verifier and remains
       non-passing with settlement visibility `Blocked`.
-- [ ] No fixture, test output, or model includes credentials or private keys.
-- [ ] Focused tests, existing #7162 tests, formatting, and Clippy pass.
+- [x] No fixture, test output, or model includes credentials or private keys.
+- [x] Focused tests, existing #7162 tests, formatting, and Clippy pass.
 
 ## Files To Touch
 
@@ -127,3 +127,27 @@ Integration:
 - Run both the new verifier contract and the existing #7162 contract.
 - Verify the real fixture remains non-passing and no external call occurs.
 - Run package tests, formatting, Clippy, and secret-pattern checks.
+
+## Implementation Evidence
+
+- The public harness API exposes complete and partial evidence models, digest
+  builders, a typed verdict, and structured stage/field errors.
+- Domain-separated length-prefix commitments cover challenge, approval,
+  settlement, and service result; request authority hashes exact canonical
+  request bytes.
+- The mutation matrix covers missing stages and fields, malformed and changed
+  digests, cross-stage identities, economic terms, expiry, and stage order.
+- The normalized #7162 observation maps into the shared attempt model and
+  returns `Blocked(PEER_AUTHORITY_FIELD_MISSING)` at the challenge stage.
+- All implementation and test files stay below 200 lines and all functions stay
+  below 25 lines after the mandatory split.
+- `RUST_TEST_THREADS=1 cargo test -p kamn-e2e-harness` passes the full package;
+  focused Clippy passes with warnings denied.
+
+## Deviations
+
+The first concurrent package run exposed the existing load-sensitive
+`spec_c24_duplicate_agent_process_fails_with_transport_provenance_code` actor
+fixture with a transient keypair lookup failure. The exact isolated rerun
+passed, and the complete package passed with `RUST_TEST_THREADS=1`. No actor
+verifier code was changed by this issue.

--- a/specs/7171-peer-receipt-authority-verifier.md
+++ b/specs/7171-peer-receipt-authority-verifier.md
@@ -1,0 +1,129 @@
+# 7171 Peer Receipt-Authority Verifier
+
+## Objective
+
+Add a reusable offline verifier that proves or rejects the complete peer
+request, challenge, approval, settlement, and service-result receipt chain
+without trusting ambient actor evidence or opaque peer assertions.
+
+## Inputs / Outputs
+
+Inputs:
+- canonical request and result bytes
+- request, challenge, approval, settlement, and result digest claims
+- stable challenge ID, nonce, expiry, and stage timestamps
+- payer, payee, asset, network, and amount claims at every economic stage
+- authoritative settlement receipt ID and transaction ID
+- the existing normalized #7162 external observation
+
+Outputs:
+- a typed `Pass`, `Fail`, or `Blocked` verdict
+- stable machine-readable error code
+- failing stage and field context
+- recomputed domain-separated SHA-256 commitments
+
+## Boundaries / Non-Goals
+
+- This is an offline conformance verifier, not an x402 wire-format standard.
+- A synthetic passing chain proves verifier behavior, not external
+  interoperability or a live settlement.
+- Do not spend funds, use credentials, or call the external peer again.
+- Do not change KAMN service, SDK, CLI, MCP, bridge, or settlement behavior.
+- Do not add dependencies or modify CI.
+- Do not infer missing evidence from matching actor or payment terms.
+
+## Canonical Digest Contract
+
+- Request digest: SHA-256 over the exact canonical request bytes.
+- Challenge digest: domain `kamn.peer.challenge.v1`, then length-prefixed request
+  digest, challenge ID, nonce, expiry, payer, payee, asset, network, and amount.
+- Approval digest: domain `kamn.peer.approval.v1`, then length-prefixed request
+  and challenge digests, challenge ID, nonce, approval timestamp, and the same
+  economic fields.
+- Settlement digest: domain `kamn.peer.settlement.v1`, then length-prefixed
+  request, challenge, and approval digests, receipt ID, transaction ID,
+  finalized timestamp, and the same economic fields.
+- Service-result digest: domain `kamn.peer.result.v1`, then length-prefixed
+  request and settlement digests plus exact canonical result bytes.
+
+All digest strings use lowercase `sha256:` plus 64 hexadecimal characters.
+
+## Failure Modes
+
+- A required stage or field is absent.
+- A digest has malformed encoding or does not recompute.
+- Request, challenge, approval, settlement, or result identities disagree.
+- Challenge ID or nonce changes after the challenge.
+- Approval occurs after absolute challenge expiry.
+- Settlement predates approval or result predates settlement.
+- Payer, payee, asset, network, or amount changes between stages.
+- Settlement receipt ID or transaction ID is absent.
+- The external #7162 observation is promoted to `Pass` despite missing stages.
+
+## Acceptance Criteria
+
+- [ ] `kamn-e2e-harness` exports the evidence model, digest builders, verifier,
+      verdict, and structured error.
+- [ ] A deterministic complete synthetic chain evaluates to `Pass`.
+- [ ] Every digest is recomputed from the canonical fields defined above.
+- [ ] Missing stages and fields fail with `PEER_AUTHORITY_STAGE_MISSING` or
+      `PEER_AUTHORITY_FIELD_MISSING`.
+- [ ] Malformed and recomputation-mismatched digests fail with
+      `PEER_AUTHORITY_DIGEST_INVALID` or `PEER_AUTHORITY_DIGEST_MISMATCH`.
+- [ ] Identity and economic mutations fail with
+      `PEER_AUTHORITY_BINDING_MISMATCH`.
+- [ ] Expiry and stage-order mutations fail with
+      `PEER_AUTHORITY_TIME_INVALID`.
+- [ ] The #7162 fixture is evaluated through the shared verifier and remains
+      non-passing with settlement visibility `Blocked`.
+- [ ] No fixture, test output, or model includes credentials or private keys.
+- [ ] Focused tests, existing #7162 tests, formatting, and Clippy pass.
+
+## Files To Touch
+
+- `specs/7171-peer-receipt-authority-verifier.md`
+- `crates/kamn-e2e-harness/src/lib.rs`
+- `crates/kamn-e2e-harness/src/peer_receipt_authority.rs`
+- `crates/kamn-e2e-harness/src/peer_receipt_authority_digest.rs`
+- `crates/kamn-e2e-harness/src/peer_receipt_authority_validate.rs`
+- `crates/kamn-e2e-harness/tests/peer_receipt_authority_contract.rs`
+- `crates/kamn-e2e-harness/tests/peer_receipt_authority_contract/support.rs`
+- `crates/kamn-e2e-harness/tests/external_a2a_x402_receipt_authority_contract.rs`
+
+## Error Semantics
+
+`PeerReceiptAuthorityError` includes `code`, `message`, `stage`, `field`,
+context, and an optional cause. Expected conformance failures use typed errors;
+parsing failures preserve their source text as the cause. Interior validation
+does not log. Missing or malformed evidence never falls back to `Pass`.
+
+`Blocked` means the observation explicitly stopped before settlement because
+of a no-funds or no-credentials boundary. It does not erase an earlier
+challenge failure: the verdict retains the validation error and reports
+settlement visibility separately.
+
+## Test Plan
+
+Red:
+- Compile-time public API contract.
+- Complete synthetic chain PASS contract.
+- Missing-stage and missing-field table.
+- Digest mutation table.
+- Identity/economic mutation table.
+- Expiry/order mutation table.
+- Existing #7162 fixture integration contract.
+
+Green:
+- Add the minimum public evidence types and digest builders.
+- Validate each stage sequentially and fail on the first unsupported claim.
+- Map the normalized external fixture into the shared attempt model.
+
+Refactor:
+- Separate digest construction from binding validation.
+- Centralize shared economic and digest checks.
+- Keep every file under 200 lines and every function under 25 lines.
+
+Integration:
+- Run both the new verifier contract and the existing #7162 contract.
+- Verify the real fixture remains non-passing and no external call occurs.
+- Run package tests, formatting, Clippy, and secret-pattern checks.


### PR DESCRIPTION
## Human Summary

- Adds a reusable offline verifier for request, challenge, approval, settlement, and service-result receipt authority.
- Recomputes domain-separated SHA-256 commitments and rejects missing, malformed, cross-bound, expired, reordered, or economically inconsistent evidence.
- Adds a deterministic synthetic PASS contract and mutation matrices without presenting them as live peer proof.
- Routes the real #7162 observation through the shared verifier; it remains `FAIL`/`BLOCKED` at the missing challenge-binding boundary.

Closes #7171

Spec: [`specs/7171-peer-receipt-authority-verifier.md`](https://github.com/njfio/kamn/blob/7171-peer-receipt-authority-verifier/specs/7171-peer-receipt-authority-verifier.md)

## Testing

- `cargo test -p kamn-e2e-harness --test peer_receipt_authority_contract --test external_a2a_x402_receipt_authority_contract`
- Exact isolated rerun: `cargo test -p kamn-e2e-harness --test independent_agent_transaction_actor_verifier_contract spec_c24_duplicate_agent_process_fails_with_transport_provenance_code -- --exact --nocapture`
- `RUST_TEST_THREADS=1 cargo test -p kamn-e2e-harness`
- `cargo fmt --all -- --check`
- `cargo clippy -p kamn-e2e-harness --tests -- -D warnings`
- `git diff --check`

## Notes for Reviewers

The first concurrent package run exposed the existing load-sensitive `spec_c24` actor fixture with a transient keypair lookup failure. It passed alone, and the full package passed serially. This PR does not change that actor verifier.

The synthetic PASS fixture verifies the conformance algorithm only. No external payment, signed retry, credential, or new network request occurred.

## AI Agent Details

- Public models represent complete or partial peer evidence and retain settlement visibility separately from validation failure.
- Stable codes cover missing stages/fields, invalid or mismatched digests, binding mismatches, and invalid time ordering.
- The implementation is split into model, digest, orchestration, required-field, binding, and support modules; all touched files are under 200 lines and functions under 25 lines.
- No dependencies, CI configuration, database schemas, public service APIs, MCP tools, or shell surfaces changed.