### PR TITLE
feat: unify live settlement authority parity

### DIFF
--- a/crates/kamn-e2e-harness/src/drivers/authoritative_settlement_observation.rs
+++ b/crates/kamn-e2e-harness/src/drivers/authoritative_settlement_observation.rs
@@ -1,8 +1,8 @@
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 /// Driver-neutral projection of service-issued settlement authority.
 pub struct AuthoritativeSettlementObservation {
     /// Bridge operation identifier.

--- a/crates/kamn-e2e-harness/src/lib.rs
+++ b/crates/kamn-e2e-harness/src/lib.rs
@@ -59,6 +59,7 @@ mod peer_receipt_authority_validate_bindings;
 mod peer_receipt_authority_validate_required;
 mod peer_receipt_authority_validate_support;
 mod settlement_authority_parity;
+mod settlement_authority_parity_support;
 mod settlement_authority_parity_validate;
 
 /// Driver implementations for each execution mode.

--- a/crates/kamn-e2e-harness/src/lib.rs
+++ b/crates/kamn-e2e-harness/src/lib.rs
@@ -25,6 +25,11 @@ pub use peer_receipt_authority_digest::{
     peer_settlement_digest,
 };
 pub use peer_receipt_authority_validate::verify_peer_receipt_authority;
+pub use settlement_authority_parity::{
+    SettlementAuthorityAttempt, SettlementAuthorityDriver, SettlementAuthorityParityError,
+    SettlementAuthorityParityReport,
+};
+pub use settlement_authority_parity_validate::verify_settlement_authority_parity;
 
 mod agent_transaction_actor_authority;
 mod agent_transaction_demo;
@@ -53,6 +58,8 @@ mod peer_receipt_authority_validate;
 mod peer_receipt_authority_validate_bindings;
 mod peer_receipt_authority_validate_required;
 mod peer_receipt_authority_validate_support;
+mod settlement_authority_parity;
+mod settlement_authority_parity_validate;
 
 /// Driver implementations for each execution mode.
 pub mod drivers;

--- a/crates/kamn-e2e-harness/src/settlement_authority_parity.rs
+++ b/crates/kamn-e2e-harness/src/settlement_authority_parity.rs
@@ -1,0 +1,67 @@
+use serde_json::Value;
+
+/// Driver surface participating in one settlement-authority parity proof.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SettlementAuthorityDriver {
+    /// Direct Rust SDK entrypoint.
+    Sdk,
+    /// Scriptable CLI entrypoint.
+    Cli,
+    /// MCP tool entrypoint.
+    Mcp,
+}
+
+/// One driver's claim about a shared authoritative settlement.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SettlementAuthorityAttempt {
+    /// Driver that produced the response.
+    pub driver: SettlementAuthorityDriver,
+    /// Escrow identity claimed by the driver invocation.
+    pub escrow_id: String,
+    /// Idempotency identity claimed by the driver invocation.
+    pub idempotency_key: String,
+    /// Raw service or entrypoint response containing authoritative settlement.
+    pub response: Value,
+}
+
+/// Verified three-driver settlement-authority parity evidence.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SettlementAuthorityParityReport {
+    /// Shared escrow identity.
+    pub escrow_id: String,
+    /// Shared idempotency identity.
+    pub idempotency_key: String,
+    /// Canonical serialized authoritative settlement.
+    pub canonical_authority: String,
+    /// Number of economic settlement submissions.
+    pub settlement_submissions: u64,
+}
+
+/// Structured failure from settlement-authority parity verification.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SettlementAuthorityParityError {
+    /// Stable machine-readable error code.
+    pub code: &'static str,
+    /// Driver that produced the rejected evidence, when applicable.
+    pub driver: Option<SettlementAuthorityDriver>,
+    /// Field or validation surface that failed.
+    pub field: &'static str,
+    /// Human-readable failure description.
+    pub message: String,
+}
+
+impl SettlementAuthorityParityError {
+    pub(crate) fn new(
+        code: &'static str,
+        driver: Option<SettlementAuthorityDriver>,
+        field: &'static str,
+        message: impl Into<String>,
+    ) -> Self {
+        Self {
+            code,
+            driver,
+            field,
+            message: message.into(),
+        }
+    }
+}

--- a/crates/kamn-e2e-harness/src/settlement_authority_parity_support.rs
+++ b/crates/kamn-e2e-harness/src/settlement_authority_parity_support.rs
@@ -1,0 +1,86 @@
+use crate::drivers::AuthoritativeSettlementObservation;
+use crate::{
+    SettlementAuthorityDriver, SettlementAuthorityParityError, SettlementAuthorityParityReport,
+};
+
+pub(crate) const AUTHORITY_ERROR: &str = "PI_SERVICE_AUTHORITY_MISMATCH";
+const CHAIN_ERROR: &str = "RECEIPT_CHAIN_INVALID";
+pub(crate) const REPLAY_ERROR: &str = "SERVICE_AUTHORITY_REPLAY";
+
+pub(crate) fn validate_submission_count(count: u64) -> Result<(), SettlementAuthorityParityError> {
+    if count == 1 {
+        return Ok(());
+    }
+    Err(error(
+        REPLAY_ERROR,
+        None,
+        "settlement_submissions",
+        format!("expected one settlement submission, observed {count}"),
+    ))
+}
+
+pub(crate) fn build_report(
+    escrow: &str,
+    idempotency: &str,
+    authority: &AuthoritativeSettlementObservation,
+    count: u64,
+) -> Result<SettlementAuthorityParityReport, SettlementAuthorityParityError> {
+    let canonical_authority = canonical_authority(authority)?;
+    Ok(SettlementAuthorityParityReport {
+        escrow_id: escrow.to_owned(),
+        idempotency_key: idempotency.to_owned(),
+        canonical_authority,
+        settlement_submissions: count,
+    })
+}
+
+fn canonical_authority(
+    authority: &AuthoritativeSettlementObservation,
+) -> Result<String, SettlementAuthorityParityError> {
+    serde_json::to_value(authority)
+        .and_then(|value| serde_json::to_string(&value))
+        .map_err(|source| {
+            error(
+                AUTHORITY_ERROR,
+                None,
+                "authoritative_settlement",
+                format!("failed to serialize normalized authority: {source}"),
+            )
+        })
+}
+
+pub(crate) fn normalize_error(
+    driver: SettlementAuthorityDriver,
+    source: &str,
+) -> SettlementAuthorityParityError {
+    let code = if source == "SERVICE_AUTHORITY_DIGEST_INVALID" {
+        CHAIN_ERROR
+    } else {
+        AUTHORITY_ERROR
+    };
+    error(code, Some(driver), "authoritative_settlement", source)
+}
+
+pub(crate) fn identity_error(
+    driver: SettlementAuthorityDriver,
+    field: &'static str,
+) -> SettlementAuthorityParityError {
+    identity_error_with_code(driver, AUTHORITY_ERROR, field)
+}
+
+pub(crate) fn identity_error_with_code(
+    driver: SettlementAuthorityDriver,
+    code: &'static str,
+    field: &'static str,
+) -> SettlementAuthorityParityError {
+    error(code, Some(driver), field, format!("driver changed {field}"))
+}
+
+pub(crate) fn error(
+    code: &'static str,
+    driver: Option<SettlementAuthorityDriver>,
+    field: &'static str,
+    message: impl Into<String>,
+) -> SettlementAuthorityParityError {
+    SettlementAuthorityParityError::new(code, driver, field, message)
+}

--- a/crates/kamn-e2e-harness/src/settlement_authority_parity_validate.rs
+++ b/crates/kamn-e2e-harness/src/settlement_authority_parity_validate.rs
@@ -4,14 +4,14 @@ use crate::drivers::{
     normalize_authoritative_settlement, AuthoritativeSettlementObservation,
     AuthoritativeSettlementReplayGuard,
 };
+use crate::settlement_authority_parity_support::{
+    build_report, error, identity_error, identity_error_with_code, normalize_error,
+    validate_submission_count, AUTHORITY_ERROR, REPLAY_ERROR,
+};
 use crate::{
     SettlementAuthorityAttempt, SettlementAuthorityDriver, SettlementAuthorityParityError,
     SettlementAuthorityParityReport,
 };
-
-const AUTHORITY_ERROR: &str = "PI_SERVICE_AUTHORITY_MISMATCH";
-const CHAIN_ERROR: &str = "RECEIPT_CHAIN_INVALID";
-const REPLAY_ERROR: &str = "SERVICE_AUTHORITY_REPLAY";
 
 /// Verifies complete, identical authority across SDK, CLI, and MCP attempts.
 pub fn verify_settlement_authority_parity(
@@ -127,76 +127,4 @@ fn validate_retry_parity(
         })?;
     }
     Ok(())
-}
-
-fn validate_submission_count(count: u64) -> Result<(), SettlementAuthorityParityError> {
-    if count == 1 {
-        return Ok(());
-    }
-    Err(error(
-        REPLAY_ERROR,
-        None,
-        "settlement_submissions",
-        format!("expected one settlement submission, observed {count}"),
-    ))
-}
-
-fn build_report(
-    escrow: &str,
-    idempotency: &str,
-    authority: &AuthoritativeSettlementObservation,
-    count: u64,
-) -> Result<SettlementAuthorityParityReport, SettlementAuthorityParityError> {
-    let canonical_authority = serde_json::to_value(authority)
-        .and_then(|value| serde_json::to_string(&value))
-        .map_err(|source| {
-            error(
-                AUTHORITY_ERROR,
-                None,
-                "authoritative_settlement",
-                format!("failed to serialize normalized authority: {source}"),
-            )
-        })?;
-    Ok(SettlementAuthorityParityReport {
-        escrow_id: escrow.to_owned(),
-        idempotency_key: idempotency.to_owned(),
-        canonical_authority,
-        settlement_submissions: count,
-    })
-}
-
-fn normalize_error(
-    driver: SettlementAuthorityDriver,
-    source: &str,
-) -> SettlementAuthorityParityError {
-    let code = if source == "SERVICE_AUTHORITY_DIGEST_INVALID" {
-        CHAIN_ERROR
-    } else {
-        AUTHORITY_ERROR
-    };
-    error(code, Some(driver), "authoritative_settlement", source)
-}
-
-fn identity_error(
-    driver: SettlementAuthorityDriver,
-    field: &'static str,
-) -> SettlementAuthorityParityError {
-    identity_error_with_code(driver, AUTHORITY_ERROR, field)
-}
-
-fn identity_error_with_code(
-    driver: SettlementAuthorityDriver,
-    code: &'static str,
-    field: &'static str,
-) -> SettlementAuthorityParityError {
-    error(code, Some(driver), field, format!("driver changed {field}"))
-}
-
-fn error(
-    code: &'static str,
-    driver: Option<SettlementAuthorityDriver>,
-    field: &'static str,
-    message: impl Into<String>,
-) -> SettlementAuthorityParityError {
-    SettlementAuthorityParityError::new(code, driver, field, message)
 }

--- a/crates/kamn-e2e-harness/src/settlement_authority_parity_validate.rs
+++ b/crates/kamn-e2e-harness/src/settlement_authority_parity_validate.rs
@@ -1,0 +1,202 @@
+use std::collections::HashSet;
+
+use crate::drivers::{
+    normalize_authoritative_settlement, AuthoritativeSettlementObservation,
+    AuthoritativeSettlementReplayGuard,
+};
+use crate::{
+    SettlementAuthorityAttempt, SettlementAuthorityDriver, SettlementAuthorityParityError,
+    SettlementAuthorityParityReport,
+};
+
+const AUTHORITY_ERROR: &str = "PI_SERVICE_AUTHORITY_MISMATCH";
+const CHAIN_ERROR: &str = "RECEIPT_CHAIN_INVALID";
+const REPLAY_ERROR: &str = "SERVICE_AUTHORITY_REPLAY";
+
+/// Verifies complete, identical authority across SDK, CLI, and MCP attempts.
+pub fn verify_settlement_authority_parity(
+    expected_escrow: &str,
+    expected_actor: &str,
+    expected_idempotency: &str,
+    attempts: Vec<SettlementAuthorityAttempt>,
+    settlement_submissions: u64,
+) -> Result<SettlementAuthorityParityReport, SettlementAuthorityParityError> {
+    validate_driver_set(attempts.as_slice())?;
+    let observations = normalize_attempts(
+        attempts.as_slice(),
+        expected_escrow,
+        expected_actor,
+        expected_idempotency,
+    )?;
+    validate_retry_parity(observations.as_slice())?;
+    validate_submission_count(settlement_submissions)?;
+    build_report(
+        expected_escrow,
+        expected_idempotency,
+        &observations[0].1,
+        settlement_submissions,
+    )
+}
+
+fn validate_driver_set(
+    attempts: &[SettlementAuthorityAttempt],
+) -> Result<(), SettlementAuthorityParityError> {
+    let drivers = attempts
+        .iter()
+        .map(|attempt| attempt.driver)
+        .collect::<HashSet<_>>();
+    if attempts.len() == 3 && drivers.len() == 3 {
+        return Ok(());
+    }
+    Err(error(
+        AUTHORITY_ERROR,
+        None,
+        "driver_set",
+        "SDK, CLI, and MCP attempts are each required exactly once",
+    ))
+}
+
+fn normalize_attempts(
+    attempts: &[SettlementAuthorityAttempt],
+    escrow: &str,
+    actor: &str,
+    idempotency: &str,
+) -> Result<
+    Vec<(
+        SettlementAuthorityDriver,
+        AuthoritativeSettlementObservation,
+    )>,
+    SettlementAuthorityParityError,
+> {
+    attempts
+        .iter()
+        .map(|attempt| normalize_attempt(attempt, escrow, actor, idempotency))
+        .collect()
+}
+
+fn normalize_attempt(
+    attempt: &SettlementAuthorityAttempt,
+    escrow: &str,
+    actor: &str,
+    idempotency: &str,
+) -> Result<
+    (
+        SettlementAuthorityDriver,
+        AuthoritativeSettlementObservation,
+    ),
+    SettlementAuthorityParityError,
+> {
+    validate_attempt_identity(attempt, escrow, idempotency)?;
+    let authority = normalize_authoritative_settlement(&attempt.response, escrow, actor)
+        .map_err(|source| normalize_error(attempt.driver, source.as_str()))?;
+    if authority.idempotency_key != idempotency {
+        return Err(error(
+            AUTHORITY_ERROR,
+            Some(attempt.driver),
+            "idempotency_key",
+            "authoritative settlement changed the shared idempotency identity",
+        ));
+    }
+    Ok((attempt.driver, authority))
+}
+
+fn validate_attempt_identity(
+    attempt: &SettlementAuthorityAttempt,
+    escrow: &str,
+    idempotency: &str,
+) -> Result<(), SettlementAuthorityParityError> {
+    if attempt.escrow_id != escrow {
+        return Err(identity_error(attempt.driver, "escrow_id"));
+    }
+    if attempt.idempotency_key != idempotency {
+        return Err(identity_error(attempt.driver, "idempotency_key"));
+    }
+    Ok(())
+}
+
+fn validate_retry_parity(
+    observations: &[(
+        SettlementAuthorityDriver,
+        AuthoritativeSettlementObservation,
+    )],
+) -> Result<(), SettlementAuthorityParityError> {
+    let mut guard = AuthoritativeSettlementReplayGuard::default();
+    for (driver, authority) in observations {
+        guard.observe(authority).map_err(|_| {
+            identity_error_with_code(*driver, REPLAY_ERROR, "authoritative_settlement")
+        })?;
+    }
+    Ok(())
+}
+
+fn validate_submission_count(count: u64) -> Result<(), SettlementAuthorityParityError> {
+    if count == 1 {
+        return Ok(());
+    }
+    Err(error(
+        REPLAY_ERROR,
+        None,
+        "settlement_submissions",
+        format!("expected one settlement submission, observed {count}"),
+    ))
+}
+
+fn build_report(
+    escrow: &str,
+    idempotency: &str,
+    authority: &AuthoritativeSettlementObservation,
+    count: u64,
+) -> Result<SettlementAuthorityParityReport, SettlementAuthorityParityError> {
+    let canonical_authority = serde_json::to_value(authority)
+        .and_then(|value| serde_json::to_string(&value))
+        .map_err(|source| {
+            error(
+                AUTHORITY_ERROR,
+                None,
+                "authoritative_settlement",
+                format!("failed to serialize normalized authority: {source}"),
+            )
+        })?;
+    Ok(SettlementAuthorityParityReport {
+        escrow_id: escrow.to_owned(),
+        idempotency_key: idempotency.to_owned(),
+        canonical_authority,
+        settlement_submissions: count,
+    })
+}
+
+fn normalize_error(
+    driver: SettlementAuthorityDriver,
+    source: &str,
+) -> SettlementAuthorityParityError {
+    let code = if source == "SERVICE_AUTHORITY_DIGEST_INVALID" {
+        CHAIN_ERROR
+    } else {
+        AUTHORITY_ERROR
+    };
+    error(code, Some(driver), "authoritative_settlement", source)
+}
+
+fn identity_error(
+    driver: SettlementAuthorityDriver,
+    field: &'static str,
+) -> SettlementAuthorityParityError {
+    identity_error_with_code(driver, AUTHORITY_ERROR, field)
+}
+
+fn identity_error_with_code(
+    driver: SettlementAuthorityDriver,
+    code: &'static str,
+    field: &'static str,
+) -> SettlementAuthorityParityError {
+    error(code, Some(driver), field, format!("driver changed {field}"))
+}
+
+fn error(
+    code: &'static str,
+    driver: Option<SettlementAuthorityDriver>,
+    field: &'static str,
+    message: impl Into<String>,
+) -> SettlementAuthorityParityError {
+    SettlementAuthorityParityError::new(code, driver, field, message)
+}

--- a/crates/kamn-e2e-harness/tests/authoritative_settlement_entrypoint_parity.rs
+++ b/crates/kamn-e2e-harness/tests/authoritative_settlement_entrypoint_parity.rs
@@ -1,31 +1,32 @@
-use kamn_agent_lib::KamnAgentHandle;
-use kamn_e2e_harness::drivers::normalize_authoritative_settlement;
-use serde_json::{json, Value};
-use std::io::{Read, Write};
-use std::net::TcpListener;
+#[path = "authoritative_settlement_entrypoint_parity/support.rs"]
+mod support;
 
-const AGENT: &str = "kamn-cli";
-const ESCROW: &str = "escrow-1";
-const IDEMPOTENCY: &str = "operation-1";
+use kamn_agent_lib::KamnAgentHandle;
+use kamn_e2e_harness::{
+    verify_settlement_authority_parity, SettlementAuthorityAttempt, SettlementAuthorityDriver,
+};
+use serde_json::{json, Value};
+use support::{
+    authority_value, release_payload, StatefulAuthorityService, AGENT, ESCROW, IDEMPOTENCY,
+};
 
 #[test]
-fn sdk_cli_and_mcp_entrypoints_preserve_identical_authority() {
+fn real_entrypoints_share_one_authority_and_submission() {
     std::env::set_var("KAMN_AGENT_LIB_ALLOW_DETERMINISTIC_IDENTITY", "1");
-    let listener = TcpListener::bind("127.0.0.1:0").expect("listener");
-    let endpoint = format!("http://{}", listener.local_addr().expect("address"));
-    let handle =
-        KamnAgentHandle::connect(&endpoint, "http://127.0.0.1:9", AGENT).expect("SDK handle");
-    let actor = handle.identity().did().as_str().to_owned();
-    let response = service_response(actor.as_str());
-    let server = serve(listener, response);
+    let identity_handle =
+        KamnAgentHandle::connect("http://127.0.0.1:9", "http://127.0.0.1:9", AGENT)
+            .expect("identity handle");
+    let actor = identity_handle.identity().did().as_str().to_owned();
+    let service = StatefulAuthorityService::spawn(actor.as_str());
+    let endpoint = service.endpoint();
 
-    let sdk = handle
+    let sdk_handle =
+        KamnAgentHandle::connect(&endpoint, "http://127.0.0.1:9", AGENT).expect("SDK handle");
+    let sdk = sdk_handle
         .release_escrow_with_payload(ESCROW, release_payload().as_str())
         .expect("SDK release")
         .authoritative_settlement
         .expect("SDK authority");
-    let sdk = normalize_authoritative_settlement(&authority_value(&sdk), ESCROW, actor.as_str())
-        .expect("SDK normalization");
 
     let cli_args = kamn_cli::parse_cli_args([
         "kamn-cli",
@@ -38,13 +39,11 @@ fn sdk_cli_and_mcp_entrypoints_preserve_identical_authority() {
     ])
     .expect("CLI args");
     let cli_output = kamn_cli::dispatch(&cli_args).expect("CLI release");
-    let cli_value = serde_json::from_str::<Value>(cli_output.json.as_str()).expect("CLI json");
-    let cli = normalize_authoritative_settlement(&cli_value, ESCROW, actor.as_str())
-        .expect("CLI normalization");
+    let cli = serde_json::from_str::<Value>(cli_output.json.as_str()).expect("CLI json");
 
     let mcp_handle =
         KamnAgentHandle::connect(&endpoint, "http://127.0.0.1:9", AGENT).expect("MCP handle");
-    let mcp_response = kamn_mcp_server::dispatch_tool_request_json(
+    let mcp = kamn_mcp_server::dispatch_tool_request_json(
         &mcp_handle,
         json!({
             "id": "parity-1",
@@ -56,88 +55,28 @@ fn sdk_cli_and_mcp_entrypoints_preserve_identical_authority() {
         .as_str(),
     )
     .expect("MCP release");
-    let mcp_value = serde_json::from_str::<Value>(mcp_response.as_str()).expect("MCP json");
-    let mcp_authority = &mcp_value["result"]["settlement_service_receipt"];
-    let mcp = normalize_authoritative_settlement(mcp_authority, ESCROW, actor.as_str())
-        .expect("MCP normalization");
+    let mcp = serde_json::from_str::<Value>(mcp.as_str()).expect("MCP json");
 
-    server.join().expect("server");
-    assert_eq!(sdk, cli);
-    assert_eq!(cli, mcp);
+    service.finish();
+    let attempts = vec![
+        attempt(SettlementAuthorityDriver::Sdk, authority_value(&sdk)),
+        attempt(SettlementAuthorityDriver::Cli, cli),
+        attempt(
+            SettlementAuthorityDriver::Mcp,
+            mcp["result"]["settlement_service_receipt"].clone(),
+        ),
+    ];
+    let report =
+        verify_settlement_authority_parity(ESCROW, actor.as_str(), IDEMPOTENCY, attempts, 1)
+            .expect("entrypoint parity");
+    assert_eq!(report.settlement_submissions, 1);
 }
 
-fn serve(listener: TcpListener, body: String) -> std::thread::JoinHandle<()> {
-    std::thread::spawn(move || {
-        for _ in 0..3 {
-            let (mut stream, _) = listener.accept().expect("connection");
-            let mut request = [0_u8; 8192];
-            let _ = stream.read(&mut request).expect("request");
-            let response = format!(
-                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
-                body.len(),
-                body
-            );
-            stream.write_all(response.as_bytes()).expect("response");
-        }
-    })
-}
-
-fn release_payload() -> String {
-    json!({
-        "idempotency_key": IDEMPOTENCY,
-        "authority_mode": "bridge-receipt",
-        "bridge_id": "bridge-1",
-    })
-    .to_string()
-}
-
-fn service_response(actor: &str) -> String {
-    let authority = authority(actor);
-    json!({
-        "actor_did": actor, "escrow_id": ESCROW, "state": "release-authorized",
-        "receipt_id": "release-1", "receipt_digest": digest('e'),
-        "action": "escrow:release-authorize", "bridge_id": "bridge-1",
-        "settlement_receipt_id": "settlement-1",
-        "settlement_receipt_digest": digest('b'),
-        "settlement_receipt_action": "settlement:confirmed",
-        "settlement_receipt_resource_id": ESCROW,
-        "settlement_receipt_state": "confirmed",
-        "authoritative_settlement": authority,
-    })
-    .to_string()
-}
-
-fn authority(actor: &str) -> Value {
-    json!({
-        "bridge_id": "bridge-1", "bridge_receipt_id": "bridge-receipt-1",
-        "bridge_receipt_digest": digest('a'), "settlement_receipt_id": "settlement-1",
-        "settlement_receipt_digest": digest('b'), "action": "settlement:confirmed",
-        "resource_id": ESCROW, "actor_did": actor, "resulting_state": "confirmed",
-        "task_id": "task-1", "escrow_id": ESCROW, "recipient": "recipient-1",
-        "amount_lamports": 31, "asset": "lamports", "network": "solana:devnet",
-        "transaction_signature": "signature-1", "commitment": "finalized",
-        "finalized_slot": 42, "receipt_chain_commitment": digest('c'),
-        "terms_digest": "terms-1", "idempotency_key": IDEMPOTENCY,
-    })
-}
-
-fn authority_value(value: &kamn_agent_lib::ServiceAuthoritativeSettlement) -> Value {
-    json!({
-        "bridge_id": value.bridge_id, "bridge_receipt_id": value.bridge_receipt_id,
-        "bridge_receipt_digest": value.bridge_receipt_digest,
-        "settlement_receipt_id": value.settlement_receipt_id,
-        "settlement_receipt_digest": value.settlement_receipt_digest,
-        "action": value.action, "resource_id": value.resource_id, "actor_did": value.actor_did,
-        "resulting_state": value.resulting_state, "task_id": value.task_id,
-        "escrow_id": value.escrow_id, "recipient": value.recipient,
-        "amount_lamports": value.amount_lamports, "asset": value.asset,
-        "network": value.network, "transaction_signature": value.transaction_signature,
-        "commitment": value.commitment, "finalized_slot": value.finalized_slot,
-        "receipt_chain_commitment": value.receipt_chain_commitment,
-        "terms_digest": value.terms_digest, "idempotency_key": value.idempotency_key,
-    })
-}
-
-fn digest(value: char) -> String {
-    format!("sha256:{}", value.to_string().repeat(64))
+fn attempt(driver: SettlementAuthorityDriver, response: Value) -> SettlementAuthorityAttempt {
+    SettlementAuthorityAttempt {
+        driver,
+        escrow_id: ESCROW.to_owned(),
+        idempotency_key: IDEMPOTENCY.to_owned(),
+        response,
+    }
 }

--- a/crates/kamn-e2e-harness/tests/authoritative_settlement_entrypoint_parity/support.rs
+++ b/crates/kamn-e2e-harness/tests/authoritative_settlement_entrypoint_parity/support.rs
@@ -1,0 +1,137 @@
+use kamn_agent_lib::ServiceAuthoritativeSettlement;
+use serde_json::{json, Value};
+use std::collections::HashSet;
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::sync::{Arc, Mutex};
+
+pub const AGENT: &str = "kamn-cli";
+pub const ESCROW: &str = "escrow-1";
+pub const IDEMPOTENCY: &str = "operation-1";
+
+pub struct StatefulAuthorityService {
+    endpoint: String,
+    submissions: Arc<Mutex<HashSet<String>>>,
+    server: std::thread::JoinHandle<()>,
+}
+
+impl StatefulAuthorityService {
+    pub fn spawn(actor: &str) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("listener");
+        let endpoint = format!("http://{}", listener.local_addr().expect("address"));
+        let submissions = Arc::new(Mutex::new(HashSet::new()));
+        let server = serve(listener, service_response(actor), submissions.clone());
+        Self {
+            endpoint,
+            submissions,
+            server,
+        }
+    }
+
+    pub fn endpoint(&self) -> String {
+        self.endpoint.clone()
+    }
+
+    pub fn finish(self) {
+        self.server.join().expect("server");
+        assert_eq!(self.submissions.lock().expect("submissions").len(), 1);
+    }
+}
+
+fn serve(
+    listener: TcpListener,
+    body: String,
+    submissions: Arc<Mutex<HashSet<String>>>,
+) -> std::thread::JoinHandle<()> {
+    std::thread::spawn(move || {
+        for _ in 0..3 {
+            let (mut stream, _) = listener.accept().expect("connection");
+            let request = read_request(&mut stream);
+            assert!(request.contains(ESCROW), "request must bind shared escrow");
+            assert!(
+                request.contains(IDEMPOTENCY),
+                "request must bind shared idempotency key"
+            );
+            submissions
+                .lock()
+                .expect("submissions")
+                .insert(IDEMPOTENCY.to_owned());
+            write_response(&mut stream, body.as_str());
+        }
+    })
+}
+
+fn read_request(stream: &mut std::net::TcpStream) -> String {
+    let mut request = [0_u8; 8192];
+    let length = stream.read(&mut request).expect("request");
+    String::from_utf8(request[..length].to_vec()).expect("utf8 request")
+}
+
+fn write_response(stream: &mut std::net::TcpStream, body: &str) {
+    let response = format!(
+        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+        body.len(),
+        body
+    );
+    stream.write_all(response.as_bytes()).expect("response");
+}
+
+pub fn release_payload() -> String {
+    json!({
+        "idempotency_key": IDEMPOTENCY,
+        "authority_mode": "bridge-receipt",
+        "bridge_id": "bridge-1",
+    })
+    .to_string()
+}
+
+fn service_response(actor: &str) -> String {
+    json!({
+        "actor_did": actor, "escrow_id": ESCROW, "state": "release-authorized",
+        "receipt_id": "release-1", "receipt_digest": digest('e'),
+        "action": "escrow:release-authorize", "bridge_id": "bridge-1",
+        "settlement_receipt_id": "settlement-1",
+        "settlement_receipt_digest": digest('b'),
+        "settlement_receipt_action": "settlement:confirmed",
+        "settlement_receipt_resource_id": ESCROW,
+        "settlement_receipt_state": "confirmed",
+        "authoritative_settlement": authority(actor),
+    })
+    .to_string()
+}
+
+fn authority(actor: &str) -> Value {
+    json!({
+        "bridge_id": "bridge-1", "bridge_receipt_id": "bridge-receipt-1",
+        "bridge_receipt_digest": digest('a'), "settlement_receipt_id": "settlement-1",
+        "settlement_receipt_digest": digest('b'), "action": "settlement:confirmed",
+        "resource_id": ESCROW, "actor_did": actor, "resulting_state": "confirmed",
+        "task_id": "task-1", "escrow_id": ESCROW, "recipient": "recipient-1",
+        "amount_lamports": 31, "asset": "lamports", "network": "solana:devnet",
+        "transaction_signature": "signature-1", "commitment": "finalized",
+        "finalized_slot": 42, "receipt_chain_commitment": digest('c'),
+        "terms_digest": digest('d'), "idempotency_key": IDEMPOTENCY,
+    })
+}
+
+pub fn authority_value(value: &ServiceAuthoritativeSettlement) -> Value {
+    json!({
+        "bridge_id": value.bridge_id, "bridge_receipt_id": value.bridge_receipt_id,
+        "bridge_receipt_digest": value.bridge_receipt_digest,
+        "settlement_receipt_id": value.settlement_receipt_id,
+        "settlement_receipt_digest": value.settlement_receipt_digest,
+        "action": value.action, "resource_id": value.resource_id,
+        "actor_did": value.actor_did, "resulting_state": value.resulting_state,
+        "task_id": value.task_id, "escrow_id": value.escrow_id,
+        "recipient": value.recipient, "amount_lamports": value.amount_lamports,
+        "asset": value.asset, "network": value.network,
+        "transaction_signature": value.transaction_signature,
+        "commitment": value.commitment, "finalized_slot": value.finalized_slot,
+        "receipt_chain_commitment": value.receipt_chain_commitment,
+        "terms_digest": value.terms_digest, "idempotency_key": value.idempotency_key,
+    })
+}
+
+fn digest(value: char) -> String {
+    format!("sha256:{}", value.to_string().repeat(64))
+}

--- a/crates/kamn-e2e-harness/tests/live_s05_settlement_authority_parity.rs
+++ b/crates/kamn-e2e-harness/tests/live_s05_settlement_authority_parity.rs
@@ -1,0 +1,121 @@
+use kamn_e2e_harness::{
+    verify_settlement_authority_parity, SettlementAuthorityAttempt, SettlementAuthorityDriver,
+};
+use serde_json::{json, Value};
+use std::path::{Path, PathBuf};
+
+const INPUT_ENV: &str = "KAMN_E2E_S05_AUTHORITY_PARITY_CAPTURE";
+const OUTPUT_ENV: &str = "KAMN_E2E_S05_AUTHORITY_PARITY_REPORT";
+
+#[test]
+#[ignore = "requires an explicitly captured funded S-05 parity execution"]
+fn integration_live_s05_authority_parity_capture_is_complete() {
+    let capture_path = required_path(INPUT_ENV);
+    let capture = read_json(capture_path.as_path());
+    let escrow = required_string(&capture, "escrow_id");
+    let actor = required_string(&capture, "actor_did");
+    let idempotency = required_string(&capture, "idempotency_key");
+    validate_balance_movement(&capture);
+    validate_rpc_artifact(&capture);
+
+    let submissions = required_u64(&capture, "settlement_submissions");
+    let report = verify_settlement_authority_parity(
+        escrow,
+        actor,
+        idempotency,
+        attempts(&capture, escrow, idempotency),
+        submissions,
+    )
+    .expect("live authority parity capture must verify");
+    write_report(&capture, &report.canonical_authority);
+}
+
+fn attempts(capture: &Value, escrow: &str, idempotency: &str) -> Vec<SettlementAuthorityAttempt> {
+    [
+        (SettlementAuthorityDriver::Sdk, "sdk"),
+        (SettlementAuthorityDriver::Cli, "cli"),
+        (SettlementAuthorityDriver::Mcp, "mcp"),
+    ]
+    .into_iter()
+    .map(|(driver, key)| SettlementAuthorityAttempt {
+        driver,
+        escrow_id: escrow.to_owned(),
+        idempotency_key: idempotency.to_owned(),
+        response: capture["attempts"][key].clone(),
+    })
+    .collect()
+}
+
+fn validate_balance_movement(capture: &Value) {
+    let payer_before = required_u64(capture, "payer_balance_before");
+    let payer_after = required_u64(capture, "payer_balance_after");
+    let recipient_before = required_u64(capture, "recipient_balance_before");
+    let recipient_after = required_u64(capture, "recipient_balance_after");
+    assert!(payer_after < payer_before, "payer balance must decrease");
+    assert!(
+        recipient_after > recipient_before,
+        "recipient balance must increase"
+    );
+}
+
+fn validate_rpc_artifact(capture: &Value) {
+    let path = PathBuf::from(required_string(capture, "authoritative_rpc_artifact"));
+    let artifact = read_json(path.as_path());
+    assert_eq!(artifact["confirmationStatus"], "finalized");
+    assert!(artifact["meta"]["err"].is_null());
+    let signature = required_string(capture, "transaction_signature");
+    assert!(
+        artifact.to_string().contains(signature),
+        "RPC artifact must bind the settlement signature"
+    );
+}
+
+fn write_report(capture: &Value, canonical_authority: &str) {
+    let output = std::env::var(OUTPUT_ENV)
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from(".kamn/e2e/live-s05-authority-parity/report.json"));
+    if let Some(parent) = output.parent() {
+        std::fs::create_dir_all(parent).expect("create live parity report directory");
+    }
+    let report = json!({
+        "status": "PASS",
+        "proof_kind": "executed-funded-live",
+        "escrow_id": capture["escrow_id"],
+        "idempotency_key": capture["idempotency_key"],
+        "settlement_submissions": capture["settlement_submissions"],
+        "transaction_signature": capture["transaction_signature"],
+        "authoritative_rpc_artifact": capture["authoritative_rpc_artifact"],
+        "canonical_authority": canonical_authority,
+    });
+    std::fs::write(
+        output,
+        serde_json::to_vec_pretty(&report).expect("report json"),
+    )
+    .expect("write live parity report");
+}
+
+fn required_path(name: &str) -> PathBuf {
+    let value = std::env::var(name).unwrap_or_else(|_| panic!("required env missing: {name}"));
+    assert!(!value.trim().is_empty(), "required env empty: {name}");
+    PathBuf::from(value)
+}
+
+fn read_json(path: &Path) -> Value {
+    let bytes = std::fs::read(path)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", path.display()));
+    serde_json::from_slice(bytes.as_slice())
+        .unwrap_or_else(|error| panic!("invalid JSON in {}: {error}", path.display()))
+}
+
+fn required_string<'a>(value: &'a Value, key: &str) -> &'a str {
+    value[key]
+        .as_str()
+        .filter(|item| !item.trim().is_empty())
+        .unwrap_or_else(|| panic!("capture missing non-empty {key}"))
+}
+
+fn required_u64(value: &Value, key: &str) -> u64 {
+    value[key]
+        .as_u64()
+        .unwrap_or_else(|| panic!("capture missing integer {key}"))
+}

--- a/crates/kamn-e2e-harness/tests/settlement_authority_parity_contract.rs
+++ b/crates/kamn-e2e-harness/tests/settlement_authority_parity_contract.rs
@@ -1,0 +1,143 @@
+use kamn_e2e_harness::{
+    verify_settlement_authority_parity, SettlementAuthorityAttempt, SettlementAuthorityDriver,
+};
+use serde_json::{json, Value};
+
+const ESCROW: &str = "escrow-1";
+const ACTOR: &str = "did:kamn:actor";
+const IDEMPOTENCY: &str = "operation-1";
+
+#[test]
+fn three_drivers_prove_one_authoritative_settlement() {
+    let report = verify_settlement_authority_parity(
+        ESCROW,
+        ACTOR,
+        IDEMPOTENCY,
+        attempts(fixture()),
+        1,
+    )
+    .expect("complete shared authority should pass");
+
+    assert_eq!(report.escrow_id, ESCROW);
+    assert_eq!(report.idempotency_key, IDEMPOTENCY);
+    assert_eq!(report.settlement_submissions, 1);
+    assert_eq!(report.canonical_authority, canonical_fixture());
+}
+
+#[test]
+fn missing_tampered_and_cross_resource_authority_fail_closed() {
+    let mut missing = fixture();
+    missing
+        .as_object_mut()
+        .expect("fixture object")
+        .remove("transaction_signature");
+    assert_error(missing, "PI_SERVICE_AUTHORITY_MISMATCH");
+
+    let mut tampered = fixture();
+    tampered["receipt_chain_commitment"] = json!("sha256:bad");
+    assert_error(tampered, "RECEIPT_CHAIN_INVALID");
+
+    let mut cross_resource = fixture();
+    cross_resource["resource_id"] = json!("escrow-2");
+    assert_error(cross_resource, "PI_SERVICE_AUTHORITY_MISMATCH");
+}
+
+#[test]
+fn conflicting_retry_and_duplicate_submission_fail_closed() {
+    let mut conflicting = attempts(fixture());
+    conflicting[2].response["finalized_slot"] = json!(43);
+    let error =
+        verify_settlement_authority_parity(ESCROW, ACTOR, IDEMPOTENCY, conflicting, 1)
+            .expect_err("same-key different authority must fail");
+    assert_eq!(error.code, "SERVICE_AUTHORITY_REPLAY");
+    assert_eq!(error.driver, Some(SettlementAuthorityDriver::Mcp));
+
+    let error =
+        verify_settlement_authority_parity(ESCROW, ACTOR, IDEMPOTENCY, attempts(fixture()), 2)
+            .expect_err("duplicate settlement must fail");
+    assert_eq!(error.code, "SERVICE_AUTHORITY_REPLAY");
+    assert_eq!(error.field, "settlement_submissions");
+}
+
+#[test]
+fn missing_driver_and_changed_identity_fail_closed() {
+    let mut missing = attempts(fixture());
+    missing.pop();
+    let error = verify_settlement_authority_parity(ESCROW, ACTOR, IDEMPOTENCY, missing, 1)
+        .expect_err("all three drivers are required");
+    assert_eq!(error.code, "PI_SERVICE_AUTHORITY_MISMATCH");
+    assert_eq!(error.field, "driver_set");
+
+    let error = verify_settlement_authority_parity(
+        ESCROW,
+        ACTOR,
+        "operation-other",
+        attempts(fixture()),
+        1,
+    )
+    .expect_err("shared idempotency identity is required");
+    assert_eq!(error.code, "PI_SERVICE_AUTHORITY_MISMATCH");
+    assert_eq!(error.field, "idempotency_key");
+}
+
+fn assert_error(value: Value, expected: &str) {
+    let error = verify_settlement_authority_parity(
+        ESCROW,
+        ACTOR,
+        IDEMPOTENCY,
+        attempts(value),
+        1,
+    )
+    .expect_err("invalid authority must fail");
+    assert_eq!(error.code, expected);
+}
+
+fn attempts(response: Value) -> Vec<SettlementAuthorityAttempt> {
+    [
+        SettlementAuthorityDriver::Sdk,
+        SettlementAuthorityDriver::Cli,
+        SettlementAuthorityDriver::Mcp,
+    ]
+    .into_iter()
+    .map(|driver| SettlementAuthorityAttempt {
+        driver,
+        escrow_id: ESCROW.to_owned(),
+        idempotency_key: IDEMPOTENCY.to_owned(),
+        response: response.clone(),
+    })
+    .collect()
+}
+
+fn canonical_fixture() -> String {
+    serde_json::to_string(&fixture()).expect("canonical fixture")
+}
+
+fn fixture() -> Value {
+    json!({
+        "bridge_id": "bridge-1",
+        "bridge_receipt_id": "bridge-receipt-1",
+        "bridge_receipt_digest": digest('a'),
+        "settlement_receipt_id": "settlement-1",
+        "settlement_receipt_digest": digest('b'),
+        "action": "settlement:confirmed",
+        "resource_id": ESCROW,
+        "actor_did": ACTOR,
+        "resulting_state": "confirmed",
+        "task_id": "task-1",
+        "escrow_id": ESCROW,
+        "recipient": "recipient-1",
+        "amount_lamports": 31,
+        "asset": "lamports",
+        "network": "solana:devnet",
+        "transaction_signature": "signature-1",
+        "commitment": "finalized",
+        "finalized_slot": 42,
+        "receipt_chain_commitment": digest('c'),
+        "terms_digest": digest('d'),
+        "idempotency_key": IDEMPOTENCY,
+    })
+}
+
+fn digest(value: char) -> String {
+    format!("sha256:{}", value.to_string().repeat(64))
+}

--- a/crates/kamn-e2e-harness/tests/settlement_authority_parity_contract.rs
+++ b/crates/kamn-e2e-harness/tests/settlement_authority_parity_contract.rs
@@ -9,14 +9,9 @@ const IDEMPOTENCY: &str = "operation-1";
 
 #[test]
 fn three_drivers_prove_one_authoritative_settlement() {
-    let report = verify_settlement_authority_parity(
-        ESCROW,
-        ACTOR,
-        IDEMPOTENCY,
-        attempts(fixture()),
-        1,
-    )
-    .expect("complete shared authority should pass");
+    let report =
+        verify_settlement_authority_parity(ESCROW, ACTOR, IDEMPOTENCY, attempts(fixture()), 1)
+            .expect("complete shared authority should pass");
 
     assert_eq!(report.escrow_id, ESCROW);
     assert_eq!(report.idempotency_key, IDEMPOTENCY);
@@ -46,9 +41,8 @@ fn missing_tampered_and_cross_resource_authority_fail_closed() {
 fn conflicting_retry_and_duplicate_submission_fail_closed() {
     let mut conflicting = attempts(fixture());
     conflicting[2].response["finalized_slot"] = json!(43);
-    let error =
-        verify_settlement_authority_parity(ESCROW, ACTOR, IDEMPOTENCY, conflicting, 1)
-            .expect_err("same-key different authority must fail");
+    let error = verify_settlement_authority_parity(ESCROW, ACTOR, IDEMPOTENCY, conflicting, 1)
+        .expect_err("same-key different authority must fail");
     assert_eq!(error.code, "SERVICE_AUTHORITY_REPLAY");
     assert_eq!(error.driver, Some(SettlementAuthorityDriver::Mcp));
 
@@ -81,14 +75,8 @@ fn missing_driver_and_changed_identity_fail_closed() {
 }
 
 fn assert_error(value: Value, expected: &str) {
-    let error = verify_settlement_authority_parity(
-        ESCROW,
-        ACTOR,
-        IDEMPOTENCY,
-        attempts(value),
-        1,
-    )
-    .expect_err("invalid authority must fail");
+    let error = verify_settlement_authority_parity(ESCROW, ACTOR, IDEMPOTENCY, attempts(value), 1)
+        .expect_err("invalid authority must fail");
     assert_eq!(error.code, expected);
 }
 

--- a/docs/validation/live-s05-settlement-authority-parity.md
+++ b/docs/validation/live-s05-settlement-authority-parity.md
@@ -1,0 +1,48 @@
+# Live S-05 Settlement Authority Parity
+
+## Claim Boundary
+
+The deterministic `authoritative_settlement_entrypoint_parity` test proves that
+the real SDK, CLI, and MCP dispatch surfaces preserve one escrow, one
+idempotency key, byte-identical normalized authority, and one deduplicated
+submission at a stateful service boundary. It does not prove funded devnet
+execution.
+
+Funded proof exists only when the ignored-live test completes and writes
+`.kamn/e2e/live-s05-authority-parity/report.json`. An absent report is
+`NOT_EXECUTED`, not `PASS`.
+
+## Capture Contract
+
+Set `KAMN_E2E_S05_AUTHORITY_PARITY_CAPTURE` to a JSON capture from one live
+escrow release retried through SDK, CLI, and MCP. The capture must contain:
+
+- `escrow_id`, `actor_did`, and `idempotency_key`
+- `attempts.sdk`, `attempts.cli`, and `attempts.mcp` raw response objects
+- `settlement_submissions` from
+  `settlement_intents[escrow_id].submission_attempt_count`
+- payer and recipient balances before and after the release attempts
+- `transaction_signature`
+- `authoritative_rpc_artifact`, pointing to finalized successful RPC JSON
+
+The three attempts must use the same live endpoint and release payload. Capture
+balances before the SDK attempt and after the MCP attempt. Do not include
+private keys, bearer tokens, or environment values in the capture.
+
+## Verification
+
+```bash
+cargo test -p kamn-e2e-harness \
+  --test live_s05_settlement_authority_parity \
+  -- --ignored --exact integration_live_s05_authority_parity_capture_is_complete
+```
+
+The test rejects missing or partial authority, identity drift, receipt-chain
+tampering, cross-resource reuse, conflicting retries, duplicate submissions,
+missing balance movement, and non-finalized RPC evidence.
+
+## External Peer Boundary
+
+This proof does not alter the external x402 result. That lane remains
+FAIL/BLOCKED until the peer supplies the request digest, nonce, challenge ID,
+expiry, approval linkage, and authoritative settlement receipt fields.

--- a/specs/7173-live-settlement-authority-parity.md
+++ b/specs/7173-live-settlement-authority-parity.md
@@ -1,0 +1,106 @@
+# 7173 Live Settlement Authority Parity
+
+## Objective
+
+Prove that SDK, CLI, and MCP settlement attempts preserve one escrow,
+idempotency identity, and complete bridge-authorized settlement receipt while
+causing exactly one economic submission.
+
+## Inputs / Outputs
+
+Inputs:
+- one escrow ID and one idempotency key shared by all three drivers
+- SDK, CLI, and MCP release responses
+- the expected actor DID, resource ID, and economic terms
+- authoritative bridge and settlement receipt fields
+- a settlement-submission counter
+- optional live payer and recipient balances plus finalized RPC evidence
+
+Outputs:
+- one byte-stable normalized authoritative settlement per driver
+- a parity report containing the shared identity and submission count
+- structured authority or replay errors for every rejected attempt
+- an ignored-live evidence report when funded execution is explicitly enabled
+
+## Boundaries / Non-Goals
+
+- Do not redesign the public settlement authority schema.
+- Do not create three independent escrows and call them parity evidence.
+- Do not accept `escrow_id` and `state` without complete authority.
+- Do not add dependencies, modify CI, or spend funds automatically.
+- Deterministic integration evidence does not prove a funded devnet transfer.
+- Do not promote the external x402 probe while peer receipt fields are absent.
+
+## Failure Modes
+
+- A driver changes the escrow ID or idempotency key.
+- A response omits or partially populates authoritative settlement.
+- Receipt digests, actor, resource, economics, terms, or receipt chain differ.
+- A transaction signature or finalized slot is missing.
+- The same idempotency key is replayed with different authority.
+- A receipt from another escrow or transaction is reused.
+- More than one settlement submission occurs across the three attempts.
+- Live balance movement, RPC confirmation, or submission count is absent.
+
+## Acceptance Criteria
+
+- [ ] The harness exports a shared three-driver settlement parity verifier.
+- [ ] SDK, CLI, and MCP attempts bind to one escrow ID and idempotency key.
+- [ ] All drivers yield byte-identical normalized authoritative settlement.
+- [ ] Complete bridge, receipt, actor, resource, economic, transaction, slot,
+      terms, and receipt-chain fields are validated before parity passes.
+- [ ] Missing, partial, tampered, cross-resource, and conflicting replay
+      evidence fails closed with existing structured error taxonomy.
+- [ ] A deterministic integration test exercises real SDK, CLI, and MCP
+      dispatch entrypoints against one stateful service boundary.
+- [ ] The stateful boundary records exactly one settlement submission.
+- [ ] An ignored-live path records before/after balances, finalized RPC
+      evidence, and exactly one submission for the same transfer identity.
+- [ ] Documentation distinguishes deterministic contract evidence from an
+      actually executed funded proof.
+- [ ] Focused tests, formatting, Clippy, and the serial suite pass.
+
+## Files To Touch
+
+- `specs/7173-live-settlement-authority-parity.md`
+- `crates/kamn-e2e-harness/src/lib.rs`
+- `crates/kamn-e2e-harness/src/settlement_authority_parity.rs`
+- `crates/kamn-e2e-harness/src/settlement_authority_parity_validate.rs`
+- `crates/kamn-e2e-harness/tests/settlement_authority_parity_contract.rs`
+- `crates/kamn-e2e-harness/tests/authoritative_settlement_entrypoint_parity.rs`
+- `crates/kamn-e2e-harness/tests/live_s05_settlement_authority_parity.rs`
+- `docs/validation/live-s05-settlement-authority-parity.md`
+
+## Error Semantics
+
+Authority validation precedes parity or settlement-evidence promotion.
+Missing or inconsistent authority returns `PI_SERVICE_AUTHORITY_MISMATCH`.
+Malformed receipt-chain evidence returns `RECEIPT_CHAIN_INVALID`. Reusing the
+same idempotency key with different authority returns the existing replay
+error. Every error includes the driver and mismatched field in context.
+Interior validation returns typed errors and does not log.
+
+## Test Plan
+
+Red:
+- Public API and complete three-driver parity contract.
+- Missing and partial authority mutation table.
+- Receipt, actor, resource, economic, terms, and chain mutation table.
+- Same-key/different-authority and cross-resource replay table.
+- Exactly-once stateful entrypoint integration contract.
+
+Green:
+- Add the minimum shared attempt, report, and structured error types.
+- Validate each normalized authority field and byte equality.
+- Count one stateful settlement submission across the three real entrypoints.
+
+Refactor:
+- Separate identity, authority, and exactly-once validation.
+- Centralize driver-specific response normalization.
+- Keep every file under 200 lines and every function under 25 lines.
+
+Integration:
+- Replace the fixed-response parity test with a stateful service boundary.
+- Add an ignored-live coordinator that requires explicit live environment.
+- Persist live balances, RPC confirmation, and submission-count evidence.
+- Run focused tests, formatting, Clippy, and the serial repository suite.

--- a/specs/7173-live-settlement-authority-parity.md
+++ b/specs/7173-live-settlement-authority-parity.md
@@ -44,21 +44,22 @@ Outputs:
 
 ## Acceptance Criteria
 
-- [ ] The harness exports a shared three-driver settlement parity verifier.
-- [ ] SDK, CLI, and MCP attempts bind to one escrow ID and idempotency key.
-- [ ] All drivers yield byte-identical normalized authoritative settlement.
-- [ ] Complete bridge, receipt, actor, resource, economic, transaction, slot,
+- [x] The harness exports a shared three-driver settlement parity verifier.
+- [x] SDK, CLI, and MCP attempts bind to one escrow ID and idempotency key.
+- [x] All drivers yield byte-identical normalized authoritative settlement.
+- [x] Complete bridge, receipt, actor, resource, economic, transaction, slot,
       terms, and receipt-chain fields are validated before parity passes.
-- [ ] Missing, partial, tampered, cross-resource, and conflicting replay
+- [x] Missing, partial, tampered, cross-resource, and conflicting replay
       evidence fails closed with existing structured error taxonomy.
-- [ ] A deterministic integration test exercises real SDK, CLI, and MCP
+- [x] A deterministic integration test exercises real SDK, CLI, and MCP
       dispatch entrypoints against one stateful service boundary.
-- [ ] The stateful boundary records exactly one settlement submission.
+- [x] The stateful boundary records exactly one settlement submission.
 - [ ] An ignored-live path records before/after balances, finalized RPC
       evidence, and exactly one submission for the same transfer identity.
-- [ ] Documentation distinguishes deterministic contract evidence from an
+- [x] Documentation distinguishes deterministic contract evidence from an
       actually executed funded proof.
-- [ ] Focused tests, formatting, Clippy, and the serial suite pass.
+- [x] Focused tests, formatting, and Clippy pass.
+- [ ] The serial repository suite passes on a host with GNU `timeout`.
 
 ## Files To Touch
 
@@ -104,3 +105,24 @@ Integration:
 - Add an ignored-live coordinator that requires explicit live environment.
 - Persist live balances, RPC confirmation, and submission-count evidence.
 - Run focused tests, formatting, Clippy, and the serial repository suite.
+
+## Verification Evidence
+
+- `cargo test -p kamn-e2e-harness --test settlement_authority_parity_contract
+  --test authoritative_settlement_entrypoint_parity
+  --test live_s05_settlement_authority_parity`: five passed; the funded live
+  capture remained ignored because no explicit capture was supplied.
+- `cargo fmt --all -- --check`: passed.
+- `cargo clippy -p kamn-e2e-harness --all-targets -- -D warnings`: passed.
+- `RUST_TEST_THREADS=1 make test`: reached
+  `shell_test_surface_migration_wave1`; 17 tests passed and three wrapper
+  parity tests could not start because this macOS host has no GNU `timeout`.
+  No #7173 assertion failed.
+
+## Deviations
+
+The deterministic acceptance surface is complete. A funded capture is still
+`NOT_EXECUTED`, so this change does not claim live economic movement. The full
+serial suite is also not recorded as passed until it runs on a host providing
+GNU `timeout`; the observed failure is an environment prerequisite, not a
+waiver or a weakened test.


### PR DESCRIPTION
## Human Summary

- Adds one shared verifier for SDK, CLI, and MCP settlement authority.
- Requires all three entrypoints to bind the same escrow, idempotency identity, receipt chain, economics, transaction, and finalized slot.
- Exercises the real dispatch entrypoints against one stateful boundary and proves exactly one economic submission.
- Keeps funded live settlement explicitly unproven unless an external capture supplies balances and finalized RPC evidence.

Closes #7173

Spec: `specs/7173-live-settlement-authority-parity.md`

## Testing

- `cargo test -p kamn-e2e-harness --test settlement_authority_parity_contract --test authoritative_settlement_entrypoint_parity --test live_s05_settlement_authority_parity`
- `cargo fmt --all -- --check`
- `cargo clippy -p kamn-e2e-harness --all-targets -- -D warnings`
- `RUST_TEST_THREADS=1 make test` reached `shell_test_surface_migration_wave1`; 17 tests in that binary passed, while three existing wrapper tests could not start because GNU `timeout` is unavailable on this macOS host.

## Notes for Reviewers

The deterministic integration proof is complete. The ignored funded path remains `NOT_EXECUTED`, and this PR does not claim live economic movement.

## AI Agent Details

- Shared authority validation is split across identity, field completeness/parity, receipt-chain validation, and exactly-once submission checks.
- The entrypoint test uses the actual SDK, CLI, and MCP dispatch adapters against one stateful service support boundary.
- Structured failures preserve `PI_SERVICE_AUTHORITY_MISMATCH`, `RECEIPT_CHAIN_INVALID`, and replay-conflict taxonomy.